### PR TITLE
PYI-423: Use ID instead of ARN for IAM role

### DIFF
--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -7,7 +7,7 @@ resource "aws_ssm_parameter" "credential-issuers-config" {
 
 resource "aws_iam_role_policy" "get-credential-issuers-config" {
   name = "get-credential-issuers-config"
-  role = module.credential-issuer.iam_role_arn
+  role = module.credential-issuer.iam_role_id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/modules/endpoint/outputs.tf
+++ b/terraform/modules/endpoint/outputs.tf
@@ -3,7 +3,7 @@ output "trigger" {
   value       = sha1(jsonencode(aws_api_gateway_integration.endpoint_integration))
 }
 
-output "iam_role_arn" {
-  description = "The ARN of the IAM role used by the lambda"
-  value       = aws_iam_role.lambda_iam_role.arn
+output "iam_role_id" {
+  description = "The ID of the IAM role used by the lambda"
+  value       = aws_iam_role.lambda_iam_role.id
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When creating a aws_iam_role_policy you need to give it an ID and not an
ARN.


