### PR TITLE
BAU: Enums should use CONSTANT_CASE

### DIFF
--- a/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
@@ -5,17 +5,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorResponse {
-    MissingQueryParameters(1000, "Missing query parameters for auth request"),
-    MissingRedirectURI(1001, "Redirect URI is missing from auth request"),
-    FailedToParseTokenRequest(1002, "Failed to parse token request"),
-    MissingAuthorizationCode(1003, "Missing authorization code"),
-    FailedToExchangeAuthorizationCode(1004, "Failed to exchange the authorization code for an access token"),
-    MissingAccessToken(1005, "Missing access token from user info request"),
-    FailedToParseAccessToken(1006, "Failed to parse access token"),
-    MissingCredentialIssuerId(1007, "Missing credential issuer id"),
-    InvalidCredentialIssuerId(1008, "Invalid credential issuer id"),
-    InvalidTokenRequest(1009, "Invalid token request"),
-    MissingSessionId(1010, "Missing session id");
+    MISSING_QUERY_PARAMETERS(1000, "Missing query parameters for auth request"),
+    MISSING_REDIRECT_URI(1001, "Redirect URI is missing from auth request"),
+    FAILED_TO_PARSE_TOKEN_REQUEST(1002, "Failed to parse token request"),
+    MISSING_AUTHORIZATION_CODE(1003, "Missing authorization code"),
+    FAILED_TO_EXCHANGE_AUTHORIZATION_CODE(1004, "Failed to exchange the authorization code for an access token"),
+    MISSING_ACCESS_TOKEN(1005, "Missing access token from user info request"),
+    FAILED_TO_PARSE_ACCESS_TOKEN(1006, "Failed to parse access token"),
+    MISSING_CREDENTIAL_ISSUER_ID(1007, "Missing credential issuer id"),
+    INVALID_CREDENTIAL_ISSUER_ID(1008, "Invalid credential issuer id"),
+    INVALID_TOKEN_REQUEST(1009, "Invalid token request"),
+    MISSING_SESSION_ID(1010, "Missing session id");
 
     @JsonProperty("code")
     private int code;

--- a/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
@@ -42,7 +42,7 @@ public class AccessTokenHandler
 
             if (tokenRequestDto.getCode().isEmpty()) {
                 LOGGER.error("Missing authorisation code from the token request");
-                return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingAuthorizationCode);
+                return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MISSING_AUTHORIZATION_CODE);
             }
 
             TokenRequest tokenRequest = new TokenRequest(
@@ -58,7 +58,7 @@ public class AccessTokenHandler
             if (tokenResponse instanceof TokenErrorResponse) {
                 TokenErrorResponse tokenErrorResponse = tokenResponse.toErrorResponse();
                 LOGGER.error(tokenErrorResponse.getErrorObject().getDescription());
-                return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.FailedToExchangeAuthorizationCode);
+                return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.FAILED_TO_EXCHANGE_AUTHORIZATION_CODE);
             }
 
             AccessTokenResponse accessTokenResponse = tokenResponse.toSuccessResponse();
@@ -66,7 +66,7 @@ public class AccessTokenHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, accessTokenResponse.toJSONObject());
         } catch (IllegalArgumentException e) {
             LOGGER.error("Token request could not be parsed", e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.FailedToParseTokenRequest);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.FAILED_TO_PARSE_TOKEN_REQUEST);
         }
     }
 }

--- a/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.service.AuthorizationCodeService;
-import uk.gov.di.ipv.service.ConfigurationService;
 
 import java.util.Collections;
 import java.util.List;
