### PR TITLE
BAU: Set fetch depth for sonar

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
## Proposed changes

### What changed

Set fetch depth to 0.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

Sonar complains about shallow clones. It is recommended to set the fetch depth to 0 in the action that runs sonar.
