### PR TITLE
Change Authorization endpoint to return 302 and form-url-encoded resp…

### DIFF
--- a/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
@@ -8,32 +8,46 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.domain.ErrorResponse;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ApiGatewayResponseGenerator {
 
-    private static final String CONTENT_TYPE_HEADER_VALUE = "application/json";
+    private static final String JSON_CONTENT_TYPE_VALUE = "application/json";
+    private static final String FORM_URL_ENCODED_CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayResponseGenerator.class);
 
     public static APIGatewayProxyResponseEvent proxyErrorResponse(
             int statusCode, ErrorResponse errorResponse) {
         try {
-            return proxyResponse(
-                    statusCode, new ObjectMapper().writeValueAsString(errorResponse));
+            return proxyJsonResponse(
+                    statusCode, new ObjectMapper().writeValueAsString(errorResponse), Collections.emptyMap());
         } catch (JsonProcessingException e) {
             LOGGER.warn("Unable to generateApiGatewayProxyErrorResponse: " + e);
-            return proxyResponse(500, "Internal server error");
+            return proxyResponse(500, "Internal server error", Collections.emptyMap());
         }
     }
 
+    public static APIGatewayProxyResponseEvent proxyJsonResponse(int statusCode, String body, Map<String, String> headers) {
+        Map<String, String> responseHeaders = new HashMap<>(headers);
+        responseHeaders.putIfAbsent(HttpHeaders.CONTENT_TYPE, JSON_CONTENT_TYPE_VALUE);
+
+        return proxyResponse(statusCode, body, responseHeaders);
+    }
+
+    public static APIGatewayProxyResponseEvent proxyFormUrlEncodedResponse(int statusCode, String body, Map<String, String> headers) {
+        Map<String, String> responseHeaders = new HashMap<>(headers);
+        responseHeaders.putIfAbsent(HttpHeaders.CONTENT_TYPE, FORM_URL_ENCODED_CONTENT_TYPE_VALUE);
+
+        return proxyResponse(statusCode, body, responseHeaders);
+    }
+
     public static APIGatewayProxyResponseEvent proxyResponse(
-            int statusCode, String body) {
+            int statusCode, String body, Map<String, String> headers) {
         APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
                 new APIGatewayProxyResponseEvent();
-        Map<String, String> headers = Map.of(
-                HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_HEADER_VALUE
-        );
         apiGatewayProxyResponseEvent.setHeaders(headers);
         apiGatewayProxyResponseEvent.setStatusCode(statusCode);
         apiGatewayProxyResponseEvent.setBody(body);

--- a/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.helpers.ResponseBodyHelper;
 import uk.gov.di.ipv.service.AccessTokenService;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class AccessTokenHandler
@@ -67,7 +68,7 @@ public class AccessTokenHandler
             }
 
             AccessTokenResponse accessTokenResponse = tokenResponse.toSuccessResponse();
-            return ApiGatewayResponseGenerator.proxyResponse(200, accessTokenResponse.toJSONObject().toJSONString());
+            return ApiGatewayResponseGenerator.proxyJsonResponse(200, accessTokenResponse.toJSONObject().toJSONString(), Collections.emptyMap());
         } catch (IllegalArgumentException e) {
             LOGGER.error("Token request could not be parsed", e);
             return ApiGatewayResponseGenerator.proxyErrorResponse(400, ErrorResponse.FailedToParseTokenRequest);

--- a/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
@@ -8,6 +8,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationSuccessResponse;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.domain.ErrorResponse;
@@ -22,7 +23,6 @@ import java.util.stream.Collectors;
 public class AuthorizationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>  {
 
-    private static final String LOCATION_HEADER = "Location";
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationHandler.class);
 
     private final AuthorizationCodeService authorizationCodeService;
@@ -62,7 +62,7 @@ public class AuthorizationHandler
                 authenticationRequest.getResponseMode()
         );
 
-        Map<String, String> headers = Map.of(LOCATION_HEADER, authorizationResponse.toURI().toString());
+        Map<String, String> headers = Map.of(HttpHeaders.LOCATION, authorizationResponse.toURI().toString());
 
         return ApiGatewayResponseGenerator.proxyFormUrlEncodedResponse(302, null, headers);
     }

