### PR TITLE
BAU: Pull spotless to root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,10 @@
 plugins {
 	id "org.sonarqube" version "3.3"
+	id "com.diffplug.spotless" version "6.1.0"
+}
+
+repositories {
+	mavenCentral()
 }
 
 sonarqube {
@@ -7,5 +12,20 @@ sonarqube {
 		property "sonar.projectKey", "alphagov_di-ipv-core-back"
 		property "sonar.organization", "alphagov"
 		property "sonar.host.url", "https://sonarcloud.io"
+	}
+}
+
+spotless {
+	java {
+		target "**/src/**/*.java"
+		googleJavaFormat("1.13.0").aosp()
+		importOrder "", "javax", "java", "\\#"
+		endWithNewline()
+	}
+	groovyGradle {
+		target '**/*.gradle'
+		greclipse()
+		trimTrailingWhitespace()
+		endWithNewline()
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id "java"
 	id "org.sonarqube" version "3.3"
 	id "com.diffplug.spotless" version "6.1.0"
 }

--- a/lambdas/accesstoken/build.gradle
+++ b/lambdas/accesstoken/build.gradle
@@ -3,7 +3,6 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
-	id "com.diffplug.spotless" version "6.1.0"
 }
 
 repositories {
@@ -59,20 +58,5 @@ jacocoTestReport {
 	dependsOn test
 	reports {
 		xml.required
-	}
-}
-
-spotless {
-	java {
-		target "src/**/*.java"
-		// googleJavaFormat("1.13.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-	groovyGradle {
-		target '**/*.gradle'
-		greclipse()
-		trimTrailingWhitespace()
-		endWithNewline()
 	}
 }

--- a/lambdas/accesstoken/build.gradle
+++ b/lambdas/accesstoken/build.gradle
@@ -57,6 +57,6 @@ test {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.required
+		xml.required.set(true)
 	}
 }

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
@@ -71,7 +70,8 @@ class AccessTokenHandlerTest {
                 .thenReturn(ValidationResult.createValidResult());
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
         assertEquals(
                 ContentType.APPLICATION_JSON.getType(), response.getHeaders().get("Content-Type"));
         assertEquals(200, response.getStatusCode());

--- a/lambdas/authorization/build.gradle
+++ b/lambdas/authorization/build.gradle
@@ -3,7 +3,6 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
-	id "com.diffplug.spotless" version "6.1.0"
 }
 
 repositories {
@@ -59,20 +58,5 @@ jacocoTestReport {
 	dependsOn test
 	reports {
 		xml.required
-	}
-}
-
-spotless {
-	java {
-		target "src/**/*.java"
-		// googleJavaFormat("1.13.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-	groovyGradle {
-		target '**/*.gradle'
-		greclipse()
-		trimTrailingWhitespace()
-		endWithNewline()
 	}
 }

--- a/lambdas/authorization/build.gradle
+++ b/lambdas/authorization/build.gradle
@@ -57,6 +57,6 @@ test {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.required
+		xml.required.set(true)
 	}
 }

--- a/lambdas/authorization/src/main/java/uk/gov/di/ipv/core/authorization/AuthorizationHandler.java
+++ b/lambdas/authorization/src/main/java/uk/gov/di/ipv/core/authorization/AuthorizationHandler.java
@@ -102,7 +102,8 @@ public class AuthorizationHandler
             return new ValidationResult<>(false, ErrorResponse.MISSING_QUERY_PARAMETERS);
         }
 
-        String ipvSessionId = RequestHelper.getHeaderByKey(requestHeaders, IPV_SESSION_ID_HEADER_KEY);
+        String ipvSessionId =
+                RequestHelper.getHeaderByKey(requestHeaders, IPV_SESSION_ID_HEADER_KEY);
         if (StringUtils.isBlank(ipvSessionId)) {
             return new ValidationResult<>(false, ErrorResponse.MISSING_IPV_SESSION_ID);
         }

