### PR TITLE
PYI-312: Use `cidrnetwork` function

### DIFF
--- a/terraform/networking/vpc.tf
+++ b/terraform/networking/vpc.tf
@@ -13,7 +13,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_subnet" "ipv_public" {
   count             = length(data.aws_availability_zones.available.names)
   vpc_id            = aws_vpc.ipv.id
-  cidr_block        = "10.1.${count.index + 128}.0/24"
+  cidr_block        = cidrsubnet("10.1.0.0/16", 8, 128 + count.index)
   availability_zone = data.aws_availability_zones.available.names[count.index]
 
   tags = merge(local.default_tags, {


### PR DESCRIPTION

## Proposed changes

### What changed

Terraform has a builtin function for computing CIDR network blocks.
This is much better than doing string interpolation, particularly when
you get networks which aren't /8, /16 or /24.


### Why did it change

Good to get this pattern in early so people can copy it.

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

