### PR TITLE
PYI-300 header downcase

### DIFF
--- a/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
@@ -7,7 +7,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-public class RequestBodyHelper {
+public class RequestHelper {
 
     public static Map<String, String> parseRequestBody(String body) {
         Map<String, String> query_pairs = new HashMap<>();

--- a/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/RequestHelper.java
@@ -1,11 +1,14 @@
 package uk.gov.di.ipv.helpers;
 
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class RequestHelper {
 
@@ -17,5 +20,19 @@ public class RequestHelper {
         }
 
         return query_pairs;
+    }
+
+    public static Optional<String> getHeader(Map<String, String> headers, String headerKey) {
+        var values = headers.entrySet().stream()
+                .filter(e -> headerKey.equalsIgnoreCase(e.getKey()))
+                .map(e -> e.getValue())
+                .collect(Collectors.toList());
+        if (values.size() == 1) {
+            var value = values.get(0);
+            if (StringUtils.isNotBlank(value)) {
+                return Optional.of(value);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.dto.TokenRequestDto;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
-import uk.gov.di.ipv.helpers.RequestBodyHelper;
+import uk.gov.di.ipv.helpers.RequestHelper;
 import uk.gov.di.ipv.service.AccessTokenService;
 
 import java.util.Map;
@@ -40,7 +40,7 @@ public class AccessTokenHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
         ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, String> body = RequestBodyHelper.parseRequestBody(input.getBody());
+        Map<String, String> body = RequestHelper.parseRequestBody(input.getBody());
 
         try {
             TokenRequestDto tokenRequestDto = objectMapper.convertValue(body, TokenRequestDto.class);

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -9,7 +9,7 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
-import uk.gov.di.ipv.helpers.RequestBodyHelper;
+import uk.gov.di.ipv.helpers.RequestHelper;
 
 import java.util.Collections;
 import java.util.Map;
@@ -23,7 +23,7 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
 
-        Map<String, String> body = RequestBodyHelper.parseRequestBody(input.getBody());
+        Map<String, String> body = RequestHelper.parseRequestBody(input.getBody());
         ObjectMapper objectMapper = new ObjectMapper();
         CredentialIssuerRequestDto request = objectMapper.convertValue(body, CredentialIssuerRequestDto.class);
 

--- a/src/main/java/uk/gov/di/ipv/lambda/UserInfoHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/UserInfoHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.dto.UserInfoDto;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.helpers.RequestHelper;
 import uk.gov.di.ipv.service.UserInfoService;
 
 public class UserInfoHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -31,15 +32,14 @@ public class UserInfoHandler implements RequestHandler<APIGatewayProxyRequestEve
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
 
-        String accessTokenString = input.getHeaders().get(AUTHORIZATION_HEADER);
-
-        if (accessTokenString == null || accessTokenString.isEmpty()) {
+        var accessTokenString = RequestHelper.getHeader(input.getHeaders(), AUTHORIZATION_HEADER);
+        if (accessTokenString.isEmpty()) {
             LOGGER.error("Missing access token from Authorization header");
             return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingAccessToken);
         }
 
         try {
-            AccessToken accessToken = AccessToken.parse(accessTokenString);
+            AccessToken accessToken = AccessToken.parse(accessTokenString.get());
             UserInfoDto userInfo = userInfoService.handleUserInfo(accessToken);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, userInfo);

--- a/src/test/java/uk/gov/di/ipv/helpers/RequestHelperTest.java
+++ b/src/test/java/uk/gov/di/ipv/helpers/RequestHelperTest.java
@@ -1,0 +1,30 @@
+package uk.gov.di.ipv.helpers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RequestHelperTest {
+
+    Map<String, String> headers = Map.of(
+            "foo", "bar",
+            "Foo", "bar",
+            "baz", "bar"
+    );
+
+    @ParameterizedTest(name = "with matching header: {0}")
+    @ValueSource(strings = {"Baz", "baz"})
+    void matchHeaderByDownCasing(String headerName) {
+        assertEquals("bar", RequestHelper.getHeader(headers, headerName).get());
+    }
+
+    @ParameterizedTest(name = "with non-matching header: {0}")
+    @ValueSource(strings = {"boo", "", "foo", "Foo"})
+    void noMatchingHeader(String headerName) {
+        assertTrue(RequestHelper.getHeader(headers, headerName).isEmpty());
+    }
+}


### PR DESCRIPTION
## Proposed changes
HTTP headers are case-insensitive so our RequestHelper should handle either.

For context: Our UserInfoHandler has a case-senstive check for the `Authorization` header. In localstack this header is translated to `authorizaton` so the header is not found against the `Authorization` key.
### What changed

Add a static method to RequestHelper that matches headers in a case-insensitive way, and provides the value when matched.

If there is more than one matching header, then provide no matching value. 

<!-- Describe the changes in detail - the "what"-->

### Why did it change

HTTP headers should be case-insensitive, see https://datatracker.ietf.org/doc/html/rfc7230#section-3.2

Practically, for our local startup story, we can't match on the `Authorization` header, and can't complete a journey.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-300](https://govukverify.atlassian.net/browse/PYI-300) (tangentially related)

## Checklists

- [ ] Check that a localstack journey works on this branch
