### PR TITLE
PYI-312: create terraform networking module

### DIFF
--- a/terraform/networking/README.md
+++ b/terraform/networking/README.md
@@ -1,0 +1,17 @@
+# networking module
+
+This directory contains a terraform module which creates the low-level networking infrastructure required to deploy the components in this repo.
+In particular, it creates:
+
+- VPC
+- subnets, routing tables, internet gateway
+
+It may in future also contain some other useful shared network-related things, such as security groups for cross-component communication, or route 53 zones, or service discovery things.
+
+The intended usage is that this module creates resources, which are then discovered via terraform data sources in other modules.
+
+## Variables
+
+|Name|Type|Description|
+|:---|:---|:---|
+|`environment`|string|Name of environment to deploy. Used to tag resources.|

--- a/terraform/networking/variables.tf
+++ b/terraform/networking/variables.tf
@@ -1,0 +1,10 @@
+variable "environment" {
+  type = string
+}
+
+locals {
+  default_tags = {
+    Environment = var.environment
+    Source      = "github.com/alphagov/di-ipv-core-back/terraform/networking"
+  }
+}

--- a/terraform/networking/vpc.tf
+++ b/terraform/networking/vpc.tf
@@ -1,0 +1,51 @@
+resource "aws_vpc" "ipv" {
+  cidr_block           = "10.1.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-ipv-vpc"
+  })
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "ipv_public" {
+  count             = length(data.aws_availability_zones.available.names)
+  vpc_id            = aws_vpc.ipv.id
+  cidr_block        = "10.1.${count.index + 128}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-public-${data.aws_availability_zones.available.names[count.index]}"
+  })
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.ipv.id
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-ipv"
+  })
+}
+
+resource "aws_route_table" "public_route_table" {
+  vpc_id = aws_vpc.ipv.id
+
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-public-ipv"
+  })
+}
+
+resource "aws_route" "public_to_internet" {
+  route_table_id         = aws_route_table.public_route_table.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_route_table_association" "public_to_internet" {
+  count = length(data.aws_availability_zones.available.names)
+
+  route_table_id = aws_route_table.public_route_table.id
+  subnet_id      = aws_subnet.ipv_public[count.index].id
+}


### PR DESCRIPTION
This contains a terraform module which creates the low-level
networking infrastructure required to deploy the components in this
repo.  In particular, it creates:

- VPC
- subnets, routing tables, internet gateway