### PR TITLE
PYI-284: Create minimal authorisation handler lambda to accept oath flow request from core front

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,12 @@ repositories {
 dependencies {
 
     implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-            "com.amazonaws:aws-lambda-java-events:3.10.0"
+            "com.amazonaws:aws-lambda-java-events:3.10.0",
+            "com.nimbusds:oauth2-oidc-sdk:9.3.1",
+            "com.fasterxml.jackson.core:jackson-core:2.13.0",
+            "com.fasterxml.jackson.core:jackson-databind:2.13.0",
+            "com.fasterxml.jackson.core:jackson-annotations:2.13.0",
+            "org.slf4j:slf4j-simple:1.7.32"
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1',
             "org.mockito:mockito-core:3.12.4"

--- a/src/main/java/uk/gov/di/ipv/entity/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/entity/ErrorResponse.java
@@ -1,0 +1,31 @@
+package uk.gov.di.ipv.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ErrorResponse {
+    ERROR_1000(1000, "Missing query parameters for auth request"),
+    ERROR_1001(1001, "Redirect URI is missing from auth request");
+
+    @JsonProperty("code")
+    private int code;
+
+    @JsonProperty("message")
+    private String message;
+
+    ErrorResponse(
+            @JsonProperty(required = true, value = "code") int code,
+            @JsonProperty(required = true, value = "message") String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
@@ -7,22 +7,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.entity.ErrorResponse;
 
-public class ApiGatewayResponseHelper {
+public class ApiGatewayResponseGenerator {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayResponseHelper.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayResponseGenerator.class);
 
-    public static APIGatewayProxyResponseEvent generateApiGatewayProxyErrorResponse(
+    public static APIGatewayProxyResponseEvent proxyErrorResponse(
             int statusCode, ErrorResponse errorResponse) {
         try {
-            return generateApiGatewayProxyResponse(
+            return proxyResponse(
                     statusCode, new ObjectMapper().writeValueAsString(errorResponse));
         } catch (JsonProcessingException e) {
             LOGGER.warn("Unable to generateApiGatewayProxyErrorResponse: " + e);
-            return generateApiGatewayProxyResponse(500, "Internal server error");
+            return proxyResponse(500, "Internal server error");
         }
     }
 
-    public static APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
+    public static APIGatewayProxyResponseEvent proxyResponse(
             int statusCode, String body) {
         APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
                 new APIGatewayProxyResponseEvent();

--- a/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseHelper.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseHelper.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.entity.ErrorResponse;
+
+public class ApiGatewayResponseHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayResponseHelper.class);
+
+    public static APIGatewayProxyResponseEvent generateApiGatewayProxyErrorResponse(
+            int statusCode, ErrorResponse errorResponse) {
+        try {
+            return generateApiGatewayProxyResponse(
+                    statusCode, new ObjectMapper().writeValueAsString(errorResponse));
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Unable to generateApiGatewayProxyErrorResponse: " + e);
+            return generateApiGatewayProxyResponse(500, "Internal server error");
+        }
+    }
+
+    public static APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
+            int statusCode, String body) {
+        APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
+                new APIGatewayProxyResponseEvent();
+        apiGatewayProxyResponseEvent.setStatusCode(statusCode);
+        apiGatewayProxyResponseEvent.setBody(body);
+
+        return apiGatewayProxyResponseEvent;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
@@ -13,15 +13,13 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.entity.ErrorResponse;
+import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.service.AuthorizationCodeService;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static uk.gov.di.ipv.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
-import static uk.gov.di.ipv.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class AuthorizationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>  {
@@ -46,13 +44,13 @@ public class AuthorizationHandler
         try {
             if (queryStringParameters == null || queryStringParameters.isEmpty()) {
                 LOGGER.error("Missing required query parameters for authorisation request");
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
+                return ApiGatewayResponseGenerator.proxyErrorResponse(400, ErrorResponse.ERROR_1000);
             }
             authenticationRequest = AuthenticationRequest.parse(queryStringParameters);
             LOGGER.info("Successfully parsed authentication request");
         } catch (ParseException e) {
             LOGGER.error("Authentication request could not be parsed", e);
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+            return ApiGatewayResponseGenerator.proxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
 
         final AuthorizationCode authorizationCode = authorizationCodeService.generateAuthorisationCode();
@@ -65,7 +63,7 @@ public class AuthorizationHandler
                 authenticationRequest.getResponseMode()
         );
 
-        return generateApiGatewayProxyResponse(200, generateResponseBody(authorizationResponse));
+        return ApiGatewayResponseGenerator.proxyResponse(200, generateResponseBody(authorizationResponse));
     }
 
     private Map<String, List<String>> getQueryStringParametersAsMap(final APIGatewayProxyRequestEvent input) {

--- a/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.service;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+
+public class AuthorizationCodeService {
+
+    public AuthorizationCode generateAuthorisationCode() {
+        return new AuthorizationCode();
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
@@ -1,27 +1,159 @@
 package uk.gov.di.ipv.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.entity.ErrorResponse;
+import uk.gov.di.ipv.service.AuthorizationCodeService;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-class AuthorizationHandlerTest {
-
+public class AuthorizationHandlerTest {
     private final Context context = mock(Context.class);
+    private final AuthorizationCodeService authorizationCodeService = mock(AuthorizationCodeService.class);
 
     private AuthorizationHandler handler;
+    private AuthorizationCode authorizationCode;
 
     @BeforeEach
     public void setUp() {
-        handler = new AuthorizationHandler();
+        authorizationCode = new AuthorizationCode();
+        when(authorizationCodeService.generateAuthorisationCode()).thenReturn(authorizationCode);
+
+        handler = new AuthorizationHandler(authorizationCodeService);
     }
 
     @Test
-    public void shouldRespondWithKnownValue(){
-        String result = handler.handleRequest("Some input", context);
-        assertEquals("Hello, this is the stub AuthorizationHandler", result);
+    public void shouldReturn200OnSuccessfulOauthRequest(){
+        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        final Map<String, String> params = new HashMap<>();
+        params.put("redirect_uri", "http://test.co.uk");
+        params.put("client_id", "12345");
+        params.put("response_type", "code");
+        params.put("scope", "openid");
+        event.setQueryStringParameters(params);
+
+        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        assertEquals(200, response.getStatusCode());
     }
 
+    @Test
+    public void shouldReturnAuthResponseOnSuccessfulOauthRequest() throws Exception {
+        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        final Map<String, String> params = new HashMap<>();
+        params.put("redirect_uri", "http://test.co.uk");
+        params.put("client_id", "12345");
+        params.put("response_type", "code");
+        params.put("scope", "openid");
+        event.setQueryStringParameters(params);
+
+        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        final Map<String, String> authCode = (Map) responseBody.get("authorizationCode");
+
+        assertEquals(authorizationCode.toString(), authCode.get("value"));
+        assertEquals(event.getQueryStringParameters().get("redirect_uri"), responseBody.get("redirectionURI"));
+    }
+
+    @Test
+    public void shouldReturn400OnMissingRedirectUriParam() throws Exception {
+        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        final Map<String, String> params = new HashMap<>();
+        params.put("client_id", "12345");
+        params.put("response_type", "code");
+        params.put("scope", "openid");
+        event.setQueryStringParameters(params);
+
+        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.ERROR_1001.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.ERROR_1001.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    public void shouldReturn400OnMissingClientIdParam() throws Exception {
+        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        final Map<String, String> params = new HashMap<>();
+        params.put("redirect_uri", "http://test.co.uk");
+        params.put("response_type", "code");
+        params.put("scope", "openid");
+        event.setQueryStringParameters(params);
+
+        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.ERROR_1001.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.ERROR_1001.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    public void shouldReturn400OnMissingResponseTypeParam() throws Exception {
+        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        final Map<String, String> params = new HashMap<>();
+        params.put("redirect_uri", "http://test.co.uk");
+        params.put("client_id", "12345");
+        params.put("scope", "openid");
+        event.setQueryStringParameters(params);
+
+        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.ERROR_1001.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.ERROR_1001.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    public void shouldReturn400OnMissingScopeParam() throws Exception {
+        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        final Map<String, String> params = new HashMap<>();
+        params.put("redirect_uri", "http://test.co.uk");
+        params.put("client_id", "12345");
+        params.put("response_type", "code");
+        event.setQueryStringParameters(params);
+
+        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.ERROR_1001.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.ERROR_1001.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    public void shouldReturn400OnMissingQueryParameters() throws Exception {
+        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.ERROR_1000.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.ERROR_1000.getMessage(), responseBody.get("message"));
+    }
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Created the new minimal Authorisation handler lambda that accepts the auth request and returns an authorisation code.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Allow the core front app to initiate an oath authorisation request and send back an authorisation code.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-284](https://govukverify.atlassian.net/browse/PYI-284)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

