### PR TITLE
BAU: Test local SSM Client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0"
+			"com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 }
 
 java {

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -12,8 +12,10 @@ import java.util.Optional;
 
 public class ConfigurationService {
 
+    public static final int LOCALHOST_PORT = 4567;
+    private static final String LOCALHOST_URI = "http://localhost:" + LOCALHOST_PORT;
     private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
-    private static final String LOCALHOST_URI = "http://localhost:4567";
+    private static final String IS_LOCAL = "IS_LOCAL";
 
     private final SSMProvider ssmProvider;
 
@@ -22,7 +24,7 @@ public class ConfigurationService {
     }
 
     public ConfigurationService() {
-        if (Boolean.parseBoolean(System.getenv("IS_LOCAL"))) {
+        if (isRunningLocally()) {
             this.ssmProvider =
                     ParamManager.getSsmProvider(
                             SsmClient.builder()
@@ -34,8 +36,12 @@ public class ConfigurationService {
         }
     }
 
+    public SSMProvider getSsmProvider() {
+        return ssmProvider;
+    }
+
     public boolean isRunningLocally() {
-        return Boolean.parseBoolean(System.getenv("IS_LOCAL"));
+        return Boolean.parseBoolean(System.getenv(IS_LOCAL));
     }
 
     public String getAuthCodesTableName() {

--- a/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
@@ -1,5 +1,9 @@
 package uk.gov.di.ipv.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,23 +12,39 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.dto.CredentialIssuers;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Set;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+@WireMockTest(httpPort = ConfigurationService.LOCALHOST_PORT)
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 class ConfigurationServiceTest {
 
     public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1 =
             "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmJvYi5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbAogIC0gaWQ6IEZyYXVkSXNzdWVyCiAgICB0b2tlblVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbQogICAgY3JlZGVudGlhbFVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbS9jcmVkZW50aWFsCg==";
+
     public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2 =
             "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @SystemStub private SystemProperties systemProperties;
+
     @Mock SSMProvider ssmProvider;
 
     private CredentialIssuers credentialIssuers;
@@ -71,5 +91,31 @@ class ConfigurationServiceTest {
         CredentialIssuers credentialIssuers2 = underTest.getCredentialIssuers(credentialIssuers);
 
         assertSame(credentialIssuers1, credentialIssuers2);
+    }
+
+    @Test
+    void usesLocalSSMProviderWhenRunningLocally(WireMockRuntimeInfo wmRuntimeInfo)
+            throws JsonProcessingException {
+        stubFor(post("/").willReturn(ok()));
+        environmentVariables.set("IS_LOCAL", "true");
+        environmentVariables.set("AWS_ACCESS_KEY_ID", "ASDFGHJKL");
+        environmentVariables.set("AWS_SECRET_ACCESS_KEY", "1234567890987654321");
+
+        systemProperties.set(
+                "software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+
+        assertThrows(
+                Exception.class,
+                () -> new ConfigurationService().getSsmProvider().get("any-old-thing"));
+
+        HashMap<String, Object> requestBody =
+                new ObjectMapper()
+                        .readValue(
+                                getAllServeEvents().get(0).getRequest().getBodyAsString(),
+                                HashMap.class);
+
+        assertEquals("any-old-thing", requestBody.get("Name"));
+        assertEquals(false, requestBody.get("WithDecryption"));
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a test to ensure that the SSM client is sending requests to
localhost when the "IS_LOCAL" env variable is set to true.

### Why did it change

This was mostly done to implement the mocking of environment variables.
This is achieved with the systems stubs library.

We depend on env variables more and more and they make testing
difficult. Having an easy way to mock them should be valuable.