@@ -43,13 +42,13 @@ public class AuthorizationHandler
         try {
             if (queryStringParameters == null || queryStringParameters.isEmpty()) {
                 LOGGER.error("Missing required query parameters for authorisation request");
-                return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingQueryParameters);
+                return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MISSING_QUERY_PARAMETERS);
             }
             AuthenticationRequest.parse(queryStringParameters);
             LOGGER.info("Successfully parsed authentication request");
         } catch (ParseException e) {
             LOGGER.error("Authentication request could not be parsed", e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingRedirectURI);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MISSING_REDIRECT_URI);
         }
 
         AuthorizationCode authorizationCode = authorizationCodeService.generateAuthorizationCode();

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -56,26 +56,26 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, Collections.EMPTY_MAP);
         } catch (CredentialIssuerException e) {
             LOGGER.error("Could not exchange authorization code for token: {}", e.getMessage(), e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.InvalidTokenRequest);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.INVALID_TOKEN_REQUEST);
         }
 
     }
 
     private Optional<ErrorResponse> validate(CredentialIssuerRequestDto request) {
         if (StringUtils.isBlank(request.getAuthorizationCode())) {
-            return Optional.of(ErrorResponse.MissingAuthorizationCode);
+            return Optional.of(ErrorResponse.MISSING_AUTHORIZATION_CODE);
         }
 
         if (StringUtils.isBlank(request.getCredentialIssuerId())) {
-            return Optional.of(ErrorResponse.MissingCredentialIssuerId);
+            return Optional.of(ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
         }
 
         if (StringUtils.isBlank(request.getIpvSessionId())) {
-            return Optional.of(ErrorResponse.MissingSessionId);
+            return Optional.of(ErrorResponse.MISSING_SESSION_ID);
         }
 
         if (getCredentialIssuerConfig(request) == null) {
-            return Optional.of(ErrorResponse.InvalidCredentialIssuerId);
+            return Optional.of(ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
         }
         return Optional.empty();
     }

--- a/src/main/java/uk/gov/di/ipv/lambda/UserInfoHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/UserInfoHandler.java
@@ -35,7 +35,7 @@ public class UserInfoHandler implements RequestHandler<APIGatewayProxyRequestEve
         var accessTokenString = RequestHelper.getHeader(input.getHeaders(), AUTHORIZATION_HEADER);
         if (accessTokenString.isEmpty()) {
             LOGGER.error("Missing access token from Authorization header");
-            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MissingAccessToken);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.MISSING_ACCESS_TOKEN);
         }
 
         try {
@@ -45,7 +45,7 @@ public class UserInfoHandler implements RequestHandler<APIGatewayProxyRequestEve
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, userInfo);
         } catch (ParseException e) {
             LOGGER.error("Failed to parse access token");
-            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.FailedToParseAccessToken);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(400, ErrorResponse.FAILED_TO_PARSE_ACCESS_TOKEN);
         }
     }
 }

--- a/src/test/java/uk/gov/di/ipv/lambda/AccessTokenHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AccessTokenHandlerTest.java
@@ -76,8 +76,8 @@ public class AccessTokenHandlerTest {
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.FailedToParseTokenRequest.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.FailedToParseTokenRequest.getMessage(), responseBody.get("message"));
+        assertEquals(ErrorResponse.FAILED_TO_PARSE_TOKEN_REQUEST.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.FAILED_TO_PARSE_TOKEN_REQUEST.getMessage(), responseBody.get("message"));
     }
 
     @Test
@@ -97,8 +97,8 @@ public class AccessTokenHandlerTest {
         Map<String, String> responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.FailedToExchangeAuthorizationCode.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.FailedToExchangeAuthorizationCode.getMessage(), responseBody.get("message"));
+        assertEquals(ErrorResponse.FAILED_TO_EXCHANGE_AUTHORIZATION_CODE.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.FAILED_TO_EXCHANGE_AUTHORIZATION_CODE.getMessage(), responseBody.get("message"));
     }
 
     @Test
@@ -115,7 +115,7 @@ public class AccessTokenHandlerTest {
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MissingAuthorizationCode.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.MissingAuthorizationCode.getMessage(), responseBody.get("message"));
+        assertEquals(ErrorResponse.MISSING_AUTHORIZATION_CODE.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_AUTHORIZATION_CODE.getMessage(), responseBody.get("message"));
     }
 }

--- a/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
@@ -83,8 +83,8 @@ public class AuthorizationHandlerTest {
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MissingRedirectURI.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.MissingRedirectURI.getMessage(), responseBody.get("message"));
+        assertEquals(ErrorResponse.MISSING_REDIRECT_URI.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_REDIRECT_URI.getMessage(), responseBody.get("message"));
     }
 
     @Test
