### PR TITLE
PYI-554: Add lambda to return all credentials

### DIFF
--- a/lambdas/issuedcredentials/build.gradle
+++ b/lambdas/issuedcredentials/build.gradle
@@ -1,0 +1,47 @@
+plugins {
+	id "java"
+	id "application"
+	id "idea"
+	id "jacoco"
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+
+	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
+			"com.amazonaws:aws-lambda-java-events:3.11.0",
+			project(":lib")
+
+	testImplementation 'com.google.code.gson:gson:2.8.9',
+			'org.junit.jupiter:junit-jupiter:5.8.2',
+			'org.mockito:mockito-junit-jupiter:4.2.0'
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_11
+	targetCompatibility = JavaVersion.VERSION_11
+}
+
+task buildZip(type: Zip) {
+	from compileJava
+	from processResources
+	destinationDirectory = file("$rootDir/dist")
+	into("lib") {
+		from configurations.runtimeClasspath
+	}
+}
+
+test {
+	useJUnitPlatform ()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required.set(true)
+	}
+}

--- a/lambdas/issuedcredentials/src/main/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandler.java
+++ b/lambdas/issuedcredentials/src/main/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.util.Collections;
@@ -21,6 +22,8 @@ public class IssuedCredentialsHandler
     private static final Integer OK = 200;
     private static final Integer BAD_REQUEST = 400;
 
+    public static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
+
     private final UserIdentityService userIdentityService;
 
     public IssuedCredentialsHandler(UserIdentityService userIdentityService) {
@@ -35,7 +38,8 @@ public class IssuedCredentialsHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        String ipvSessionId = input.getBody();
+        var ipvSessionId =
+                RequestHelper.getHeaderByKey(input.getHeaders(), IPV_SESSION_ID_HEADER_KEY);
 
         if (ipvSessionId == null || ipvSessionId.isEmpty()) {
             LOGGER.log(WARNING, "User credentials could not be retrieved. No session ID received.");

--- a/lambdas/issuedcredentials/src/main/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandler.java
+++ b/lambdas/issuedcredentials/src/main/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandler.java
@@ -1,0 +1,65 @@
+package uk.gov.di.ipv.core.issuedcredentials;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
+
+public class IssuedCredentialsHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOGGER = Logger.getLogger(IssuedCredentialsHandler.class.getName());
+    private static final Integer OK = 200;
+    private static final Integer BAD_REQUEST = 400;
+
+    private final UserIdentityService userIdentityService;
+
+    public IssuedCredentialsHandler(UserIdentityService userIdentityService) {
+        this.userIdentityService = userIdentityService;
+    }
+
+    @ExcludeFromGeneratedCoverageReport
+    public IssuedCredentialsHandler() {
+        this.userIdentityService = new UserIdentityService();
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        String ipvSessionId = input.getBody();
+
+        if (ipvSessionId == null || ipvSessionId.isEmpty()) {
+            LOGGER.log(WARNING, "User credentials could not be retrieved. No session ID received.");
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    BAD_REQUEST, Collections.emptyMap());
+        }
+
+        Map<String, String> credentials =
+                userIdentityService.getUserIssuedCredentials(ipvSessionId);
+
+        // This is here to allow us to test the functionality with core-front in the short term.
+        // When ready, we can switch to returning the credentials retrieved above.
+        Map<String, String> stubCredentials = getStubCredentials();
+
+        return ApiGatewayResponseGenerator.proxyJsonResponse(OK, stubCredentials);
+    }
+
+    public static Map<String, String> getStubCredentials() {
+        return Map.of(
+                "passportIssuer",
+                        "{\"attributes\":{\"names\":{\"givenNames\":[\"Mary\"],\"familyName\":\"Watson\"},\"passportNo\":\"824159121\",\"passportExpiryDate\":\"2030-01-01\",\"dateOfBirth\":\"2021-03-01\"},\"gpg45Score\":{\"evidence\":{\"strength\":5,\"validity\":3}}}",
+                "fraudIssuer",
+                        "{\"attributes\":{\"names\":{\"givenNames\":[\"Mary\"],\"familyName\":\"Watson\"},\"someFraudAttribute\":\"notsurewhatthatmightbe\"},\"gpg45Score\":{\"fraud\":0}}",
+                "addressIssuer",
+                        "{\"attributes\":{\"address\":{\"postcode\":\"SW1A1AA\",\"houseNumber\":10}}}");
+    }
+}