--- a/lambdas/authorization/src/test/java/uk/gov/di/ipv/core/authorization/AuthorizationHandlerTest.java
+++ b/lambdas/authorization/src/test/java/uk/gov/di/ipv/core/authorization/AuthorizationHandlerTest.java
@@ -73,7 +73,8 @@ class AuthorizationHandlerTest {
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Map<String, String>> responseBody = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        Map<String, Map<String, String>> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
         Map<String, String> authCode = responseBody.get("code");
 
         verify(mockAuthorizationCodeService)

--- a/lambdas/build.gradle
+++ b/lambdas/build.gradle
@@ -4,5 +4,4 @@ plugins {
 }
 
 allprojects {
-
 }

--- a/lambdas/credentialissuer/build.gradle
+++ b/lambdas/credentialissuer/build.gradle
@@ -3,7 +3,6 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
-	id "com.diffplug.spotless" version "6.1.0"
 }
 
 repositories {
@@ -59,20 +58,5 @@ jacocoTestReport {
 	dependsOn test
 	reports {
 		xml.required
-	}
-}
-
-spotless {
-	java {
-		target "src/**/*.java"
-		// googleJavaFormat("1.13.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-	groovyGradle {
-		target '**/*.gradle'
-		greclipse()
-		trimTrailingWhitespace()
-		endWithNewline()
 	}
 }

--- a/lambdas/credentialissuer/build.gradle
+++ b/lambdas/credentialissuer/build.gradle
@@ -57,6 +57,6 @@ test {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.required
+		xml.required.set(true)
 	}
 }

--- a/lambdas/credentialissuerconfig/build.gradle
+++ b/lambdas/credentialissuerconfig/build.gradle
@@ -3,7 +3,6 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
-	id "com.diffplug.spotless" version "6.1.0"
 }
 
 repositories {
@@ -40,20 +39,5 @@ jacocoTestReport {
 	dependsOn test
 	reports {
 		xml.required
-	}
-}
-
-spotless {
-	java {
-		target "src/**/*.java"
-		// googleJavaFormat("1.13.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-	groovyGradle {
-		target '**/*.gradle'
-		greclipse()
-		trimTrailingWhitespace()
-		endWithNewline()
 	}
 }

--- a/lambdas/credentialissuerconfig/build.gradle
+++ b/lambdas/credentialissuerconfig/build.gradle
@@ -38,6 +38,6 @@ test {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.required
+		xml.required.set(true)
 	}
 }

--- a/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
+++ b/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
@@ -14,5 +14,4 @@ public class CredentialIssuerConfigHandler
             APIGatewayProxyRequestEvent input, Context context) {
         return ApiGatewayResponseGenerator.proxyJsonResponse(200, "Hello World");
     }
-
 }

--- a/lambdas/session/build.gradle
+++ b/lambdas/session/build.gradle
@@ -3,7 +3,6 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
-	id "com.diffplug.spotless" version "6.1.0"
 }
 
 repositories {
@@ -59,20 +58,5 @@ jacocoTestReport {
 	dependsOn test
 	reports {
 		xml.required
-	}
-}
-
-spotless {
-	java {
-		target "src/**/*.java"
-		// googleJavaFormat("1.13.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-	groovyGradle {
-		target '**/*.gradle'
-		greclipse()
-		trimTrailingWhitespace()
-		endWithNewline()
 	}
 }

--- a/lambdas/session/build.gradle
+++ b/lambdas/session/build.gradle
@@ -57,6 +57,6 @@ test {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.required
+		xml.required.set(true)
 	}
 }

--- a/lambdas/session/src/test/java/uk/gov/di/ipv/core/session/IpvSessionHandlerTest.java
+++ b/lambdas/session/src/test/java/uk/gov/di/ipv/core/session/IpvSessionHandlerTest.java
@@ -45,7 +45,8 @@ class IpvSessionHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent response = ipvSessionHandler.handleRequest(event, mockContext);
 
-        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         assertEquals(ipvSessionId, responseBody.get("ipvSessionId"));

--- a/lambdas/useridentity/build.gradle
+++ b/lambdas/useridentity/build.gradle
@@ -60,6 +60,6 @@ test {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.required
+		xml.required.set(true)
 	}
 }

