### PR TITLE
PYI-395: Store auth code in dynamoDB after its generated in AuthorizationHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,14 @@ dependencies {
 
     implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
             "com.amazonaws:aws-lambda-java-events:3.10.0",
+            "com.amazonaws:aws-java-sdk-dynamodb:1.12.118",
             "com.nimbusds:oauth2-oidc-sdk:9.3.1",
             "com.fasterxml.jackson.core:jackson-core:2.13.0",
             "com.fasterxml.jackson.core:jackson-databind:2.13.0",
             "com.fasterxml.jackson.core:jackson-annotations:2.13.0",
             "org.apache.httpcomponents:httpclient:4.5.13",
-            "org.slf4j:slf4j-simple:1.7.32"
+            "org.slf4j:slf4j-simple:1.7.32",
+            "software.amazon.awssdk:dynamodb-enhanced:2.17.89"
 
 
     compileOnly 'org.projectlombok:lombok:1.18.22'

--- a/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
@@ -13,10 +13,12 @@ import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.service.AuthorizationCodeService;
+import uk.gov.di.ipv.service.ConfigurationService;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class AuthorizationHandler
@@ -26,12 +28,12 @@ public class AuthorizationHandler
 
     private final AuthorizationCodeService authorizationCodeService;
 
-    public AuthorizationHandler(AuthorizationCodeService authorizationCodeService) {
-        this.authorizationCodeService = authorizationCodeService;
-    }
-
     public AuthorizationHandler() {
         this.authorizationCodeService = new AuthorizationCodeService();
+    }
+
+    public AuthorizationHandler(AuthorizationCodeService authorizationCodeService) {
+        this.authorizationCodeService = authorizationCodeService;
     }
 
     @Override
@@ -50,7 +52,10 @@ public class AuthorizationHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingRedirectURI);
         }
 
-        AuthorizationCode authorizationCode = authorizationCodeService.generateAuthorisationCode();
+        AuthorizationCode authorizationCode = authorizationCodeService.generateAuthorizationCode();
+
+        // TODO: Load sessionID value properly
+        authorizationCodeService.persistAuthorizationCode(UUID.randomUUID().toString(), authorizationCode.getValue());
 
         Map<String, Identifier> payload = Map.of("code", authorizationCode);
 

