### PR TITLE
PYI-337: Re-use endpoint module to deploy all of the oauth lambda infrastructure.

### DIFF
--- a/terraform/lambda/token.tf
+++ b/terraform/lambda/token.tf
@@ -1,12 +1,12 @@
-module "authorize" {
+module "token" {
   source      = "../modules/endpoint"
   environment = var.environment
 
   rest_api_id            = aws_api_gateway_rest_api.ipv_internal.id
   rest_api_execution_arn = aws_api_gateway_rest_api.ipv_internal.execution_arn
   root_resource_id       = aws_api_gateway_rest_api.ipv_internal.root_resource_id
-  path_part              = "authorize"
-  handler                = "uk.gov.di.ipv.lambda.AuthorizationHandler::handleRequest"
-  function_name          = "${var.environment}-authorize"
-  role_name              = "${var.environment}-authorize-role"
+  path_part              = "token"
+  handler                = "uk.gov.di.ipv.lambda.AccessTokenHandler::handleRequest"
+  function_name          = "${var.environment}-token"
+  role_name              = "${var.environment}-token-role"
 }

--- a/terraform/lambda/user-identity.tf
+++ b/terraform/lambda/user-identity.tf
@@ -1,12 +1,12 @@
-module "authorize" {
+module "user-identity" {
   source      = "../modules/endpoint"
   environment = var.environment
 
   rest_api_id            = aws_api_gateway_rest_api.ipv_internal.id
   rest_api_execution_arn = aws_api_gateway_rest_api.ipv_internal.execution_arn
   root_resource_id       = aws_api_gateway_rest_api.ipv_internal.root_resource_id
-  path_part              = "authorize"
-  handler                = "uk.gov.di.ipv.lambda.AuthorizationHandler::handleRequest"
-  function_name          = "${var.environment}-authorize"
-  role_name              = "${var.environment}-authorize-role"
+  path_part              = "user-identity"
+  handler                = "uk.gov.di.ipv.lambda.UserInfoHandler::handleRequest"
+  function_name          = "${var.environment}-user-identity"
+  role_name              = "${var.environment}-user-identity-role"
 }

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -22,6 +22,21 @@ variable "path_part" {
   description = "path part to register the new resource under"
 }
 
+variable "handler" {
+  type       = string
+  description = "Class handler for each of the lambdas"
+}
+
+variable "function_name" {
+  type       = string
+  description = "Lambda function name"
+}
+
+variable "role_name" {
+  type       = string
+  description = "Lambda iam role name"
+}
+
 locals {
   default_tags = {
     Environment = var.environment


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Create new terraform files for the user-info and token-exchange lambda's and parameterise the rest of the endpoint module variables.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Made the endpoint module re-usable for all future lambdas that we need to deploy.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-337](https://govukverify.atlassian.net/browse/PYI-337)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