@@ -102,8 +102,8 @@ public class AuthorizationHandlerTest {
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MissingRedirectURI.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.MissingRedirectURI.getMessage(), responseBody.get("message"));
+        assertEquals(ErrorResponse.MISSING_REDIRECT_URI.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_REDIRECT_URI.getMessage(), responseBody.get("message"));
     }
 
     @Test
@@ -121,8 +121,8 @@ public class AuthorizationHandlerTest {
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MissingRedirectURI.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.MissingRedirectURI.getMessage(), responseBody.get("message"));
+        assertEquals(ErrorResponse.MISSING_REDIRECT_URI.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_REDIRECT_URI.getMessage(), responseBody.get("message"));
     }
 
     @Test
@@ -140,8 +140,8 @@ public class AuthorizationHandlerTest {
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MissingRedirectURI.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.MissingRedirectURI.getMessage(), responseBody.get("message"));
+        assertEquals(ErrorResponse.MISSING_REDIRECT_URI.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_REDIRECT_URI.getMessage(), responseBody.get("message"));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class AuthorizationHandlerTest {
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MissingQueryParameters.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.MissingQueryParameters.getMessage(), responseBody.get("message"));
+        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
     }
 }

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -50,7 +50,7 @@ class CredentialIssuerHandlerTest {
                 Map.of("credential_issuer_id", "foo"),
                 Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService).handleRequest(input, context);
-        assert400Response(response, ErrorResponse.MissingAuthorizationCode);
+        assert400Response(response, ErrorResponse.MISSING_AUTHORIZATION_CODE);
     }
 
     @Test
@@ -60,7 +60,7 @@ class CredentialIssuerHandlerTest {
                 Map.of("ipv-session-id", sessionId));
 
         APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService).handleRequest(input, context);
-        assert400Response(response, ErrorResponse.MissingCredentialIssuerId);
+        assert400Response(response, ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
     }
 
     @Test
@@ -69,7 +69,7 @@ class CredentialIssuerHandlerTest {
                 Map.of("authorization_code", "foo", "credential_issuer_id", "an invalid id"),
                 Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService).handleRequest(input, context);
-        assert400Response(response, ErrorResponse.InvalidCredentialIssuerId);
+        assert400Response(response, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
     }
 
     @Test
@@ -78,7 +78,7 @@ class CredentialIssuerHandlerTest {
                 Map.of("authorization_code", "foo", "credential_issuer_id", passportIssuerId),
                 Map.of());
         APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService).handleRequest(input, context);
-        assert400Response(response, ErrorResponse.MissingSessionId);
+        assert400Response(response, ErrorResponse.MISSING_SESSION_ID);
     }
 
     @Test
@@ -119,7 +119,7 @@ class CredentialIssuerHandlerTest {
         Integer statusCode = response.getStatusCode();
         Map responseBody = getResponseBodyAsMap(response);
         assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
-        assertEquals(ErrorResponse.InvalidTokenRequest.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.INVALID_TOKEN_REQUEST.getCode(), responseBody.get("code"));
         verifyNoInteractions(context);
     }
 

--- a/src/test/java/uk/gov/di/ipv/lambda/UserInfoHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/UserInfoHandlerTest.java
@@ -86,7 +86,7 @@ class UserInfoHandlerTest {
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, context);
         responseBody = objectMapper.readValue(response.getBody(), Map.class);
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MissingAccessToken.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_ACCESS_TOKEN.getCode(), responseBody.get("code"));
         assertEquals("Missing access token from user info request", responseBody.get("message"));
     }
 
@@ -99,7 +99,7 @@ class UserInfoHandlerTest {
         responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.FailedToParseAccessToken.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.FAILED_TO_PARSE_ACCESS_TOKEN.getCode(), responseBody.get("code"));
         assertEquals("Failed to parse access token", responseBody.get("message"));
 
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Update enums in `ErrorResponse` to use CONSTANT_CASE.

### Why did it change

The GDS Way java style guide (via the google java style guide) mandates that enums should be named with CONSTANT_CASE. Unless we have a very good reason not to, we should stick to this.
