### PR TITLE
PYI-537 - Added new module to deploy credential issuer params

### DIFF
--- a/terraform/modules/credential_issuer/main.tf
+++ b/terraform/modules/credential_issuer/main.tf
@@ -1,0 +1,15 @@
+resource "aws_ssm_parameter" "token_url" {
+  for_each  = var.issuers
+  name      = "/${var.environment}/IPV/Core/CredentialIssuers/${each.value.id}/tokenUrl"
+  type      = var.type
+  value     = each.value.token_url
+  overwrite = var.overwrite
+}
+
+resource "aws_ssm_parameter" "credential_url" {
+  for_each  = var.issuers
+  name      = "/${var.environment}/IPV/Core/CredentialIssuers/${each.value.id}/credentialUrl"
+  type      = var.type
+  value     = each.value.credential_url
+  overwrite = var.overwrite
+}

--- a/terraform/modules/credential_issuer/variables.tf
+++ b/terraform/modules/credential_issuer/variables.tf
@@ -1,0 +1,21 @@
+variable "issuers" {
+  description = "Map of credential issuers configuration to store in Parameter Store"
+  type        = map(any)
+}
+
+variable "environment" {
+  description = "Name of the environment this is being created in"
+  type        = string
+}
+
+variable "overwrite" {
+  description = "Overwrite the value already stored inside of Parameter Store"
+  default     = true
+  type        = bool
+}
+
+variable "type" {
+  description = "Type of value to store in Parameter Store"
+  default     = "String"
+  type        = string
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Created new credential issuer module for storing related parameters in AWS
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Call the new parameter module that lives within core-back, this will create all the credential-isssuers config in Parameter Store.
We decided to move away from a base64 encoded string. ADR is being written (link will be added asap)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-537](https://govukverify.atlassian.net/browse/PYI-537)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
