### PR TITLE
PYI-356: Set up DynamoDB table for user credentials

### DIFF
--- a/terraform/lambda/dynamodb.tf
+++ b/terraform/lambda/dynamodb.tf
@@ -1,0 +1,46 @@
+resource "aws_dynamodb_table" "user-credentials-table" {
+  name         = "user-credentials-table"
+  hash_key     = "SessionId"
+  range_key    = "CredentialIssuer"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "SessionId"
+    type = "S"
+  }
+
+  attribute {
+    name = "CredentialIssuer"
+    type = "S"
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_iam_policy" "dynamo-db-user-credentials-table-policy" {
+  name = "dynamo-db-user-credentials-table-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "AllowDynamoDbReadWrite"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:BatchWriteItem",
+          "dynamodb:GetItem",
+          "dynamodb:BatchGetItem",
+          "dynamodb:Scan",
+          "dynamodb:Query",
+          "dynamodb:ConditionCheckItem"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_dynamodb_table.user-credentials-table.arn,
+          "${aws_dynamodb_table.user-credentials-table.arn}/index/*"
+        ]
+      },
+    ]
+  })
+}

--- a/terraform/lambda/dynamodb.tf
+++ b/terraform/lambda/dynamodb.tf
@@ -1,5 +1,5 @@
-resource "aws_dynamodb_table" "user-credentials-table" {
-  name         = "user-credentials-table"
+resource "aws_dynamodb_table" "user-issued-credentials" {
+  name         = "${var.environment}-user-issued-credentials"
   hash_key     = "SessionId"
   range_key    = "CredentialIssuer"
   billing_mode = "PAY_PER_REQUEST"
@@ -17,14 +17,14 @@ resource "aws_dynamodb_table" "user-credentials-table" {
   tags = local.default_tags
 }
 
-resource "aws_iam_policy" "dynamo-db-user-credentials-table-policy" {
-  name = "dynamo-db-user-credentials-table-policy"
+resource "aws_iam_policy" "access-user-issued-credentials-table" {
+  name = "access-user-issued-credentials-table"
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid = "AllowDynamoDbReadWrite"
+        Sid = "AccessUserIssuedCredentialsTable"
         Action = [
           "dynamodb:PutItem",
           "dynamodb:UpdateItem",
@@ -37,8 +37,8 @@ resource "aws_iam_policy" "dynamo-db-user-credentials-table-policy" {
         ]
         Effect = "Allow"
         Resource = [
-          aws_dynamodb_table.user-credentials-table.arn,
-          "${aws_dynamodb_table.user-credentials-table.arn}/index/*"
+          aws_dynamodb_table.user-issued-credentials.arn,
+          "${aws_dynamodb_table.user-issued-credentials.arn}/index/*"
         ]
       },
     ]

--- a/terraform/lambda/user-identity.tf
+++ b/terraform/lambda/user-identity.tf
@@ -10,4 +10,8 @@ module "user-identity" {
   handler                = "uk.gov.di.ipv.lambda.UserInfoHandler::handleRequest"
   function_name          = "${var.environment}-user-identity"
   role_name              = "${var.environment}-user-identity-role"
+
+  allow_access_to_user_credentials_table     = true
+  dynamodb_user_credentials_table_policy_arn = aws_iam_policy.dynamo-db-user-credentials-table-policy.arn
+  dynamodb_user_credentials_table_name       = aws_dynamodb_table.user-credentials-table.name
 }

--- a/terraform/lambda/user-identity.tf
+++ b/terraform/lambda/user-identity.tf
@@ -11,7 +11,7 @@ module "user-identity" {
   function_name          = "${var.environment}-user-identity"
   role_name              = "${var.environment}-user-identity-role"
 
-  allow_access_to_user_credentials_table     = true
-  dynamodb_user_credentials_table_policy_arn = aws_iam_policy.dynamo-db-user-credentials-table-policy.arn
-  dynamodb_user_credentials_table_name       = aws_dynamodb_table.user-credentials-table.name
+  allow_access_to_user_issued_credentials_table = true
+  user_issued_credentials_table_policy_arn      = aws_iam_policy.access-user-issued-credentials-table.arn
+  user_issued_credentials_table_name            = aws_dynamodb_table.user-issued-credentials.name
 }

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -3,7 +3,7 @@ variable "environment" {
 }
 
 variable "use_localstack" {
-  type = bool
+  type    = bool
   default = false
 }
 

--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -24,9 +24,9 @@ resource "aws_iam_role" "lambda_iam_role" {
   tags = local.default_tags
 }
 
-resource "aws_iam_role_policy_attachment" "dynamodb-user-credentials-table-policy-attachment" {
-  count      = var.allow_access_to_user_credentials_table ? 1 : 0
+resource "aws_iam_role_policy_attachment" "user_issued_credentials_table_policy_to_lambda_iam_role" {
+  count      = var.allow_access_to_user_issued_credentials_table ? 1 : 0
   role       = aws_iam_role.lambda_iam_role.name
-  policy_arn = var.dynamodb_user_credentials_table_policy_arn
+  policy_arn = var.user_issued_credentials_table_policy_arn
 }
 

--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -1,0 +1,32 @@
+data "aws_iam_policy_document" "lambda_can_assume_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "lambda.amazonaws.com"
+      ]
+      type = "Service"
+    }
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+  }
+}
+
+resource "aws_iam_role" "lambda_iam_role" {
+  name = var.role_name
+
+  assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
+
+  tags = local.default_tags
+}
+
+resource "aws_iam_role_policy_attachment" "dynamodb-user-credentials-table-policy-attachment" {
+  count      = var.allow_access_to_user_credentials_table ? 1 : 0
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = var.dynamodb_user_credentials_table_policy_arn
+}
+

