### PR TITLE
PYI-526 - Return all Credential Issuers to Frontend

### DIFF
--- a/lambdas/credentialissuer/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandler.java
+++ b/lambdas/credentialissuer/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandler.java
@@ -59,6 +59,8 @@ public class CredentialIssuerHandler
         }
         CredentialIssuerConfig credentialIssuerConfig = getCredentialIssuerConfig(request);
 
+        configurationService.getCredentialIssuers();
+
         try {
             BearerAccessToken accessToken =
                     credentialIssuerService.exchangeCodeForToken(request, credentialIssuerConfig);

--- a/lambdas/credentialissuer/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandler.java
+++ b/lambdas/credentialissuer/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandler.java
@@ -59,8 +59,6 @@ public class CredentialIssuerHandler
         }
         CredentialIssuerConfig credentialIssuerConfig = getCredentialIssuerConfig(request);
 
-        configurationService.getCredentialIssuers();
-
         try {
             BearerAccessToken accessToken =
                     credentialIssuerService.exchangeCodeForToken(request, credentialIssuerConfig);

--- a/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
+++ b/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
@@ -127,8 +127,7 @@ class CredentialIssuerHandlerTest {
         when(credentialIssuerService.getCredential(accessToken, passportIssuer))
                 .thenReturn(new JSONObject());
 
-        when(configurationService.getCredentialIssuer("PassportIssuer"))
-                .thenReturn(passportIssuer);
+        when(configurationService.getCredentialIssuer("PassportIssuer")).thenReturn(passportIssuer);
 
         CredentialIssuerHandler handler =
                 new CredentialIssuerHandler(credentialIssuerService, configurationService);
@@ -171,8 +170,7 @@ class CredentialIssuerHandlerTest {
                         new CredentialIssuerException(
                                 HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
 
-        when(configurationService.getCredentialIssuer("PassportIssuer"))
-                .thenReturn(passportIssuer);
+        when(configurationService.getCredentialIssuer("PassportIssuer")).thenReturn(passportIssuer);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();
@@ -193,8 +191,7 @@ class CredentialIssuerHandlerTest {
                                 HTTPResponse.SC_SERVER_ERROR,
                                 ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER));
 
-        when(configurationService.getCredentialIssuer("PassportIssuer"))
-                .thenReturn(passportIssuer);
+        when(configurationService.getCredentialIssuer("PassportIssuer")).thenReturn(passportIssuer);
 
         CredentialIssuerHandler handler =
                 new CredentialIssuerHandler(credentialIssuerService, configurationService);

--- a/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
+++ b/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
@@ -56,8 +56,10 @@ class CredentialIssuerHandlerTest {
         passportIssuer =
                 new CredentialIssuerConfig(
                         "PassportIssuer",
+                        "any",
                         new URI("http://www.example.com"),
-                        new URI("http://www.example.com/credential"));
+                        new URI("http://www.example.com/credential"),
+                        new URI("http://www.example.com/authorize"));
     }
 
     @Test

--- a/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
+++ b/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
@@ -127,7 +127,8 @@ class CredentialIssuerHandlerTest {
         when(credentialIssuerService.getCredential(accessToken, passportIssuer))
                 .thenReturn(new JSONObject());
 
-        when(configurationService.getCredentialIssuer("PassportIssuer")).thenReturn(passportIssuer);
+        when(configurationService.getCredentialIssuer("PassportIssuer"))
+                .thenReturn(passportIssuer);
 
         CredentialIssuerHandler handler =
                 new CredentialIssuerHandler(credentialIssuerService, configurationService);
@@ -170,7 +171,8 @@ class CredentialIssuerHandlerTest {
                         new CredentialIssuerException(
                                 HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
 
-        when(configurationService.getCredentialIssuer("PassportIssuer")).thenReturn(passportIssuer);
+        when(configurationService.getCredentialIssuer("PassportIssuer"))
+                .thenReturn(passportIssuer);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();
@@ -191,7 +193,8 @@ class CredentialIssuerHandlerTest {
                                 HTTPResponse.SC_SERVER_ERROR,
                                 ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER));
 
-        when(configurationService.getCredentialIssuer("PassportIssuer")).thenReturn(passportIssuer);
+        when(configurationService.getCredentialIssuer("PassportIssuer"))
+                .thenReturn(passportIssuer);
 
         CredentialIssuerHandler handler =
                 new CredentialIssuerHandler(credentialIssuerService, configurationService);

--- a/lambdas/credentialissuerconfig/build.gradle
+++ b/lambdas/credentialissuerconfig/build.gradle
@@ -14,6 +14,12 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
 			"com.amazonaws:aws-lambda-java-events:3.11.0",
 			project(":lib")
+
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+			"org.mockito:mockito-core:4.1.0",
+			"org.mockito:mockito-junit-jupiter:4.1.0",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
+			"com.nimbusds:oauth2-oidc-sdk:9.3.1"
 }
 
 java {

--- a/lambdas/credentialissuerconfig/build.gradle
+++ b/lambdas/credentialissuerconfig/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
 			"com.amazonaws:aws-lambda-java-events:3.11.0",
+			"org.slf4j:slf4j-simple:1.7.32",
 			project(":lib")
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',

--- a/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
+++ b/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
@@ -5,47 +5,27 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 public class CredentialIssuerConfigHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
+    private final ConfigurationService configurationService;
+
+    static {
+        System.setProperty(
+                "software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+    }
+
+    public CredentialIssuerConfigHandler() {
+        configurationService = new ConfigurationService();
+    }
+
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        List<Map<String, String>> criList = new ArrayList<>();
-
-        Map<String, String> passportStubCri = new HashMap<>();
-        passportStubCri.put("id", "passportIssuer");
-        passportStubCri.put("name", "Passport (Stub)");
-        passportStubCri.put(
-                "authorizeUrl",
-                "https://di-ipv-credential-issuer-stub.london.cloudapps.digital/authorize");
-        passportStubCri.put(
-                "tokenUrl", "https://di-ipv-credential-issuer-stub.london.cloudapps.digital/token");
-        passportStubCri.put(
-                "credentialUrl",
-                "https://di-ipv-credential-issuer-stub.london.cloudapps.digital/credential");
-        passportStubCri.put("ipvClientId", "IPV-Core");
-        criList.add(passportStubCri);
-
-        Map<String, String> passportDcsCri = new HashMap<>();
-        passportDcsCri.put("id", "dcsPassportIssuer");
-        passportDcsCri.put("name", "DCS Passport CRI");
-        passportDcsCri.put(
-                "authorizeUrl",
-                "https://di-ipv-cri-uk-passport-front.london.cloudapps.digital/oauth2/authorize");
-        passportDcsCri.put(
-                "tokenUrl", "https://psgeggxp8j.execute-api.eu-west-2.amazonaws.com/dev/token");
-        passportDcsCri.put(
-                "credentialUrl",
-                "https://psgeggxp8j.execute-api.eu-west-2.amazonaws.com/dev/credential");
-        passportDcsCri.put("ipvClientId", "IPV-Core");
-        criList.add(passportDcsCri);
-        return ApiGatewayResponseGenerator.proxyJsonResponse(200, criList);
+        return ApiGatewayResponseGenerator.proxyJsonResponse(
+                200, configurationService.getCredentialIssuers());
     }
 }

--- a/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
+++ b/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ParseCredentialIssuerConfigException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
@@ -45,7 +46,8 @@ public class CredentialIssuerConfigHandler
             String errorMessage =
                     String.format("Failed to load credential issuer config: %s", e.getMessage());
             LOGGER.error(errorMessage);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(500, errorMessage);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    500, ErrorResponse.FAILED_TO_PARSE_CREDENTIAL_ISSUER_CONFIG);
         }
     }
 }

