### PR TITLE
Set ipv-internal API to regional

### DIFF
--- a/terraform/lambda/api-gateway.tf
+++ b/terraform/lambda/api-gateway.tf
@@ -2,6 +2,10 @@ resource "aws_api_gateway_rest_api" "ipv_internal" {
   name        = "${var.environment}-ipv-internal"
   description = "The api accessed by internal IPV systems, e.g. di-ipv-core-front"
   tags        = local.default_tags
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
 }
 
 resource "aws_api_gateway_deployment" "deployment" {


### PR DESCRIPTION
This sets the ipv-internal REST API to be a "regional endpoint".

Docs:
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-endpoint-types.html

There are two types of endpoint: edge and regional.

Edge endpoints are created by default.  These route requests to the
nearest CloudFront Point of Presence.

Regional endpoints are intended for clients in the same region.  From
the docs: "When a client running on an EC2 instance calls an API in
the same region, or when an API is intended to serve a small number of
clients with high demands, a regional API reduces connection
overhead."

The ipv-internal endpoint is intended to be called only by the
core-front app running in PaaS-London, which is in the same region.

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

### Other considerations

- [X] Update [README](./blob/main/README.md) with any new instructions or tasks
