### PR TITLE
PYI-403: Provide credential-issuer config to lambda

### DIFF
--- a/terraform/lambda/credential-issuer.tf
+++ b/terraform/lambda/credential-issuer.tf
@@ -10,4 +10,6 @@ module "credential-issuer" {
   handler                = "uk.gov.di.ipv.lambda.CredentialIssuerHandler::handleRequest"
   function_name          = "${var.environment}-credential-issuer"
   role_name              = "${var.environment}-credential-issuer-role"
+
+  credential_issuer_config = var.credential_issuer_config
 }

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -7,6 +7,12 @@ variable "use_localstack" {
   default = false
 }
 
+variable "credential_issuer_config" {
+  type = string
+  default = null
+  description = "Base64 encoded YAML credential issuer config"
+}
+
 locals {
   default_tags = var.use_localstack ? null : {
     Environment = var.environment

--- a/terraform/modules/endpoint/main.tf
+++ b/terraform/modules/endpoint/main.tf
@@ -23,6 +23,7 @@ resource "aws_lambda_function" "lambda_function" {
     variables = {
       USER_ISSUED_CREDENTIALS_TABLE_NAME = var.user_issued_credentials_table_name
       AUTH_CODES_TABLE_NAME = var.auth_codes_table_name
+      CREDENTIAL_ISSUER_CONFIG = var.credential_issuer_config
     }
   }
 

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -78,6 +78,12 @@ variable "auth_codes_table_name" {
   description = "Name of the DynamoDB auth-codes table"
 }
 
+variable "credential_issuer_config" {
+  type = string
+  default = null
+  description = "Base64 encoded YAML credential issuer config"
+}
+
 locals {
   default_tags = {
     Environment = var.environment


### PR DESCRIPTION
**To be merged with https://github.com/alphagov/di-ipv-config/pull/53**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds terraform to set an env variable on the credential issuer lambda
that will contain a base64 encoded string of a yaml file defined in the
di-ipv-config repo.

Co-authored-by: Dan Pomfret <daniel.pomfret@digital.cabinet-office.gov.uk>


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-403](https://govukverify.atlassian.net/browse/PYI-403)