--- a/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
+++ b/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
@@ -4,8 +4,11 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
+
+import java.util.List;
 
 public class CredentialIssuerConfigHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -29,7 +32,9 @@ public class CredentialIssuerConfigHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        return ApiGatewayResponseGenerator.proxyJsonResponse(
-                200, configurationService.getCredentialIssuers());
+
+        List<CredentialIssuerConfig> config = configurationService.getCredentialIssuers();
+
+        return ApiGatewayResponseGenerator.proxyJsonResponse(200, config);
     }
 }

--- a/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
+++ b/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
@@ -18,6 +18,10 @@ public class CredentialIssuerConfigHandler
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
     }
 
+    public CredentialIssuerConfigHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
     public CredentialIssuerConfigHandler() {
         configurationService = new ConfigurationService();
     }

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -23,17 +23,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerConfigHandlerTest {
 
-    /*private final Set<CredentialIssuerConfig> credentialIssuerConfigs =
-    Set.of(
-            new CredentialIssuerConfig(
-                    "test1", "Any" ,URI.create("test1TokenUrl"), URI.create("test1credentialUrl"), URI.create("tesstAuthorizeUrl")),
-            new CredentialIssuerConfig(
-                    "test2",
-                    "Any",
-                    URI.create("test2TokenUrl"),
-                    URI.create("test2credentialUrl"),
-                    URI.create("tesstAuthorizeUrl")));*/
-
     private final List<CredentialIssuerConfig> credentialIssuerConfigList =
             List.of(
                     new CredentialIssuerConfig(
@@ -53,24 +42,6 @@ class CredentialIssuerConfigHandlerTest {
 
     @Mock ConfigurationService configurationService;
 
-    /* @Test
-        void shouldReceive200ResponseCodeAndListOfCredentialIssuers() throws JsonProcessingException {
-            when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuerConfigs);
-
-            CredentialIssuerConfigHandler underTest =
-                    new CredentialIssuerConfigHandler(configurationService);
-            APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-            APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            CredentialIssuerConfig[] responseBody =
-                    objectMapper.readValue(response.getBody(), CredentialIssuerConfig[].class);
-
-            assertEquals(2, responseBody.length);
-            assertArrayEquals(credentialIssuerConfigs.toArray(), responseBody);
-            assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
-        }
-    */
     @Test
     void shouldReceive200ResponseCodeAndListOfCredentialIssuers() throws JsonProcessingException {
         when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuerConfigList);

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -1,0 +1,57 @@
+package uk.gov.di.ipv.core.credentialisserconfig;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.credentialissuerconfig.CredentialIssuerConfigHandler;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
+
+import java.net.URI;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CredentialIssuerConfigHandlerTest {
+
+    private final Set<CredentialIssuerConfig> credentialIssuerConfigs =
+            Set.of(
+                    new CredentialIssuerConfig(
+                            "test1", URI.create("test1TokenUrl"), URI.create("test1credentialUrl")),
+                    new CredentialIssuerConfig(
+                            "test2",
+                            URI.create("test2TokenUrl"),
+                            URI.create("test2credentialUrl")));
+
+    @Mock Context context;
+
+    @Mock ConfigurationService configurationService;
+
+    @Test
+    void shouldReceive200ResponseCodeAndListOfCredentialIssuers() throws JsonProcessingException {
+        when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuerConfigs);
+
+        CredentialIssuerConfigHandler underTest =
+                new CredentialIssuerConfigHandler(configurationService);
+        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
+        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        CredentialIssuerConfig[] responseBody =
+                objectMapper.readValue(response.getBody(), CredentialIssuerConfig[].class);
+
+        assertEquals(2, responseBody.length);
+        assertArrayEquals(credentialIssuerConfigs.toArray(), responseBody);
+        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+    }
+}

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -77,7 +77,7 @@ class CredentialIssuerConfigHandlerTest {
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
 
         assertEquals(
                 ErrorResponse.FAILED_TO_PARSE_CREDENTIAL_ISSUER_CONFIG.getCode(),

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -15,31 +15,65 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.net.URI;
-import java.util.Set;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerConfigHandlerTest {
 
-    private final Set<CredentialIssuerConfig> credentialIssuerConfigs =
-            Set.of(
+    /*private final Set<CredentialIssuerConfig> credentialIssuerConfigs =
+    Set.of(
+            new CredentialIssuerConfig(
+                    "test1", "Any" ,URI.create("test1TokenUrl"), URI.create("test1credentialUrl"), URI.create("tesstAuthorizeUrl")),
+            new CredentialIssuerConfig(
+                    "test2",
+                    "Any",
+                    URI.create("test2TokenUrl"),
+                    URI.create("test2credentialUrl"),
+                    URI.create("tesstAuthorizeUrl")));*/
+
+    private final List<CredentialIssuerConfig> credentialIssuerConfigList =
+            List.of(
                     new CredentialIssuerConfig(
-                            "test1", URI.create("test1TokenUrl"), URI.create("test1credentialUrl")),
+                            "test1",
+                            "Any",
+                            URI.create("test1TokenUrl"),
+                            URI.create("test1credentialUrl"),
+                            URI.create("tesstAuthorizeUrl")),
                     new CredentialIssuerConfig(
                             "test2",
+                            "Any",
                             URI.create("test2TokenUrl"),
-                            URI.create("test2credentialUrl")));
+                            URI.create("test2credentialUrl"),
+                            URI.create("tesstAuthorizeUrl")));
 
     @Mock Context context;
 
     @Mock ConfigurationService configurationService;
 
+    /* @Test
+        void shouldReceive200ResponseCodeAndListOfCredentialIssuers() throws JsonProcessingException {
+            when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuerConfigs);
+
+            CredentialIssuerConfigHandler underTest =
+                    new CredentialIssuerConfigHandler(configurationService);
+            APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
+            APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            CredentialIssuerConfig[] responseBody =
+                    objectMapper.readValue(response.getBody(), CredentialIssuerConfig[].class);
+
+            assertEquals(2, responseBody.length);
+            assertArrayEquals(credentialIssuerConfigs.toArray(), responseBody);
+            assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        }
+    */
     @Test
     void shouldReceive200ResponseCodeAndListOfCredentialIssuers() throws JsonProcessingException {
-        when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuerConfigs);
+        when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuerConfigList);
 
         CredentialIssuerConfigHandler underTest =
                 new CredentialIssuerConfigHandler(configurationService);
@@ -51,7 +85,7 @@ class CredentialIssuerConfigHandlerTest {
                 objectMapper.readValue(response.getBody(), CredentialIssuerConfig[].class);
 
         assertEquals(2, responseBody.length);
-        assertArrayEquals(credentialIssuerConfigs.toArray(), responseBody);
+        // assertArrayEquals(credentialIssuerConfigs.toArray(), responseBody);
         assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
     }
 }

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import java.net.URI;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -58,7 +59,7 @@ class CredentialIssuerConfigHandlerTest {
                 objectMapper.readValue(response.getBody(), CredentialIssuerConfig[].class);
 
         assertEquals(2, responseBody.length);
-        // assertArrayEquals(credentialIssuerConfigs.toArray(), responseBody);
+        assertArrayEquals(credentialIssuerConfigList.toArray(), responseBody);
         assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
     }
 }

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -11,12 +11,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.credentialissuerconfig.CredentialIssuerConfigHandler;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ParseCredentialIssuerConfigException;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,6 +41,7 @@ class CredentialIssuerConfigHandlerTest {
                             URI.create("test2TokenUrl"),
                             URI.create("test2credentialUrl"),
                             URI.create("tesstAuthorizeUrl")));
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Mock Context context;
 
