### PR TITLE
PYI-553: Use correct var name for 2nd cri param

### DIFF
--- a/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
+++ b/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
@@ -34,17 +34,17 @@ public class CredentialIssuerConfigHandler
         criList.add(passportStubCri);
 
         Map<String, String> passportDcsCri = new HashMap<>();
-        passportStubCri.put("id", "DcsPassportIssuer");
-        passportStubCri.put("name", "DCS Passport CRI");
-        passportStubCri.put(
+        passportDcsCri.put("id", "DcsPassportIssuer");
+        passportDcsCri.put("name", "DCS Passport CRI");
+        passportDcsCri.put(
                 "authorizeUrl",
                 "https://di-ipv-cri-uk-passport-front.london.cloudapps.digital/oauth2/authorize");
-        passportStubCri.put(
+        passportDcsCri.put(
                 "tokenUrl", "https://psgeggxp8j.execute-api.eu-west-2.amazonaws.com/dev/token");
-        passportStubCri.put(
+        passportDcsCri.put(
                 "credentialUrl",
                 "https://psgeggxp8j.execute-api.eu-west-2.amazonaws.com/dev/credential");
-        passportStubCri.put("ipvClientId", "IPV-Core");
+        passportDcsCri.put("ipvClientId", "IPV-Core");
         criList.add(passportDcsCri);
         return ApiGatewayResponseGenerator.proxyJsonResponse(200, criList);
     }

--- a/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
+++ b/lambdas/credentialissuerconfig/src/main/java/uk/gov/di/ipv/core/credentialissuerconfig/CredentialIssuerConfigHandler.java
@@ -20,7 +20,7 @@ public class CredentialIssuerConfigHandler
         List<Map<String, String>> criList = new ArrayList<>();
 
         Map<String, String> passportStubCri = new HashMap<>();
-        passportStubCri.put("id", "PassportIssuer");
+        passportStubCri.put("id", "passportIssuer");
         passportStubCri.put("name", "Passport (Stub)");
         passportStubCri.put(
                 "authorizeUrl",
@@ -34,7 +34,7 @@ public class CredentialIssuerConfigHandler
         criList.add(passportStubCri);
 
         Map<String, String> passportDcsCri = new HashMap<>();
-        passportDcsCri.put("id", "DcsPassportIssuer");
+        passportDcsCri.put("id", "dcsPassportIssuer");
         passportDcsCri.put("name", "DCS Passport CRI");
         passportDcsCri.put(
                 "authorizeUrl",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Fix var name for the hard coded json example response.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Mistakenly used the previous variable name and override the map parameters.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-553](https://govukverify.atlassian.net/browse/PYI-553)

