### PR TITLE
BAU: Ignore no arg constructors from coverage reports

### DIFF
--- a/src/main/java/uk/gov/di/ipv/annotations/ExcludeFromGeneratedCoverageReport.java
+++ b/src/main/java/uk/gov/di/ipv/annotations/ExcludeFromGeneratedCoverageReport.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.CONSTRUCTOR)
+public @interface ExcludeFromGeneratedCoverageReport {}

--- a/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
+++ b/src/main/java/uk/gov/di/ipv/dto/CredentialIssuers.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.dto;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 public class CredentialIssuers {
@@ -35,11 +36,21 @@ public class CredentialIssuers {
         this.source = source;
     }
 
-    public String getSource() {
-        return source;
-    }
-
     public boolean fromDifferentSource(String credentialIssuerConfigBase64) {
         return !this.source.equals(credentialIssuerConfigBase64);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CredentialIssuers that = (CredentialIssuers) o;
+        return Objects.equals(credentialIssuerConfigs, that.credentialIssuerConfigs)
+                && Objects.equals(source, that.source);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(credentialIssuerConfigs, source);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AccessTokenHandler.java
@@ -17,6 +17,7 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.service.AccessTokenService;
 import uk.gov.di.ipv.service.AuthorizationCodeService;
@@ -46,6 +47,7 @@ public class AccessTokenHandler
         this.authorizationCodeService = authorizationCodeService;
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public AccessTokenHandler() {
         this.accessTokenService = new AccessTokenService();
         this.authorizationCodeService = new AuthorizationCodeService();

--- a/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/AuthorizationHandler.java
@@ -11,6 +11,7 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.helpers.RequestHelper;
@@ -39,6 +40,7 @@ public class AuthorizationHandler
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public AuthorizationHandler() {
         this.authorizationCodeService = new AuthorizationCodeService();
     }

--- a/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/CredentialIssuerHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import net.minidev.json.JSONObject;
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
@@ -43,6 +44,7 @@ public class CredentialIssuerHandler
         this.credentialIssuers = configurationService.getCredentialIssuers(credentialIssuers);
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public CredentialIssuerHandler() {
         this.credentialIssuerService = new CredentialIssuerService();
         this.configurationService = new ConfigurationService();

--- a/src/main/java/uk/gov/di/ipv/lambda/UserIdentityHandler.java
+++ b/src/main/java/uk/gov/di/ipv/lambda/UserIdentityHandler.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.helpers.RequestHelper;
 import uk.gov.di.ipv.service.AccessTokenService;
@@ -40,6 +41,7 @@ public class UserIdentityHandler
         this.accessTokenService = accessTokenService;
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public UserIdentityHandler() {
         this.userIdentityService = new UserIdentityService();
         this.accessTokenService = new AccessTokenService();

--- a/src/main/java/uk/gov/di/ipv/persistence/DataStore.java
+++ b/src/main/java/uk/gov/di/ipv/persistence/DataStore.java
@@ -7,7 +7,6 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.service.ConfigurationService;
 
 import java.net.URI;
@@ -19,33 +18,25 @@ public class DataStore<T> {
     private static final String LOCALHOST_URI = "http://localhost:4567";
 
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
-    private final ConfigurationService configurationService;
     private final String tableName;
     private final Class<T> typeParameterClass;
-
-    @ExcludeFromGeneratedCoverageReport
-    public DataStore(String tableName, Class<T> typeParameterClass) {
-        this.tableName = tableName;
-        this.typeParameterClass = typeParameterClass;
-        this.configurationService = new ConfigurationService();
-
-        DynamoDbClient client =
-                configurationService.isRunningLocally()
-                        ? createLocalDbClient()
-                        : DynamoDbClient.create();
-
-        dynamoDbEnhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
-    }
 
     public DataStore(
             String tableName,
             Class<T> typeParameterClass,
-            DynamoDbEnhancedClient dynamoDbEnhancedClient,
-            ConfigurationService configurationService) {
+            DynamoDbEnhancedClient dynamoDbEnhancedClient) {
         this.tableName = tableName;
         this.typeParameterClass = typeParameterClass;
         this.dynamoDbEnhancedClient = dynamoDbEnhancedClient;
-        this.configurationService = configurationService;
+    }
+
+    public static DynamoDbEnhancedClient getClient() {
+        DynamoDbClient client =
+                new ConfigurationService().isRunningLocally()
+                        ? createLocalDbClient()
+                        : DynamoDbClient.create();
+
+        return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
     }
 
     public void create(T item) {
@@ -83,7 +74,7 @@ public class DataStore<T> {
         return delete(Key.builder().partitionValue(partitionValue).build());
     }
 
-    private DynamoDbClient createLocalDbClient() {
+    private static DynamoDbClient createLocalDbClient() {
         return DynamoDbClient.builder()
                 .endpointOverride(URI.create(LOCALHOST_URI))
                 .region(Region.EU_WEST_2)

--- a/src/main/java/uk/gov/di/ipv/persistence/DataStore.java
+++ b/src/main/java/uk/gov/di/ipv/persistence/DataStore.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.service.ConfigurationService;
 
 import java.net.URI;
@@ -22,6 +23,7 @@ public class DataStore<T> {
     private final String tableName;
     private final Class<T> typeParameterClass;
 
+    @ExcludeFromGeneratedCoverageReport
     public DataStore(String tableName, Class<T> typeParameterClass) {
         this.tableName = tableName;
         this.typeParameterClass = typeParameterClass;

--- a/src/main/java/uk/gov/di/ipv/service/AccessTokenService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AccessTokenService.java
@@ -25,7 +25,9 @@ public class AccessTokenService {
         this.configurationService = new ConfigurationService();
         this.dataStore =
                 new DataStore<>(
-                        configurationService.getAccessTokensTableName(), AccessTokenItem.class);
+                        configurationService.getAccessTokensTableName(),
+                        AccessTokenItem.class,
+                        DataStore.getClient());
     }
 
     public AccessTokenService(

--- a/src/main/java/uk/gov/di/ipv/service/AccessTokenService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AccessTokenService.java
@@ -9,6 +9,7 @@ import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.validation.ValidationResult;
@@ -19,6 +20,7 @@ public class AccessTokenService {
     private final DataStore<AccessTokenItem> dataStore;
     private final ConfigurationService configurationService;
 
+    @ExcludeFromGeneratedCoverageReport
     public AccessTokenService() {
         this.configurationService = new ConfigurationService();
         this.dataStore =

--- a/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.service;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.AuthorizationCodeItem;
 
@@ -10,6 +11,7 @@ public class AuthorizationCodeService {
     private final DataStore<AuthorizationCodeItem> dataStore;
     private final ConfigurationService configurationService;
 
+    @ExcludeFromGeneratedCoverageReport
     public AuthorizationCodeService() {
         this.configurationService = new ConfigurationService();
         this.dataStore =

--- a/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
+++ b/src/main/java/uk/gov/di/ipv/service/AuthorizationCodeService.java
@@ -16,7 +16,9 @@ public class AuthorizationCodeService {
         this.configurationService = new ConfigurationService();
         this.dataStore =
                 new DataStore<>(
-                        configurationService.getAuthCodesTableName(), AuthorizationCodeItem.class);
+                        configurationService.getAuthCodesTableName(),
+                        AuthorizationCodeItem.class,
+                        DataStore.getClient());
     }
 
     public AuthorizationCodeService(

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -9,6 +9,7 @@ import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
 import net.minidev.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.domain.CredentialIssuerException;
 import uk.gov.di.ipv.domain.ErrorResponse;
 import uk.gov.di.ipv.dto.CredentialIssuerConfig;
@@ -29,6 +30,7 @@ public class CredentialIssuerService {
     private final DataStore<UserIssuedCredentialsItem> dataStore;
     private final ConfigurationService configurationService;
 
+    @ExcludeFromGeneratedCoverageReport
     public CredentialIssuerService() {
         this.configurationService = new ConfigurationService();
         this.dataStore =

--- a/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
+++ b/src/main/java/uk/gov/di/ipv/service/CredentialIssuerService.java
@@ -36,7 +36,8 @@ public class CredentialIssuerService {
         this.dataStore =
                 new DataStore<>(
                         configurationService.getUserIssuedCredentialTableName(),
-                        UserIssuedCredentialsItem.class);
+                        UserIssuedCredentialsItem.class,
+                        DataStore.getClient());
     }
 
     // used for testing

--- a/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
+++ b/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
@@ -17,7 +17,9 @@ public class IpvSessionService {
         this.configurationService = new ConfigurationService();
         dataStore =
                 new DataStore<>(
-                        configurationService.getIpvSessionTableName(), IpvSessionItem.class);
+                        configurationService.getIpvSessionTableName(),
+                        IpvSessionItem.class,
+                        DataStore.getClient());
     }
 
     public IpvSessionService(

--- a/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
+++ b/src/main/java/uk/gov/di/ipv/service/IpvSessionService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.service;
 
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.IpvSessionItem;
 
@@ -11,6 +12,7 @@ public class IpvSessionService {
     private final DataStore<IpvSessionItem> dataStore;
     private final ConfigurationService configurationService;
 
+    @ExcludeFromGeneratedCoverageReport
     public IpvSessionService() {
         this.configurationService = new ConfigurationService();
         dataStore =

--- a/src/main/java/uk/gov/di/ipv/service/UserIdentityService.java
+++ b/src/main/java/uk/gov/di/ipv/service/UserIdentityService.java
@@ -18,7 +18,8 @@ public class UserIdentityService {
         this.dataStore =
                 new DataStore<>(
                         configurationService.getUserIssuedCredentialTableName(),
-                        UserIssuedCredentialsItem.class);
+                        UserIssuedCredentialsItem.class,
+                        DataStore.getClient());
     }
 
     public UserIdentityService(

--- a/src/main/java/uk/gov/di/ipv/service/UserIdentityService.java
+++ b/src/main/java/uk/gov/di/ipv/service/UserIdentityService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.service;
 
+import uk.gov.di.ipv.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.UserIssuedCredentialsItem;
 
@@ -11,6 +12,7 @@ public class UserIdentityService {
     private final ConfigurationService configurationService;
     private final DataStore<UserIssuedCredentialsItem> dataStore;
 
+    @ExcludeFromGeneratedCoverageReport
     public UserIdentityService() {
         this.configurationService = new ConfigurationService();
         this.dataStore =

--- a/src/test/java/uk/gov/di/ipv/helpers/APIGatewayResponseGeneratorTest.java
+++ b/src/test/java/uk/gov/di/ipv/helpers/APIGatewayResponseGeneratorTest.java
@@ -1,0 +1,20 @@
+package uk.gov.di.ipv.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class APIGatewayResponseGeneratorTest {
+
+    @Test
+    void proxyJsonResponseRaises500IfInvalidJson() {
+        // using a mock causes ObjectMapper().writeValueAsString() to throw a
+        // JsonProcessingException
+        Object stringMock = mock(Object.class);
+        APIGatewayProxyResponseEvent response =
+                ApiGatewayResponseGenerator.proxyJsonResponse(200, stringMock);
+        assertEquals(500, response.getStatusCode());
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/helpers/RequestHelperTest.java
+++ b/src/test/java/uk/gov/di/ipv/helpers/RequestHelperTest.java
@@ -1,11 +1,16 @@
 package uk.gov.di.ipv.helpers;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RequestHelperTest {
@@ -26,5 +31,27 @@ class RequestHelperTest {
     @ValueSource(strings = {"boo", "", "foo", "Foo"})
     void noMatchingHeader(String headerName) {
         assertTrue(RequestHelper.getHeader(headers, headerName).isEmpty());
+    }
+
+    @Test
+    void getHeaderShouldReturnEmptyOptionalIfHeadersIsNull() {
+        Optional<String> result = RequestHelper.getHeader(null, "someHeader");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getHeaderShouldReturnEmptyOptionalIfHeaderValueIsBlank() {
+        Map<String, String> blank1 = Map.of("illbeblank", "");
+        Map<String, String> blank2 = new HashMap<>();
+        blank2.put("illbeblank", null);
+
+        for (Map<String, String> headers : List.of(blank1, blank2)) {
+            assertTrue(RequestHelper.getHeader(headers, "illbeblank").isEmpty());
+        }
+    }
+
+    @Test
+    void getHeaderByKeyShouldReturnNullIfHeaderNotFound() {
+        assertNull(RequestHelper.getHeaderByKey(Map.of("tome", "toyou"), "ohdearohdear"));
     }
 }

--- a/src/test/java/uk/gov/di/ipv/persistance/DataStoreTest.java
+++ b/src/test/java/uk/gov/di/ipv/persistance/DataStoreTest.java
@@ -12,7 +12,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import uk.gov.di.ipv.persistence.DataStore;
 import uk.gov.di.ipv.persistence.item.AuthorizationCodeItem;
-import uk.gov.di.ipv.service.ConfigurationService;
 
 import java.util.stream.Stream;
 
@@ -30,7 +29,6 @@ class DataStoreTest {
 
     private DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
     private DynamoDbTable<AuthorizationCodeItem> mockDynamoDbTable;
-    private ConfigurationService mockConfigurationService;
 
     private AuthorizationCodeItem authorizationCodeItem;
     private DataStore<AuthorizationCodeItem> dataStore;
@@ -39,9 +37,7 @@ class DataStoreTest {
     void setUp() {
         mockDynamoDbEnhancedClient = mock(DynamoDbEnhancedClient.class);
         mockDynamoDbTable = mock(DynamoDbTable.class);
-        mockConfigurationService = mock(ConfigurationService.class);
 
-        when(mockConfigurationService.isRunningLocally()).thenReturn(true);
         when(mockDynamoDbEnhancedClient.table(anyString(), any(TableSchema.class)))
                 .thenReturn(mockDynamoDbTable);
 
@@ -51,10 +47,7 @@ class DataStoreTest {
 
         dataStore =
                 new DataStore<>(
-                        TEST_TABLE_NAME,
-                        AuthorizationCodeItem.class,
-                        mockDynamoDbEnhancedClient,
-                        mockConfigurationService);
+                        TEST_TABLE_NAME, AuthorizationCodeItem.class, mockDynamoDbEnhancedClient);
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/service/ConfigurationServiceTest.java
@@ -20,7 +20,8 @@ import uk.org.webcompere.systemstubs.properties.SystemProperties;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.Set;
+import java.util.HashSet;
+import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,10 +37,10 @@ import static org.mockito.Mockito.when;
 class ConfigurationServiceTest {
 
     public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1 =
-            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmJvYi5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbAogIC0gaWQ6IEZyYXVkSXNzdWVyCiAgICB0b2tlblVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbQogICAgY3JlZGVudGlhbFVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbS9jcmVkZW50aWFsCg==";
+            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
 
     public static final String CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2 =
-            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tCiAgICBjcmVkZW50aWFsVXJsOiBodHRwOi8vd3d3LmV4YW1wbGUuY29tL2NyZWRlbnRpYWwKICAtIGlkOiBGcmF1ZElzc3VlcgogICAgdG9rZW5Vcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbA==";
+            "Y3JlZGVudGlhbElzc3VlckNvbmZpZ3M6CiAgLSBpZDogUGFzc3BvcnRJc3N1ZXIKICAgIHRva2VuVXJsOiBodHRwOi8vd3d3LmJvYi5jb20KICAgIGNyZWRlbnRpYWxVcmw6IGh0dHA6Ly93d3cuZXhhbXBsZS5jb20vY3JlZGVudGlhbAogIC0gaWQ6IEZyYXVkSXNzdWVyCiAgICB0b2tlblVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbQogICAgY3JlZGVudGlhbFVybDogaHR0cDovL3d3dy5leGFtcGxlLmNvbS9jcmVkZW50aWFsCg==";
 
     @SystemStub private EnvironmentVariables environmentVariables;
 
@@ -48,47 +49,60 @@ class ConfigurationServiceTest {
     @Mock SSMProvider ssmProvider;
 
     private CredentialIssuers credentialIssuers;
+    private ConfigurationService configurationService;
 
     @BeforeEach
     void setUp() throws URISyntaxException {
+        configurationService = new ConfigurationService(ssmProvider);
         credentialIssuers =
                 new CredentialIssuers(
-                        Set.of(
-                                new CredentialIssuerConfig(
-                                        "PassportIssuer",
-                                        new URI("http://www.example.com"),
-                                        new URI("http://www.example.com/credential")),
-                                new CredentialIssuerConfig(
-                                        "FraudIssuer",
-                                        new URI("http://www.example.com"),
-                                        new URI("http://www.example.com/credential"))),
+                        new HashSet<>(
+                                List.of(
+                                        new CredentialIssuerConfig(
+                                                "PassportIssuer",
+                                                new URI("http://www.example.com"),
+                                                new URI("http://www.example.com/credential")),
+                                        new CredentialIssuerConfig(
+                                                "FraudIssuer",
+                                                new URI("http://www.example.com"),
+                                                new URI("http://www.example.com/credential")))),
                         CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
     }
 
     @Test
+    void shouldReturnCredentialIssuersWhenPassedNull() {
+        when(ssmProvider.get(any())).thenReturn(CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
+
+        CredentialIssuers testCredentialIssuers = configurationService.getCredentialIssuers(null);
+        assertEquals(credentialIssuers, testCredentialIssuers);
+    }
+
+    @Test
     void shouldReturnDifferentCredentialIssuersWhenBase64EncodingHasChanged() {
-        ConfigurationService underTest = new ConfigurationService(ssmProvider);
         when(ssmProvider.get(any()))
                 .thenReturn(
                         CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1,
                         CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_2);
 
-        CredentialIssuers credentialIssuers1 = underTest.getCredentialIssuers(credentialIssuers);
-        CredentialIssuers credentialIssuers2 = underTest.getCredentialIssuers(credentialIssuers);
+        CredentialIssuers credentialIssuers1 =
+                configurationService.getCredentialIssuers(credentialIssuers);
+        CredentialIssuers credentialIssuers2 =
+                configurationService.getCredentialIssuers(credentialIssuers);
 
         assertNotEquals(credentialIssuers1, credentialIssuers2);
     }
 
     @Test
     void shouldReturnSameCredentialIssuersWhenBase64EncodingHasNotChanged() {
-        ConfigurationService underTest = new ConfigurationService(ssmProvider);
         when(ssmProvider.get(any()))
                 .thenReturn(
                         CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1,
                         CREDENTIAL_ISSUER_CONFIG_BASE64_VERSION_1);
 
-        CredentialIssuers credentialIssuers1 = underTest.getCredentialIssuers(credentialIssuers);
-        CredentialIssuers credentialIssuers2 = underTest.getCredentialIssuers(credentialIssuers);
+        CredentialIssuers credentialIssuers1 =
+                configurationService.getCredentialIssuers(credentialIssuers);
+        CredentialIssuers credentialIssuers2 =
+                configurationService.getCredentialIssuers(credentialIssuers);
 
         assertSame(credentialIssuers1, credentialIssuers2);
     }
@@ -105,11 +119,10 @@ class ConfigurationServiceTest {
                 "software.amazon.awssdk.http.service.impl",
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
 
-        assertThrows(
-                Exception.class,
-                () -> new ConfigurationService().getSsmProvider().get("any-old-thing"));
+        SSMProvider ssmProvider = new ConfigurationService().getSsmProvider();
+        assertThrows(NullPointerException.class, () -> ssmProvider.get("any-old-thing"));
 
-        HashMap<String, Object> requestBody =
+        HashMap requestBody =
                 new ObjectMapper()
                         .readValue(
                                 getAllServeEvents().get(0).getRequest().getBodyAsString(),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Turns out that jacoco will ignore code marked with an annotation that
includes the word "Generated".

The first commit adds a new annotation we can apply only to constructors which we
can use to ignore those constructors which are painful to test.

The second commit refactors the DataStore to have one constructor used by the
lambda handlers as well as the tests.

The third commit adds a few tests to pick some low hanging fruit with regards to 
coverage.

### Why did it change

To move us away from out code coverage quality gate threshold