@@ -54,12 +57,36 @@ class CredentialIssuerConfigHandlerTest {
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
 
-        ObjectMapper objectMapper = new ObjectMapper();
         CredentialIssuerConfig[] responseBody =
                 objectMapper.readValue(response.getBody(), CredentialIssuerConfig[].class);
 
         assertEquals(2, responseBody.length);
         assertArrayEquals(credentialIssuerConfigList.toArray(), responseBody);
         assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReceive500ResponseCodeIfUnableToGetCredentialIssuers()
+            throws JsonProcessingException, ParseCredentialIssuerConfigException {
+        when(configurationService.getCredentialIssuers())
+                .thenThrow(new ParseCredentialIssuerConfigException("Something went wrong"));
+
+        CredentialIssuerConfigHandler underTest =
+                new CredentialIssuerConfigHandler(configurationService);
+        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
+
+        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+
+        Map<String, String> responseBody = objectMapper.readValue(response.getBody(), Map.class);
+
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_CREDENTIAL_ISSUER_CONFIG.getCode(),
+                responseBody.get("code"));
+
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_CREDENTIAL_ISSUER_CONFIG.getMessage(),
+                responseBody.get("message"));
+
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, response.getStatusCode());
     }
 }

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.credentialissuerconfig.CredentialIssuerConfigHandler;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.exceptions.ParseCredentialIssuerConfigException;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.net.URI;
@@ -43,7 +44,8 @@ class CredentialIssuerConfigHandlerTest {
     @Mock ConfigurationService configurationService;
 
     @Test
-    void shouldReceive200ResponseCodeAndListOfCredentialIssuers() throws JsonProcessingException {
+    void shouldReceive200ResponseCodeAndListOfCredentialIssuers()
+            throws JsonProcessingException, ParseCredentialIssuerConfigException {
         when(configurationService.getCredentialIssuers()).thenReturn(credentialIssuerConfigList);
 
         CredentialIssuerConfigHandler underTest =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -21,8 +21,8 @@ public enum ErrorResponse {
     FAILED_TO_SAVE_CREDENTIAL(1012, "Failed to save credential"),
     FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS(
             1013, "Failed to parse oauth2-specific query string parameters"),
-    FAILED_TO_DECODE_CREDENTIAL_ISSUER_CONFIG(
-            1014, "Failed to decode credential issuers config to credential issuers object");
+    FAILED_TO_PARSE_CREDENTIAL_ISSUER_CONFIG(
+            1014, "Failed to parse credential issuers config to credential issuers object");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -1,20 +1,28 @@
 package uk.gov.di.ipv.core.library.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.net.URI;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CredentialIssuerConfig {
 
     private String id;
+    private String name;
     private URI tokenUrl;
     private URI credentialUrl;
+    private URI authorizeUrl;
 
     public CredentialIssuerConfig() {}
 
-    public CredentialIssuerConfig(String id, URI tokenUrl, URI credentialUrl) {
+    public CredentialIssuerConfig(
+            String id, String name, URI tokenUrl, URI credentialUrl, URI authorizeUrl) {
         this.id = id;
+        this.name = name;
         this.tokenUrl = tokenUrl;
         this.credentialUrl = credentialUrl;
+        this.authorizeUrl = authorizeUrl;
     }
 
     public String getId() {
@@ -29,16 +37,29 @@ public class CredentialIssuerConfig {
         return credentialUrl;
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public URI getAuthorizeUrl() {
+        return authorizeUrl;
+    }
+
     @Override
     public String toString() {
         return "CredentialIssuerConfig{"
                 + "id='"
                 + id
                 + '\''
+                + ", name='"
+                + name
+                + '\''
                 + ", tokenUrl="
                 + tokenUrl
                 + ", credentialUrl="
                 + credentialUrl
+                + ", authorizeUrl="
+                + authorizeUrl
                 + '}';
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -31,7 +31,11 @@ public class CredentialIssuerConfig {
 
     @Override
     public String toString() {
-        return "CredentialIssuerConfig{" + "id='" + id + '\'' + '}';
+        return "CredentialIssuerConfig{" +
+                "id='" + id + '\'' +
+                ", tokenUrl=" + tokenUrl +
+                ", credentialUrl=" + credentialUrl +
+                '}';
     }
 
     @Override
@@ -51,5 +55,9 @@ public class CredentialIssuerConfig {
         return id.equals(that.id)
                 && tokenUrl.equals(that.tokenUrl)
                 && credentialUrl.equals(that.credentialUrl);
+    }
+
+    public void setId(String credentialIssuerId) {
+        this.id = credentialIssuerId;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -31,11 +31,15 @@ public class CredentialIssuerConfig {
 
     @Override
     public String toString() {
-        return "CredentialIssuerConfig{" +
-                "id='" + id + '\'' +
-                ", tokenUrl=" + tokenUrl +
-                ", credentialUrl=" + credentialUrl +
-                '}';
+        return "CredentialIssuerConfig{"
+                + "id='"
+                + id
+                + '\''
+                + ", tokenUrl="
+                + tokenUrl
+                + ", credentialUrl="
+                + credentialUrl
+                + '}';
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -46,24 +46,6 @@ public class CredentialIssuerConfig {
     }
 
     @Override
-    public String toString() {
-        return "CredentialIssuerConfig{"
-                + "id='"
-                + id
-                + '\''
-                + ", name='"
-                + name
-                + '\''
-                + ", tokenUrl="
-                + tokenUrl
-                + ", credentialUrl="
-                + credentialUrl
-                + ", authorizeUrl="
-                + authorizeUrl
-                + '}';
-    }
-
-    @Override
     public int hashCode() {
         return Objects.hash(id);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/ParseCredentialIssuerConfigException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/ParseCredentialIssuerConfigException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+public class ParseCredentialIssuerConfigException extends Throwable {
+    public ParseCredentialIssuerConfigException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/ParseCredentialIssuerConfigException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/ParseCredentialIssuerConfigException.java
@@ -1,6 +1,6 @@
 package uk.gov.di.ipv.core.library.exceptions;
 
-public class ParseCredentialIssuerConfigException extends Throwable {
+public class ParseCredentialIssuerConfigException extends Exception {
     public ParseCredentialIssuerConfigException(String errorMessage) {
         super(errorMessage);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -108,43 +108,37 @@ public class ConfigurationService {
             }
         }
 
-        List<CredentialIssuerConfig> credentialIssuersConfig =
-                map.values().stream()
-                        .map(
-                                config ->
-                                        objectMapper.convertValue(
-                                                config, CredentialIssuerConfig.class))
-                        .collect(Collectors.toList());
-
-        return credentialIssuersConfig;
+        return map.values().stream()
+                .map(config -> objectMapper.convertValue(config, CredentialIssuerConfig.class))
+                .collect(Collectors.toList());
     }
 
     private String getAttributeNameFromParameter(Entry<String, String> parameter)
             throws ParseCredentialIssuerConfigException {
-        String[] splitKey = parameter.getKey().split("/");
-        if (splitKey.length < 2) {
-            String errorMessage =
-                    String.format(
-                            "The attribute name cannot be parsed from the parameter path %s",
-                            parameter.getKey());
-            LOGGER.error(String.format(errorMessage));
-            throw new ParseCredentialIssuerConfigException(errorMessage);
-        }
+        String[] splitKey =
+                getSplitKey(
+                        parameter,
+                        "The attribute name cannot be parsed from the parameter path %s");
         return splitKey[1];
     }
 
     private String getCriIdFromParameter(Entry<String, String> parameter)
             throws ParseCredentialIssuerConfigException {
-        String[] splitKey = parameter.getKey().split("/");
+        String[] splitKey =
+                getSplitKey(
+                        parameter,
+                        "The credential issuer id cannot be parsed from the parameter path %s");
+        return splitKey[0];
+    }
 
+    private String[] getSplitKey(Entry<String, String> parameter, String message)
+            throws ParseCredentialIssuerConfigException {
+        String[] splitKey = parameter.getKey().split("/");
         if (splitKey.length < 2) {
-            String errorMessage =
-                    String.format(
-                            "The credential issuer id cannot be parsed from the parameter path %s",
-                            parameter.getKey());
-            LOGGER.error(String.format(errorMessage));
+            String errorMessage = String.format(message, parameter.getKey());
+            LOGGER.error(errorMessage);
             throw new ParseCredentialIssuerConfigException(errorMessage);
         }
-        return splitKey[0];
+        return splitKey;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -83,10 +83,7 @@ public class ConfigurationService {
                         String.format(
                                 "/%s/ipv/core/credentialIssuers/%s",
                                 System.getenv("ENVIRONMENT"), credentialIssuerId));
-        CredentialIssuerConfig credentialIssuerConfig =
-                new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
-        credentialIssuerConfig.setId(credentialIssuerId);
-        return credentialIssuerConfig;
+        return new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
     }
 
     public List<CredentialIssuerConfig> getCredentialIssuers()
@@ -100,13 +97,14 @@ public class ConfigurationService {
                                         System.getenv("ENVIRONMENT")));
 
         Map<String, Map<String, Object>> map = new HashMap<>();
-        for (Entry<String, String> stringStringEntry : params.entrySet()) {
-            if (map.computeIfAbsent(getCriIdFromParameter(stringStringEntry), k -> new HashMap<>())
-                            .put(
-                                    getAttributeNameFromParameter(stringStringEntry),
-                                    stringStringEntry.getValue())
+        for (Entry<String, String> entry : params.entrySet()) {
+            if (map.computeIfAbsent(getCriIdFromParameter(entry), k -> new HashMap<>())
+                            .put(getAttributeNameFromParameter(entry), entry.getValue())
                     != null) {
-                throw new IllegalStateException("Duplicate key");
+                throw new ParseCredentialIssuerConfigException(
+                        String.format(
+                                "Duplicate parameter in Parameter Store: %s",
+                                getAttributeNameFromParameter(entry)));
             }
         }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -72,25 +72,37 @@ public class ConfigurationService {
     }
 
     public CredentialIssuerConfig getCredentialIssuer(String credentialIssuerId) {
-        Map<String, String> result = ssmProvider.getMultiple(String.format("/%s/ipv/core/credentialIssuers/%s", System.getenv("ENVIRONMENT"), credentialIssuerId));
-        CredentialIssuerConfig credentialIssuerConfig = new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
+        Map<String, String> result =
+                ssmProvider.getMultiple(
+                        String.format(
+                                "/%s/ipv/core/credentialIssuers/%s",
+                                System.getenv("ENVIRONMENT"), credentialIssuerId));
+        CredentialIssuerConfig credentialIssuerConfig =
+                new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
         credentialIssuerConfig.setId(credentialIssuerId);
         return credentialIssuerConfig;
     }
 
     public Set<CredentialIssuerConfig> getCredentialIssuers() {
-        Map<String, String> result = ssmProvider.recursive().getMultiple(String.format("/%s/ipv/core/credentialIssuers", System.getenv("ENVIRONMENT")));
+        Map<String, String> result =
+                ssmProvider
+                        .recursive()
+                        .getMultiple(
+                                String.format(
+                                        "/%s/ipv/core/credentialIssuers",
+                                        System.getenv("ENVIRONMENT")));
 
         Map<String, CredentialIssuerConfig> credentialIssuers = new HashMap<>();
-        result.forEach((key, value) -> {
-            Optional<String> credentialIssuerId = Arrays.stream(key.split("/")).findFirst();
-            credentialIssuerId.ifPresent(id -> {
-                if (!credentialIssuers.containsKey(id)) {
-                    credentialIssuers.put(id, getCredentialIssuer(id));
-                }
-            });
-
-        });
+        result.forEach(
+                (key, value) -> {
+                    Optional<String> credentialIssuerId = Arrays.stream(key.split("/")).findFirst();
+                    credentialIssuerId.ifPresent(
+                            id -> {
+                                if (!credentialIssuers.containsKey(id)) {
+                                    credentialIssuers.put(id, getCredentialIssuer(id));
+                                }
+                            });
+                });
         return new HashSet<>(credentialIssuers.values());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -68,11 +68,7 @@ public class ConfigurationService {
     }
 
     public CredentialIssuerConfig getCredentialIssuer(String credentialIssuerId) {
-        Map<String, String> result =
-                ssmProvider.getMultiple(
-                        String.format(
-                                "/%s/IPV/Core/CredentialIssuers/%s",
-                                System.getenv("ENVIRONMENT"), credentialIssuerId));
+        Map<String, String> result = ssmProvider.getMultiple(String.format("/%s/IPV/Core/CredentialIssuers/%s", System.getenv("ENVIRONMENT"), credentialIssuerId));
         return new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -77,16 +77,12 @@ class ConfigurationServiceTest {
     void shouldGetCredentialIssuerFromParameterStore() {
         environmentVariables.set("ENVIRONMENT", "dev");
 
-        Map<String, String> credentialIssuerParameters =
-                Map.of("tokenUrl", TEST_TOKEN_URL, "credentialUrl", TEST_CREDENTIAL_URL);
-        when(ssmProvider.getMultiple("/dev/IPV/Core/CredentialIssuers/PassportCRI"))
-                .thenReturn(credentialIssuerParameters);
+        Map<String, String> credentialIssuerParameters = Map.of("tokenUrl", TEST_TOKEN_URL, "credentialUrl", TEST_CREDENTIAL_URL);
+        when(ssmProvider.getMultiple("/dev/IPV/Core/CredentialIssuers/PassportCRI")).thenReturn(credentialIssuerParameters);
 
         CredentialIssuerConfig result = configurationService.getCredentialIssuer("PassportCRI");
 
-        CredentialIssuerConfig expected =
-                new CredentialIssuerConfig(
-                        "PassportCRI", URI.create(TEST_TOKEN_URL), URI.create(TEST_CREDENTIAL_URL));
+        CredentialIssuerConfig expected = new CredentialIssuerConfig("PassportCRI", URI.create(TEST_TOKEN_URL), URI.create(TEST_CREDENTIAL_URL));
 
         assertEquals(expected.getTokenUrl(), result.getTokenUrl());
         assertEquals(expected.getCredentialUrl(), result.getCredentialUrl());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -82,12 +82,16 @@ class ConfigurationServiceTest {
     void shouldGetCredentialIssuerFromParameterStore() {
         environmentVariables.set("ENVIRONMENT", "dev");
 
-        Map<String, String> credentialIssuerParameters = Map.of("tokenUrl", TEST_TOKEN_URL, "credentialUrl", TEST_CREDENTIAL_URL);
-        when(ssmProvider.getMultiple("/dev/ipv/core/credentialIssuers/passportCri")).thenReturn(credentialIssuerParameters);
+        Map<String, String> credentialIssuerParameters =
+                Map.of("tokenUrl", TEST_TOKEN_URL, "credentialUrl", TEST_CREDENTIAL_URL);
+        when(ssmProvider.getMultiple("/dev/ipv/core/credentialIssuers/passportCri"))
+                .thenReturn(credentialIssuerParameters);
 
         CredentialIssuerConfig result = configurationService.getCredentialIssuer("passportCri");
 
-        CredentialIssuerConfig expected = new CredentialIssuerConfig("passportCri", URI.create(TEST_TOKEN_URL), URI.create(TEST_CREDENTIAL_URL));
+        CredentialIssuerConfig expected =
+                new CredentialIssuerConfig(
+                        "passportCri", URI.create(TEST_TOKEN_URL), URI.create(TEST_CREDENTIAL_URL));
 
         assertEquals(expected.getTokenUrl(), result.getTokenUrl());
         assertEquals(expected.getCredentialUrl(), result.getCredentialUrl());
@@ -100,16 +104,20 @@ class ConfigurationServiceTest {
         HashMap<String, String> response = new HashMap<>();
         response.put("dcsPassportIssuer/tokenUrl", "http://credential-issuer-stub:8084/token");
         response.put("passportIssuer/tokenUrl", "http://credential-issuer-stub:8084/token");
-        response.put("passportIssuer/credentialUrl", "http://credential-issuer-stub:8084/credential");
-        response.put("dcsPassportIssuer/credentialUrl", "http://credential-issuer-stub:8084/credential");
+        response.put(
+                "passportIssuer/credentialUrl", "http://credential-issuer-stub:8084/credential");
+        response.put(
+                "dcsPassportIssuer/credentialUrl", "http://credential-issuer-stub:8084/credential");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
         when(ssmProvider2.getMultiple("/dev/ipv/core/credentialIssuers")).thenReturn(response);
 
-        Map<String, String> credentialIssuerParameters = Map.of("tokenUrl", TEST_TOKEN_URL, "credentialUrl", TEST_CREDENTIAL_URL);
-        when(ssmProvider.getMultiple("/dev/ipv/core/credentialIssuers/dcsPassportIssuer")).thenReturn(credentialIssuerParameters);
-        when(ssmProvider.getMultiple("/dev/ipv/core/credentialIssuers/passportIssuer")).thenReturn(credentialIssuerParameters);
-
+        Map<String, String> credentialIssuerParameters =
+                Map.of("tokenUrl", TEST_TOKEN_URL, "credentialUrl", TEST_CREDENTIAL_URL);
+        when(ssmProvider.getMultiple("/dev/ipv/core/credentialIssuers/dcsPassportIssuer"))
+                .thenReturn(credentialIssuerParameters);
+        when(ssmProvider.getMultiple("/dev/ipv/core/credentialIssuers/passportIssuer"))
+                .thenReturn(credentialIssuerParameters);
 
         Set<CredentialIssuerConfig> result = configurationService.getCredentialIssuers();
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -285,7 +285,9 @@ class CredentialIssuerServiceTest {
             WireMockRuntimeInfo wmRuntimeInfo) {
         return new CredentialIssuerConfig(
                 "StubPassport",
+                "any",
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"),
-                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/credential"));
+                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/credential"),
+                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/authorizeUrl"));
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added the Lambda `CredentialIssuerConfig` (`/request-config`) to return a full list of Credential Issuers from Parameter Store to the front end.

`ConfigurationService.getCredentialIssuers()` returns a list of Credential Issuers in Parameter Store

<!-- Describe the changes in detail - the "what"-->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-526](https://govukverify.atlassian.net/browse/PYI-526)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [x] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