--- a/terraform/modules/endpoint/main.tf
+++ b/terraform/modules/endpoint/main.tf
@@ -8,33 +8,6 @@ data "archive_file" "dummy" {
   }
 }
 
-data "aws_iam_policy_document" "lambda_can_assume_policy" {
-  version = "2012-10-17"
-
-  statement {
-    effect = "Allow"
-    principals {
-      identifiers = [
-        "lambda.amazonaws.com"
-      ]
-      type = "Service"
-    }
-
-    actions = [
-      "sts:AssumeRole"
-    ]
-  }
-}
-
-resource "aws_iam_role" "lambda_iam_role" {
-  name = var.role_name
-
-  assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
-
-  tags = local.default_tags
-}
-
-
 resource "aws_lambda_function" "lambda_function" {
   filename         = data.archive_file.dummy.output_path
   function_name    = var.function_name
@@ -45,6 +18,12 @@ resource "aws_lambda_function" "lambda_function" {
   publish          = false
   timeout          = 30
   memory_size      = 2048
+
+  environment {
+    variables = {
+      DYNAMODB_USER_CREDENTIALS_TABLE_NAME = var.dynamodb_user_credentials_table_name
+    }
+  }
 
   # There is an outstanding bug in terraform (Issue #3630) that means it always tries to update the
   # last modified date, even if no other attributes in the lambda need changing

--- a/terraform/modules/endpoint/main.tf
+++ b/terraform/modules/endpoint/main.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "lambda_function" {
 
   environment {
     variables = {
-      DYNAMODB_USER_CREDENTIALS_TABLE_NAME = var.dynamodb_user_credentials_table_name
+      USER_ISSUED_CREDENTIALS_TABLE_NAME = var.user_issued_credentials_table_name
     }
   }
 
@@ -79,5 +79,4 @@ resource "aws_lambda_permission" "endpoint_execution_permission" {
   principal     = "apigateway.amazonaws.com"
   qualifier     = aws_lambda_alias.alias_active.name
   source_arn    = "${var.rest_api_execution_arn}/*/${aws_api_gateway_method.endpoint_method.http_method}/${var.path_part}"
-
 }

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -42,19 +42,19 @@ variable "role_name" {
   description = "Lambda iam role name"
 }
 
-variable "allow_access_to_user_credentials_table" {
+variable "allow_access_to_user_issued_credentials_table" {
   type        = bool
   default     = false
   description = "Should the lambda be given access to the user-credentials DynamoDB table"
 }
 
-variable "dynamodb_user_credentials_table_policy_arn" {
+variable "user_issued_credentials_table_policy_arn" {
   type        = string
   default     = null
   description = "ARN of the policy to allow read write to the user-credentials DynamoDB table"
 }
 
-variable "dynamodb_user_credentials_table_name" {
+variable "user_issued_credentials_table_name" {
   type        = string
   default     = "not-set-for-this-lambda"
   description = "Name of the DynamoDB user-credentials table"

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -28,18 +28,36 @@ variable "path_part" {
 }
 
 variable "handler" {
-  type       = string
+  type        = string
   description = "Class handler for each of the lambdas"
 }
 
 variable "function_name" {
-  type       = string
+  type        = string
   description = "Lambda function name"
 }
 
 variable "role_name" {
-  type       = string
+  type        = string
   description = "Lambda iam role name"
+}
+
+variable "allow_access_to_user_credentials_table" {
+  type        = bool
+  default     = false
+  description = "Should the lambda be given access to the user-credentials DynamoDB table"
+}
+
+variable "dynamodb_user_credentials_table_policy_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the policy to allow read write to the user-credentials DynamoDB table"
+}
+
+variable "dynamodb_user_credentials_table_name" {
+  type        = string
+  default     = "not-set-for-this-lambda"
+  description = "Name of the DynamoDB user-credentials table"
 }
 
 locals {


### PR DESCRIPTION
### What changed

**These changes have been manually tested and the result can be seen in the AWS dev account**

Defines a table in DynamoDB for the lambdas to store and retrieve user
info received from credential issuers.

It defines it with a composite primary key based on the users session ID
and the credential issuer. This will have to change in future when we
use longer term IDs for users.

The TF also defines the IAM policy to allow the lambdas to access the
DB, as well as providing the table name to the lambda as an env var.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-356](https://govukverify.atlassian.net/browse/PYI-356)
