### PR TITLE
PYI-412: Create new ipv-session endpoint

### DIFF
--- a/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/ApiGatewayResponseGenerator.java
@@ -41,7 +41,7 @@ public class ApiGatewayResponseGenerator {
     }
 
     private static <T> String generateResponseBody(T body) throws JsonProcessingException {
-            return new ObjectMapper().writeValueAsString(body);
+        return new ObjectMapper().writeValueAsString(body);
     }
 
 }

--- a/src/main/java/uk/gov/di/ipv/lambda/IpvSessionHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/IpvSessionHandler.java
@@ -6,10 +6,13 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.http.HttpStatus;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
-import uk.gov.di.ipv.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.service.IpvSessionService;
 
+import java.util.Map;
+
 public class IpvSessionHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final String IPV_SESSION_ID_KEY = "ipvSessionId";
 
     private final IpvSessionService ipvSessionService;
 
@@ -23,8 +26,10 @@ public class IpvSessionHandler implements RequestHandler<APIGatewayProxyRequestE
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
-        IpvSessionItem ipvSession = ipvSessionService.generateIpvSession();
+        String ipvSessionId = ipvSessionService.generateIpvSession();
 
-        return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, ipvSession);
+        Map<String, String> response = Map.of(IPV_SESSION_ID_KEY, ipvSessionId);
+
+        return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, response);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/lambda/IpvSessionHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/IpvSessionHandler.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.service.IpvSessionService;
+
+public class IpvSessionHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IpvSessionHandler.class);
+
+    private final IpvSessionService ipvSessionService;
+
+    public IpvSessionHandler() {
+        this.ipvSessionService = new IpvSessionService();
+    }
+
+    public IpvSessionHandler(IpvSessionService ipvSessionService) {
+        this.ipvSessionService = ipvSessionService;
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+        IpvSessionItem ipvSession = ipvSessionService.generateIpvSession();
+
+        return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, ipvSession);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/lambda/IpvSessionHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/IpvSessionHandler.java
@@ -5,15 +5,11 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.service.IpvSessionService;
 
 public class IpvSessionHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(IpvSessionHandler.class);
 
     private final IpvSessionService ipvSessionService;
 

