### PR TITLE
PYI-419: Create credential-issuers param

### DIFF
--- a/terraform/lambda/credential-issuer.tf
+++ b/terraform/lambda/credential-issuer.tf
@@ -14,4 +14,7 @@ module "credential-issuer" {
   allow_access_to_user_issued_credentials_table = true
   user_issued_credentials_table_policy_arn      = aws_iam_policy.policy-user-issued-credentials-table.arn
   user_issued_credentials_table_name            = aws_dynamodb_table.user-issued-credentials.name
+
+  credential_issuer_config_parameter_store_key = aws_ssm_parameter.credential-issuers-config.name
 }
+

--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -1,0 +1,5 @@
+resource "aws_ssm_parameter" "credential-issuers-config" {
+  name  = "/${var.environment}/credential-issuers-config"
+  type  = "String"
+  value = var.credential_issuers_config
+}

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -7,6 +7,11 @@ variable "use_localstack" {
   default = false
 }
 
+variable "credential_issuers_config" {
+  type        = string
+  description = "Base64 encoded YAML config for credential issuers"
+}
+
 locals {
   default_tags = var.use_localstack ? null : {
     Environment = var.environment

--- a/terraform/modules/endpoint/main.tf
+++ b/terraform/modules/endpoint/main.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "lambda_function" {
       USER_ISSUED_CREDENTIALS_TABLE_NAME = var.user_issued_credentials_table_name
       AUTH_CODES_TABLE_NAME = var.auth_codes_table_name
       ACCESS_TOKENS_TABLE_NAME = var.access_tokens_table_name
+      CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY = var.credential_issuer_config_parameter_store_key
     }
   }
 

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -96,6 +96,12 @@ variable "access_tokens_table_name" {
   description = "Name of the DynamoDB access-tokens table"
 }
 
+variable "credential_issuer_config_parameter_store_key" {
+  type        = string
+  default     = null
+  description = "Name of the credential issuer config parameter in the parameter store"
+}
+
 locals {
   default_tags = {
     Environment = var.environment


### PR DESCRIPTION
**To be merged with https://github.com/alphagov/di-ipv-config/pull/55**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds an SSM parameter that contains the base64 encoded credential
issuers config yaml files from the di-ipv-config repo.

Also handles providing the name of that parameter to the
credential-issuer lambda as an env variable.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-419](https://govukverify.atlassian.net/browse/PYI-419)
