### PR TITLE
Fix AccessTokenHandler lambda to correctly parse a x-www-form-urlencoded http request body

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,9 @@ dependencies {
             "com.fasterxml.jackson.core:jackson-core:2.13.0",
             "com.fasterxml.jackson.core:jackson-databind:2.13.0",
             "com.fasterxml.jackson.core:jackson-annotations:2.13.0",
+            "org.apache.httpcomponents:httpclient:4.5.13",
             "org.slf4j:slf4j-simple:1.7.32"
+
 
     compileOnly 'org.projectlombok:lombok:1.18.22'
     annotationProcessor 'org.projectlombok:lombok:1.18.22'

--- a/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
@@ -3,11 +3,16 @@ package uk.gov.di.ipv.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.domain.ErrorResponse;
 
+import java.util.Map;
+
 public class ApiGatewayResponseGenerator {
+
+    private static final String CONTENT_TYPE_HEADER_VALUE = "application/json";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayResponseGenerator.class);
 
@@ -26,6 +31,10 @@ public class ApiGatewayResponseGenerator {
             int statusCode, String body) {
         APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
                 new APIGatewayProxyResponseEvent();
+        Map<String, String> headers = Map.of(
+                HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_HEADER_VALUE
+        );
+        apiGatewayProxyResponseEvent.setHeaders(headers);
         apiGatewayProxyResponseEvent.setStatusCode(statusCode);
         apiGatewayProxyResponseEvent.setBody(body);
 

--- a/src/main/java/uk/gov/di/ipv/helpers/ResponseBodyHelper.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/ResponseBodyHelper.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.helpers;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResponseBodyHelper {
+
+    public static Map<String, String> parseRequestBody(String body) {
+        Map<String, String> query_pairs = new HashMap<>();
+
+        for (NameValuePair pair : URLEncodedUtils.parse(body, Charset.defaultCharset())) {
+            query_pairs.put(pair.getName(), pair.getValue());
+        }
+
+        return query_pairs;
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/lambda/AccessTokenHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AccessTokenHandlerTest.java
@@ -14,10 +14,8 @@ import com.nimbusds.oauth2.sdk.token.Tokens;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.domain.ErrorResponse;
-import uk.gov.di.ipv.dto.TokenRequestDto;
 import uk.gov.di.ipv.service.AccessTokenService;
 
-import java.net.URI;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,13 +42,8 @@ public class AccessTokenHandlerTest {
     @Test
     public void shouldReturn200OnSuccessfulAccessTokenExchange() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        TokenRequestDto tokenRequestDto = new TokenRequestDto(
-                "12345",
-                new URI("http://test.com"),
-                "test_grant_type",
-                "test_client_id"
-        );
-        event.setBody(new ObjectMapper().writeValueAsString(tokenRequestDto));
+        String tokenRequestBody = "code=12345&redirect_uri=http://test.com&grant_type=test_grant_type&client_id=test_client_id";
+        event.setBody(tokenRequestBody);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
@@ -60,13 +53,8 @@ public class AccessTokenHandlerTest {
     @Test
     public void shouldReturnAccessTokenOnSuccessfulExchange() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        TokenRequestDto tokenRequestDto = new TokenRequestDto(
-                "12345",
-                new URI("http://test.com"),
-                "test_grant_type",
-                "test_client_id"
-        );
-        event.setBody(new ObjectMapper().writeValueAsString(tokenRequestDto));
+        String tokenRequestBody = "code=12345&redirect_uri=http://test.com&grant_type=test_grant_type&client_id=test_client_id";
+        event.setBody(tokenRequestBody);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
@@ -99,13 +87,9 @@ public class AccessTokenHandlerTest {
         when(accessTokenService.exchangeCodeForToken(any())).thenReturn(tokenResponse);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        TokenRequestDto tokenRequestDto = new TokenRequestDto(
-                "12345",
-                new URI("http://test.com"),
-                "test_grant_type",
-                "test_client_id"
-        );
-        event.setBody(new ObjectMapper().writeValueAsString(tokenRequestDto));
+        String tokenRequestBody = "code=12345&redirect_uri=http://test.com&grant_type=test_grant_type&client_id=test_client_id";
+
+        event.setBody(tokenRequestBody);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
@@ -120,13 +104,10 @@ public class AccessTokenHandlerTest {
     @Test
     public void shouldReturn400OnMissingAuthorisationCode() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        TokenRequestDto tokenRequestDto = new TokenRequestDto(
-                "",
-                new URI("http://test.com"),
-                "test_grant_type",
-                "test_client_id"
-        );
-        event.setBody(new ObjectMapper().writeValueAsString(tokenRequestDto));
+
+        String tokenRequestBody = "code=&redirect_uri=http://test.com&grant_type=test_grant_type&client_id=test_client_id";
+
+        event.setBody(tokenRequestBody);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the token exchange lambda to correctly parse a x-www-form-urlencoded String body into a TokenRequestDto.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The POST request body is x-www-form-urlencoded instead of JSON.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-286](https://govukverify.atlassian.net/browse/PYI-286)