--- a/src/main/java/uk/gov/di/ipv/persistence/item/IpvSessionItem.java
+++ b/src/main/java/uk/gov/di/ipv/persistence/item/IpvSessionItem.java
@@ -1,0 +1,27 @@
+package uk.gov.di.ipv.persistence.item;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class IpvSessionItem {
+    private String ipvSessionId;
+    private String creationDateTime;
+
+    @DynamoDbPartitionKey
+    public String getIpvSessionId() {
+        return ipvSessionId;
+    }
+
+    public void setIpvSessionId(String ipvSessionId) {
+        this.ipvSessionId = ipvSessionId;
+    }
+
+    public String getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(String creationDateTime) {
+        this.creationDateTime = creationDateTime;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -29,6 +29,10 @@ public class ConfigurationService {
 
     public String getAccessTokensTableName() { return System.getenv("ACCESS_TOKENS_TABLE_NAME"); }
 
+    public String getIpvSessionTableName() {
+        return System.getenv("IPV_SESSIONS_TABLE_NAME");
+    }
+
     public long getBearerAccessTokenTtl() {
         return Optional.of(System.getenv("BEARER_TOKEN_TTL"))
                 .map(Long::valueOf)

--- a/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
+++ b/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
@@ -1,0 +1,32 @@
+package uk.gov.di.ipv.service;
+
+import uk.gov.di.ipv.persistence.DataStore;
+import uk.gov.di.ipv.persistence.item.IpvSessionItem;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class IpvSessionService {
+
+    private final DataStore<IpvSessionItem> dataStore;
+    private final ConfigurationService configurationService;
+
+    public IpvSessionService() {
+        this.configurationService = ConfigurationService.getInstance();
+        dataStore = new DataStore<>(configurationService.getIpvSessionTableName(), IpvSessionItem.class);
+    }
+
+    public IpvSessionService(DataStore<IpvSessionItem> dataStore, ConfigurationService configurationService) {
+        this.dataStore = dataStore;
+        this.configurationService = configurationService;
+    }
+
+    public IpvSessionItem generateIpvSession() {
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
+        dataStore.create(ipvSessionItem);
+
+        return ipvSessionItem;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
+++ b/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
@@ -21,12 +21,12 @@ public class IpvSessionService {
         this.configurationService = configurationService;
     }
 
-    public IpvSessionItem generateIpvSession() {
+    public String generateIpvSession() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         dataStore.create(ipvSessionItem);
 
-        return ipvSessionItem;
+        return ipvSessionItem.getIpvSessionId();
     }
 }

--- a/src/test/java/uk/gov/di/ipv/lambda/IpvSessionHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/IpvSessionHandlerTest.java
@@ -1,0 +1,62 @@
+package uk.gov.di.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.service.IpvSessionService;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IpvSessionHandlerTest {
+
+    @Mock
+    private Context mockContext;
+
+    @Mock
+    private IpvSessionService mockIpvSessionService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String testUserId = UUID.randomUUID().toString();
+
+    private IpvSessionHandler ipvSessionHandler;
+
+    @BeforeEach
+    void setUp() {
+        ipvSessionHandler = new IpvSessionHandler(mockIpvSessionService);
+    }
+
+    @Test
+    void shouldReturnIpvSessionIdWhenProvidedValidRequest() throws JsonProcessingException {
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
+
+        when(mockIpvSessionService.generateIpvSession()).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        String requestBody = "userId=" + testUserId;
+        event.setBody(requestBody);
+
+        APIGatewayProxyResponseEvent response = ipvSessionHandler.handleRequest(event, mockContext);
+
+        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+        assertEquals(ipvSessionItem.getCreationDateTime().toString(), responseBody.get("creationDateTime"));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/lambda/IpvSessionHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/IpvSessionHandlerTest.java
@@ -5,15 +5,14 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.service.IpvSessionService;
 
-import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
@@ -41,22 +40,15 @@ class IpvSessionHandlerTest {
 
     @Test
     void shouldReturnIpvSessionIdWhenProvidedValidRequest() throws JsonProcessingException {
-        IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(Instant.now().toString());
-
-        when(mockIpvSessionService.generateIpvSession()).thenReturn(ipvSessionItem);
+        String ipvSessionId = UUID.randomUUID().toString();
+        when(mockIpvSessionService.generateIpvSession()).thenReturn(ipvSessionId);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        String requestBody = "userId=" + testUserId;
-        event.setBody(requestBody);
-
         APIGatewayProxyResponseEvent response = ipvSessionHandler.handleRequest(event, mockContext);
 
         Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
-        assertEquals(ipvSessionItem.getCreationDateTime().toString(), responseBody.get("creationDateTime"));
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(ipvSessionId, responseBody.get("ipvSessionId"));
     }
 }

--- a/src/test/java/uk/gov/di/ipv/lambda/UserIdentityHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/UserIdentityHandlerTest.java
@@ -12,7 +12,6 @@ import com.nimbusds.oauth2.sdk.token.BearerTokenError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.service.AccessTokenService;

--- a/src/test/java/uk/gov/di/ipv/service/IpvSessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/IpvSessionServiceTest.java
@@ -9,8 +9,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.IpvSessionItem;
 
-import java.util.UUID;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
@@ -19,10 +17,10 @@ import static org.mockito.Mockito.verify;
 class IpvSessionServiceTest {
 
     @Mock
-    DataStore<IpvSessionItem> mockDataStore;
+    private DataStore<IpvSessionItem> mockDataStore;
 
     @Mock
-    ConfigurationService mockConfigurationService;
+    private ConfigurationService mockConfigurationService;
 
     private IpvSessionService ipvSessionService;
 
@@ -33,16 +31,13 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldCreateSessionItem() {
-        String userId = UUID.randomUUID().toString();
-
-        IpvSessionItem ipvSessionItem = ipvSessionService.generateIpvSession();
+        String ipvSessionID = ipvSessionService.generateIpvSession();
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor = ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockDataStore).create(ipvSessionItemArgumentCaptor.capture());
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId());
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
 
-        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionItem.getIpvSessionId());
-        assertEquals(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime(), ipvSessionItem.getCreationDateTime());
+        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
     }
 }

--- a/src/test/java/uk/gov/di/ipv/service/IpvSessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/IpvSessionServiceTest.java
@@ -1,0 +1,48 @@
+package uk.gov.di.ipv.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.persistence.DataStore;
+import uk.gov.di.ipv.persistence.item.IpvSessionItem;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class IpvSessionServiceTest {
+
+    @Mock
+    DataStore<IpvSessionItem> mockDataStore;
+
+    @Mock
+    ConfigurationService mockConfigurationService;
+
+    private IpvSessionService ipvSessionService;
+
+    @BeforeEach
+    void setUp() {
+        ipvSessionService = new IpvSessionService(mockDataStore, mockConfigurationService);
+    }
+
+    @Test
+    void shouldCreateSessionItem() {
+        String userId = UUID.randomUUID().toString();
+
+        IpvSessionItem ipvSessionItem = ipvSessionService.generateIpvSession();
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor = ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockDataStore).create(ipvSessionItemArgumentCaptor.capture());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
+
+        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionItem.getIpvSessionId());
+        assertEquals(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime(), ipvSessionItem.getCreationDateTime());
+    }
+}

--- a/terraform/lambda/dynamodb.tf
+++ b/terraform/lambda/dynamodb.tf
@@ -43,6 +43,19 @@ resource "aws_dynamodb_table" "access-tokens" {
   tags = local.default_tags
 }
 
+resource "aws_dynamodb_table" "ipv-sessions" {
+  name         = "${var.environment}-ipv-sessions"
+  hash_key     = "ipvSessionId"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "ipvSessionId"
+    type = "S"
+  }
+
+  tags = local.default_tags
+}
+
 resource "aws_iam_policy" "policy-user-issued-credentials-table" {
   name = "policy-user-issued-credentials-table"
 
@@ -113,6 +126,30 @@ resource "aws_iam_policy" "policy-access-tokens-table" {
         Resource = [
           aws_dynamodb_table.access-tokens.arn,
           "${aws_dynamodb_table.access-tokens.arn}/index/*"
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "policy-ipv-sessions-table" {
+  name = "policy-ipv-sessions-table"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "IpvSessionsTable"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query"
+        ]
+        Effect = "Allow"
+        Resource = [
+          aws_dynamodb_table.ipv-sessions.arn,
+          "${aws_dynamodb_table.ipv-sessions.arn}/index/*"
         ]
       },
     ]

--- a/terraform/lambda/ipv-session.tf
+++ b/terraform/lambda/ipv-session.tf
@@ -1,0 +1,17 @@
+module "ipv-session" {
+  source      = "../modules/endpoint"
+  environment = var.environment
+
+  rest_api_id            = aws_api_gateway_rest_api.ipv_internal.id
+  rest_api_execution_arn = aws_api_gateway_rest_api.ipv_internal.execution_arn
+  root_resource_id       = aws_api_gateway_rest_api.ipv_internal.root_resource_id
+  http_method            = "POST"
+  path_part              = "ipv-session"
+  handler                = "uk.gov.di.ipv.lambda.IpvSessionHandler::handleRequest"
+  function_name          = "${var.environment}-create-ipv-session"
+  role_name              = "${var.environment}-ipv-session-role"
+
+  allow_access_to_ipv_sessions_table = true
+  ipv_sessions_table_policy_arn      = aws_iam_policy.policy-ipv-sessions-table.arn
+  ipv_sessions_table_name            = aws_dynamodb_table.ipv-sessions.name
+}

--- a/terraform/modules/endpoint/iam.tf
+++ b/terraform/modules/endpoint/iam.tf
@@ -42,3 +42,9 @@ resource "aws_iam_role_policy_attachment" "tokens_table_policy_to_lambda_iam_rol
   policy_arn = var.access_tokens_table_policy_arn
 }
 
+resource "aws_iam_role_policy_attachment" "ipv_sessions_table_policy_to_lambda_iam_role" {
+  count      = var.allow_access_to_ipv_sessions_table ? 1 : 0
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = var.ipv_sessions_table_policy_arn
+}
+

--- a/terraform/modules/endpoint/main.tf
+++ b/terraform/modules/endpoint/main.tf
@@ -24,6 +24,7 @@ resource "aws_lambda_function" "lambda_function" {
       USER_ISSUED_CREDENTIALS_TABLE_NAME = var.user_issued_credentials_table_name
       AUTH_CODES_TABLE_NAME = var.auth_codes_table_name
       ACCESS_TOKENS_TABLE_NAME = var.access_tokens_table_name
+      IPV_SESSIONS_TABLE_NAME = var.ipv_sessions_table_name
     }
   }
 