--- a/lambdas/useridentity/build.gradle
+++ b/lambdas/useridentity/build.gradle
@@ -3,7 +3,6 @@ plugins {
 	id "application"
 	id "idea"
 	id "jacoco"
-	id "com.diffplug.spotless" version "6.1.0"
 }
 
 repositories {
@@ -62,20 +61,5 @@ jacocoTestReport {
 	dependsOn test
 	reports {
 		xml.required
-	}
-}
-
-spotless {
-	java {
-		target "src/**/*.java"
-		// googleJavaFormat("1.13.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-	groovyGradle {
-		target '**/*.gradle'
-		greclipse()
-		trimTrailingWhitespace()
-		endWithNewline()
 	}
 }

--- a/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
+++ b/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
@@ -89,7 +89,8 @@ class UserIdentityHandlerTest {
                 .thenReturn(userIssuedCredential);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
-        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(userIssuedCredential.get("id"), responseBody.get("id"));
         assertEquals(userIssuedCredential.get("type"), responseBody.get("type"));
@@ -154,7 +155,8 @@ class UserIdentityHandlerTest {
         when(mockAccessTokenService.getIpvSessionIdByAccessToken(anyString())).thenReturn(null);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
-        Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(403, response.getStatusCode());
         assertEquals(OAuth2Error.ACCESS_DENIED.getCode(), responseBody.get("error"));

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,33 +1,33 @@
 plugins {
-    // Apply the java-library plugin for API and implementation separation.
-    id 'java-library'
+	// Apply the java-library plugin for API and implementation separation.
+	id 'java-library'
 	id "idea"
 	id "jacoco"
 }
 
 
 repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
+	// Use Maven Central for resolving dependencies.
+	mavenCentral()
 }
 
 dependencies {
 
-    implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-        "com.amazonaws:aws-lambda-java-events:3.11.0",
-        "com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-        "com.nimbusds:oauth2-oidc-sdk:9.3.1",
-        "com.fasterxml.jackson.core:jackson-core:2.13.0",
-        "com.fasterxml.jackson.core:jackson-databind:2.13.0",
-        "com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-        "org.apache.httpcomponents:httpclient:4.5.13",
-        "org.apache.commons:commons-lang3:3.5",
-        "org.slf4j:slf4j-simple:1.7.32",
-        "software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-        "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
-        "software.amazon.lambda:powertools-parameters:1.8.0"
+	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
+			"com.amazonaws:aws-lambda-java-events:3.11.0",
+			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
+			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
+			"com.fasterxml.jackson.core:jackson-core:2.13.0",
+			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
+			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
+			"org.apache.httpcomponents:httpclient:4.5.13",
+			"org.apache.commons:commons-lang3:3.5",
+			"org.slf4j:slf4j-simple:1.7.32",
+			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
+			"software.amazon.lambda:powertools-parameters:1.8.0"
 
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
 			"com.github.tomakehurst:wiremock-jre8:2.31.0",
@@ -40,14 +40,14 @@ dependencies {
 java {
 	sourceCompatibility = JavaVersion.VERSION_11
 	targetCompatibility = JavaVersion.VERSION_11
-    withSourcesJar()
+	withSourcesJar()
 }
 
 tasks.named('jar') {
-    manifest {
-        attributes('Implementation-Title': project.name,
-                   'Implementation-Version': project.version)
-    }
+	manifest {
+		attributes('Implementation-Title': project.name,
+		'Implementation-Version': project.version)
+	}
 }
 
 test {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -58,6 +58,6 @@ test {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.required
+		xml.required.set(true)
 	}
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'java-library'
 	id "idea"
 	id "jacoco"
-	id "com.diffplug.spotless" version "6.1.0"
 }
 
 
@@ -62,13 +61,3 @@ jacocoTestReport {
 		xml.required
 	}
 }
-
-spotless {
-	java {
-		target "lib/**/*.java"
-		googleJavaFormat("1.13.0").aosp()
-		importOrder "", "javax", "java", "\\#"
-		endWithNewline()
-	}
-}
-

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
@@ -40,7 +40,8 @@ class DataStoreTest {
 
     @BeforeEach
     void setUp() {
-        when(mockDynamoDbEnhancedClient.table(anyString(), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any()))
+        when(mockDynamoDbEnhancedClient.table(
+                        anyString(), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any()))
                 .thenReturn(mockDynamoDbTable);
 
         authorizationCodeItem = new AuthorizationCodeItem();
@@ -59,7 +60,10 @@ class DataStoreTest {
         ArgumentCaptor<AuthorizationCodeItem> authorizationCodeItemArgumentCaptor =
                 ArgumentCaptor.forClass(AuthorizationCodeItem.class);
 
-        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
+        verify(mockDynamoDbEnhancedClient)
+                .table(
+                        eq(TEST_TABLE_NAME),
+                        ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
         verify(mockDynamoDbTable).putItem(authorizationCodeItemArgumentCaptor.capture());
         assertEquals(
                 authorizationCodeItem.getAuthCode(),
@@ -75,7 +79,10 @@ class DataStoreTest {
 
         ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
 
-        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
+        verify(mockDynamoDbEnhancedClient)
+                .table(
+                        eq(TEST_TABLE_NAME),
+                        ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
         verify(mockDynamoDbTable).getItem(keyCaptor.capture());
         assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
         assertEquals("sort-key-12345", keyCaptor.getValue().sortKeyValue().get().s());
@@ -87,7 +94,10 @@ class DataStoreTest {
 
         ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
 
-        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
+        verify(mockDynamoDbEnhancedClient)
+                .table(
+                        eq(TEST_TABLE_NAME),
+                        ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
         verify(mockDynamoDbTable).getItem(keyCaptor.capture());
         assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
         assertTrue(keyCaptor.getValue().sortKeyValue().isEmpty());
@@ -100,7 +110,10 @@ class DataStoreTest {
 
         dataStore.getItems("partition-key-12345");
 
-        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
+        verify(mockDynamoDbEnhancedClient)
+                .table(
+                        eq(TEST_TABLE_NAME),
+                        ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
         verify(mockDynamoDbTable).query(any(QueryConditional.class));
     }
 
@@ -111,7 +124,10 @@ class DataStoreTest {
         ArgumentCaptor<AuthorizationCodeItem> authorizationCodeItemArgumentCaptor =
                 ArgumentCaptor.forClass(AuthorizationCodeItem.class);
 
-        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
+        verify(mockDynamoDbEnhancedClient)
+                .table(
+                        eq(TEST_TABLE_NAME),
+                        ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
         verify(mockDynamoDbTable).updateItem(authorizationCodeItemArgumentCaptor.capture());
         assertEquals(
                 authorizationCodeItem.getAuthCode(),
@@ -127,7 +143,10 @@ class DataStoreTest {
 
         ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
 
-        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
+        verify(mockDynamoDbEnhancedClient)
+                .table(
+                        eq(TEST_TABLE_NAME),
+                        ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
         verify(mockDynamoDbTable).deleteItem(keyCaptor.capture());
         assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
         assertEquals("sort-key-12345", keyCaptor.getValue().sortKeyValue().get().s());
@@ -139,7 +158,10 @@ class DataStoreTest {
 
         ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
 
-        verify(mockDynamoDbEnhancedClient).table(eq(TEST_TABLE_NAME), ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
+        verify(mockDynamoDbEnhancedClient)
+                .table(
+                        eq(TEST_TABLE_NAME),
+                        ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
         verify(mockDynamoDbTable).deleteItem(keyCaptor.capture());
         assertEquals("partition-key-12345", keyCaptor.getValue().partitionKeyValue().s());
         assertTrue(keyCaptor.getValue().sortKeyValue().isEmpty());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeServiceTest.java
@@ -26,7 +26,8 @@ class AuthorizationCodeServiceTest {
 
     @BeforeEach
     void setUp() {
-        authorizationCodeService = new AuthorizationCodeService(mockDataStore, mockConfigurationService);
+        authorizationCodeService =
+                new AuthorizationCodeService(mockDataStore, mockConfigurationService);
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -38,7 +38,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
-
 @WireMockTest
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerServiceTest {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,10 @@
 rootProject.name = 'di-ipv-core-back'
 
 include "lib",
-        "lambdas",
-        "lambdas:accesstoken",
-        "lambdas:authorization",
-        "lambdas:credentialissuer",
-        "lambdas:session",
-        "lambdas:useridentity",
-        "lambdas:credentialissuerconfig"
-
+		"lambdas",
+		"lambdas:accesstoken",
+		"lambdas:authorization",
+		"lambdas:credentialissuer",
+		"lambdas:session",
+		"lambdas:useridentity",
+		"lambdas:credentialissuerconfig"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->
**Review commit by commit.**
## Proposed changes

### What changed

Moved the spotless definition to the root gradle project
Added the java plugin to the root project
Ran spotlessApply on all files
Correctly sets the xml.required property for jacoco test reports

### Why did it change

Move the spotless config to the root project so we don't have to manage
it in a bunch of places.

Without the Java plugin the `spotlessApply` task is not automatically run when
the `check` task is run (which is in turn run by the build task). Without it we'd 
need to set up a hook to make sure that spotless is being run. This seems easier 
and less fragile.

Sets the `xml.required` property to true for jacoco reports which will fix the sonarqube
issue.
