### PR TITLE
BAU: Fix ipv-session-header case sensitive validation check

### DIFF
--- a/lambdas/authorization/src/main/java/uk/gov/di/ipv/core/authorization/AuthorizationHandler.java
+++ b/lambdas/authorization/src/main/java/uk/gov/di/ipv/core/authorization/AuthorizationHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Identifier;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -101,7 +102,8 @@ public class AuthorizationHandler
             return new ValidationResult<>(false, ErrorResponse.MISSING_QUERY_PARAMETERS);
         }
 
-        if (!requestHeaders.containsKey(IPV_SESSION_ID_HEADER_KEY)) {
+        String ipvSessionId = RequestHelper.getHeaderByKey(requestHeaders, IPV_SESSION_ID_HEADER_KEY);
+        if (StringUtils.isBlank(ipvSessionId)) {
             return new ValidationResult<>(false, ErrorResponse.MISSING_IPV_SESSION_ID);
         }
         return ValidationResult.createValidResult();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the validation to use the case-insensitive request helper method for retrieving request header values.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Header names should be case-insensitive especially since running locally the header names can be changed to contain upper-case characters.
<!-- Describe the reason these changes were made - the "why" -->