--- a/terraform/modules/endpoint/variables.tf
+++ b/terraform/modules/endpoint/variables.tf
@@ -96,6 +96,24 @@ variable "access_tokens_table_name" {
   description = "Name of the DynamoDB access-tokens table"
 }
 
+variable "allow_access_to_ipv_sessions_table" {
+  type        = bool
+  default     = false
+  description = "Should the lambda be given access to the ipv-sessions DynamoDB table"
+}
+
+variable "ipv_sessions_table_policy_arn" {
+  type        = string
+  default     = null
+  description = "ARN of the policy to allow read write to the ipv-sessions DynamoDB table"
+}
+
+variable "ipv_sessions_table_name" {
+  type        = string
+  default     = "not-set-for-this-lambda"
+  description = "Name of the DynamoDB ipv-sessions table"
+}
+
 locals {
   default_tags = {
     Environment = var.environment


### PR DESCRIPTION

Co-authored-by: Tal Nagra <tal.nagra@digital.cabinet-office.gov.uk>

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Create new IpvSession lambda to initialise an ipvSession.
Add new terraform resources to create the aws api gateway endpoint.
Add new terraform resources to create new DynamoDB table to store the ipv-session
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To be used by core front to initialise a session with core-back.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-412](https://govukverify.atlassian.net/browse/PYI-412)