--- a/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
+++ b/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
@@ -28,7 +28,7 @@ public class IssuedCredentialsHandlerTest {
     void shouldReturn200OnSuccessfulRequest() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         String ipvSessionId = "a-session-id";
-        event.setBody(ipvSessionId);
+        event.setHeaders(Map.of(IssuedCredentialsHandler.IPV_SESSION_ID_HEADER_KEY, ipvSessionId));
 
         Map<String, String> userIssuedCredentials =
                 Map.of(
@@ -51,6 +51,7 @@ public class IssuedCredentialsHandlerTest {
     @Test
     void shouldReturn400IfNoSessionId() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of());
         IssuedCredentialsHandler issuedCredentialsHandler =
                 new IssuedCredentialsHandler(mockUserIdentityService);
 
@@ -63,7 +64,7 @@ public class IssuedCredentialsHandlerTest {
     @Test
     void shouldReturn400IfSessionIdIsEmptyString() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody("");
+        event.setHeaders(Map.of(IssuedCredentialsHandler.IPV_SESSION_ID_HEADER_KEY, ""));
         IssuedCredentialsHandler issuedCredentialsHandler =
                 new IssuedCredentialsHandler(mockUserIdentityService);
 

--- a/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
+++ b/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
@@ -1,0 +1,75 @@
+package uk.gov.di.ipv.core.issuedcredentials;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.issuedcredentials.IssuedCredentialsHandler.getStubCredentials;
+
+@ExtendWith(MockitoExtension.class)
+public class IssuedCredentialsHandlerTest {
+
+    @Mock private Context mockContext;
+    @Mock private UserIdentityService mockUserIdentityService;
+
+    private final Gson gson = new Gson();
+
+    @Test
+    void shouldReturn200OnSuccessfulRequest() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        String ipvSessionId = "a-session-id";
+        event.setBody(ipvSessionId);
+
+        Map<String, String> userIssuedCredentials =
+                Map.of(
+                        "criOne", "credential issued by criOne",
+                        "criTwo", "credential issued by criTwo",
+                        "criThree", "credential issued by criThree");
+        when(mockUserIdentityService.getUserIssuedCredentials(ipvSessionId))
+                .thenReturn(userIssuedCredentials);
+        IssuedCredentialsHandler issuedCredentialsHandler =
+                new IssuedCredentialsHandler(mockUserIdentityService);
+
+        APIGatewayProxyResponseEvent response =
+                issuedCredentialsHandler.handleRequest(event, mockContext);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(gson.toJson(getStubCredentials()), response.getBody());
+        //        assertEquals(gson.toJson(userIssuedCredentials), response.getBody());
+    }
+
+    @Test
+    void shouldReturn400IfNoSessionId() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        IssuedCredentialsHandler issuedCredentialsHandler =
+                new IssuedCredentialsHandler(mockUserIdentityService);
+
+        APIGatewayProxyResponseEvent response =
+                issuedCredentialsHandler.handleRequest(event, mockContext);
+
+        assertEquals(400, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturn400IfSessionIdIsEmptyString() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody("");
+        IssuedCredentialsHandler issuedCredentialsHandler =
+                new IssuedCredentialsHandler(mockUserIdentityService);
+
+        APIGatewayProxyResponseEvent response =
+                issuedCredentialsHandler.handleRequest(event, mockContext);
+
+        assertEquals(400, response.getStatusCode());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,10 @@
 rootProject.name = 'di-ipv-core-back'
-
 include "lib",
 		"lambdas",
 		"lambdas:accesstoken",
 		"lambdas:authorization",
 		"lambdas:credentialissuer",
+		"lambdas:credentialissuerconfig",
+		"lambdas:issuedcredentials",
 		"lambdas:session",
-		"lambdas:useridentity",
-		"lambdas:credentialissuerconfig"
+		"lambdas:useridentity"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This is very similar to the useridentity lambda except without the token
check. This is because the request is coming from the same (our) system.

For now it returns some stub data, but can easily be updated to actually
chat to the database.

I've tried to import as few dependencies as possible, hence the use of
java.util.logging. Very much up for debate.

This doesn't deploy the thing.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-554](https://govukverify.atlassian.net/browse/PYI-554)

