### PR TITLE
PYI-362 get credential issuer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Request evidence from a credential issuer
  
   * `authorization_code [string, required]`
   * `credential_issuer_id [string, required]`
-  * `redirect_uri [string, required]`
+  * `session_id [string, required]`
 
 
 * **Success Response:**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,43 @@
 # Digital Identity IPV Core Back
-`di-ipv-core-back`
 
 This the back-end code for the core of the Identity Proofing and Verification (IPV) system within the GDS digital identity platform, GOV.UK Sign In.
 
+
+## REST API interface
+
+### Request Evidence
+<hr/>
+Request evidence from a credential issuer
+
+* **URL**
+
+  `/request-evidence`
+
+* **Method:**
+
+  `POST`
+
+* **Content-Type:**
+
+    `application/x-www-form-urlencoded`
+
+* **URL Params**
+
+   None
+
+* **Data Params**
+ 
+  * `authorization_code [string, required]`
+  * `credential_issuer_id [string, required]`
+  * `redirect_uri [string, required]`
+
+
+* **Success Response:**
+
+  * Code: `200`
+  * Content: `{}`
+
+* **Error Response:**
+
+  * Code: `400` 
+  * Content: `{ "code" : "1001", "message": "error message" }`

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1',
-            "org.mockito:mockito-core:3.12.4"
+            "org.mockito:mockito-core:3.12.4",
+            "org.mockito:mockito-junit-jupiter:4.1.0"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,8 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1',
             "org.mockito:mockito-core:3.12.4",
