### PR TITLE
PYI-363: Fetch credential from credential issuer

### DIFF
--- a/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
@@ -15,7 +15,8 @@ public enum ErrorResponse {
     MISSING_CREDENTIAL_ISSUER_ID(1007, "Missing credential issuer id"),
     INVALID_CREDENTIAL_ISSUER_ID(1008, "Invalid credential issuer id"),
     INVALID_TOKEN_REQUEST(1009, "Invalid token request"),
-    MISSING_SESSION_ID(1010, "Missing session id");
+    MISSING_SESSION_ID(1010, "Missing session id"),
+    FAILED_TO_GET_CREDENTIAL_FROM_ISSUER(1011, "Failed to get credential from issuer");
 
     @JsonProperty("code")
     private int code;

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
@@ -7,10 +7,12 @@ public class CredentialIssuerConfig {
 
     private final String id;
     private final URI tokenUrl;
+    private final URI credentialUrl;
 
-    public CredentialIssuerConfig(String id, URI tokenUrl) {
+    public CredentialIssuerConfig(String id, URI tokenUrl, URI credentialUrl) {
         this.id = id;
         this.tokenUrl = tokenUrl;
+        this.credentialUrl = credentialUrl;
     }
 
     public String getId() {
@@ -19,6 +21,10 @@ public class CredentialIssuerConfig {
 
     public URI getTokenUrl() {
         return tokenUrl;
+    }
+
+    public URI getCredentialUrl() {
+        return credentialUrl;
     }
 
     @Override

--- a/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/CredentialIssuerServiceTest.java
@@ -4,6 +4,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
@@ -11,9 +13,7 @@ import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
 
 import java.net.URI;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,9 +35,7 @@ class CredentialIssuerServiceTest {
                 "cred_issuer_id_1",
                 "http://www.example.com/redirect"
         );
-        CredentialIssuerConfig credentialIssuerConfig = new CredentialIssuerConfig(
-                "StubPassport",
-                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"));
+        CredentialIssuerConfig credentialIssuerConfig = getStubCredentialIssuerConfig(wmRuntimeInfo);
 
         AccessToken accessToken = credentialIssuerService.exchangeCodeForToken(credentialIssuerRequestDto, credentialIssuerConfig);
         AccessTokenType type = accessToken.getType();
@@ -63,9 +61,7 @@ class CredentialIssuerServiceTest {
                 "cred_issuer_id_1",
                 "http://www.example.com/redirect"
         );
-        CredentialIssuerConfig credentialIssuerConfig = new CredentialIssuerConfig(
-                "StubPassport",
-                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"));
+        CredentialIssuerConfig credentialIssuerConfig = getStubCredentialIssuerConfig(wmRuntimeInfo);
 
         CredentialIssuerException exception = assertThrows(CredentialIssuerException.class, () -> {
             credentialIssuerService.exchangeCodeForToken(credentialIssuerRequestDto, credentialIssuerConfig);
@@ -89,12 +85,9 @@ class CredentialIssuerServiceTest {
                 "cred_issuer_id_1",
                 "http://www.example.com/redirect"
         );
-        CredentialIssuerConfig credentialIssuerConfig = new CredentialIssuerConfig(
-                "StubPassport",
-                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"));
-
+        CredentialIssuerConfig credentialIssuerConfig = getStubCredentialIssuerConfig(wmRuntimeInfo);
         CredentialIssuerException exception = assertThrows(CredentialIssuerException.class, () -> {
-            AccessToken accessToken = credentialIssuerService.exchangeCodeForToken(credentialIssuerRequestDto, credentialIssuerConfig);
+            credentialIssuerService.exchangeCodeForToken(credentialIssuerRequestDto, credentialIssuerConfig);
         });
 
         String expectedMessage = "The HTTP Content-Type header must be application/json";
@@ -102,4 +95,84 @@ class CredentialIssuerServiceTest {
         assertTrue(actualMessage.contains(expectedMessage));
     }
 
+    @Test
+    void getCredentialCorrectlyCallsACredentialIssuer(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get("/credential")
+                .willReturn(
+                        aResponse()
+                        .withHeader("Content-Type", "application/json;charset=UTF-8")
+                        .withBody("{\"id\": \"some-resource-id\", \"evidenceType\": \"passport\", \"evidenceID\": \"passport-abc-12345\"}")
+                )
+        );
+
+        CredentialIssuerService credentialIssuerService = new CredentialIssuerService();
+        CredentialIssuerConfig credentialIssuerConfig = getStubCredentialIssuerConfig(wmRuntimeInfo);;
+        BearerAccessToken accessToken = new BearerAccessToken();
+
+        JSONObject credential = credentialIssuerService.getCredential(accessToken, credentialIssuerConfig);
+
+        assertEquals(credential.get("id"), "some-resource-id");
+        assertEquals(credential.get("evidenceType"), "passport");
+        assertEquals(credential.get("evidenceID"), "passport-abc-12345");
+
+        verify(
+                getRequestedFor(
+                        urlEqualTo("/credential")
+                ).withHeader(
+                        "Authorization",
+                        equalTo("Bearer " + accessToken.getValue())
+                )
+        );
+    }
+
+    @Test
+    void getCredentialThrowsIfResponseIsNotOk(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get("/credential")
+                .willReturn(
+                        aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Something bad happened...")
+                )
+        );
+
+        CredentialIssuerService credentialIssuerService = new CredentialIssuerService();
+        CredentialIssuerConfig credentialIssuerConfig = getStubCredentialIssuerConfig(wmRuntimeInfo);;
+        BearerAccessToken accessToken = new BearerAccessToken();
+
+        CredentialIssuerException thrown = assertThrows(CredentialIssuerException.class, () -> {
+            credentialIssuerService.getCredential(accessToken, credentialIssuerConfig);
+        });
+
+        assertTrue(thrown.getMessage().contains("500: Server Error"));
+    }
+
+    @Test
+    void getCredentialThrowsIfNotValidJsonInResponse(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get("/credential")
+                .willReturn(
+                        aResponse()
+                        .withHeader("Content-Type", "application/json;charset=UTF-8")
+                        .withBody("What on earth is this?")
+                )
+        );
+
+        CredentialIssuerService credentialIssuerService = new CredentialIssuerService();
+        CredentialIssuerConfig credentialIssuerConfig = getStubCredentialIssuerConfig(wmRuntimeInfo);
+        BearerAccessToken accessToken = new BearerAccessToken();
+
+        CredentialIssuerException thrown = assertThrows(CredentialIssuerException.class, () -> {
+            credentialIssuerService.getCredential(accessToken, credentialIssuerConfig);
+        });
+
+        assertTrue(thrown.getMessage().contains("ParseException: Invalid JSON: Unexpected token What on earth is this?"));
+    }
+
+    private CredentialIssuerConfig getStubCredentialIssuerConfig(WireMockRuntimeInfo wmRuntimeInfo) {
+        return new CredentialIssuerConfig(
+                "StubPassport",
+                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"),
+                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/credential")
+        );
+    }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Adds a new method to the CredentialIssuerService to fetch the protected
resource credential from the credential issuer.

Currently this just returns the credential as a JSON object as that's
what the stub returns.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-363](https://govukverify.atlassian.net/browse/PYI-363)