### PR TITLE
PYI-403: credential issuer config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,9 @@ dependencies {
             "com.fasterxml.jackson.core:jackson-annotations:2.13.0",
             "org.apache.httpcomponents:httpclient:4.5.13",
             "org.slf4j:slf4j-simple:1.7.32",
-            "software.amazon.awssdk:dynamodb-enhanced:2.17.89"
+            "software.amazon.awssdk:dynamodb-enhanced:2.17.89",
+            "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
+            "software.amazon.lambda:powertools-parameters:1.8.0"
 
 
     compileOnly 'org.projectlombok:lombok:1.18.22'

--- a/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/domain/ErrorResponse.java
@@ -18,13 +18,14 @@ public enum ErrorResponse {
     MISSING_IPV_SESSION_ID(1010, "Missing ipv session id header"),
     FAILED_TO_GET_CREDENTIAL_FROM_ISSUER(1011, "Failed to get credential from issuer"),
     FAILED_TO_SAVE_CREDENTIAL(1012, "Failed to save credential"),
-    FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS(1013, "Failed to parse oauth2-specific query string parameters");
+    FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS(1013, "Failed to parse oauth2-specific query string parameters"),
+    FAILED_TO_DECODE_CREDENTIAL_ISSUER_CONFIG(1014, "Failed to decode credential issuers config to credential issuers object");
 
     @JsonProperty("code")
-    private int code;
+    private final int code;
 
     @JsonProperty("message")
-    private String message;
+    private final String message;
 
     ErrorResponse(
             @JsonProperty(required = true, value = "code") int code,

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
@@ -5,9 +5,11 @@ import java.util.Objects;
 
 public class CredentialIssuerConfig {
 
-    private final String id;
-    private final URI tokenUrl;
-    private final URI credentialUrl;
+    private String id;
+    private URI tokenUrl;
+    private URI credentialUrl;
+
+    public CredentialIssuerConfig() {}
 
     public CredentialIssuerConfig(String id, URI tokenUrl, URI credentialUrl) {
         this.id = id;
@@ -33,6 +35,13 @@ public class CredentialIssuerConfig {
         if (o == null || getClass() != o.getClass()) return false;
         CredentialIssuerConfig that = (CredentialIssuerConfig) o;
         return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public String toString() {
+        return "CredentialIssuerConfig{" +
+                "id='" + id + '\'' +
+                '}';
     }
 
     @Override

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
@@ -1,0 +1,42 @@
+package uk.gov.di.ipv.dto;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+public class CredentialIssuers {
+
+    private final Set<CredentialIssuerConfig> credentialIssuerConfigs;
+
+    public CredentialIssuers() {
+        credentialIssuerConfigs = Collections.emptySet();
+    }
+
+    public CredentialIssuers(Set<CredentialIssuerConfig> credentialIssuerConfigs) {
+        this.credentialIssuerConfigs = credentialIssuerConfigs;
+    }
+
+    public Set<CredentialIssuerConfig> getCredentialIssuerConfigs() {
+        return credentialIssuerConfigs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CredentialIssuers that = (CredentialIssuers) o;
+        return Objects.equals(credentialIssuerConfigs, that.credentialIssuerConfigs);
+    }
+
+    @Override
+    public String toString() {
+        return "CredentialIssuers{" +
+                "credentialIssuerConfigs=" + credentialIssuerConfigs +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(credentialIssuerConfigs);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/helpers/CredentialIssuerLoader.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/CredentialIssuerLoader.java
@@ -1,0 +1,35 @@
+package uk.gov.di.ipv.helpers;
+
+import com.amazonaws.util.Base64;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.domain.CredentialIssuerException;
+import uk.gov.di.ipv.domain.ErrorResponse;
+import uk.gov.di.ipv.dto.CredentialIssuers;
+
+import java.io.IOException;
+
+public class CredentialIssuerLoader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CredentialIssuerLoader.class);
+
+    public static CredentialIssuers loadCredentialIssuers(String credentialIssuerConfigBase64) {
+        YAMLFactory yamlFactory = new YAMLFactory();
+        ObjectMapper mapper = new ObjectMapper(yamlFactory);
+        CredentialIssuers credentialIssuers;
+        try {
+            byte[] decode = Base64.decode(credentialIssuerConfigBase64);
+            YAMLParser yamlParser = yamlFactory.createParser(decode);
+            credentialIssuers = mapper.readValue(yamlParser, CredentialIssuers.class);
+            LOGGER.info("Loaded Credential Issuers: {}", credentialIssuers.toString());
+        } catch (IllegalArgumentException | IOException e) {
+            throw new CredentialIssuerException(HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_DECODE_CREDENTIAL_ISSUER_CONFIG);
+        }
+
+        return credentialIssuers;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/helpers/CredentialIssuerLoader.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/CredentialIssuerLoader.java
@@ -17,6 +17,8 @@ public class CredentialIssuerLoader {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CredentialIssuerLoader.class);
 
+    private CredentialIssuerLoader() {}
+
     public static CredentialIssuers loadCredentialIssuers(String credentialIssuerConfigBase64) {
         YAMLFactory yamlFactory = new YAMLFactory();
         ObjectMapper mapper = new ObjectMapper(yamlFactory);
@@ -25,7 +27,7 @@ public class CredentialIssuerLoader {
             byte[] decode = Base64.decode(credentialIssuerConfigBase64);
             YAMLParser yamlParser = yamlFactory.createParser(decode);
             credentialIssuers = mapper.readValue(yamlParser, CredentialIssuers.class);
-            LOGGER.info("Loaded Credential Issuers: {}", credentialIssuers.toString());
+            LOGGER.info("Loaded Credential Issuers: {}", credentialIssuers);
         } catch (IllegalArgumentException | IOException e) {
             throw new CredentialIssuerException(HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_DECODE_CREDENTIAL_ISSUER_CONFIG);
         }

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -25,18 +25,14 @@ public class CredentialIssuerHandler implements RequestHandler<APIGatewayProxyRe
 
     private final CredentialIssuers credentialIssuers;
 
-    private final ConfigurationService configurationService;
-
     public CredentialIssuerHandler(CredentialIssuerService credentialIssuerService, ConfigurationService configurationService) {
         this.credentialIssuerService = credentialIssuerService;
-        this.configurationService = configurationService;
         this.credentialIssuers = configurationService.getCredentialIssuers();
     }
 
     public CredentialIssuerHandler() {
-        this.configurationService = new ConfigurationService();
         this.credentialIssuerService = new CredentialIssuerService();
-        this.credentialIssuers = configurationService.getCredentialIssuers();
+        this.credentialIssuers = new ConfigurationService().getCredentialIssuers();
     }
 
     @Override

--- a/src/main/java/uk/gov/di/ipv/persistence/DataStore.java
+++ b/src/main/java/uk/gov/di/ipv/persistence/DataStore.java
@@ -25,8 +25,7 @@ public class DataStore<T> {
     public DataStore(String tableName, Class<T> typeParameterClass) {
         this.tableName = tableName;
         this.typeParameterClass = typeParameterClass;
-
-        configurationService = ConfigurationService.getInstance();
+        this.configurationService = new ConfigurationService();
 
         DynamoDbClient client = configurationService.isRunningLocally()
                 ? createLocalDbClient()

--- a/src/main/java/uk/gov/di/ipv/service/AccessTokenService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AccessTokenService.java
@@ -20,7 +20,7 @@ public class AccessTokenService {
     private final ConfigurationService configurationService;
 
     public AccessTokenService() {
-        this.configurationService = ConfigurationService.getInstance();
+        this.configurationService = new ConfigurationService();
         this.dataStore = new DataStore<>(configurationService.getAccessTokensTableName(), AccessTokenItem.class);
     }
 

--- a/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
@@ -11,7 +11,7 @@ public class AuthorizationCodeService {
     private final ConfigurationService configurationService;
 
     public AuthorizationCodeService() {
-        this.configurationService = ConfigurationService.getInstance();
+        this.configurationService = new ConfigurationService();
         this.dataStore = new DataStore<>(configurationService.getAuthCodesTableName(), AuthorizationCodeItem.class);
     }
 

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -29,15 +29,17 @@ public class ConfigurationService {
     }
 
     public CredentialIssuers getCredentialIssuers() {
-        String value = ssmProvider.get("credentialIssuerConfig");
-        return CredentialIssuerLoader.loadCredentialIssuers(value);
+        return CredentialIssuerLoader.loadCredentialIssuers(
+            ssmProvider.get(System.getenv("CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY")));
     }
 
     public String getUserIssuedCredentialTableName() {
         return System.getenv("USER_ISSUED_CREDENTIALS_TABLE_NAME");
     }
 
-    public String getAccessTokensTableName() { return System.getenv("ACCESS_TOKENS_TABLE_NAME"); }
+    public String getAccessTokensTableName() {
+        return System.getenv("ACCESS_TOKENS_TABLE_NAME");
+    }
 
     public String getIpvSessionTableName() {
         return System.getenv("IPV_SESSIONS_TABLE_NAME");
@@ -45,8 +47,8 @@ public class ConfigurationService {
 
     public long getBearerAccessTokenTtl() {
         return Optional.of(System.getenv("BEARER_TOKEN_TTL"))
-                .map(Long::valueOf)
-                .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
+            .map(Long::valueOf)
+            .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
     }
 
 }

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -1,26 +1,36 @@
 package uk.gov.di.ipv.service;
 
 import java.util.Optional;
+import software.amazon.lambda.powertools.parameters.ParamManager;
+import software.amazon.lambda.powertools.parameters.SSMProvider;
+import uk.gov.di.ipv.dto.CredentialIssuers;
+import uk.gov.di.ipv.helpers.CredentialIssuerLoader;
 
 public class ConfigurationService {
 
     private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
 
-    private static ConfigurationService configurationService;
+    private final SSMProvider ssmProvider;
 
-    public static ConfigurationService getInstance() {
-        if (configurationService == null) {
-            configurationService = new ConfigurationService();
-        }
-        return configurationService;
+    public ConfigurationService(SSMProvider ssmProvider) {
+        this.ssmProvider = ssmProvider;
+    }
+
+    public ConfigurationService() {
+        this.ssmProvider = ParamManager.getSsmProvider();
     }
 
     public boolean isRunningLocally() {
-        return Boolean.parseBoolean(System.getenv("IS_LOCAL")) ;
+        return Boolean.parseBoolean(System.getenv("IS_LOCAL"));
     }
 
     public String getAuthCodesTableName() {
         return System.getenv("AUTH_CODES_TABLE_NAME");
+    }
+
+    public CredentialIssuers getCredentialIssuers() {
+        String value = ssmProvider.get("credentialIssuerConfig");
+        return CredentialIssuerLoader.loadCredentialIssuers(value);
     }
 
     public String getUserIssuedCredentialTableName() {

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -30,7 +30,7 @@ public class CredentialIssuerService {
     private final ConfigurationService configurationService;
 
     public CredentialIssuerService() {
-        this.configurationService = ConfigurationService.getInstance();
+        this.configurationService =  new ConfigurationService();
         this.dataStore = new DataStore<>(configurationService.getUserIssuedCredentialTableName(), UserIssuedCredentialsItem.class);
     }
 

--- a/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
+++ b/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
@@ -12,7 +12,7 @@ public class IpvSessionService {
     private final ConfigurationService configurationService;
 
     public IpvSessionService() {
-        this.configurationService = ConfigurationService.getInstance();
+        this.configurationService = new ConfigurationService();
         dataStore = new DataStore<>(configurationService.getIpvSessionTableName(), IpvSessionItem.class);
     }
 

--- a/src/main/java/uk/gov/di/ipv/service/UserIdentityService.java
+++ b/src/main/java/uk/gov/di/ipv/service/UserIdentityService.java
@@ -8,11 +8,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class UserIdentityService {
-    private ConfigurationService configurationService;
-    private DataStore<UserIssuedCredentialsItem> dataStore;
+    private final ConfigurationService configurationService;
+    private final DataStore<UserIssuedCredentialsItem> dataStore;
 
     public UserIdentityService() {
-        this.configurationService = ConfigurationService.getInstance();
+        this.configurationService = new ConfigurationService();
         this.dataStore = new DataStore<>(configurationService.getUserIssuedCredentialTableName(), UserIssuedCredentialsItem.class);
     }
 

--- a/src/test/java/uk/gov/di/ipv/helpers/CredentialIssuerLoaderTest.java
+++ b/src/test/java/uk/gov/di/ipv/helpers/CredentialIssuerLoaderTest.java
@@ -1,0 +1,37 @@
+package uk.gov.di.ipv.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.domain.CredentialIssuerException;
+import uk.gov.di.ipv.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.dto.CredentialIssuers;
+
+class CredentialIssuerLoaderTest {
+
+    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64 = "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
+
+    private CredentialIssuers expectedCredentialIssuers;
+
+    @BeforeEach
+    void setUp() throws URISyntaxException {
+        expectedCredentialIssuers = new CredentialIssuers(Set.of(new CredentialIssuerConfig("PassportIssuer", new URI("http://www.example.com"), new URI("http://www.example.com/credential")), new CredentialIssuerConfig("FraudIssuer", new URI("http://www.example.com"), new URI("http://www.example.com/credential"))));
+    }
+
+    @Test
+    void shouldLoadCredentialIssuersFromBase64EncodedString() {
+        assertEquals(expectedCredentialIssuers, CredentialIssuerLoader.loadCredentialIssuers(CREDENTIAL_ISSUER_CONFIG_BASE64));
+    }
+
+    @Test
+    void shouldThrowCredentialIssuerExceptionWhenUnableToDecodeString()  {
+        CredentialIssuerException thrownCredentialIssuerException = assertThrows(CredentialIssuerException.class, () -> CredentialIssuerLoader.loadCredentialIssuers("asd"));
+        assertTrue(thrownCredentialIssuerException.getErrorResponse().getMessage().contains("Failed to decode credential issuers config to credential issuers object"));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -110,8 +110,8 @@ class CredentialIssuerHandlerTest {
         ).thenReturn(accessToken);
 
         when(credentialIssuerService.getCredential(
-                eq(accessToken),
-                eq(passportIssuer))
+                accessToken,
+                passportIssuer)
         ).thenReturn(new JSONObject());
 
         CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService, configurationService);

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -1,5 +1,12 @@
 package uk.gov.di.ipv.lambda;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
@@ -7,7 +14,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -16,19 +30,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.domain.ErrorResponse;
+import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
+import uk.gov.di.ipv.dto.CredentialIssuers;
+import uk.gov.di.ipv.service.ConfigurationService;
 import uk.gov.di.ipv.service.CredentialIssuerService;
-
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerHandlerTest {
@@ -42,16 +48,27 @@ class CredentialIssuerHandlerTest {
     @Mock
     CredentialIssuerService credentialIssuerService;
 
+    @Mock
+    ConfigurationService configurationService;
+
     String authorization_code = "bar";
     String sessionId = UUID.randomUUID().toString();
     String passportIssuerId = "PassportIssuer";
+    CredentialIssuerConfig passportIssuer;
+
+    @BeforeEach
+    void setUp() throws URISyntaxException {
+        passportIssuer = new CredentialIssuerConfig("PassportIssuer", new URI("http://www.example.com"), new URI("http://www.example.com/credential"));
+        CredentialIssuers credentialIssuers = new CredentialIssuers(Set.of(passportIssuer));
+        when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuers);
+    }
 
     @Test
     void shouldReceive400ResponseCodeIfAuthorizationCodeNotPresent() throws JsonProcessingException {
         APIGatewayProxyRequestEvent input = createRequestEvent(
                 Map.of("credential_issuer_id", "foo"),
                 Map.of("ipv-session-id", sessionId));
-        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService).handleRequest(input, context);
+        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService, configurationService).handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_AUTHORIZATION_CODE);
     }
 
@@ -61,7 +78,7 @@ class CredentialIssuerHandlerTest {
                 Map.of("authorization_code", "foo"),
                 Map.of("ipv-session-id", sessionId));
 
-        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService).handleRequest(input, context);
+        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService, configurationService).handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
     }
 
@@ -70,7 +87,7 @@ class CredentialIssuerHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent(
                 Map.of("authorization_code", "foo", "credential_issuer_id", "an invalid id"),
                 Map.of("ipv-session-id", sessionId));
-        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService).handleRequest(input, context);
+        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService, configurationService).handleRequest(input, context);
         assert400Response(response, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
     }
 
@@ -79,7 +96,7 @@ class CredentialIssuerHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent(
                 Map.of("authorization_code", "foo", "credential_issuer_id", passportIssuerId),
                 Map.of());
-        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService).handleRequest(input, context);
+        APIGatewayProxyResponseEvent response = new CredentialIssuerHandler(credentialIssuerService, configurationService).handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_IPV_SESSION_ID);
     }
 
@@ -89,15 +106,15 @@ class CredentialIssuerHandlerTest {
 
         when(credentialIssuerService.exchangeCodeForToken(
                 requestDto.capture(),
-                eq(CredentialIssuerHandler.PASSPORT_ISSUER))
+                eq(passportIssuer))
         ).thenReturn(accessToken);
 
         when(credentialIssuerService.getCredential(
-                accessToken,
-                CredentialIssuerHandler.PASSPORT_ISSUER)
+                eq(accessToken),
+                eq(passportIssuer))
         ).thenReturn(new JSONObject());
 
-        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService);
+        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input = createRequestEvent(
                 Map.of("authorization_code", authorization_code, "credential_issuer_id", passportIssuerId),
                 Map.of("ipv-session-id", sessionId));
@@ -115,12 +132,12 @@ class CredentialIssuerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerServiceThrowsException() throws JsonProcessingException {
-        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService);
+        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input = createRequestEvent(
                 Map.of("authorization_code", "foo", "credential_issuer_id", passportIssuerId),
                 Map.of("ipv-session-id", sessionId));
 
-        when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(CredentialIssuerHandler.PASSPORT_ISSUER)))
+        when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
                 .thenThrow(new CredentialIssuerException(HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
@@ -142,7 +159,7 @@ class CredentialIssuerHandlerTest {
                         )
                 );
 
-        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService);
+        CredentialIssuerHandler handler = new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input = createRequestEvent(
                 Map.of("authorization_code", authorization_code, "credential_issuer_id", passportIssuerId),
                 Map.of("ipv-session-id", sessionId));

--- a/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
@@ -1,7 +1,7 @@
 package uk.gov.di.ipv.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
@@ -19,7 +19,6 @@ import uk.gov.di.ipv.dto.CredentialIssuers;
 class ConfigurationServiceTest {
 
     public static final String CREDENTIAL_ISSUER_CONFIG_BASE64 = "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
-
     @Mock
     SSMProvider ssmProvider;
 
@@ -31,9 +30,7 @@ class ConfigurationServiceTest {
             new CredentialIssuerConfig("FraudIssuer", new URI("http://www.example.com"),
                 new URI("http://www.example.com/credential"))));
 
-        when(ssmProvider.get(
-            eq("credentialIssuerConfig"))
-        ).thenReturn(CREDENTIAL_ISSUER_CONFIG_BASE64);
+        when(ssmProvider.get(any())).thenReturn(CREDENTIAL_ISSUER_CONFIG_BASE64);
 
         ConfigurationService underTest = new ConfigurationService(ssmProvider);
         assertEquals(credentialIssuers, underTest.getCredentialIssuers());

--- a/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.lambda.powertools.parameters.SSMProvider;
+import uk.gov.di.ipv.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.dto.CredentialIssuers;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigurationServiceTest {
+
+    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64 = "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
+
+    @Mock
+    SSMProvider ssmProvider;
+
+    @Test
+    void getCredentialIssuers() throws URISyntaxException {
+        CredentialIssuers credentialIssuers = new CredentialIssuers(Set.of(
+            new CredentialIssuerConfig("PassportIssuer", new URI("http://www.example.com"),
+                new URI("http://www.example.com/credential")),
+            new CredentialIssuerConfig("FraudIssuer", new URI("http://www.example.com"),
+                new URI("http://www.example.com/credential"))));
+
+        when(ssmProvider.get(
+            eq("credentialIssuerConfig"))
+        ).thenReturn(CREDENTIAL_ISSUER_CONFIG_BASE64);
+
+        ConfigurationService underTest = new ConfigurationService(ssmProvider);
+        assertEquals(credentialIssuers, underTest.getCredentialIssuers());
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds terraform to set an env variable on the credential issuer lambda that will contain a base64 encoded string of a yaml file defined in the di-ipv-config repo.

Adds SSM call to retrieve the credential issuer config base64 string then decodes and parses into a credential issuers object to be used by the credential issuer handler.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-403](https://govukverify.atlassian.net/browse/PYI-403)
