### PR TITLE
BAU: Increase test coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ jacocoTestReport {
 	dependsOn test
 	reports {
 		xml.enabled true
+		html.enabled true
 	}
 }
 

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.dto;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 public class CredentialIssuers {
@@ -35,11 +36,21 @@ public class CredentialIssuers {
         this.source = source;
     }
 
-    public String getSource() {
-        return source;
-    }
-
     public boolean fromDifferentSource(String credentialIssuerConfigBase64) {
         return !this.source.equals(credentialIssuerConfigBase64);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CredentialIssuers that = (CredentialIssuers) o;
+        return Objects.equals(credentialIssuerConfigs, that.credentialIssuerConfigs)
+                && Objects.equals(source, that.source);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(credentialIssuerConfigs, source);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/service/ConfigurationService.java
@@ -12,10 +12,18 @@ import java.util.Optional;
 
 public class ConfigurationService {
 
+    public static final String ACCESS_TOKENS_TABLE_NAME = "ACCESS_TOKENS_TABLE_NAME";
+    public static final String AUTH_CODES_TABLE_NAME = "AUTH_CODES_TABLE_NAME";
+    public static final String IPV_SESSIONS_TABLE_NAME = "IPV_SESSIONS_TABLE_NAME";
+    public static final String USER_ISSUED_CREDENTIALS_TABLE_NAME =
+            "USER_ISSUED_CREDENTIALS_TABLE_NAME";
+    public static final String BEARER_TOKEN_TTL = "BEARER_TOKEN_TTL";
+    public static final String CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY =
+            "CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY";
+    public static final String IS_LOCAL = "IS_LOCAL";
     public static final int LOCALHOST_PORT = 4567;
+    public static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
     private static final String LOCALHOST_URI = "http://localhost:" + LOCALHOST_PORT;
-    private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
-    private static final String IS_LOCAL = "IS_LOCAL";
 
     private final SSMProvider ssmProvider;
 
@@ -45,13 +53,13 @@ public class ConfigurationService {
     }
 
     public String getAuthCodesTableName() {
-        return System.getenv("AUTH_CODES_TABLE_NAME");
+        return System.getenv(AUTH_CODES_TABLE_NAME);
     }
 
     public CredentialIssuers getCredentialIssuers(CredentialIssuers credentialIssuers) {
 
         String credentialIssuerConfigBase64 =
-                ssmProvider.get(System.getenv("CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY"));
+                ssmProvider.get(System.getenv(CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY));
 
         if (credentialIssuers == null
                 || credentialIssuers.fromDifferentSource(credentialIssuerConfigBase64)) {
@@ -62,19 +70,19 @@ public class ConfigurationService {
     }
 
     public String getUserIssuedCredentialTableName() {
-        return System.getenv("USER_ISSUED_CREDENTIALS_TABLE_NAME");
+        return System.getenv(USER_ISSUED_CREDENTIALS_TABLE_NAME);
     }
 
     public String getAccessTokensTableName() {
-        return System.getenv("ACCESS_TOKENS_TABLE_NAME");
+        return System.getenv(ACCESS_TOKENS_TABLE_NAME);
     }
 
     public String getIpvSessionTableName() {
-        return System.getenv("IPV_SESSIONS_TABLE_NAME");
+        return System.getenv(IPV_SESSIONS_TABLE_NAME);
     }
 
     public long getBearerAccessTokenTtl() {
-        return Optional.ofNullable(System.getenv("BEARER_TOKEN_TTL"))
+        return Optional.ofNullable(System.getenv(BEARER_TOKEN_TTL))
                 .map(Long::valueOf)
                 .orElse(DEFAULT_BEARER_TOKEN_TTL_IN_SECS);
     }

--- a/src/test/java/uk/gov/di/ipv/helpers/APIGatewayResponseGeneratorTest.java
+++ b/src/test/java/uk/gov/di/ipv/helpers/APIGatewayResponseGeneratorTest.java
@@ -1,0 +1,20 @@
+package uk.gov.di.ipv.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class APIGatewayResponseGeneratorTest {
+
+    @Test
+    void proxyJsonResponseRaises500IfInvalidJson() {
+        // using a mock causes ObjectMapper().writeValueAsString() to throw a
+        // JsonProcessingException
+        Object stringMock = mock(Object.class);
+        APIGatewayProxyResponseEvent response =
+                ApiGatewayResponseGenerator.proxyJsonResponse(200, stringMock);
+        assertEquals(500, response.getStatusCode());
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/helpers/RequestHelperTest.java
+++ b/src/test/java/uk/gov/di/ipv/helpers/RequestHelperTest.java
@@ -1,11 +1,16 @@
 package uk.gov.di.ipv.helpers;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RequestHelperTest {
@@ -26,5 +31,27 @@ class RequestHelperTest {
     @ValueSource(strings = {"boo", "", "foo", "Foo"})
     void noMatchingHeader(String headerName) {
         assertTrue(RequestHelper.getHeader(headers, headerName).isEmpty());
+    }
+
+    @Test
+    void getHeaderShouldReturnEmptyOptionalIfHeadersIsNull() {
+        Optional<String> result = RequestHelper.getHeader(null, "someHeader");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getHeaderShouldReturnEmptyOptionalIfHeaderValueIsBlank() {
+        Map<String, String> blank1 = Map.of("illbeblank", "");
+        Map<String, String> blank2 = new HashMap<>();
+        blank2.put("illbeblank", null);
+
+        for (Map<String, String> headers : List.of(blank1, blank2)) {
+            assertTrue(RequestHelper.getHeader(headers, "illbeblank").isEmpty());
+        }
+    }
+
+    @Test
+    void getHeaderByKeyShouldReturnNullIfHeaderNotFound() {
+        assertNull(RequestHelper.getHeaderByKey(Map.of("tome", "toyou"), "ohdearohdear"));
     }
 }

--- a/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/AuthorizationHandlerTest.java
@@ -8,19 +8,29 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.service.AuthorizationCodeService;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.service.ConfigurationService.IS_LOCAL;
 
+@ExtendWith(SystemStubsExtension.class)
 class AuthorizationHandlerTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
     private static final Map<String, String> TEST_EVENT_HEADERS = Map.of("ipv-session-id", "12345");
 
     private final Context context = mock(Context.class);
@@ -38,6 +48,12 @@ class AuthorizationHandlerTest {
                 .thenReturn(authorizationCode);
 
         handler = new AuthorizationHandler(mockAuthorizationCodeService);
+    }
+
+    @Test
+    void noArgsConstructor() {
+        environmentVariables.set(IS_LOCAL, "true");
+        assertDoesNotThrow(() -> new AuthorizationHandler());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/CredentialIssuerHandlerTest.java
@@ -22,6 +22,9 @@ import uk.gov.di.ipv.dto.CredentialIssuerRequestDto;
 import uk.gov.di.ipv.dto.CredentialIssuers;
 import uk.gov.di.ipv.service.ConfigurationService;
 import uk.gov.di.ipv.service.CredentialIssuerService;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -38,7 +41,10 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 class CredentialIssuerHandlerTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
 
     @Mock private Context context;
 

--- a/src/test/java/uk/gov/di/ipv/lambda/IpvSessionHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/IpvSessionHandlerTest.java
@@ -12,15 +12,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.service.IpvSessionService;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.service.ConfigurationService.IS_LOCAL;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 class IpvSessionHandlerTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
 
     @Mock private Context mockContext;
 
@@ -34,6 +42,12 @@ class IpvSessionHandlerTest {
     @BeforeEach
     void setUp() {
         ipvSessionHandler = new IpvSessionHandler(mockIpvSessionService);
+    }
+
+    @Test
+    void noArgsConstructor() {
+        environmentVariables.set(IS_LOCAL, "true");
+        assertDoesNotThrow(() -> new IpvSessionHandler());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/lambda/UserIdentityHandlerTest.java
+++ b/src/test/java/uk/gov/di/ipv/lambda/UserIdentityHandlerTest.java
@@ -16,19 +16,27 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.service.AccessTokenService;
 import uk.gov.di.ipv.service.UserIdentityService;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.service.ConfigurationService.IS_LOCAL;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 class UserIdentityHandlerTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
 
     private static final String TEST_IPV_SESSION_ID = UUID.randomUUID().toString();
 
@@ -54,6 +62,12 @@ class UserIdentityHandlerTest {
         userIssuedCredential.put("foo", "bar");
 
         userInfoHandler = new UserIdentityHandler(mockUserIdentityService, mockAccessTokenService);
+    }
+
+    @Test
+    void noArgsConstructor() {
+        environmentVariables.set(IS_LOCAL, "true");
+        assertDoesNotThrow(() -> new UserIdentityHandler());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/persistance/DataStoreTest.java
+++ b/src/test/java/uk/gov/di/ipv/persistance/DataStoreTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.persistance;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -13,19 +14,29 @@ import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.service.ConfigurationService;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.service.ConfigurationService.IS_LOCAL;
 
+@ExtendWith(SystemStubsExtension.class)
 class DataStoreTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @SystemStub private SystemProperties systemProperties;
+
     private static final String TEST_TABLE_NAME = "test-auth-code-table";
 
     private DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
@@ -55,6 +66,15 @@ class DataStoreTest {
                         AuthorizationCodeItem.class,
                         mockDynamoDbEnhancedClient,
                         mockConfigurationService);
+    }
+
+    @Test
+    void handlerConstructor() {
+        environmentVariables.set(IS_LOCAL, "true");
+        systemProperties.set(
+                "software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+        assertDoesNotThrow(() -> new DataStore<>("tableName", AuthorizationCodeItem.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/service/AccessTokenServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/AccessTokenServiceTest.java
@@ -16,25 +16,31 @@ import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.validation.ValidationResult;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.net.URI;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.service.ConfigurationService.IS_LOCAL;
 
+@ExtendWith(SystemStubsExtension.class)
 class AccessTokenServiceTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @SystemStub private SystemProperties systemProperties;
 
     private DataStore<AccessTokenItem> mockDataStore;
     private ConfigurationService mockConfigurationService;
@@ -45,6 +51,16 @@ class AccessTokenServiceTest {
         this.mockConfigurationService = mock(ConfigurationService.class);
         this.mockDataStore = mock(DataStore.class);
         this.accessTokenService = new AccessTokenService(mockDataStore, mockConfigurationService);
+    }
+
+    @Test
+    void noArgsConstructor() {
+        environmentVariables.set(IS_LOCAL, "true");
+        systemProperties.set(
+                "software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+
+        assertDoesNotThrow(() -> new AccessTokenService());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/service/AuthorizationCodeServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/AuthorizationCodeServiceTest.java
@@ -3,18 +3,27 @@ package uk.gov.di.ipv.service;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.AuthorizationCodeItem;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.service.ConfigurationService.IS_LOCAL;
 
+@ExtendWith(SystemStubsExtension.class)
 class AuthorizationCodeServiceTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @SystemStub private SystemProperties systemProperties;
 
     private DataStore<AuthorizationCodeItem> mockDataStore;
     private ConfigurationService mockConfigurationService;
@@ -29,6 +38,16 @@ class AuthorizationCodeServiceTest {
 
         authorizationCodeService =
                 new AuthorizationCodeService(mockDataStore, mockConfigurationService);
+    }
+
+    @Test
+    void noArgsConstructor() {
+        environmentVariables.set(IS_LOCAL, "true");
+        systemProperties.set(
+                "software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+
+        assertDoesNotThrow(() -> new AuthorizationCodeService());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
@@ -20,30 +20,29 @@ import uk.org.webcompere.systemstubs.properties.SystemProperties;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.Set;
+import java.util.HashSet;
+import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.service.ConfigurationService.*;
 
 @WireMockTest(httpPort = ConfigurationService.LOCALHOST_PORT)
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SystemStubsExtension.class)
 class ConfigurationServiceTest {
 
-    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1 =
-            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmJvYi5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbAogIC0gaWQ6IEZyYXVkSXNzdWVyCiAgICB0b2tlblVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbQogICAgY3JlZGVudGlhbFVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbS9jcmVkZW50aWFsCg==";
-
-    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2 =
-            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
-
     @SystemStub private EnvironmentVariables environmentVariables;
 
     @SystemStub private SystemProperties systemProperties;
+
+    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1 =
+            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
+
+    public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2 =
+            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmJvYi5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbAogIC0gaWQ6IEZyYXVkSXNzdWVyCiAgICB0b2tlblVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbQogICAgY3JlZGVudGlhbFVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbS9jcmVkZW50aWFsCg==";
 
     @Mock SSMProvider ssmProvider;
 
@@ -53,16 +52,26 @@ class ConfigurationServiceTest {
     void setUp() throws URISyntaxException {
         credentialIssuers =
                 new CredentialIssuers(
-                        Set.of(
-                                new CredentialIssuerConfig(
-                                        "PassportIssuer",
-                                        new URI("http://www.example.com"),
-                                        new URI("http://www.example.com/credential")),
-                                new CredentialIssuerConfig(
-                                        "FraudIssuer",
-                                        new URI("http://www.example.com"),
-                                        new URI("http://www.example.com/credential"))),
+                        new HashSet<>(
+                                List.of(
+                                        new CredentialIssuerConfig(
+                                                "PassportIssuer",
+                                                new URI("http://www.example.com"),
+                                                new URI("http://www.example.com/credential")),
+                                        new CredentialIssuerConfig(
+                                                "FraudIssuer",
+                                                new URI("http://www.example.com"),
+                                                new URI("http://www.example.com/credential")))),
                         CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
+    }
+
+    @Test
+    void shouldReturnCredentialIssuersWhenPassedNull() {
+        ConfigurationService underTest = new ConfigurationService(ssmProvider);
+        when(ssmProvider.get(any())).thenReturn(CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
+
+        CredentialIssuers testCredentialIssuers = underTest.getCredentialIssuers(null);
+        assertEquals(credentialIssuers, testCredentialIssuers);
     }
 
     @Test
@@ -97,7 +106,7 @@ class ConfigurationServiceTest {
     void usesLocalSSMProviderWhenRunningLocally(WireMockRuntimeInfo wmRuntimeInfo)
             throws JsonProcessingException {
         stubFor(post("/").willReturn(ok()));
-        environmentVariables.set("IS_LOCAL", "true");
+        environmentVariables.set(IS_LOCAL, "true");
         environmentVariables.set("AWS_ACCESS_KEY_ID", "ASDFGHJKL");
         environmentVariables.set("AWS_SECRET_ACCESS_KEY", "1234567890987654321");
 
@@ -105,11 +114,10 @@ class ConfigurationServiceTest {
                 "software.amazon.awssdk.http.service.impl",
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
 
-        assertThrows(
-                Exception.class,
-                () -> new ConfigurationService().getSsmProvider().get("any-old-thing"));
+        SSMProvider ssmProvider = new ConfigurationService().getSsmProvider();
+        assertThrows(NullPointerException.class, () -> ssmProvider.get("any-old-thing"));
 
-        HashMap<String, Object> requestBody =
+        HashMap requestBody =
                 new ObjectMapper()
                         .readValue(
                                 getAllServeEvents().get(0).getRequest().getBodyAsString(),
@@ -117,5 +125,34 @@ class ConfigurationServiceTest {
 
         assertEquals("any-old-thing", requestBody.get("Name"));
         assertEquals(false, requestBody.get("WithDecryption"));
+    }
+
+    @Test
+    void noArgsConstructor() {
+        environmentVariables.set("AWS_REGION", "eu-west-2");
+        assertDoesNotThrow(() -> new ConfigurationService());
+    }
+
+    @Test
+    void gettingEnvVariables() {
+        environmentVariables.set("AWS_REGION", "eu-west-2");
+        ConfigurationService configurationService = new ConfigurationService();
+
+        environmentVariables.set(AUTH_CODES_TABLE_NAME, "auth codes table name");
+        environmentVariables.set(USER_ISSUED_CREDENTIALS_TABLE_NAME, "user issued cred table name");
+        environmentVariables.set(ACCESS_TOKENS_TABLE_NAME, "access token table name");
+        environmentVariables.set(IPV_SESSIONS_TABLE_NAME, "ipv sessions table name");
+
+        assertEquals("auth codes table name", configurationService.getAuthCodesTableName());
+        assertEquals(
+                "user issued cred table name",
+                configurationService.getUserIssuedCredentialTableName());
+        assertEquals("access token table name", configurationService.getAccessTokensTableName());
+        assertEquals("ipv sessions table name", configurationService.getIpvSessionTableName());
+        assertEquals(
+                DEFAULT_BEARER_TOKEN_TTL_IN_SECS, configurationService.getBearerAccessTokenTtl());
+
+        environmentVariables.set(BEARER_TOKEN_TTL, "1");
+        assertEquals(1L, configurationService.getBearerAccessTokenTtl());
     }
 }

--- a/src/test/java/uk/gov/di/ipv/service/IpvSessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/IpvSessionServiceTest.java
@@ -8,13 +8,22 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.IpvSessionItem;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
+import static uk.gov.di.ipv.service.ConfigurationService.IS_LOCAL;
 
+@ExtendWith(SystemStubsExtension.class)
 @ExtendWith(MockitoExtension.class)
 class IpvSessionServiceTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @SystemStub private SystemProperties systemProperties;
 
     @Mock private DataStore<IpvSessionItem> mockDataStore;
 
@@ -25,6 +34,16 @@ class IpvSessionServiceTest {
     @BeforeEach
     void setUp() {
         ipvSessionService = new IpvSessionService(mockDataStore, mockConfigurationService);
+    }
+
+    @Test
+    void noArgsConstructor() {
+        environmentVariables.set(IS_LOCAL, "true");
+        systemProperties.set(
+                "software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+
+        assertDoesNotThrow(() -> new IpvSessionService());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/service/UserIdentityServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/UserIdentityServiceTest.java
@@ -7,17 +7,28 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.UserIssuedCredentialsItem;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.service.ConfigurationService.IS_LOCAL;
 
+@ExtendWith(SystemStubsExtension.class)
 @ExtendWith(MockitoExtension.class)
 class UserIdentityServiceTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @SystemStub private SystemProperties systemProperties;
 
     @Mock private ConfigurationService mockConfigurationService;
 
@@ -28,6 +39,16 @@ class UserIdentityServiceTest {
     @BeforeEach
     void setUp() {
         userIdentityService = new UserIdentityService(mockConfigurationService, mockDataStore);
+    }
+
+    @Test
+    void noArgsConstructor() {
+        environmentVariables.set(IS_LOCAL, "true");
+        systemProperties.set(
+                "software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+
+        assertDoesNotThrow(() -> new UserIdentityService());
     }
 
     @Test


### PR DESCRIPTION




<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds a few tests to cover the lines that are missing according to
sonarcloud.
### Why did it change

A lot of these are just testing the no arg constructors for the handlers
and services used by the lambdas. Whilst there is not much merit in
testing them this way, it does boost our coverage report.

Our quality gate is set to 80% coverage. Without these changes we're
quite close to this boundary. Having code in these constructors drag us
down isn't helpful.
