### PR TITLE
BAU: Fix null pointer in optional environment variable loading

### DIFF
--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -60,7 +60,7 @@ public class ConfigurationService {
     }
 
     public long getBearerAccessTokenTtl() {
-        return Optional.of(System.getenv("BEARER_TOKEN_TTL"))
+        return Optional.ofNullable(System.getenv("BEARER_TOKEN_TTL"))
                 .map(Long::valueOf)
                 .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Use Optional.ofNullable to handle loading missing optional BEARER_TOKEN_TTL env variable.
<!-- Describe the changes in detail - the "what"-->