-            "org.mockito:mockito-junit-jupiter:4.1.0"
+            "org.mockito:mockito-junit-jupiter:4.1.0",
+            "com.github.tomakehurst:wiremock-jre8:2.31.0"
 }
 
 test {

--- a/src/main/java/uk/gov/di/ipv/domain/CredentialIssuerException.java
+++ b/src/main/java/uk/gov/di/ipv/domain/CredentialIssuerException.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.domain;
+
+public class CredentialIssuerException extends RuntimeException{
+
+    public CredentialIssuerException() {
+    }
+
+    public CredentialIssuerException(String message) {
+        super(message);
+    }
+
+    public CredentialIssuerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CredentialIssuerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/domain/CredentialIssuerException.java
+++ b/src/main/java/uk/gov/di/ipv/domain/CredentialIssuerException.java
@@ -2,15 +2,8 @@ package uk.gov.di.ipv.domain;
 
 public class CredentialIssuerException extends RuntimeException{
 
-    public CredentialIssuerException() {
-    }
-
     public CredentialIssuerException(String message) {
         super(message);
-    }
-
-    public CredentialIssuerException(String message, Throwable cause) {
-        super(message, cause);
     }
 
     public CredentialIssuerException(Throwable cause) {

--- a/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
@@ -13,7 +13,8 @@ public enum ErrorResponse {
     MissingAccessToken(1005, "Missing access token from user info request"),
     FailedToParseAccessToken(1006, "Failed to parse access token"),
     MissingCredentialIssuerId(1007, "Missing credential issuer id"),
-    InvalidCredentialIssuerId(1008, "Invalid credential issuer id");
+    InvalidCredentialIssuerId(1008, "Invalid credential issuer id"),
+    InvalidTokenRequest(1009, "Invalid token request");
 
     @JsonProperty("code")
     private int code;

--- a/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
@@ -14,7 +14,8 @@ public enum ErrorResponse {
     FailedToParseAccessToken(1006, "Failed to parse access token"),
     MissingCredentialIssuerId(1007, "Missing credential issuer id"),
     InvalidCredentialIssuerId(1008, "Invalid credential issuer id"),
-    InvalidTokenRequest(1009, "Invalid token request");
+    InvalidTokenRequest(1009, "Invalid token request"),
+    MissingSessionId(1010, "Missing session id");
 
     @JsonProperty("code")
     private int code;

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.dto;
 
 import java.net.URI;
+import java.util.Objects;
 
 public class CredentialIssuerConfig {
 
@@ -18,5 +19,18 @@ public class CredentialIssuerConfig {
 
     public URI getTokenUrl() {
         return tokenUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CredentialIssuerConfig that = (CredentialIssuerConfig) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
@@ -1,0 +1,22 @@
+package uk.gov.di.ipv.dto;
+
+import java.net.URI;
+
+public class CredentialIssuerConfig {
+
+    private final String id;
+    private final URI tokenUrl;
+
+    public CredentialIssuerConfig(String id, URI tokenUrl) {
+        this.id = id;
+        this.tokenUrl = tokenUrl;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public URI getTokenUrl() {
+        return tokenUrl;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
@@ -11,9 +11,9 @@ public class CredentialIssuerRequestDto {
     private final String redirect_uri;
 
     public CredentialIssuerRequestDto(
-            @JsonProperty(value = "authorization_code", required = true) String authorization_code,
-            @JsonProperty(value = "credential_issuer_id", required = true) String credential_issuer_id,
-            @JsonProperty(value = "redirect_uri", required = true) String redirect_uri
+            @JsonProperty(value = "authorization_code") String authorization_code,
+            @JsonProperty(value = "credential_issuer_id") String credential_issuer_id,
+            @JsonProperty(value = "redirect_uri") String redirect_uri
     ) {
         this.authorization_code = authorization_code;
         this.credential_issuer_id = credential_issuer_id;

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
@@ -4,24 +4,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CredentialIssuerRequestDto {
 
-    @JsonProperty("authorization_code")
-    private String authorization_code;
+    private final String authorization_code;
 
-    @JsonProperty("credential_issuer_id")
-    private String credential_issuer_id;
+    private final String credential_issuer_id;
 
-    @JsonProperty("redirect_uri")
-    private String redirect_uri;
+    private final String redirect_uri;
 
     public CredentialIssuerRequestDto(
-            @JsonProperty(value = "authorization_code") String authorization_code,
-            @JsonProperty(value = "credential_issuer_id") String credential_issuer_id,
-            @JsonProperty(value = "redirect_uri") String redirect_uri
+            @JsonProperty(value = "authorization_code", required = true) String authorization_code,
+            @JsonProperty(value = "credential_issuer_id", required = true) String credential_issuer_id,
+            @JsonProperty(value = "redirect_uri", required = true) String redirect_uri
     ) {
         this.authorization_code = authorization_code;
         this.credential_issuer_id = credential_issuer_id;
         this.redirect_uri = redirect_uri;
-     }
+    }
 
     public String getAuthorization_code() {
         return authorization_code;

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
@@ -7,18 +7,21 @@ public class CredentialIssuerRequestDto {
     @JsonProperty("authorization_code")
     private String authorization_code;
 
-
     @JsonProperty("credential_issuer_id")
     private String credential_issuer_id;
 
+    @JsonProperty("redirect_uri")
+    private String redirect_uri;
 
     public CredentialIssuerRequestDto(
             @JsonProperty(value = "authorization_code") String authorization_code,
-            @JsonProperty(value = "credential_issuer_id") String credential_issuer_id
+            @JsonProperty(value = "credential_issuer_id") String credential_issuer_id,
+            @JsonProperty(value = "redirect_uri") String redirect_uri
     ) {
         this.authorization_code = authorization_code;
         this.credential_issuer_id = credential_issuer_id;
-    }
+        this.redirect_uri = redirect_uri;
+     }
 
     public String getAuthorization_code() {
         return authorization_code;
@@ -27,4 +30,9 @@ public class CredentialIssuerRequestDto {
     public String getCredential_issuer_id() {
         return credential_issuer_id;
     }
+
+    public String getRedirect_uri() {
+        return redirect_uri;
+    }
+
 }

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
@@ -4,31 +4,31 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CredentialIssuerRequestDto {
 
-    private final String authorization_code;
+    private final String authorizationCode;
 
-    private final String credential_issuer_id;
+    private final String credentialIssuerId;
 
-    private final String ipv_session_id;
+    private final String ipvSessionId;
 
     public CredentialIssuerRequestDto(
-            @JsonProperty(value = "authorization_code") String authorization_code,
-            @JsonProperty(value = "credential_issuer_id") String credential_issuer_id,
-            @JsonProperty(value = "ipv_session_id") String ipv_session_id
+            @JsonProperty(value = "authorization_code") String authorizationCode,
+            @JsonProperty(value = "credential_issuer_id") String credentialIssuerId,
+            @JsonProperty(value = "ipv_session_id") String ipvSessionId
     ) {
-        this.authorization_code = authorization_code;
-        this.credential_issuer_id = credential_issuer_id;
-        this.ipv_session_id = ipv_session_id;
+        this.authorizationCode = authorizationCode;
+        this.credentialIssuerId = credentialIssuerId;
+        this.ipvSessionId = ipvSessionId;
     }
 
-    public String getAuthorization_code() {
-        return authorization_code;
+    public String getAuthorizationCode() {
+        return authorizationCode;
     }
 
-    public String getCredential_issuer_id() {
-        return credential_issuer_id;
+    public String getCredentialIssuerId() {
+        return credentialIssuerId;
     }
 
-    public String getIpv_session_id() {
-        return ipv_session_id;
+    public String getIpvSessionId() {
+        return ipvSessionId;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
@@ -8,16 +8,16 @@ public class CredentialIssuerRequestDto {
 
     private final String credential_issuer_id;
 
-    private final String redirect_uri;
+    private final String session_id;
 
     public CredentialIssuerRequestDto(
             @JsonProperty(value = "authorization_code") String authorization_code,
             @JsonProperty(value = "credential_issuer_id") String credential_issuer_id,
-            @JsonProperty(value = "redirect_uri") String redirect_uri
+            @JsonProperty(value = "session_id") String session_id
     ) {
         this.authorization_code = authorization_code;
         this.credential_issuer_id = credential_issuer_id;
-        this.redirect_uri = redirect_uri;
+        this.session_id = session_id;
     }
 
     public String getAuthorization_code() {
@@ -28,8 +28,7 @@ public class CredentialIssuerRequestDto {
         return credential_issuer_id;
     }
 
-    public String getRedirect_uri() {
-        return redirect_uri;
+    public String getSession_id() {
+        return session_id;
     }
-
 }

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerRequestDto.java
@@ -8,16 +8,16 @@ public class CredentialIssuerRequestDto {
 
     private final String credential_issuer_id;
 
-    private final String session_id;
+    private final String ipv_session_id;
 
     public CredentialIssuerRequestDto(
             @JsonProperty(value = "authorization_code") String authorization_code,
             @JsonProperty(value = "credential_issuer_id") String credential_issuer_id,
-            @JsonProperty(value = "session_id") String session_id
+            @JsonProperty(value = "ipv_session_id") String ipv_session_id
     ) {
         this.authorization_code = authorization_code;
         this.credential_issuer_id = credential_issuer_id;
-        this.session_id = session_id;
+        this.ipv_session_id = ipv_session_id;
     }
 
     public String getAuthorization_code() {
@@ -28,7 +28,7 @@ public class CredentialIssuerRequestDto {
         return credential_issuer_id;
     }
 
-    public String getSession_id() {
-        return session_id;
+    public String getIpv_session_id() {
+        return ipv_session_id;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
@@ -14,9 +14,11 @@ import java.util.stream.Collectors;
 
 public class RequestHelper {
 
+    public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
+
     public static <T> T convertRequest(APIGatewayProxyRequestEvent request, Class<T> type) {
         Map<String, String> map = parseRequestBody(request.getBody());
-        getHeader(request.getHeaders(), "ipv-session-id").ifPresent(h -> map.put("ipv_session_id", h));
+        getHeader(request.getHeaders(), IPV_SESSION_ID_HEADER).ifPresent(h -> map.put("ipv_session_id", h));
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.convertValue(map, type);
     }

--- a/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.helpers;
 
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.NameValuePair;
@@ -13,8 +14,9 @@ import java.util.stream.Collectors;
 
 public class RequestHelper {
 
-    public static <T> T convertRequestBody(String body, Class<T> type) {
-        Map<String, String> map = parseRequestBody(body);
+    public static <T> T convertRequest(APIGatewayProxyRequestEvent request, Class<T> type) {
+        Map<String, String> map = parseRequestBody(request.getBody());
+        getHeader(request.getHeaders(), "ipv-session-id").ifPresent(h -> map.put("ipv_session_id", h));
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.convertValue(map, type);
     }
@@ -30,6 +32,9 @@ public class RequestHelper {
     }
 
     public static Optional<String> getHeader(Map<String, String> headers, String headerKey) {
+        if (headers == null) {
+            return Optional.empty();
+        }
         var values = headers.entrySet().stream()
                 .filter(e -> headerKey.equalsIgnoreCase(e.getKey()))
                 .map(e -> e.getValue())

--- a/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.helpers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -11,6 +12,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class RequestHelper {
+
+    public static <T> T convertRequestBody(String body, Class<T> type) {
+        Map<String, String> map = parseRequestBody(body);
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.convertValue(map, type);
+    }
 
     public static Map<String, String> parseRequestBody(String body) {
         Map<String, String> query_pairs = new HashMap<>();

--- a/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
@@ -19,8 +18,6 @@ import uk.gov.di.ipv.dto.TokenRequestDto;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.helpers.RequestHelper;
 import uk.gov.di.ipv.service.AccessTokenService;
-
-import java.util.Map;
 
 public class AccessTokenHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -39,11 +36,9 @@ public class AccessTokenHandler
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, String> body = RequestHelper.parseRequestBody(input.getBody());
 
         try {
-            TokenRequestDto tokenRequestDto = objectMapper.convertValue(body, TokenRequestDto.class);
+            TokenRequestDto tokenRequestDto = RequestHelper.convertRequestBody(input.getBody(), TokenRequestDto.class);
 
             if (tokenRequestDto.getCode().isEmpty()) {
                 LOGGER.error("Missing authorisation code from the token request");

--- a/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
@@ -38,7 +38,7 @@ public class AccessTokenHandler
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
 
         try {
-            TokenRequestDto tokenRequestDto = RequestHelper.convertRequestBody(input.getBody(), TokenRequestDto.class);
+            TokenRequestDto tokenRequestDto = RequestHelper.convertRequest(input, TokenRequestDto.class);
 
             if (tokenRequestDto.getCode().isEmpty()) {
                 LOGGER.error("Missing authorisation code from the token request");

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -5,12 +5,24 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.SerializeException;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.domain.ErrorResponse;
+import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.helpers.RequestHelper;
 
+import java.io.IOException;
+import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -18,7 +30,14 @@ import java.util.Set;
 
 public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CredentialIssuerHandler.class);
+
     private Set<String> validCredentialIssuers = Set.of("PassportIssuer", "FraudIssuer");
+
+
+    private Map<String, CredentialIssuerConfig> validCredentialIssuers2 = Map.of(
+            "PassportIssuer", new CredentialIssuerConfig("PassportIssuer", URI.create("http://www.example.com"))
+    );
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
@@ -31,6 +50,18 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
         if (errorResponse.isPresent()) {
             return errorResponse.get();
         } else {
+
+            CredentialIssuerConfig credentialIssuerConfig = validCredentialIssuers2.get(request.getCredential_issuer_id());
+
+            AuthorizationCode authorizationCode = new AuthorizationCode(request.getAuthorization_code());
+            TokenRequest tokenRequest = new TokenRequest(
+                    credentialIssuerConfig.getTokenUrl(),
+                    new ClientID("IPV_CLIENT_1"),
+                    new AuthorizationCodeGrant(authorizationCode, credentialIssuerConfig.getTokenUrl())
+            );
+
+            HTTPResponse httpResponse = sendHttpRequest(tokenRequest.toHTTPRequest());
+
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, Collections.EMPTY_MAP);
         }
 
@@ -49,6 +80,16 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
             return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.InvalidCredentialIssuerId));
         }
         return Optional.empty();
+    }
+
+    private HTTPResponse sendHttpRequest(HTTPRequest httpRequest) {
+        try {
+            return httpRequest.send();
+        } catch (IOException | SerializeException exception) {
+            LOGGER.error("Failed to send a http request", exception);
+            // todo what error to throw, and how to handle
+            throw new RuntimeException("Failed to send a http request", exception);
+        }
     }
 
 }

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -80,8 +80,8 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
             return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingCredentialIssuerId));
         }
 
-        if (StringUtils.isBlank(request.getRedirect_uri())) {
-            return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingRedirectURI));
+        if (StringUtils.isBlank(request.getSession_id())) {
+            return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingSessionId));
         }
 
         Optional<CredentialIssuerConfig> first = getCredentialIssuerConfig(request);

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -62,15 +62,15 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
     }
 
     private Optional<ErrorResponse> validate(CredentialIssuerRequestDto request) {
-        if (StringUtils.isBlank(request.getAuthorization_code())) {
+        if (StringUtils.isBlank(request.getAuthorizationCode())) {
             return Optional.of(ErrorResponse.MissingAuthorizationCode);
         }
 
-        if (StringUtils.isBlank(request.getCredential_issuer_id())) {
+        if (StringUtils.isBlank(request.getCredentialIssuerId())) {
             return Optional.of(ErrorResponse.MissingCredentialIssuerId);
         }
 
-        if (StringUtils.isBlank(request.getIpv_session_id())) {
+        if (StringUtils.isBlank(request.getIpvSessionId())) {
             return Optional.of(ErrorResponse.MissingSessionId);
         }
 
@@ -82,7 +82,7 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
 
     private CredentialIssuerConfig getCredentialIssuerConfig(CredentialIssuerRequestDto request) {
         return CREDENTIAL_ISSUERS.stream()
-                .filter(config -> request.getCredential_issuer_id().equals(config.getId()))
+                .filter(config -> request.getCredentialIssuerId().equals(config.getId()))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -44,7 +44,7 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
 
         Map<String, String> body = RequestHelper.parseRequestBody(input.getBody());
         ObjectMapper objectMapper = new ObjectMapper();
-        CredentialIssuerRequestDto request = objectMapper.convertValue(body, CredentialIssuerRequestDto.class);
+        CredentialIssuerRequestDto request =  objectMapper.convertValue(body, CredentialIssuerRequestDto.class);
 
         var errorResponse = validate(request);
         if (errorResponse.isPresent()) {
@@ -57,7 +57,7 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
             TokenRequest tokenRequest = new TokenRequest(
                     credentialIssuerConfig.getTokenUrl(),
                     new ClientID("IPV_CLIENT_1"),
-                    new AuthorizationCodeGrant(authorizationCode, credentialIssuerConfig.getTokenUrl())
+                    new AuthorizationCodeGrant(authorizationCode, URI.create(request.getRedirect_uri()))
             );
 
             HTTPResponse httpResponse = sendHttpRequest(tokenRequest.toHTTPRequest());
@@ -79,6 +79,7 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
         if (!validCredentialIssuers.contains(request.getCredential_issuer_id())) {
             return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.InvalidCredentialIssuerId));
         }
+        //todo check that the redirect_uri is in config list
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -78,8 +78,8 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
             return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingSessionId));
         }
 
-        Optional<CredentialIssuerConfig> first = getCredentialIssuerConfig(request);
-        if (first.isEmpty()) {
+        Optional<CredentialIssuerConfig> match = getCredentialIssuerConfig(request);
+        if (match.isEmpty()) {
             return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.InvalidCredentialIssuerId));
         }
         return Optional.empty();
@@ -91,6 +91,5 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
                 .findFirst();
         return first;
     }
-
 
 }

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -36,7 +36,7 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
     private Set<CredentialIssuerConfig> credentialIssuers;
 
     public CredentialIssuerHandler(Set<CredentialIssuerConfig> credentialIssuerConfig) {
-        this.credentialIssuers = Objects.requireNonNull(credentialIssuerConfig);
+        this.credentialIssuers = credentialIssuerConfig;
     }
 
     public CredentialIssuerHandler() {
@@ -67,9 +67,7 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
         );
 
         HTTPResponse httpResponse = sendHttpRequest(tokenRequest.toHTTPRequest());
-
         return ApiGatewayResponseGenerator.proxyJsonResponse(200, Collections.EMPTY_MAP);
-
 
     }
 
@@ -80,6 +78,10 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
 
         if (StringUtils.isBlank(request.getCredential_issuer_id())) {
             return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingCredentialIssuerId));
+        }
+
+        if (StringUtils.isBlank(request.getRedirect_uri())) {
+            return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingRedirectURI));
         }
 
         Optional<CredentialIssuerConfig> first = getCredentialIssuerConfig(request);

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -4,28 +4,20 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
-import com.nimbusds.oauth2.sdk.SerializeException;
-import com.nimbusds.oauth2.sdk.TokenRequest;
-import com.nimbusds.oauth2.sdk.http.HTTPRequest;
-import com.nimbusds.oauth2.sdk.http.HTTPResponse;
-import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.helpers.RequestHelper;
+import uk.gov.di.ipv.service.CredentialIssuerService;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -33,9 +25,12 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CredentialIssuerHandler.class);
 
+    private final CredentialIssuerService credentialIssuerService;
+
     private Set<CredentialIssuerConfig> credentialIssuers;
 
-    public CredentialIssuerHandler(Set<CredentialIssuerConfig> credentialIssuerConfig) {
+    public CredentialIssuerHandler(CredentialIssuerService credentialIssuerService, Set<CredentialIssuerConfig> credentialIssuerConfig) {
+        this.credentialIssuerService = credentialIssuerService;
         this.credentialIssuers = credentialIssuerConfig;
     }
 
@@ -43,14 +38,13 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
         CredentialIssuerConfig passportIssuer = new CredentialIssuerConfig("PassportIssuer", URI.create("http://www.example.com"));
         CredentialIssuerConfig fraudIssuer = new CredentialIssuerConfig("FraudIssuer", URI.create("http://www.example.com"));
         this.credentialIssuers = Set.of(passportIssuer, fraudIssuer);
+        this.credentialIssuerService = new CredentialIssuerService();
     }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
 
-        Map<String, String> body = RequestHelper.parseRequestBody(input.getBody());
-        ObjectMapper objectMapper = new ObjectMapper();
-        CredentialIssuerRequestDto request = objectMapper.convertValue(body, CredentialIssuerRequestDto.class);
+        CredentialIssuerRequestDto request = RequestHelper.convertRequestBody(input.getBody(), CredentialIssuerRequestDto.class);
 
         var errorResponse = validate(request);
         if (errorResponse.isPresent()) {
@@ -59,15 +53,15 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
 
         CredentialIssuerConfig credentialIssuerConfig = getCredentialIssuerConfig(request).get();
 
-        AuthorizationCode authorizationCode = new AuthorizationCode(request.getAuthorization_code());
-        TokenRequest tokenRequest = new TokenRequest(
-                credentialIssuerConfig.getTokenUrl(),
-                new ClientID("IPV_CLIENT_1"),
-                new AuthorizationCodeGrant(authorizationCode, URI.create(request.getRedirect_uri()))
-        );
-
-        HTTPResponse httpResponse = sendHttpRequest(tokenRequest.toHTTPRequest());
-        return ApiGatewayResponseGenerator.proxyJsonResponse(200, Collections.EMPTY_MAP);
+        try {
+            AccessToken accessToken = credentialIssuerService.exchangeCodeForToken(request, credentialIssuerConfig);
+            // todo var credential = getCredential(accessToken);
+            // todo save credential
+            return ApiGatewayResponseGenerator.proxyJsonResponse(200, Collections.EMPTY_MAP);
+        } catch (CredentialIssuerException e) {
+            LOGGER.error("Could not exchange authorization code for token: {}", e.getMessage(), e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.InvalidTokenRequest);
+        }
 
     }
 
@@ -88,7 +82,6 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
         if (first.isEmpty()) {
             return Optional.of(ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.InvalidCredentialIssuerId));
         }
-        //todo check that the redirect_uri is in config list
         return Optional.empty();
     }
 
@@ -99,14 +92,5 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
         return first;
     }
 
-    private HTTPResponse sendHttpRequest(HTTPRequest httpRequest) {
-        try {
-            return httpRequest.send();
-        } catch (IOException | SerializeException exception) {
-            LOGGER.error("Failed to send a http request", exception);
-            // todo what error to throw, and how to handle
-            throw new RuntimeException("Failed to send a http request", exception);
-        }
-    }
 
 }

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.service;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
@@ -21,6 +22,7 @@ import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
 import javax.security.auth.login.CredentialException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Objects;
 
 public class CredentialIssuerService {
 
@@ -42,18 +44,18 @@ public class CredentialIssuerService {
 
             if (tokenResponse instanceof TokenErrorResponse) {
                 TokenErrorResponse errorResponse = tokenResponse.toErrorResponse();
-                var description = errorResponse.getErrorObject().getDescription();
-                var code = errorResponse.getErrorObject().getCode();
-                // todo handle logging
-                throw new CredentialIssuerException(code + " " + description); //todo handle what exception if any to return
-
+                ErrorObject errorObject = Objects.requireNonNullElse(
+                        errorResponse.getErrorObject(),
+                        new ErrorObject("unknown", "unknown")
+                );
+                throw new CredentialIssuerException(String.format("%s: %s", errorObject.getCode(), errorObject.getDescription()));
             }
             return tokenResponse
                     .toSuccessResponse()
                     .getTokens()
                     .getAccessToken();
         } catch (IOException | ParseException e) {
-            throw new CredentialIssuerException(e); //todo fixme
+            throw new CredentialIssuerException(e);
         }
 
     }

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -14,9 +14,11 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
 
+import javax.security.auth.login.CredentialException;
 import java.io.IOException;
 import java.net.URI;
 
@@ -38,8 +40,10 @@ public class CredentialIssuerService {
 
             if (tokenResponse instanceof TokenErrorResponse) {
                 TokenErrorResponse errorResponse = tokenResponse.toErrorResponse();
+                var description = errorResponse.getErrorObject().getDescription();
+                var code = errorResponse.getErrorObject().getCode();
                 // todo handle logging
-                return null; //todo handle what exception if any to return
+                throw new CredentialIssuerException(code + " " + description); //todo handle what exception if any to return
 
             }
             return tokenResponse
@@ -47,7 +51,7 @@ public class CredentialIssuerService {
                     .getTokens()
                     .getAccessToken();
         } catch (IOException | ParseException e) {
-            throw new RuntimeException(); //todo fixme
+            throw new CredentialIssuerException(e); //todo fixme
         }
 
     }

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -23,7 +23,7 @@ public class CredentialIssuerService {
 
     public AccessToken exchangeCodeForToken(CredentialIssuerRequestDto request, CredentialIssuerConfig config) {
 
-        AuthorizationCode authorizationCode = new AuthorizationCode(request.getAuthorization_code());
+        AuthorizationCode authorizationCode = new AuthorizationCode(request.getAuthorizationCode());
         try {
             TokenRequest tokenRequest = new TokenRequest(
                     config.getTokenUrl(),

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -26,7 +26,9 @@ public class CredentialIssuerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CredentialIssuerService.class);
 
-    public AccessToken exchangeCodeForToken(CredentialIssuerRequestDto request, AuthorizationCode authorizationCode, CredentialIssuerConfig config) {
+    public AccessToken exchangeCodeForToken(CredentialIssuerRequestDto request, CredentialIssuerConfig config) {
+
+        AuthorizationCode authorizationCode = new AuthorizationCode(request.getAuthorization_code());
 
         try {
             TokenRequest tokenRequest = new TokenRequest(

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -36,7 +36,7 @@ public class CredentialIssuerService {
             TokenRequest tokenRequest = new TokenRequest(
                     config.getTokenUrl(),
                     new ClientID("IPV_CLIENT_1"),
-                    new AuthorizationCodeGrant(authorizationCode, URI.create(request.getRedirect_uri()))
+                    new AuthorizationCodeGrant(authorizationCode, null)
             );
 
             HTTPResponse httpResponse = tokenRequest.toHTTPRequest().send();

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -1,0 +1,70 @@
+package uk.gov.di.ipv.service;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.SerializeException;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class CredentialIssuerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CredentialIssuerService.class);
+
+    public AccessToken exchangeCodeForToken(CredentialIssuerRequestDto request, AuthorizationCode authorizationCode, CredentialIssuerConfig config) {
+
+        try {
+            TokenRequest tokenRequest = new TokenRequest(
+                    config.getTokenUrl(),
+                    new ClientID("IPV_CLIENT_1"),
+                    new AuthorizationCodeGrant(authorizationCode, URI.create(request.getRedirect_uri()))
+            );
+
+            HTTPResponse httpResponse = tokenRequest.toHTTPRequest().send();
+            TokenResponse tokenResponse = parseTokenResponse(httpResponse);
+
+            if (tokenResponse instanceof TokenErrorResponse) {
+                TokenErrorResponse errorResponse = tokenResponse.toErrorResponse();
+                // todo handle logging
+                return null; //todo handle what exception if any to return
+
+            }
+            return tokenResponse
+                    .toSuccessResponse()
+                    .getTokens()
+                    .getAccessToken();
+        } catch (IOException | ParseException e) {
+            throw new RuntimeException(); //todo fixme
+        }
+
+    }
+
+    private TokenResponse parseTokenResponse(HTTPResponse httpResponse) throws ParseException {
+        return OIDCTokenResponseParser.parse(httpResponse);
+
+    }
+
+    private HTTPResponse sendHttpRequest(HTTPRequest httpRequest) {
+        try {
+            return httpRequest.send();
+        } catch (IOException | SerializeException exception) {
+            LOGGER.error("Failed to send a http request", exception);
+            // todo what error to throw, and how to handle
+            throw new RuntimeException("Failed to send a http request", exception);
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.domain.ErrorResponse;
@@ -31,88 +32,48 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerHandlerTest {
 
+    @Mock
+    private Context context;
+
     @Captor
     private ArgumentCaptor<CredentialIssuerRequestDto> requestDto;
 
+    String credentialIssuerId = "PassportIssuer";
+    String redirectUri = "http://www.example.com";
+    String authorization_code = "bar";
+
     @Test
     void shouldReceive400ResponseCodeIfAuthorizationCodeNotPresent() throws JsonProcessingException {
-
-        CredentialIssuerHandler handler = new CredentialIssuerHandler();
-        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-
-        input.setBody("credential_issuer_id=foo&redirect_uri=http://www.example.com");
-        Context context = mock(Context.class);
-        APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
-        Integer statusCode = response.getStatusCode();
-        Map responseBody = getResponseBodyAsMap(response);
-        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
-        assertEquals(ErrorResponse.MissingAuthorizationCode.getCode(), responseBody.get("code"));
-        verifyNoInteractions(context);
-
+        APIGatewayProxyRequestEvent input = createRequestEvent("credential_issuer_id=foo&redirect_uri=http://www.example.com");
+        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler().handleRequest(input, context);
+        assert400Response(response, ErrorResponse.MissingAuthorizationCode);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotPresent() throws JsonProcessingException {
-
-        CredentialIssuerHandler handler = new CredentialIssuerHandler();
-        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-        input.setBody("authorization_code=bar&redirect_uri=http://www.example.com");
-
-        Context context = mock(Context.class);
-        APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
-        Integer statusCode = response.getStatusCode();
-        Map responseBody = getResponseBodyAsMap(response);
-        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
-        assertEquals(ErrorResponse.MissingCredentialIssuerId.getCode(), responseBody.get("code"));
-        verifyNoInteractions(context);
-
+        APIGatewayProxyRequestEvent input = createRequestEvent("authorization_code=bar&redirect_uri=http://www.example.com");
+        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler().handleRequest(input, context);
+        assert400Response(response, ErrorResponse.MissingCredentialIssuerId);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotInPermittedSet() throws JsonProcessingException {
-
-        CredentialIssuerHandler handler = new CredentialIssuerHandler();
-        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-
-        input.setBody("authorization_code=bar&credential_issuer_id=bar&redirect_uri=http://www.example.com");
-        Context context = mock(Context.class);
-        APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
-        Integer statusCode = response.getStatusCode();
-        Map responseBody = getResponseBodyAsMap(response);
-        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
-        assertEquals(ErrorResponse.InvalidCredentialIssuerId.getCode(), responseBody.get("code"));
-        verifyNoInteractions(context);
-
+        APIGatewayProxyRequestEvent input = createRequestEvent("authorization_code=bar&credential_issuer_id=bar&redirect_uri=http://www.example.com");
+        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler().handleRequest(input, context);
+        assert400Response(response, ErrorResponse.InvalidCredentialIssuerId);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfRedirectUriNotPresent() throws JsonProcessingException {
-
-        CredentialIssuerHandler handler = new CredentialIssuerHandler();
-        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-
-        input.setBody("authorization_code=bar&credential_issuer_id=PassportIssuer");
-        Context context = mock(Context.class);
-        APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
-        Integer statusCode = response.getStatusCode();
-        Map responseBody = getResponseBodyAsMap(response);
-        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
-        assertEquals(ErrorResponse.MissingRedirectURI.getCode(), responseBody.get("code"));
-        verifyNoInteractions(context);
-
+        APIGatewayProxyRequestEvent input = createRequestEvent("authorization_code=bar&credential_issuer_id=PassportIssuer");
+        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler().handleRequest(input, context);
+        assert400Response(response, ErrorResponse.MissingRedirectURI);
     }
 
     @Test
     void shouldReceive200ResponseCodeIfAllRequestParametersValid() {
-
-        String credentialIssuerId = "PassportIssuer";
-        String redirectUri = "http://www.example.com";
-        String authorization_code = "bar";
-
         CredentialIssuerConfig passportIssuer = new CredentialIssuerConfig(credentialIssuerId, URI.create(redirectUri));
         CredentialIssuerConfig fraudIssuer = new CredentialIssuerConfig("FraudIssuer", URI.create(redirectUri));
-        Set<CredentialIssuerConfig> configs = Set.of(passportIssuer, fraudIssuer);
-
         CredentialIssuerService credentialIssuerService = mock(CredentialIssuerService.class);
         AccessToken accessToken = mock(AccessToken.class);
 
@@ -121,33 +82,21 @@ class CredentialIssuerHandlerTest {
                 ArgumentMatchers.eq(passportIssuer))
         ).thenReturn(accessToken);
 
-        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService, configs);
+        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService, Set.of(passportIssuer, fraudIssuer));
 
-        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-
-        input.setBody(String.format("authorization_code=%s&credential_issuer_id=%s&redirect_uri=%s", authorization_code, credentialIssuerId, redirectUri));
-        Context context = mock(Context.class);
+        APIGatewayProxyRequestEvent input = createRequestEvent(String.format("authorization_code=%s&credential_issuer_id=%s&redirect_uri=%s", authorization_code, credentialIssuerId, redirectUri));
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();
         assertEquals(HTTPResponse.SC_OK, statusCode);
-        verifyNoInteractions(context);
-
         CredentialIssuerRequestDto value = requestDto.getValue();
-
         assertEquals(redirectUri, value.getRedirect_uri());
         assertEquals(credentialIssuerId, value.getCredential_issuer_id());
         assertEquals(authorization_code, value.getAuthorization_code());
-
-
+        verifyNoInteractions(context);
     }
 
     @Test
-    void shouldReceive400ResponseCodeIfCredentialIsserServiceThrowsException() throws JsonProcessingException {
-
-        String credentialIssuerId = "PassportIssuer";
-        String redirectUri = "http://www.example.com";
-        String authorization_code = "bar";
-
+    void shouldReceive400ResponseCodeIfCredentialIssuerServiceThrowsException() throws JsonProcessingException {
         CredentialIssuerConfig passportIssuer = new CredentialIssuerConfig(credentialIssuerId, URI.create(redirectUri));
         CredentialIssuerConfig fraudIssuer = new CredentialIssuerConfig("FraudIssuer", URI.create(redirectUri));
         Set<CredentialIssuerConfig> configs = Set.of(passportIssuer, fraudIssuer);
@@ -155,26 +104,32 @@ class CredentialIssuerHandlerTest {
         CredentialIssuerService credentialIssuerService = mock(CredentialIssuerService.class);
 
         CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService, configs);
-        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-
-        input.setBody(String.format("authorization_code=%s&credential_issuer_id=%s&redirect_uri=%s", authorization_code, credentialIssuerId, redirectUri));
-        Context context = mock(Context.class);
+        APIGatewayProxyRequestEvent input = createRequestEvent(String.format("authorization_code=%s&credential_issuer_id=%s&redirect_uri=%s", authorization_code, credentialIssuerId, redirectUri));
 
         when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), ArgumentMatchers.eq(passportIssuer)))
                 .thenThrow(new CredentialIssuerException("code1: message1"));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
-        Integer statusCode = response.getStatusCode();
-        Map responseBody = getResponseBodyAsMap(response);
-        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
-        assertEquals(ErrorResponse.InvalidTokenRequest.getCode(), responseBody.get("code"));
-        verifyNoInteractions(context);
-
+        assert400Response(response, ErrorResponse.InvalidTokenRequest);
     }
 
     private Map getResponseBodyAsMap(APIGatewayProxyResponseEvent response) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
         return responseBody;
+    }
+
+    private APIGatewayProxyRequestEvent createRequestEvent(String s) {
+        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
+        input.setBody(s);
+        return input;
+    }
+
+    private void assert400Response(APIGatewayProxyResponseEvent response, ErrorResponse missingAuthorizationCode) throws JsonProcessingException {
+        Integer statusCode = response.getStatusCode();
+        Map responseBody = getResponseBodyAsMap(response);
+        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
+        assertEquals(missingAuthorizationCode.getCode(), responseBody.get("code"));
+        verifyNoInteractions(context);
     }
 }

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -99,9 +99,9 @@ class CredentialIssuerHandlerTest {
         Integer statusCode = response.getStatusCode();
         assertEquals(HTTPResponse.SC_OK, statusCode);
         CredentialIssuerRequestDto value = requestDto.getValue();
-        assertEquals(sessionId, value.getIpv_session_id());
-        assertEquals(passportIssuerId, value.getCredential_issuer_id());
-        assertEquals(authorization_code, value.getAuthorization_code());
+        assertEquals(sessionId, value.getIpvSessionId());
+        assertEquals(passportIssuerId, value.getCredentialIssuerId());
+        assertEquals(authorization_code, value.getAuthorizationCode());
         verifyNoInteractions(context);
     }
 

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
@@ -137,6 +138,37 @@ class CredentialIssuerHandlerTest {
         assertEquals(credentialIssuerId, value.getCredential_issuer_id());
         assertEquals(authorization_code, value.getAuthorization_code());
 
+
+    }
+
+    @Test
+    void shouldReceive400ResponseCodeIfCredentialIsserServiceThrowsException() throws JsonProcessingException {
+
+        String credentialIssuerId = "PassportIssuer";
+        String redirectUri = "http://www.example.com";
+        String authorization_code = "bar";
+
+        CredentialIssuerConfig passportIssuer = new CredentialIssuerConfig(credentialIssuerId, URI.create(redirectUri));
+        CredentialIssuerConfig fraudIssuer = new CredentialIssuerConfig("FraudIssuer", URI.create(redirectUri));
+        Set<CredentialIssuerConfig> configs = Set.of(passportIssuer, fraudIssuer);
+
+        CredentialIssuerService credentialIssuerService = mock(CredentialIssuerService.class);
+
+        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService, configs);
+        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
+
+        input.setBody(String.format("authorization_code=%s&credential_issuer_id=%s&redirect_uri=%s", authorization_code, credentialIssuerId, redirectUri));
+        Context context = mock(Context.class);
+
+        when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), ArgumentMatchers.eq(passportIssuer)))
+                .thenThrow(new CredentialIssuerException("code1: message1"));
+
+        APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
+        Integer statusCode = response.getStatusCode();
+        Map responseBody = getResponseBodyAsMap(response);
+        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
+        assertEquals(ErrorResponse.InvalidTokenRequest.getCode(), responseBody.get("code"));
+        verifyNoInteractions(context);
 
     }
 

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -22,7 +22,7 @@ class CredentialIssuerHandlerTest {
         CredentialIssuerHandler handler = new CredentialIssuerHandler();
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
 
-        input.setBody("credential_issuer_id=foo");
+        input.setBody("credential_issuer_id=foo&redirect_uri=http://www.example.com");
         Context context = mock(Context.class);
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();
@@ -38,7 +38,7 @@ class CredentialIssuerHandlerTest {
 
         CredentialIssuerHandler handler = new CredentialIssuerHandler();
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-        input.setBody("authorization_code=bar");
+        input.setBody("authorization_code=bar&redirect_uri=http://www.example.com");
 
         Context context = mock(Context.class);
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
@@ -56,7 +56,7 @@ class CredentialIssuerHandlerTest {
         CredentialIssuerHandler handler = new CredentialIssuerHandler();
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
 
-        input.setBody("authorization_code=bar&credential_issuer_id=barx");
+        input.setBody("authorization_code=bar&credential_issuer_id=bar&redirect_uri=http://www.example.com");
         Context context = mock(Context.class);
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();
@@ -68,12 +68,29 @@ class CredentialIssuerHandlerTest {
     }
 
     @Test
-    void shouldReceive200ResponseCodeIfAllRequestParametersValid() throws JsonProcessingException {
+    void shouldReceive400ResponseCodeIfRedirectUriNotPresent() throws JsonProcessingException {
 
         CredentialIssuerHandler handler = new CredentialIssuerHandler();
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
 
         input.setBody("authorization_code=bar&credential_issuer_id=PassportIssuer");
+        Context context = mock(Context.class);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
+        Integer statusCode = response.getStatusCode();
+        Map responseBody = getResponseBodyAsMap(response);
+        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
+        assertEquals(ErrorResponse.MissingRedirectURI.getCode(), responseBody.get("code"));
+        verifyNoInteractions(context);
+
+    }
+
+    @Test
+    void shouldReceive200ResponseCodeIfAllRequestParametersValid() throws JsonProcessingException {
+
+        CredentialIssuerHandler handler = new CredentialIssuerHandler();
+        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
+
+        input.setBody("authorization_code=bar&credential_issuer_id=PassportIssuer&redirect_uri=http://www.example.com");
         Context context = mock(Context.class);
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -102,7 +102,7 @@ class CredentialIssuerHandlerTest {
     }
 
     @Test
-    void shouldReceive200ResponseCodeIfAllRequestParametersValid() throws JsonProcessingException {
+    void shouldReceive200ResponseCodeIfAllRequestParametersValid() {
 
         String credentialIssuerId = "PassportIssuer";
         String redirectUri = "http://www.example.com";

--- a/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
@@ -4,7 +4,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
@@ -15,7 +14,9 @@ import java.net.URI;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @WireMockTest
 class CredentialIssuerServiceTest {
@@ -82,7 +83,7 @@ class CredentialIssuerServiceTest {
     @Test
     public void invalidHeaderThrowsCredentialIssuerException(WireMockRuntimeInfo wmRuntimeInfo) {
 
-        RuntimeException exception = assertThrows(CredentialIssuerException.class, () -> {
+        CredentialIssuerException exception = assertThrows(CredentialIssuerException.class, () -> {
             stubFor(post("/token")
                     .willReturn(aResponse()
                             .withHeader("Content-Type", "application/xml")
@@ -96,7 +97,8 @@ class CredentialIssuerServiceTest {
             );
             CredentialIssuerConfig credentialIssuerConfig = new CredentialIssuerConfig(
                     "StubPassport",
-                    URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"));;
+                    URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"));
+            ;
             AccessToken accessToken = credentialIssuerService.exchangeCodeForToken(credentialIssuerRequestDto, credentialIssuerConfig);
 
         });
@@ -106,9 +108,4 @@ class CredentialIssuerServiceTest {
         assertTrue(actualMessage.contains(expectedMessage));
     }
 
-
-
-
-    }
-
-
+}

--- a/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
@@ -20,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CredentialIssuerServiceTest {
 
     @Test
-    void test_token_response(WireMockRuntimeInfo wmRuntimeInfo) {
+    void test_valid_token_response(WireMockRuntimeInfo wmRuntimeInfo) {
 
         stubFor(post("/token")
                 .willReturn(aResponse()
@@ -75,7 +76,7 @@ class CredentialIssuerServiceTest {
         });
 
         String message = exception.getMessage();
-        assertEquals("invalid_request Request was missing the 'redirect_uri' parameter.", message);
+        assertEquals("invalid_request: Request was missing the 'redirect_uri' parameter.", message);
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
 
@@ -13,7 +14,7 @@ import java.net.URI;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @WireMockTest
 class CredentialIssuerServiceTest {
@@ -43,4 +44,70 @@ class CredentialIssuerServiceTest {
         assertEquals("d09rUXQZ-4AjT6DNsRXj00KBt7Pqh8tFXBq8ul6KYQ4", accessToken.getValue());
 
     }
-}
+
+    @Test
+    void test_token_error_response(WireMockRuntimeInfo wmRuntimeInfo) {
+
+        CredentialIssuerException exception = assertThrows(CredentialIssuerException.class, () -> {
+            var errorJson = "{ \"error\": \"invalid_request\", \"error_description\": \"Request was missing the 'redirect_uri' parameter.\", \"error_uri\": \"See the full API docs at https://authorization-server.com/docs/access_token\"}";
+            stubFor(post("/token")
+                    .willReturn(aResponse()
+                            .withStatus(400)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(errorJson)));
+
+            CredentialIssuerService credentialIssuerService = new CredentialIssuerService();
+            CredentialIssuerRequestDto credentialIssuerRequestDto = new CredentialIssuerRequestDto(
+                    "1234",
+                    "cred_issuer_id_1",
+                    "http://www.example.com/redirect"
+            );
+            CredentialIssuerConfig credentialIssuerConfig = new CredentialIssuerConfig(
+                    "StubPassport",
+                    URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"));
+
+            AccessToken accessToken = credentialIssuerService.exchangeCodeForToken(credentialIssuerRequestDto, credentialIssuerConfig);
+
+            AccessTokenType type = accessToken.getType();
+            assertEquals("Bearer", type.toString());
+            assertEquals(3600, accessToken.getLifetime());
+            assertEquals("d09rUXQZ-4AjT6DNsRXj00KBt7Pqh8tFXBq8ul6KYQ4", accessToken.getValue());
+        });
+
+        String message = exception.getMessage();
+        assertEquals("invalid_request Request was missing the 'redirect_uri' parameter.", message);
+    }
+
+    @Test
+    public void invalidHeaderThrowsCredentialIssuerException(WireMockRuntimeInfo wmRuntimeInfo) {
+
+        RuntimeException exception = assertThrows(CredentialIssuerException.class, () -> {
+            stubFor(post("/token")
+                    .willReturn(aResponse()
+                            .withHeader("Content-Type", "application/xml")
+                            .withBody("{\"access_token\":\"d09rUXQZ-4AjT6DNsRXj00KBt7Pqh8tFXBq8ul6KYQ4\",\"token_type\":\"Bearer\",\"expires_in\":3600}\n")));
+
+            CredentialIssuerService credentialIssuerService = new CredentialIssuerService();
+            CredentialIssuerRequestDto credentialIssuerRequestDto = new CredentialIssuerRequestDto(
+                    "1234",
+                    "cred_issuer_id_1",
+                    "http://www.example.com/redirect"
+            );
+            CredentialIssuerConfig credentialIssuerConfig = new CredentialIssuerConfig(
+                    "StubPassport",
+                    URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"));;
+            AccessToken accessToken = credentialIssuerService.exchangeCodeForToken(credentialIssuerRequestDto, credentialIssuerConfig);
+
+        });
+
+        String expectedMessage = "The HTTP Content-Type header must be application/json";
+        String actualMessage = exception.getMessage();
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+
+
+
+    }
+
+

--- a/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
@@ -1,0 +1,46 @@
+package uk.gov.di.ipv.service;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
+
+import java.net.URI;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WireMockTest
+class CredentialIssuerServiceTest {
+
+    @Test
+    void test_token_response(WireMockRuntimeInfo wmRuntimeInfo) {
+
+        stubFor(post("/token")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"access_token\":\"d09rUXQZ-4AjT6DNsRXj00KBt7Pqh8tFXBq8ul6KYQ4\",\"token_type\":\"Bearer\",\"expires_in\":3600}\n")));
+
+        CredentialIssuerService credentialIssuerService = new CredentialIssuerService();
+        CredentialIssuerRequestDto credentialIssuerRequestDto = new CredentialIssuerRequestDto(
+                "1234",
+                "cred_issuer_id_1",
+                "http://www.example.com/redirect"
+        );
+        CredentialIssuerConfig credentialIssuerConfig = new CredentialIssuerConfig(
+                "StubPassport",
+                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"));
+
+        AccessToken accessToken = credentialIssuerService.exchangeCodeForToken(credentialIssuerRequestDto, credentialIssuerConfig);
+        AccessTokenType type = accessToken.getType();
+        assertEquals("Bearer", type.toString());
+        assertEquals(3600, accessToken.getLifetime());
+        assertEquals("d09rUXQZ-4AjT6DNsRXj00KBt7Pqh8tFXBq8ul6KYQ4", accessToken.getValue());
+
+    }
+}


### PR DESCRIPTION
Given an authorization code from front end, exchange it for a token from the credential issuer.

## Proposed changes

### What changed
Added a new lambda to di-ipv-core-back which will be called by the front end and in turn will call the credential issuer for 
an OAuth token.

A subsequent story uses the token. 

The API for this lambda is documented on the repo `README.md`.

Co-Authored-By: Phillip Miller

### Issue tracking

- [PYI-362](https://govukverify.atlassian.net/browse/PYI-362)

## Checklists

- [ ] Ensure the API docs make sense
- [ ] Check that its ok to return a 400 response in all error conditions


