### PR TITLE
PYI-424: Run SSMClient against localhost

### DIFF
--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -1,15 +1,19 @@
 package uk.gov.di.ipv.service;
 
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.lambda.powertools.parameters.ParamManager;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import uk.gov.di.ipv.dto.CredentialIssuers;
 import uk.gov.di.ipv.helpers.CredentialIssuerLoader;
 
+import java.net.URI;
 import java.util.Optional;
 
 public class ConfigurationService {
 
     private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
+    private static final String LOCALHOST_URI = "http://localhost:4567";
 
     private final SSMProvider ssmProvider;
 
@@ -18,7 +22,16 @@ public class ConfigurationService {
     }
 
     public ConfigurationService() {
-        this.ssmProvider = ParamManager.getSsmProvider();
+        if (Boolean.parseBoolean(System.getenv("IS_LOCAL"))) {
+            this.ssmProvider =
+                    ParamManager.getSsmProvider(
+                            SsmClient.builder()
+                                    .endpointOverride(URI.create(LOCALHOST_URI))
+                                    .region(Region.EU_WEST_2)
+                                    .build());
+        } else {
+            this.ssmProvider = ParamManager.getSsmProvider();
+        }
     }
 
     public boolean isRunningLocally() {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The SSM tools client will try to connect to AWS proper unless you
override the endpoint. We want to do this when running in localstack to
point to localhost. We set an env variable in localstack as a flag we
can use to achieve this.

### Why did it change

So we can run in a journey in localhost

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-424](https://govukverify.atlassian.net/browse/PYI-424)
