### PR TITLE
PYI-423: Give credential-issuer lambda ssm perms

### DIFF
--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -4,3 +4,22 @@ resource "aws_ssm_parameter" "credential-issuers-config" {
   value     = var.credential_issuers_config
   overwrite = true
 }
+
+resource "aws_iam_role_policy" "get-credential-issuers-config" {
+  name = "get-credential-issuers-config"
+  role = module.credential-issuer.iam_role_arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "GetCredentialIssuersConfig"
+        Action = [
+          "ssm:GetParameter"
+        ]
+        Effect   = "Allow"
+        Resource = aws_ssm_parameter.credential-issuers-config.arn
+      }
+    ]
+  })
+}

--- a/terraform/modules/endpoint/main.tf
+++ b/terraform/modules/endpoint/main.tf
@@ -21,10 +21,10 @@ resource "aws_lambda_function" "lambda_function" {
 
   environment {
     variables = {
-      USER_ISSUED_CREDENTIALS_TABLE_NAME = var.user_issued_credentials_table_name
-      AUTH_CODES_TABLE_NAME = var.auth_codes_table_name
-      ACCESS_TOKENS_TABLE_NAME = var.access_tokens_table_name
-      IPV_SESSIONS_TABLE_NAME = var.ipv_sessions_table_name
+      USER_ISSUED_CREDENTIALS_TABLE_NAME           = var.user_issued_credentials_table_name
+      AUTH_CODES_TABLE_NAME                        = var.auth_codes_table_name
+      ACCESS_TOKENS_TABLE_NAME                     = var.access_tokens_table_name
+      IPV_SESSIONS_TABLE_NAME                      = var.ipv_sessions_table_name
       CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY = var.credential_issuer_config_parameter_store_key
     }
   }

--- a/terraform/modules/endpoint/outputs.tf
+++ b/terraform/modules/endpoint/outputs.tf
@@ -1,5 +1,9 @@
 output "trigger" {
   description = "arbitrary value which changes when the deployment needs to be retriggered"
+  value       = sha1(jsonencode(aws_api_gateway_integration.endpoint_integration))
+}
 
-  value = sha1(jsonencode(aws_api_gateway_integration.endpoint_integration))
+output "iam_role_arn" {
+  description = "The ARN of the IAM role used by the lambda"
+  value       = aws_iam_role.lambda_iam_role.arn
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The credential-issuer lambda now pulls config from the parameter store.
Without giving it the correct permissions it won't be able to do this.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-423](https://govukverify.atlassian.net/browse/PYI-423)
