### PR TITLE
BAU: Trying to get Sonar Cloud to find main branch

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -2,15 +2,15 @@
 name: gradle test and build
 
 on:
-
+  push:
+    branches:
+      - main
   pull_request:
-    branches: main
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Proposed changes

### What changed

Update to the pre-merge-checks action that is integrated with SonarCloud to see if it will fix the issue that sonar cloud doesn't see main. Copied from equivalent in `di-cri-experian-kbv-api` which seems to be ok.

### Why did it change

SonarCloud is not working correctly