--- a/src/main/java/uk/gov/di/ipv/lambda/UserInfoHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/UserInfoHandler.java
@@ -15,6 +15,8 @@ import uk.gov.di.ipv.dto.UserInfoDto;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.service.UserInfoService;
 
+import java.util.Collections;
+
 public class UserInfoHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserInfoHandler.class);
@@ -47,8 +49,7 @@ public class UserInfoHandler implements RequestHandler<APIGatewayProxyRequestEve
             ObjectMapper objectMapper = new ObjectMapper();
             String userInfoJson = objectMapper.writeValueAsString(userInfo);
 
-            return ApiGatewayResponseGenerator.proxyResponse(200, userInfoJson);
-
+            return ApiGatewayResponseGenerator.proxyJsonResponse(200, userInfoJson, Collections.emptyMap());
         } catch (ParseException | JsonProcessingException e) {
             LOGGER.error("Failed to parse access token");
             return ApiGatewayResponseGenerator.proxyErrorResponse(400, ErrorResponse.FailedToParseAccessToken);

--- a/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
@@ -8,6 +8,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.domain.ErrorResponse;
+import uk.gov.di.ipv.helpers.ResponseBodyHelper;
 import uk.gov.di.ipv.service.AuthorizationCodeService;
 
 import java.util.HashMap;
@@ -33,10 +34,10 @@ public class AuthorizationHandlerTest {
     }
 
     @Test
-    public void shouldReturn200OnSuccessfulOauthRequest(){
+    public void shouldReturn302OnSuccessfulOauthRequest(){
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
-        params.put("redirect_uri", "http://test.co.uk");
+        params.put("redirect_uri", "http://example.com");
         params.put("client_id", "12345");
         params.put("response_type", "code");
         params.put("scope", "openid");
@@ -44,14 +45,14 @@ public class AuthorizationHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        assertEquals(200, response.getStatusCode());
+        assertEquals(302, response.getStatusCode());
     }
 
     @Test
     public void shouldReturnAuthResponseOnSuccessfulOauthRequest() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
-        params.put("redirect_uri", "http://test.co.uk");
+        params.put("redirect_uri", "http://example.com");
         params.put("client_id", "12345");
         params.put("response_type", "code");
         params.put("scope", "openid");
@@ -59,12 +60,7 @@ public class AuthorizationHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
-        Map<String, String> authCode = (Map) responseBody.get("authorizationCode");
-
-        assertEquals(authorizationCode.toString(), authCode.get("value"));
-        assertEquals(event.getQueryStringParameters().get("redirect_uri"), responseBody.get("redirectionURI"));
+        assertEquals("http://example.com?code="+authorizationCode.getValue(), response.getHeaders().get("Location"));
     }
 
     @Test
@@ -90,7 +86,7 @@ public class AuthorizationHandlerTest {
     public void shouldReturn400OnMissingClientIdParam() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
-        params.put("redirect_uri", "http://test.co.uk");
+        params.put("redirect_uri", "http://example.com");
         params.put("response_type", "code");
         params.put("scope", "openid");
         event.setQueryStringParameters(params);
@@ -109,7 +105,7 @@ public class AuthorizationHandlerTest {
     public void shouldReturn400OnMissingResponseTypeParam() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
-        params.put("redirect_uri", "http://test.co.uk");
+        params.put("redirect_uri", "http://example.com");
         params.put("client_id", "12345");
         params.put("scope", "openid");
         event.setQueryStringParameters(params);
@@ -128,7 +124,7 @@ public class AuthorizationHandlerTest {
     public void shouldReturn400OnMissingScopeParam() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
-        params.put("redirect_uri", "http://test.co.uk");
+        params.put("redirect_uri", "http://example.com");
         params.put("client_id", "12345");
         params.put("response_type", "code");
         event.setQueryStringParameters(params);


### PR DESCRIPTION
…onse in Location header

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the authorize lambda to return a 302 response with the redirect url and params within the Location header.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To match the oauth spec of how this response should be returned and to fix invalid variable names being generated form jackson JSON deserialiser. 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-286](https://govukverify.atlassian.net/browse/PYI-286)


