### PR TITLE
Pyi 286/token exchange lambda

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ dependencies {
             "com.fasterxml.jackson.core:jackson-annotations:2.13.0",
             "org.slf4j:slf4j-simple:1.7.32"
 
+    compileOnly 'org.projectlombok:lombok:1.18.22'
+    annotationProcessor 'org.projectlombok:lombok:1.18.22'
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1',
             "org.mockito:mockito-core:3.12.4"
 }

--- a/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.entity;
+package uk.gov.di.ipv.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -6,7 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorResponse {
     ERROR_1000(1000, "Missing query parameters for auth request"),
-    ERROR_1001(1001, "Redirect URI is missing from auth request");
+    ERROR_1001(1001, "Redirect URI is missing from auth request"),
+    ERROR_1002(1002, "Failed to parse token request"),
+    ERROR_1003(1003, "Missing authorisation code for token request");
 
     @JsonProperty("code")
     private int code;

--- a/src/main/java/uk/gov/di/ipv/dto/TokenRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/dto/TokenRequestDto.java
@@ -1,0 +1,47 @@
+package uk.gov.di.ipv.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.net.URI;
+
+public class TokenRequestDto {
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("redirect_uri")
+    private URI redirect_uri;
+
+    @JsonProperty("grant_type")
+    private String grant_type;
+
+    @JsonProperty("client_id")
+    private String client_id;
+
+    public TokenRequestDto(
+            @JsonProperty(value="code") String code,
+            @JsonProperty(value="redirect_uri") URI redirect_uri,
+            @JsonProperty(value="grant_type") String grant_type,
+            @JsonProperty(value="client_id") String client_id
+    ) {
+        this.code = code;
+        this.redirect_uri = redirect_uri;
+        this.grant_type = grant_type;
+        this.client_id = client_id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public URI getRedirect_uri() {
+        return redirect_uri;
+    }
+
+    public String getGrant_type() {
+        return grant_type;
+    }
+
+    public String getClient_id() {
+        return client_id;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.di.ipv.entity.ErrorResponse;
+import uk.gov.di.ipv.domain.ErrorResponse;
 
 public class ApiGatewayResponseGenerator {
 

--- a/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
@@ -1,0 +1,71 @@
+package uk.gov.di.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.domain.ErrorResponse;
+import uk.gov.di.ipv.dto.TokenRequestDto;
+import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.service.AccessTokenService;
+
+public class AccessTokenHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccessTokenHandler.class);
+
+    private final AccessTokenService accessTokenService;
+
+    public AccessTokenHandler(AccessTokenService accessTokenService) {
+        this.accessTokenService = accessTokenService;
+    }
+
+    public AccessTokenHandler() {
+        this.accessTokenService = new AccessTokenService();
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            TokenRequestDto tokenRequestDto = objectMapper.readValue(input.getBody(), TokenRequestDto.class);
+
+            if (tokenRequestDto.getCode().isEmpty()) {
+                LOGGER.error("Missing authorisation code from the token request");
+                return ApiGatewayResponseGenerator.proxyErrorResponse(400, ErrorResponse.ERROR_1003);
+            }
+
+            TokenRequest tokenRequest = new TokenRequest(
+                    null,
+                    new ClientID(tokenRequestDto.getClient_id()),
+                    new AuthorizationCodeGrant(
+                            new AuthorizationCode(tokenRequestDto.getCode()),
+                            tokenRequestDto.getRedirect_uri())
+            );
+
+            TokenResponse tokenResponse = accessTokenService.exchangeCodeForToken(tokenRequest);
+
+            if (tokenResponse instanceof TokenErrorResponse) {
+                TokenErrorResponse tokenErrorResponse = tokenResponse.toErrorResponse();
+                return ApiGatewayResponseGenerator.proxyResponse(400, tokenErrorResponse.toJSONObject().toJSONString());
+            }
+
+            AccessTokenResponse accessTokenResponse = tokenResponse.toSuccessResponse();
+            return ApiGatewayResponseGenerator.proxyResponse(200, accessTokenResponse.toJSONObject().toJSONString());
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Token request could not be parsed", e);
+            return ApiGatewayResponseGenerator.proxyErrorResponse(400, ErrorResponse.ERROR_1002);
+        }
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
@@ -12,7 +12,7 @@ import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.di.ipv.entity.ErrorResponse;
+import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.service.AuthorizationCodeService;
 
@@ -28,7 +28,7 @@ public class AuthorizationHandler
 
     private final AuthorizationCodeService authorizationCodeService;
 
-    public AuthorizationHandler(final AuthorizationCodeService authorizationCodeService) {
+    public AuthorizationHandler(AuthorizationCodeService authorizationCodeService) {
         this.authorizationCodeService = authorizationCodeService;
     }
 
@@ -37,10 +37,10 @@ public class AuthorizationHandler
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
-        final Map<String, List<String>> queryStringParameters = getQueryStringParametersAsMap(input);
-        final AuthenticationRequest authenticationRequest;
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+        Map<String, List<String>> queryStringParameters = getQueryStringParametersAsMap(input);
 
+        final AuthenticationRequest authenticationRequest;
         try {
             if (queryStringParameters == null || queryStringParameters.isEmpty()) {
                 LOGGER.error("Missing required query parameters for authorisation request");
@@ -53,9 +53,9 @@ public class AuthorizationHandler
             return ApiGatewayResponseGenerator.proxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
 
-        final AuthorizationCode authorizationCode = authorizationCodeService.generateAuthorisationCode();
+        AuthorizationCode authorizationCode = authorizationCodeService.generateAuthorisationCode();
 
-        final AuthorizationSuccessResponse authorizationResponse = new AuthorizationSuccessResponse(
+        AuthorizationSuccessResponse authorizationResponse = new AuthorizationSuccessResponse(
                 authenticationRequest.getRedirectionURI(),
                 authorizationCode,
                 null,
@@ -66,7 +66,7 @@ public class AuthorizationHandler
         return ApiGatewayResponseGenerator.proxyResponse(200, generateResponseBody(authorizationResponse));
     }
 
-    private Map<String, List<String>> getQueryStringParametersAsMap(final APIGatewayProxyRequestEvent input) {
+    private Map<String, List<String>> getQueryStringParametersAsMap(APIGatewayProxyRequestEvent input) {
         if (input.getQueryStringParameters() != null) {
             return input.getQueryStringParameters().entrySet().stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, entry -> List.of(entry.getValue())));
@@ -74,10 +74,10 @@ public class AuthorizationHandler
         return Collections.emptyMap();
     }
 
-    private String generateResponseBody(final AuthorizationSuccessResponse authorizationResponse) {
+    private String generateResponseBody(AuthorizationSuccessResponse authorizationResponse) {
         try {
             return new ObjectMapper().writeValueAsString(authorizationResponse);
-        } catch (final JsonProcessingException e) {
+        } catch (JsonProcessingException e) {
             LOGGER.error("Failed to process AuthorisationSuccessResponse");
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/gov/di/ipv/service/AccessTokenService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AccessTokenService.java
@@ -1,0 +1,26 @@
+package uk.gov.di.ipv.service;
+
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.Tokens;
+
+public class AccessTokenService {
+
+    public TokenResponse exchangeCodeForToken(TokenRequest tokenRequest) {
+        if (!tokenRequest.getAuthorizationGrant().getType().equals(GrantType.AUTHORIZATION_CODE)) {
+            return new TokenErrorResponse(
+                    new ErrorObject("F-001", "Something failed during exchange of code to token")
+            );
+        }
+
+        AccessToken accessToken = new BearerAccessToken();
+
+        return new AccessTokenResponse(new Tokens(accessToken, null));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/lambda/AccessTokenHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AccessTokenHandlerTest.java
@@ -1,0 +1,140 @@
+package uk.gov.di.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.Tokens;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.domain.ErrorResponse;
+import uk.gov.di.ipv.dto.TokenRequestDto;
+import uk.gov.di.ipv.service.AccessTokenService;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AccessTokenHandlerTest {
+    private final Context context = mock(Context.class);
+    private final AccessTokenService accessTokenService = mock(AccessTokenService.class);
+
+    private AccessTokenHandler handler;
+    private TokenResponse tokenResponse;
+
+    @BeforeEach
+    public void setUp() {
+        AccessToken accessToken = new BearerAccessToken();
+        tokenResponse = new AccessTokenResponse(new Tokens(accessToken, null));
+        when(accessTokenService.exchangeCodeForToken(any())).thenReturn(tokenResponse);
+
+        handler = new AccessTokenHandler(accessTokenService);
+    }
+
+    @Test
+    public void shouldReturn200OnSuccessfulAccessTokenExchange() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        TokenRequestDto tokenRequestDto = new TokenRequestDto(
+                "12345",
+                new URI("http://test.com"),
+                "test_grant_type",
+                "test_client_id"
+        );
+        event.setBody(new ObjectMapper().writeValueAsString(tokenRequestDto));
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        assertEquals(200, response.getStatusCode());
+    }
+
+    @Test
+    public void shouldReturnAccessTokenOnSuccessfulExchange() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        TokenRequestDto tokenRequestDto = new TokenRequestDto(
+                "12345",
+                new URI("http://test.com"),
+                "test_grant_type",
+                "test_client_id"
+        );
+        event.setBody(new ObjectMapper().writeValueAsString(tokenRequestDto));
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(tokenResponse.toSuccessResponse().getTokens().getAccessToken().getValue(), responseBody.get("access_token").toString());
+    }
+
+    @Test
+    public void shouldReturn400OnInvalidTokenRequest() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        String invalidTokenRequest = "invalid-token-request";
+        event.setBody(invalidTokenRequest);
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.ERROR_1002.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.ERROR_1002.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    public void shouldReturn400OnFailedTokenExchange() throws Exception {
+        ErrorObject tokenErrorObject = new ErrorObject("F-001", "Something failed during exchange of code to token");
+        tokenResponse = new TokenErrorResponse(tokenErrorObject);
+        when(accessTokenService.exchangeCodeForToken(any())).thenReturn(tokenResponse);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        TokenRequestDto tokenRequestDto = new TokenRequestDto(
+                "12345",
+                new URI("http://test.com"),
+                "test_grant_type",
+                "test_client_id"
+        );
+        event.setBody(new ObjectMapper().writeValueAsString(tokenRequestDto));
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, String> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(tokenErrorObject.getCode(), responseBody.get("error"));
+        assertEquals(tokenErrorObject.getDescription(), responseBody.get("error_description"));
+    }
+
+    @Test
+    public void shouldReturn400OnMissingAuthorisationCode() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        TokenRequestDto tokenRequestDto = new TokenRequestDto(
+                "",
+                new URI("http://test.com"),
+                "test_grant_type",
+                "test_client_id"
+        );
+        event.setBody(new ObjectMapper().writeValueAsString(tokenRequestDto));
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.ERROR_1003.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.ERROR_1003.getMessage(), responseBody.get("message"));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.ipv.entity.ErrorResponse;
+import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.service.AuthorizationCodeService;
 
 import java.util.HashMap;
@@ -34,34 +34,34 @@ public class AuthorizationHandlerTest {
 
     @Test
     public void shouldReturn200OnSuccessfulOauthRequest(){
-        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        final Map<String, String> params = new HashMap<>();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
         params.put("redirect_uri", "http://test.co.uk");
         params.put("client_id", "12345");
         params.put("response_type", "code");
         params.put("scope", "openid");
         event.setQueryStringParameters(params);
 
-        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         assertEquals(200, response.getStatusCode());
     }
 
     @Test
     public void shouldReturnAuthResponseOnSuccessfulOauthRequest() throws Exception {
-        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        final Map<String, String> params = new HashMap<>();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
         params.put("redirect_uri", "http://test.co.uk");
         params.put("client_id", "12345");
         params.put("response_type", "code");
         params.put("scope", "openid");
         event.setQueryStringParameters(params);
 
-        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
-        final Map<String, String> authCode = (Map) responseBody.get("authorizationCode");
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        Map<String, String> authCode = (Map) responseBody.get("authorizationCode");
 
         assertEquals(authorizationCode.toString(), authCode.get("value"));
         assertEquals(event.getQueryStringParameters().get("redirect_uri"), responseBody.get("redirectionURI"));
@@ -69,17 +69,17 @@ public class AuthorizationHandlerTest {
 
     @Test
     public void shouldReturn400OnMissingRedirectUriParam() throws Exception {
-        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        final Map<String, String> params = new HashMap<>();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
         params.put("client_id", "12345");
         params.put("response_type", "code");
         params.put("scope", "openid");
         event.setQueryStringParameters(params);
 
-        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
         assertEquals(ErrorResponse.ERROR_1001.getCode(), responseBody.get("code"));
@@ -88,17 +88,17 @@ public class AuthorizationHandlerTest {
 
     @Test
     public void shouldReturn400OnMissingClientIdParam() throws Exception {
-        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        final Map<String, String> params = new HashMap<>();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
         params.put("redirect_uri", "http://test.co.uk");
         params.put("response_type", "code");
         params.put("scope", "openid");
         event.setQueryStringParameters(params);
 
-        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
         assertEquals(ErrorResponse.ERROR_1001.getCode(), responseBody.get("code"));
@@ -107,17 +107,17 @@ public class AuthorizationHandlerTest {
 
     @Test
     public void shouldReturn400OnMissingResponseTypeParam() throws Exception {
-        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        final Map<String, String> params = new HashMap<>();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
         params.put("redirect_uri", "http://test.co.uk");
         params.put("client_id", "12345");
         params.put("scope", "openid");
         event.setQueryStringParameters(params);
 
-        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
         assertEquals(ErrorResponse.ERROR_1001.getCode(), responseBody.get("code"));
@@ -126,17 +126,17 @@ public class AuthorizationHandlerTest {
 
     @Test
     public void shouldReturn400OnMissingScopeParam() throws Exception {
-        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        final Map<String, String> params = new HashMap<>();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> params = new HashMap<>();
         params.put("redirect_uri", "http://test.co.uk");
         params.put("client_id", "12345");
         params.put("response_type", "code");
         event.setQueryStringParameters(params);
 
-        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
         assertEquals(ErrorResponse.ERROR_1001.getCode(), responseBody.get("code"));
@@ -145,12 +145,12 @@ public class AuthorizationHandlerTest {
 
     @Test
     public void shouldReturn400OnMissingQueryParameters() throws Exception {
-        final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
-        final APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        final ObjectMapper objectMapper = new ObjectMapper();
-        final Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
         assertEquals(ErrorResponse.ERROR_1000.getCode(), responseBody.get("code"));

--- a/src/test/java/uk/gov/di/ipv/service/AccessTokenServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/AccessTokenServiceTest.java
@@ -1,0 +1,54 @@
+package uk.gov.di.ipv.service;
+
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.RefreshToken;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class AccessTokenServiceTest {
+
+    private final AccessTokenService accessTokenService = new AccessTokenService();
+
+    @Test
+    public void shouldReturnSuccessfulTokenResponseOnSuccessfulExchange() throws Exception {
+        TokenRequest tokenRequest = new TokenRequest(
+                null,
+                new ClientID("test-client-id"),
+                new AuthorizationCodeGrant(
+                        new AuthorizationCode("123456"),
+                        new URI("http://test.com"))
+        );
+
+        TokenResponse response = accessTokenService.exchangeCodeForToken(tokenRequest);
+
+        assertInstanceOf(AccessTokenResponse.class, response);
+        assertNotNull(response.toSuccessResponse().getTokens().getAccessToken().getValue());
+    }
+
+    @Test
+    public void shouldReturnErrorTokenResponseOnNonAuthorisationCodeGrant() throws Exception {
+        TokenRequest tokenRequest = new TokenRequest(
+                null,
+                new ClientID("test-client-id"),
+                new RefreshTokenGrant(new RefreshToken())
+        );
+
+        TokenResponse response = accessTokenService.exchangeCodeForToken(tokenRequest);
+
+        assertInstanceOf(TokenErrorResponse.class, response);
+        assertEquals(response.toErrorResponse().getErrorObject().getCode(), "F-001");
+        assertEquals(response.toErrorResponse().getErrorObject().getDescription(), "Something failed during exchange of code to token");
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
<!-- Describe the changes in detail - the "what"-->
Add new minimal lambda for the exchange of a authorisation code for an access token.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Allows the request from the front end to exchange a authorisation code for an access token to be used to access the protected user info data.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-286](https://govukverify.atlassian.net/browse/PYI-286)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

### Other considerations