--- a/src/main/java/uk/gov/di/ipv/persistence/DataStore.java
+++ b/src/main/java/uk/gov/di/ipv/persistence/DataStore.java
@@ -1,0 +1,90 @@
+package uk.gov.di.ipv.persistence;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.ipv.service.ConfigurationService;
+
+import java.net.URI;
+
+public class DataStore<T> {
+
+    private static final String LOCALHOST_URI = "http://localhost:4567";
+
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private final ConfigurationService configurationService;
+    private final String tableName;
+    private final Class<T> typeParameterClass;
+
+    public DataStore(String tableName, Class<T> typeParameterClass) {
+        this.tableName = tableName;
+        this.typeParameterClass = typeParameterClass;
+
+        configurationService = ConfigurationService.getInstance();
+
+        DynamoDbClient client = configurationService.isRunningLocally()
+                ? createLocalDbClient()
+                : DynamoDbClient.create();
+
+        dynamoDbEnhancedClient = DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(client)
+                .build();
+    }
+
+    public DataStore(
+            String tableName,
+            Class<T> typeParameterClass,
+            DynamoDbEnhancedClient dynamoDbEnhancedClient,
+            ConfigurationService configurationService) {
+        this.tableName = tableName;
+        this.typeParameterClass = typeParameterClass;
+        this.dynamoDbEnhancedClient = dynamoDbEnhancedClient;
+        this.configurationService = configurationService;
+    }
+
+    public void create(T item) {
+        getTable().putItem(item);
+    }
+
+    public T read(String partitionValue, String sortValue) {
+        return read(Key.builder().partitionValue(partitionValue).sortValue(sortValue).build());
+    }
+
+    public T read(String partitionValue) {
+        return read(Key.builder().partitionValue(partitionValue).build());
+    }
+
+    public T update(T item) {
+        return getTable().updateItem(item);
+    }
+
+    public T delete(String partitionValue, String sortValue) {
+        return delete(Key.builder().partitionValue(partitionValue).sortValue(sortValue).build());
+    }
+
+    public T delete(String partitionValue) {
+        return delete(Key.builder().partitionValue(partitionValue).build());
+    }
+
+    private DynamoDbClient createLocalDbClient() {
+        return DynamoDbClient.builder()
+                .endpointOverride(URI.create(LOCALHOST_URI))
+                .region(Region.EU_WEST_2)
+                .build();
+    }
+
+    private T read(Key key) {
+        return getTable().getItem(key);
+    }
+
+    private T delete(Key key) {
+        return getTable().deleteItem(key);
+    }
+
+    private DynamoDbTable<T> getTable() {
+        return dynamoDbEnhancedClient.table(tableName, TableSchema.fromBean(this.typeParameterClass));
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/persistence/item/AuthorizationCodeItem.java
+++ b/src/main/java/uk/gov/di/ipv/persistence/item/AuthorizationCodeItem.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.persistence.item;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class AuthorizationCodeItem {
+
+    private String sessionId;
+    private String code;
+
+    @DynamoDbPartitionKey
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
@@ -1,10 +1,35 @@
 package uk.gov.di.ipv.service;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import uk.gov.di.ipv.persistence.DataStore;
+import uk.gov.di.ipv.persistence.item.AuthorizationCodeItem;
 
 public class AuthorizationCodeService {
+    private final static String AUTH_CODE_TABLE_NAME_SUFFIX = "-auth-codes";
 
-    public AuthorizationCode generateAuthorisationCode() {
+    private final DataStore<AuthorizationCodeItem> dataStore;
+    private final ConfigurationService configurationService;
+
+    public AuthorizationCodeService() {
+        this.configurationService = ConfigurationService.getInstance();
+        String tableName = configurationService.getEnvironmentName() + AUTH_CODE_TABLE_NAME_SUFFIX;
+        this.dataStore = new DataStore<>(tableName, AuthorizationCodeItem.class);
+    }
+
+    public AuthorizationCodeService(DataStore<AuthorizationCodeItem> dataStore, ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.dataStore = dataStore;
+    }
+
+    public AuthorizationCode generateAuthorizationCode() {
         return new AuthorizationCode();
+    }
+
+    public void persistAuthorizationCode(String sessionId, String authorizationCode) {
+        AuthorizationCodeItem authorizationCodeItem = new AuthorizationCodeItem();
+        authorizationCodeItem.setSessionId(sessionId);
+        authorizationCodeItem.setCode(authorizationCode);
+
+        dataStore.create(authorizationCodeItem);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
@@ -5,15 +5,12 @@ import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.AuthorizationCodeItem;
 
 public class AuthorizationCodeService {
-    private final static String AUTH_CODE_TABLE_NAME_SUFFIX = "-auth-codes";
-
     private final DataStore<AuthorizationCodeItem> dataStore;
     private final ConfigurationService configurationService;
 
     public AuthorizationCodeService() {
         this.configurationService = ConfigurationService.getInstance();
-        String tableName = configurationService.getEnvironmentName() + AUTH_CODE_TABLE_NAME_SUFFIX;
-        this.dataStore = new DataStore<>(tableName, AuthorizationCodeItem.class);
+        this.dataStore = new DataStore<>(configurationService.getAuthCodesTableName(), AuthorizationCodeItem.class);
     }
 
     public AuthorizationCodeService(DataStore<AuthorizationCodeItem> dataStore, ConfigurationService configurationService) {

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.service;
+
+public class ConfigurationService {
+
+    private static ConfigurationService configurationService;
+
+    public static ConfigurationService getInstance() {
+        if (configurationService == null) {
+            configurationService = new ConfigurationService();
+        }
+        return configurationService;
+    }
+
+    public boolean isRunningLocally() {
+        return Boolean.parseBoolean(System.getenv("IS_LOCAL")) ;
+    }
+
+    public String getEnvironmentName() {
+        return System.getenv("ENVIRONMENT");
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -15,7 +15,7 @@ public class ConfigurationService {
         return Boolean.parseBoolean(System.getenv("IS_LOCAL")) ;
     }
 
-    public String getEnvironmentName() {
-        return System.getenv("ENVIRONMENT");
+    public String getAuthCodesTableName() {
+        return System.getenv("AUTH_CODES_TABLE_NAME");
     }
 }

--- a/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
@@ -19,17 +19,19 @@ import static org.mockito.Mockito.when;
 
 public class AuthorizationHandlerTest {
     private final Context context = mock(Context.class);
-    private final AuthorizationCodeService authorizationCodeService = mock(AuthorizationCodeService.class);
+    private AuthorizationCodeService mockAuthorizationCodeService;
 
     private AuthorizationHandler handler;
     private AuthorizationCode authorizationCode;
 
     @BeforeEach
     public void setUp() {
-        authorizationCode = new AuthorizationCode();
-        when(authorizationCodeService.generateAuthorisationCode()).thenReturn(authorizationCode);
+        mockAuthorizationCodeService = mock(AuthorizationCodeService.class);
 
-        handler = new AuthorizationHandler(authorizationCodeService);
+        authorizationCode = new AuthorizationCode();
+        when(mockAuthorizationCodeService.generateAuthorizationCode()).thenReturn(authorizationCode);
+
+        handler = new AuthorizationHandler(mockAuthorizationCodeService);
     }
 
     @Test

--- a/terraform/lambda/authorize.tf
+++ b/terraform/lambda/authorize.tf
@@ -10,4 +10,8 @@ module "authorize" {
   handler                = "uk.gov.di.ipv.lambda.AuthorizationHandler::handleRequest"
   function_name          = "${var.environment}-authorize"
   role_name              = "${var.environment}-authorize-role"
+
+  allow_access_to_auth_codes_table = true
+  auth_codes_table_policy_arn      = aws_iam_policy.access-auth-codes-table.arn
+  auth_codes_table_name            = aws_dynamodb_table.auth-codes.name
 }

--- a/terraform/lambda/dynamodb.tf
+++ b/terraform/lambda/dynamodb.tf
@@ -1,16 +1,29 @@
 resource "aws_dynamodb_table" "user-issued-credentials" {
   name         = "${var.environment}-user-issued-credentials"
-  hash_key     = "SessionId"
-  range_key    = "CredentialIssuer"
+  hash_key     = "sessionId"
+  range_key    = "credentialIssuer"
   billing_mode = "PAY_PER_REQUEST"
 
   attribute {
-    name = "SessionId"
+    name = "sessionId"
     type = "S"
   }
 
   attribute {
-    name = "CredentialIssuer"
+    name = "credentialIssuer"
+    type = "S"
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_dynamodb_table" "auth-codes" {
+  name         = "${var.environment}-auth-codes"
+  hash_key     = "sessionId"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "sessionId"
     type = "S"
   }
 
@@ -39,6 +52,34 @@ resource "aws_iam_policy" "access-user-issued-credentials-table" {
         Resource = [
           aws_dynamodb_table.user-issued-credentials.arn,
           "${aws_dynamodb_table.user-issued-credentials.arn}/index/*"
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "access-auth-codes-table" {
+  name = "access-auth-codes-table"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "AccessAuthCodesTable"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:BatchWriteItem",
+          "dynamodb:GetItem",
+          "dynamodb:BatchGetItem",
+          "dynamodb:Scan",
+          "dynamodb:Query",
+          "dynamodb:ConditionCheckItem"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_dynamodb_table.auth-codes.arn,
+          "${aws_dynamodb_table.auth-codes.arn}/index/*"
         ]
       },
     ]

--- a/terraform/lambda/token.tf
+++ b/terraform/lambda/token.tf
@@ -10,4 +10,8 @@ module "token" {
   handler                = "uk.gov.di.ipv.lambda.AccessTokenHandler::handleRequest"
   function_name          = "${var.environment}-token"
   role_name              = "${var.environment}-token-role"
+
+  allow_access_to_auth_codes_table = true
+  auth_codes_table_policy_arn      = aws_iam_policy.access-auth-codes-table.arn
+  auth_codes_table_name            = aws_dynamodb_table.auth-codes.name
 }

--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -30,3 +30,8 @@ resource "aws_iam_role_policy_attachment" "user_issued_credentials_table_policy_
   policy_arn = var.user_issued_credentials_table_policy_arn
 }
 
+resource "aws_iam_role_policy_attachment" "auth_codes_table_policy_to_lambda_iam_role" {
+  count      = var.allow_access_to_auth_codes_table ? 1 : 0
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = var.auth_codes_table_policy_arn
+}

--- a/terraform/modules/endpoint/main.tf
+++ b/terraform/modules/endpoint/main.tf
@@ -22,6 +22,7 @@ resource "aws_lambda_function" "lambda_function" {
   environment {
     variables = {
       USER_ISSUED_CREDENTIALS_TABLE_NAME = var.user_issued_credentials_table_name
+      AUTH_CODES_TABLE_NAME = var.auth_codes_table_name
     }
   }
 

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -60,6 +60,24 @@ variable "user_issued_credentials_table_name" {
   description = "Name of the DynamoDB user-credentials table"
 }
 
+variable "allow_access_to_auth_codes_table" {
+  type        = bool
+  default     = false
+  description = "Should the lambda be given access to the auth-codes DynamoDB table"
+}
+
+variable "auth_codes_table_policy_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the policy to allow read write to the auth-codes DynamoDB table"
+}
+
+variable "auth_codes_table_name" {
+  type        = string
+  default     = "not-set-for-this-lambda"
+  description = "Name of the DynamoDB auth-codes table"
+}
+
 locals {
   default_tags = {
     Environment = var.environment


### PR DESCRIPTION
Co-authored-by: Tal Nagra <tal.nagra@digital.cabinet-office.gov.uk>

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Create generic DataStore that uses the DynamoDbEhancedClient to interact with our DB.
Create a configuration service to load and configure the DataStore with environment varaiables
Persist the generated auth code from within the authorisation handler
<!-- Describe the changes in detail - the "what"-->

### Why did it change
So that when a request to exchange an auth code for a access token comes through, we can validate if their auth code is one that was generated via us and for the correct sessionID.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-395](https://govukverify.atlassian.net/browse/PYI-395)

## Checklists

### Environment variables or secrets

IS_LOCAL - used to configure the correct type of DynamoDb client, i.e one pointing to real aws or to localhost
ENVIRONMENT - used in the construction of dynamodb table names i.e "{environment}-auth-codes"

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [x] Added to local startup repository
