### PR TITLE
PYI 421 cache credential issuer config

### DIFF
--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
@@ -29,13 +29,6 @@ public class CredentialIssuerConfig {
         return credentialUrl;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CredentialIssuerConfig that = (CredentialIssuerConfig) o;
-        return Objects.equals(id, that.id);
-    }
 
     @Override
     public String toString() {
@@ -45,5 +38,18 @@ public class CredentialIssuerConfig {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CredentialIssuerConfig that = (CredentialIssuerConfig) o;
+        return id.equals(that.id) && tokenUrl.equals(that.tokenUrl) && credentialUrl.equals(
+            that.credentialUrl);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuerConfig.java
@@ -29,7 +29,6 @@ public class CredentialIssuerConfig {
         return credentialUrl;
     }
 
-
     @Override
     public String toString() {
         return "CredentialIssuerConfig{" + "id='" + id + '\'' + '}';
@@ -49,7 +48,8 @@ public class CredentialIssuerConfig {
             return false;
         }
         CredentialIssuerConfig that = (CredentialIssuerConfig) o;
-        return id.equals(that.id) && tokenUrl.equals(that.tokenUrl) && credentialUrl.equals(
-            that.credentialUrl);
+        return id.equals(that.id)
+                && tokenUrl.equals(that.tokenUrl)
+                && credentialUrl.equals(that.credentialUrl);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
@@ -9,15 +10,13 @@ public class CredentialIssuers {
 
     private final Set<CredentialIssuerConfig> credentialIssuerConfigs;
 
-    @JsonIgnore
-    private String source;
+    @JsonIgnore private String source;
 
     public CredentialIssuers() {
         credentialIssuerConfigs = Collections.emptySet();
     }
 
-    public CredentialIssuers(
-        Set<CredentialIssuerConfig> credentialIssuerConfigs, String source) {
+    public CredentialIssuers(Set<CredentialIssuerConfig> credentialIssuerConfigs, String source) {
         this.credentialIssuerConfigs = credentialIssuerConfigs;
         this.source = source;
     }

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
@@ -8,8 +9,17 @@ public class CredentialIssuers {
 
     private final Set<CredentialIssuerConfig> credentialIssuerConfigs;
 
+    @JsonIgnore
+    private String source;
+
     public CredentialIssuers() {
         credentialIssuerConfigs = Collections.emptySet();
+    }
+
+    public CredentialIssuers(
+        Set<CredentialIssuerConfig> credentialIssuerConfigs, String source) {
+        this.credentialIssuerConfigs = credentialIssuerConfigs;
+        this.source = source;
     }
 
     public CredentialIssuers(Set<CredentialIssuerConfig> credentialIssuerConfigs) {
@@ -21,14 +31,6 @@ public class CredentialIssuers {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CredentialIssuers that = (CredentialIssuers) o;
-        return Objects.equals(credentialIssuerConfigs, that.credentialIssuerConfigs);
-    }
-
-    @Override
     public String toString() {
         return "CredentialIssuers{" + "credentialIssuerConfigs=" + credentialIssuerConfigs + '}';
     }
@@ -36,5 +38,13 @@ public class CredentialIssuers {
     @Override
     public int hashCode() {
         return Objects.hash(credentialIssuerConfigs);
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getSource() {
+        return source;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Collections;
-import java.util.Objects;
 import java.util.Set;
 
 public class CredentialIssuers {
@@ -32,11 +31,6 @@ public class CredentialIssuers {
     @Override
     public String toString() {
         return "CredentialIssuers{" + "credentialIssuerConfigs=" + credentialIssuerConfigs + '}';
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(credentialIssuerConfigs);
     }
 
     public void setSource(String source) {

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.util.Collections;
 import java.util.Set;
 
@@ -9,7 +7,7 @@ public class CredentialIssuers {
 
     private final Set<CredentialIssuerConfig> credentialIssuerConfigs;
 
-    @JsonIgnore private String source;
+    private String source;
 
     public CredentialIssuers() {
         credentialIssuerConfigs = Collections.emptySet();
@@ -39,5 +37,9 @@ public class CredentialIssuers {
 
     public String getSource() {
         return source;
+    }
+
+    public boolean fromDifferentSource(String credentialIssuerConfigBase64) {
+        return !this.source.equals(credentialIssuerConfigBase64);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/helpers/CredentialIssuerLoader.java
+++ b/src/main/java/uk/gov/di/ipv/helpers/CredentialIssuerLoader.java
@@ -27,6 +27,7 @@ public class CredentialIssuerLoader {
             byte[] decode = Base64.decode(credentialIssuerConfigBase64);
             YAMLParser yamlParser = yamlFactory.createParser(decode);
             credentialIssuers = mapper.readValue(yamlParser, CredentialIssuers.class);
+            credentialIssuers.setSource(credentialIssuerConfigBase64);
             LOGGER.info("Loaded Credential Issuers: {}", credentialIssuers);
         } catch (IllegalArgumentException | IOException e) {
             throw new CredentialIssuerException(

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -26,7 +26,7 @@ public class CredentialIssuerHandler
     private final CredentialIssuerService credentialIssuerService;
     private final ConfigurationService configurationService;
 
-    private CredentialIssuers credentialIssuers = null;
+    private CredentialIssuers credentialIssuers;
 
     {
         // Set the default synchronous HTTP client to UrlConnectionHttpClient

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -16,11 +16,12 @@ import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.helpers.RequestHelper;
 import uk.gov.di.ipv.service.ConfigurationService;
 import uk.gov.di.ipv.service.CredentialIssuerService;
+
 import java.util.Collections;
 import java.util.Optional;
 
 public class CredentialIssuerHandler
-    implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final CredentialIssuerService credentialIssuerService;
     private final ConfigurationService configurationService;
@@ -35,8 +36,8 @@ public class CredentialIssuerHandler
     }
 
     public CredentialIssuerHandler(
-        CredentialIssuerService credentialIssuerService,
-        ConfigurationService configurationService) {
+            CredentialIssuerService credentialIssuerService,
+            ConfigurationService configurationService) {
         this.credentialIssuerService = credentialIssuerService;
         this.configurationService = configurationService;
         this.credentialIssuers = configurationService.getCredentialIssuers(credentialIssuers);
@@ -50,10 +51,10 @@ public class CredentialIssuerHandler
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
-        APIGatewayProxyRequestEvent input, Context context) {
+            APIGatewayProxyRequestEvent input, Context context) {
 
         CredentialIssuerRequestDto request =
-            RequestHelper.convertRequest(input, CredentialIssuerRequestDto.class);
+                RequestHelper.convertRequest(input, CredentialIssuerRequestDto.class);
 
         var errorResponse = validate(request);
         if (errorResponse.isPresent()) {
@@ -63,14 +64,14 @@ public class CredentialIssuerHandler
 
         try {
             BearerAccessToken accessToken =
-                credentialIssuerService.exchangeCodeForToken(request, credentialIssuerConfig);
+                    credentialIssuerService.exchangeCodeForToken(request, credentialIssuerConfig);
             JSONObject credential =
-                credentialIssuerService.getCredential(accessToken, credentialIssuerConfig);
+                    credentialIssuerService.getCredential(accessToken, credentialIssuerConfig);
             credentialIssuerService.persistUserCredentials(credential, request);
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, Collections.emptyMap());
         } catch (CredentialIssuerException e) {
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                e.getHttpStatusCode(), e.getErrorResponse());
+                    e.getHttpStatusCode(), e.getErrorResponse());
         }
     }
 
@@ -94,10 +95,12 @@ public class CredentialIssuerHandler
     }
 
     private CredentialIssuerConfig getCredentialIssuerConfig(CredentialIssuerRequestDto request) {
-        return configurationService.getCredentialIssuers(credentialIssuers)
-            .getCredentialIssuerConfigs().stream()
-            .filter(config -> request.getCredentialIssuerId().equals(config.getId()))
-            .findFirst()
-            .orElse(null);
+        return configurationService
+                .getCredentialIssuers(credentialIssuers)
+                .getCredentialIssuerConfigs()
+                .stream()
+                .filter(config -> request.getCredentialIssuerId().equals(config.getId()))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -16,7 +16,6 @@ import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.helpers.RequestHelper;
 import uk.gov.di.ipv.service.ConfigurationService;
 import uk.gov.di.ipv.service.CredentialIssuerService;
-
 import java.util.Collections;
 import java.util.Optional;
 

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -29,14 +29,15 @@ public class ConfigurationService {
         return System.getenv("AUTH_CODES_TABLE_NAME");
     }
 
-    public CredentialIssuers getCredentialIssuers(
-        CredentialIssuers credentialIssuers) {
+    public CredentialIssuers getCredentialIssuers(CredentialIssuers credentialIssuers) {
 
-        String credentialIssuerConfigBase64 = ssmProvider.get(
-            System.getenv("CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY"));
+        String credentialIssuerConfigBase64 =
+                ssmProvider.get(System.getenv("CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY"));
 
-        if (credentialIssuers == null || !credentialIssuerConfigBase64.equals(credentialIssuers.getSource())) {
-            var credentialIssuersResult = CredentialIssuerLoader.loadCredentialIssuers(credentialIssuerConfigBase64);
+        if (credentialIssuers == null
+                || !credentialIssuerConfigBase64.equals(credentialIssuers.getSource())) {
+            var credentialIssuersResult =
+                    CredentialIssuerLoader.loadCredentialIssuers(credentialIssuerConfigBase64);
             credentialIssuersResult.setSource(credentialIssuerConfigBase64);
             return credentialIssuersResult;
         }
@@ -58,7 +59,7 @@ public class ConfigurationService {
 
     public long getBearerAccessTokenTtl() {
         return Optional.of(System.getenv("BEARER_TOKEN_TTL"))
-            .map(Long::valueOf)
-            .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
+                .map(Long::valueOf)
+                .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -29,9 +29,19 @@ public class ConfigurationService {
         return System.getenv("AUTH_CODES_TABLE_NAME");
     }
 
-    public CredentialIssuers getCredentialIssuers() {
-        return CredentialIssuerLoader.loadCredentialIssuers(
-                ssmProvider.get(System.getenv("CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY")));
+    public CredentialIssuers getCredentialIssuers(
+        CredentialIssuers credentialIssuers) {
+
+        String credentialIssuerConfigBase64 = ssmProvider.get(
+            System.getenv("CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY"));
+
+        if (credentialIssuers == null || !credentialIssuerConfigBase64.equals(credentialIssuers.getSource())) {
+            var credentialIssuersResult = CredentialIssuerLoader.loadCredentialIssuers(credentialIssuerConfigBase64);
+            credentialIssuersResult.setSource(credentialIssuerConfigBase64);
+            return credentialIssuersResult;
+        }
+
+        return credentialIssuers;
     }
 
     public String getUserIssuedCredentialTableName() {
@@ -48,7 +58,7 @@ public class ConfigurationService {
 
     public long getBearerAccessTokenTtl() {
         return Optional.of(System.getenv("BEARER_TOKEN_TTL"))
-                .map(Long::valueOf)
-                .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
+            .map(Long::valueOf)
+            .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -35,11 +35,8 @@ public class ConfigurationService {
                 ssmProvider.get(System.getenv("CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY"));
 
         if (credentialIssuers == null
-                || !credentialIssuerConfigBase64.equals(credentialIssuers.getSource())) {
-            var credentialIssuersResult =
-                    CredentialIssuerLoader.loadCredentialIssuers(credentialIssuerConfigBase64);
-            credentialIssuersResult.setSource(credentialIssuerConfigBase64);
-            return credentialIssuersResult;
+                || credentialIssuers.fromDifferentSource(credentialIssuerConfigBase64)) {
+            return CredentialIssuerLoader.loadCredentialIssuers(credentialIssuerConfigBase64);
         }
 
         return credentialIssuers;

--- a/src/test/java/uk/gov/di/ipv/helpers/CredentialIssuerLoaderTest.java
+++ b/src/test/java/uk/gov/di/ipv/helpers/CredentialIssuerLoaderTest.java
@@ -1,18 +1,17 @@
 package uk.gov.di.ipv.helpers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuers;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CredentialIssuerLoaderTest {
 
@@ -39,8 +38,8 @@ class CredentialIssuerLoaderTest {
     @Test
     void shouldLoadCredentialIssuersFromBase64EncodedString() {
         assertEquals(
-                expectedCredentialIssuers,
-                CredentialIssuerLoader.loadCredentialIssuers(CREDENTIAL_ISSUER_CONFIG_BASE64));
+                expectedCredentialIssuers.getCredentialIssuerConfigs(),
+                CredentialIssuerLoader.loadCredentialIssuers(CREDENTIAL_ISSUER_CONFIG_BASE64).getCredentialIssuerConfigs());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/helpers/CredentialIssuerLoaderTest.java
+++ b/src/test/java/uk/gov/di/ipv/helpers/CredentialIssuerLoaderTest.java
@@ -1,17 +1,18 @@
 package uk.gov.di.ipv.helpers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuers;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CredentialIssuerLoaderTest {
 
@@ -39,7 +40,8 @@ class CredentialIssuerLoaderTest {
     void shouldLoadCredentialIssuersFromBase64EncodedString() {
         assertEquals(
                 expectedCredentialIssuers.getCredentialIssuerConfigs(),
-                CredentialIssuerLoader.loadCredentialIssuers(CREDENTIAL_ISSUER_CONFIG_BASE64).getCredentialIssuerConfigs());
+                CredentialIssuerLoader.loadCredentialIssuers(CREDENTIAL_ISSUER_CONFIG_BASE64)
+                        .getCredentialIssuerConfigs());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -1,5 +1,12 @@
 package uk.gov.di.ipv.lambda;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
@@ -7,6 +14,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,30 +36,20 @@ import uk.gov.di.ipv.dto.CredentialIssuers;
 import uk.gov.di.ipv.service.ConfigurationService;
 import uk.gov.di.ipv.service.CredentialIssuerService;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerHandlerTest {
 
-    @Mock private Context context;
+    @Mock
+    private Context context;
 
-    @Captor private ArgumentCaptor<CredentialIssuerRequestDto> requestDto;
+    @Captor
+    private ArgumentCaptor<CredentialIssuerRequestDto> requestDto;
 
-    @Mock CredentialIssuerService credentialIssuerService;
+    @Mock
+    CredentialIssuerService credentialIssuerService;
 
-    @Mock ConfigurationService configurationService;
+    @Mock
+    ConfigurationService configurationService;
 
     String authorization_code = "bar";
     String sessionId = UUID.randomUUID().toString();
@@ -56,68 +59,68 @@ class CredentialIssuerHandlerTest {
     @BeforeEach
     void setUp() throws URISyntaxException {
         passportIssuer =
-                new CredentialIssuerConfig(
-                        "PassportIssuer",
-                        new URI("http://www.example.com"),
-                        new URI("http://www.example.com/credential"));
-        CredentialIssuers credentialIssuers = new CredentialIssuers(Set.of(passportIssuer));
-        when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuers);
+            new CredentialIssuerConfig(
+                "PassportIssuer",
+                new URI("http://www.example.com"),
+                new URI("http://www.example.com/credential"));
+        when(configurationService.getCredentialIssuers(any())).thenReturn(
+            new CredentialIssuers(Set.of(passportIssuer)));
     }
 
     @Test
     void shouldReceive400ResponseCodeIfAuthorizationCodeNotPresent()
-            throws JsonProcessingException {
+        throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
-                createRequestEvent(
-                        Map.of("credential_issuer_id", "foo"), Map.of("ipv-session-id", sessionId));
+            createRequestEvent(
+                Map.of("credential_issuer_id", "foo"), Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response =
-                new CredentialIssuerHandler(credentialIssuerService, configurationService)
-                        .handleRequest(input, context);
+            new CredentialIssuerHandler(credentialIssuerService, configurationService)
+                .handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_AUTHORIZATION_CODE);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotPresent() throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
-                createRequestEvent(
-                        Map.of("authorization_code", "foo"), Map.of("ipv-session-id", sessionId));
+            createRequestEvent(
+                Map.of("authorization_code", "foo"), Map.of("ipv-session-id", sessionId));
 
         APIGatewayProxyResponseEvent response =
-                new CredentialIssuerHandler(credentialIssuerService, configurationService)
-                        .handleRequest(input, context);
+            new CredentialIssuerHandler(credentialIssuerService, configurationService)
+                .handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotInPermittedSet()
-            throws JsonProcessingException {
+        throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
-                createRequestEvent(
-                        Map.of(
-                                "authorization_code",
-                                "foo",
-                                "credential_issuer_id",
-                                "an invalid id"),
-                        Map.of("ipv-session-id", sessionId));
+            createRequestEvent(
+                Map.of(
+                    "authorization_code",
+                    "foo",
+                    "credential_issuer_id",
+                    "an invalid id"),
+                Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response =
-                new CredentialIssuerHandler(credentialIssuerService, configurationService)
-                        .handleRequest(input, context);
+            new CredentialIssuerHandler(credentialIssuerService, configurationService)
+                .handleRequest(input, context);
         assert400Response(response, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfSessionIdNotPresent() throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
-                createRequestEvent(
-                        Map.of(
-                                "authorization_code",
-                                "foo",
-                                "credential_issuer_id",
-                                passportIssuerId),
-                        Map.of());
+            createRequestEvent(
+                Map.of(
+                    "authorization_code",
+                    "foo",
+                    "credential_issuer_id",
+                    passportIssuerId),
+                Map.of());
         APIGatewayProxyResponseEvent response =
-                new CredentialIssuerHandler(credentialIssuerService, configurationService)
-                        .handleRequest(input, context);
+            new CredentialIssuerHandler(credentialIssuerService, configurationService)
+                .handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_IPV_SESSION_ID);
     }
 
@@ -126,21 +129,21 @@ class CredentialIssuerHandlerTest {
         BearerAccessToken accessToken = mock(BearerAccessToken.class);
 
         when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
-                .thenReturn(accessToken);
+            .thenReturn(accessToken);
 
         when(credentialIssuerService.getCredential(accessToken, passportIssuer))
-                .thenReturn(new JSONObject());
+            .thenReturn(new JSONObject());
 
         CredentialIssuerHandler handler =
-                new CredentialIssuerHandler(credentialIssuerService, configurationService);
+            new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input =
-                createRequestEvent(
-                        Map.of(
-                                "authorization_code",
-                                authorization_code,
-                                "credential_issuer_id",
-                                passportIssuerId),
-                        Map.of("ipv-session-id", sessionId));
+            createRequestEvent(
+                Map.of(
+                    "authorization_code",
+                    authorization_code,
+                    "credential_issuer_id",
+                    passportIssuerId),
+                Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
 
         CredentialIssuerRequestDto value = requestDto.getValue();
@@ -155,22 +158,22 @@ class CredentialIssuerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerServiceThrowsException()
-            throws JsonProcessingException {
+        throws JsonProcessingException {
         CredentialIssuerHandler handler =
-                new CredentialIssuerHandler(credentialIssuerService, configurationService);
+            new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input =
-                createRequestEvent(
-                        Map.of(
-                                "authorization_code",
-                                "foo",
-                                "credential_issuer_id",
-                                passportIssuerId),
-                        Map.of("ipv-session-id", sessionId));
+            createRequestEvent(
+                Map.of(
+                    "authorization_code",
+                    "foo",
+                    "credential_issuer_id",
+                    passportIssuerId),
+                Map.of("ipv-session-id", sessionId));
 
         when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
-                .thenThrow(
-                        new CredentialIssuerException(
-                                HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
+            .thenThrow(
+                new CredentialIssuerException(
+                    HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();
@@ -182,54 +185,54 @@ class CredentialIssuerHandlerTest {
 
     @Test
     void shouldReturn500IfCredentialIssuerServiceGetCredentialThrows()
-            throws JsonProcessingException {
+        throws JsonProcessingException {
         when(credentialIssuerService.exchangeCodeForToken(any(), any()))
-                .thenReturn(new BearerAccessToken());
+            .thenReturn(new BearerAccessToken());
         when(credentialIssuerService.getCredential(any(), any()))
-                .thenThrow(
-                        new CredentialIssuerException(
-                                HTTPResponse.SC_SERVER_ERROR,
-                                ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER));
+            .thenThrow(
+                new CredentialIssuerException(
+                    HTTPResponse.SC_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER));
 
         CredentialIssuerHandler handler =
-                new CredentialIssuerHandler(credentialIssuerService, configurationService);
+            new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input =
-                createRequestEvent(
-                        Map.of(
-                                "authorization_code",
-                                authorization_code,
-                                "credential_issuer_id",
-                                passportIssuerId),
-                        Map.of("ipv-session-id", sessionId));
+            createRequestEvent(
+                Map.of(
+                    "authorization_code",
+                    authorization_code,
+                    "credential_issuer_id",
+                    passportIssuerId),
+                Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, response.getStatusCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getCode(),
-                getResponseBodyAsMap(response).get("code"));
+            ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getCode(),
+            getResponseBodyAsMap(response).get("code"));
     }
 
     private Map getResponseBodyAsMap(APIGatewayProxyResponseEvent response)
-            throws JsonProcessingException {
+        throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
         return responseBody;
     }
 
     private APIGatewayProxyRequestEvent createRequestEvent(
-            Map<String, String> body, Map<String, String> headers) {
+        Map<String, String> body, Map<String, String> headers) {
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setBody(
-                body.keySet().stream()
-                        .map(key -> key + "=" + body.get(key))
-                        .collect(Collectors.joining("&")));
+            body.keySet().stream()
+                .map(key -> key + "=" + body.get(key))
+                .collect(Collectors.joining("&")));
         input.setHeaders(headers);
         return input;
     }
 
     private void assert400Response(
-            APIGatewayProxyResponseEvent response, ErrorResponse errorResponse)
-            throws JsonProcessingException {
+        APIGatewayProxyResponseEvent response, ErrorResponse errorResponse)
+        throws JsonProcessingException {
         Integer statusCode = response.getStatusCode();
         Map responseBody = getResponseBodyAsMap(response);
         assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -1,12 +1,5 @@
 package uk.gov.di.ipv.lambda;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
@@ -14,12 +7,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,20 +23,30 @@ import uk.gov.di.ipv.dto.CredentialIssuers;
 import uk.gov.di.ipv.service.ConfigurationService;
 import uk.gov.di.ipv.service.CredentialIssuerService;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerHandlerTest {
 
-    @Mock
-    private Context context;
+    @Mock private Context context;
 
-    @Captor
-    private ArgumentCaptor<CredentialIssuerRequestDto> requestDto;
+    @Captor private ArgumentCaptor<CredentialIssuerRequestDto> requestDto;
 
-    @Mock
-    CredentialIssuerService credentialIssuerService;
+    @Mock CredentialIssuerService credentialIssuerService;
 
-    @Mock
-    ConfigurationService configurationService;
+    @Mock ConfigurationService configurationService;
 
     String authorization_code = "bar";
     String sessionId = UUID.randomUUID().toString();
@@ -59,68 +56,68 @@ class CredentialIssuerHandlerTest {
     @BeforeEach
     void setUp() throws URISyntaxException {
         passportIssuer =
-            new CredentialIssuerConfig(
-                "PassportIssuer",
-                new URI("http://www.example.com"),
-                new URI("http://www.example.com/credential"));
-        when(configurationService.getCredentialIssuers(any())).thenReturn(
-            new CredentialIssuers(Set.of(passportIssuer)));
+                new CredentialIssuerConfig(
+                        "PassportIssuer",
+                        new URI("http://www.example.com"),
+                        new URI("http://www.example.com/credential"));
+        when(configurationService.getCredentialIssuers(any()))
+                .thenReturn(new CredentialIssuers(Set.of(passportIssuer)));
     }
 
     @Test
     void shouldReceive400ResponseCodeIfAuthorizationCodeNotPresent()
-        throws JsonProcessingException {
+            throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
-            createRequestEvent(
-                Map.of("credential_issuer_id", "foo"), Map.of("ipv-session-id", sessionId));
+                createRequestEvent(
+                        Map.of("credential_issuer_id", "foo"), Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response =
-            new CredentialIssuerHandler(credentialIssuerService, configurationService)
-                .handleRequest(input, context);
+                new CredentialIssuerHandler(credentialIssuerService, configurationService)
+                        .handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_AUTHORIZATION_CODE);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotPresent() throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
-            createRequestEvent(
-                Map.of("authorization_code", "foo"), Map.of("ipv-session-id", sessionId));
+                createRequestEvent(
+                        Map.of("authorization_code", "foo"), Map.of("ipv-session-id", sessionId));
 
         APIGatewayProxyResponseEvent response =
-            new CredentialIssuerHandler(credentialIssuerService, configurationService)
-                .handleRequest(input, context);
+                new CredentialIssuerHandler(credentialIssuerService, configurationService)
+                        .handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotInPermittedSet()
-        throws JsonProcessingException {
+            throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
-            createRequestEvent(
-                Map.of(
-                    "authorization_code",
-                    "foo",
-                    "credential_issuer_id",
-                    "an invalid id"),
-                Map.of("ipv-session-id", sessionId));
+                createRequestEvent(
+                        Map.of(
+                                "authorization_code",
+                                "foo",
+                                "credential_issuer_id",
+                                "an invalid id"),
+                        Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response =
-            new CredentialIssuerHandler(credentialIssuerService, configurationService)
-                .handleRequest(input, context);
+                new CredentialIssuerHandler(credentialIssuerService, configurationService)
+                        .handleRequest(input, context);
         assert400Response(response, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
     }
 
     @Test
     void shouldReceive400ResponseCodeIfSessionIdNotPresent() throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
-            createRequestEvent(
-                Map.of(
-                    "authorization_code",
-                    "foo",
-                    "credential_issuer_id",
-                    passportIssuerId),
-                Map.of());
+                createRequestEvent(
+                        Map.of(
+                                "authorization_code",
+                                "foo",
+                                "credential_issuer_id",
+                                passportIssuerId),
+                        Map.of());
         APIGatewayProxyResponseEvent response =
-            new CredentialIssuerHandler(credentialIssuerService, configurationService)
-                .handleRequest(input, context);
+                new CredentialIssuerHandler(credentialIssuerService, configurationService)
+                        .handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_IPV_SESSION_ID);
     }
 
@@ -129,21 +126,21 @@ class CredentialIssuerHandlerTest {
         BearerAccessToken accessToken = mock(BearerAccessToken.class);
 
         when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
-            .thenReturn(accessToken);
+                .thenReturn(accessToken);
 
         when(credentialIssuerService.getCredential(accessToken, passportIssuer))
-            .thenReturn(new JSONObject());
+                .thenReturn(new JSONObject());
 
         CredentialIssuerHandler handler =
-            new CredentialIssuerHandler(credentialIssuerService, configurationService);
+                new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input =
-            createRequestEvent(
-                Map.of(
-                    "authorization_code",
-                    authorization_code,
-                    "credential_issuer_id",
-                    passportIssuerId),
-                Map.of("ipv-session-id", sessionId));
+                createRequestEvent(
+                        Map.of(
+                                "authorization_code",
+                                authorization_code,
+                                "credential_issuer_id",
+                                passportIssuerId),
+                        Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
 
         CredentialIssuerRequestDto value = requestDto.getValue();
@@ -158,22 +155,22 @@ class CredentialIssuerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerServiceThrowsException()
-        throws JsonProcessingException {
+            throws JsonProcessingException {
         CredentialIssuerHandler handler =
-            new CredentialIssuerHandler(credentialIssuerService, configurationService);
+                new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input =
-            createRequestEvent(
-                Map.of(
-                    "authorization_code",
-                    "foo",
-                    "credential_issuer_id",
-                    passportIssuerId),
-                Map.of("ipv-session-id", sessionId));
+                createRequestEvent(
+                        Map.of(
+                                "authorization_code",
+                                "foo",
+                                "credential_issuer_id",
+                                passportIssuerId),
+                        Map.of("ipv-session-id", sessionId));
 
         when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
-            .thenThrow(
-                new CredentialIssuerException(
-                    HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
+                .thenThrow(
+                        new CredentialIssuerException(
+                                HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();
@@ -185,54 +182,54 @@ class CredentialIssuerHandlerTest {
 
     @Test
     void shouldReturn500IfCredentialIssuerServiceGetCredentialThrows()
-        throws JsonProcessingException {
+            throws JsonProcessingException {
         when(credentialIssuerService.exchangeCodeForToken(any(), any()))
-            .thenReturn(new BearerAccessToken());
+                .thenReturn(new BearerAccessToken());
         when(credentialIssuerService.getCredential(any(), any()))
-            .thenThrow(
-                new CredentialIssuerException(
-                    HTTPResponse.SC_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER));
+                .thenThrow(
+                        new CredentialIssuerException(
+                                HTTPResponse.SC_SERVER_ERROR,
+                                ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER));
 
         CredentialIssuerHandler handler =
-            new CredentialIssuerHandler(credentialIssuerService, configurationService);
+                new CredentialIssuerHandler(credentialIssuerService, configurationService);
         APIGatewayProxyRequestEvent input =
-            createRequestEvent(
-                Map.of(
-                    "authorization_code",
-                    authorization_code,
-                    "credential_issuer_id",
-                    passportIssuerId),
-                Map.of("ipv-session-id", sessionId));
+                createRequestEvent(
+                        Map.of(
+                                "authorization_code",
+                                authorization_code,
+                                "credential_issuer_id",
+                                passportIssuerId),
+                        Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, response.getStatusCode());
         assertEquals(
-            ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getCode(),
-            getResponseBodyAsMap(response).get("code"));
+                ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getCode(),
+                getResponseBodyAsMap(response).get("code"));
     }
 
     private Map getResponseBodyAsMap(APIGatewayProxyResponseEvent response)
-        throws JsonProcessingException {
+            throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
         return responseBody;
     }
 
     private APIGatewayProxyRequestEvent createRequestEvent(
-        Map<String, String> body, Map<String, String> headers) {
+            Map<String, String> body, Map<String, String> headers) {
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setBody(
-            body.keySet().stream()
-                .map(key -> key + "=" + body.get(key))
-                .collect(Collectors.joining("&")));
+                body.keySet().stream()
+                        .map(key -> key + "=" + body.get(key))
+                        .collect(Collectors.joining("&")));
         input.setHeaders(headers);
         return input;
     }
 
     private void assert400Response(
-        APIGatewayProxyResponseEvent response, ErrorResponse errorResponse)
-        throws JsonProcessingException {
+            APIGatewayProxyResponseEvent response, ErrorResponse errorResponse)
+            throws JsonProcessingException {
         Integer statusCode = response.getStatusCode();
         Map responseBody = getResponseBodyAsMap(response);
         assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);

--- a/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
@@ -1,5 +1,14 @@
 package uk.gov.di.ipv.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,38 +17,55 @@ import software.amazon.lambda.powertools.parameters.SSMProvider;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuers;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 @ExtendWith(MockitoExtension.class)
 class ConfigurationServiceTest {
 
-    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64 =
-            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
-    @Mock SSMProvider ssmProvider;
+    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1 = "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmJvYi5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbAogIC0gaWQ6IEZyYXVkSXNzdWVyCiAgICB0b2tlblVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbQogICAgY3JlZGVudGlhbFVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbS9jcmVkZW50aWFsCg==";
+    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2 =
+        "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
+    @Mock
+    SSMProvider ssmProvider;
+
+    private CredentialIssuers credentialIssuers;
+
+    @BeforeEach
+    void setUp() throws URISyntaxException {
+        credentialIssuers = new CredentialIssuers(
+            Set.of(
+                new CredentialIssuerConfig(
+                    "PassportIssuer",
+                    new URI("http://www.example.com"),
+                    new URI("http://www.example.com/credential")),
+                new CredentialIssuerConfig(
+                    "FraudIssuer",
+                    new URI("http://www.example.com"),
+                    new URI("http://www.example.com/credential"))),
+            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
+    }
 
     @Test
-    void getCredentialIssuers() throws URISyntaxException {
-        CredentialIssuers credentialIssuers =
-                new CredentialIssuers(
-                        Set.of(
-                                new CredentialIssuerConfig(
-                                        "PassportIssuer",
-                                        new URI("http://www.example.com"),
-                                        new URI("http://www.example.com/credential")),
-                                new CredentialIssuerConfig(
-                                        "FraudIssuer",
-                                        new URI("http://www.example.com"),
-                                        new URI("http://www.example.com/credential"))));
-
-        when(ssmProvider.get(any())).thenReturn(CREDENTIAL_ISSUER_CONFIG_BASE64);
-
+    void shouldReturnDifferentCredentialIssuersWhenBase64EncodingHasChanged() {
         ConfigurationService underTest = new ConfigurationService(ssmProvider);
-        assertEquals(credentialIssuers, underTest.getCredentialIssuers());
+        when(ssmProvider.get(any())).thenReturn(
+            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1,
+            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2);
+
+        CredentialIssuers credentialIssuers1 = underTest.getCredentialIssuers(credentialIssuers);
+        CredentialIssuers credentialIssuers2 = underTest.getCredentialIssuers(credentialIssuers);
+
+        assertNotEquals(credentialIssuers1, credentialIssuers2);
+    }
+
+    @Test
+    void shouldReturnSameCredentialIssuersWhenBase64EncodingHasNotChanged() {
+        ConfigurationService underTest = new ConfigurationService(ssmProvider);
+        when(ssmProvider.get(any())).thenReturn(
+            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1,
+            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
+
+        CredentialIssuers credentialIssuers1 = underTest.getCredentialIssuers(credentialIssuers);
+        CredentialIssuers credentialIssuers2 = underTest.getCredentialIssuers(credentialIssuers);
+
+        assertEquals(credentialIssuers1, credentialIssuers2);
     }
 }

--- a/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
@@ -1,13 +1,5 @@
 package uk.gov.di.ipv.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,38 +9,49 @@ import software.amazon.lambda.powertools.parameters.SSMProvider;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuers;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 class ConfigurationServiceTest {
 
-    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1 = "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmJvYi5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbAogIC0gaWQ6IEZyYXVkSXNzdWVyCiAgICB0b2tlblVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbQogICAgY3JlZGVudGlhbFVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbS9jcmVkZW50aWFsCg==";
+    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1 =
+            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmJvYi5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbAogIC0gaWQ6IEZyYXVkSXNzdWVyCiAgICB0b2tlblVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbQogICAgY3JlZGVudGlhbFVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbS9jcmVkZW50aWFsCg==";
     public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2 =
-        "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
-    @Mock
-    SSMProvider ssmProvider;
+            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
+    @Mock SSMProvider ssmProvider;
 
     private CredentialIssuers credentialIssuers;
 
     @BeforeEach
     void setUp() throws URISyntaxException {
-        credentialIssuers = new CredentialIssuers(
-            Set.of(
-                new CredentialIssuerConfig(
-                    "PassportIssuer",
-                    new URI("http://www.example.com"),
-                    new URI("http://www.example.com/credential")),
-                new CredentialIssuerConfig(
-                    "FraudIssuer",
-                    new URI("http://www.example.com"),
-                    new URI("http://www.example.com/credential"))),
-            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
+        credentialIssuers =
+                new CredentialIssuers(
+                        Set.of(
+                                new CredentialIssuerConfig(
+                                        "PassportIssuer",
+                                        new URI("http://www.example.com"),
+                                        new URI("http://www.example.com/credential")),
+                                new CredentialIssuerConfig(
+                                        "FraudIssuer",
+                                        new URI("http://www.example.com"),
+                                        new URI("http://www.example.com/credential"))),
+                        CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
     }
 
     @Test
     void shouldReturnDifferentCredentialIssuersWhenBase64EncodingHasChanged() {
         ConfigurationService underTest = new ConfigurationService(ssmProvider);
-        when(ssmProvider.get(any())).thenReturn(
-            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1,
-            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2);
+        when(ssmProvider.get(any()))
+                .thenReturn(
+                        CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1,
+                        CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2);
 
         CredentialIssuers credentialIssuers1 = underTest.getCredentialIssuers(credentialIssuers);
         CredentialIssuers credentialIssuers2 = underTest.getCredentialIssuers(credentialIssuers);
@@ -59,9 +62,10 @@ class ConfigurationServiceTest {
     @Test
     void shouldReturnSameCredentialIssuersWhenBase64EncodingHasNotChanged() {
         ConfigurationService underTest = new ConfigurationService(ssmProvider);
-        when(ssmProvider.get(any())).thenReturn(
-            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1,
-            CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
+        when(ssmProvider.get(any()))
+                .thenReturn(
+                        CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1,
+                        CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
 
         CredentialIssuers credentialIssuers1 = underTest.getCredentialIssuers(credentialIssuers);
         CredentialIssuers credentialIssuers2 = underTest.getCredentialIssuers(credentialIssuers);

--- a/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
@@ -13,10 +13,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigurationServiceTest {
@@ -70,6 +69,6 @@ class ConfigurationServiceTest {
         CredentialIssuers credentialIssuers1 = underTest.getCredentialIssuers(credentialIssuers);
         CredentialIssuers credentialIssuers2 = underTest.getCredentialIssuers(credentialIssuers);
 
-        assertEquals(credentialIssuers1, credentialIssuers2);
+        assertTrue(credentialIssuers1 == credentialIssuers2);
     }
 }


### PR DESCRIPTION
In the credential issuers , we now store the current value received when retrieving credentials from SSM  .  Initially it is blank but subsequently populated . If the value is different to the one  retrieved, then we stored (serialise) the new credentials


- [PYI-421](https://govukverify.atlassian.net/browse/PYI-421)




