### PR TITLE
BAU: Add missing ssm action for credential-issuers-config iam policy

### DIFF
--- a/terraform/lambda/parameter-store.tf
+++ b/terraform/lambda/parameter-store.tf
@@ -15,7 +15,8 @@ resource "aws_iam_role_policy" "get-credential-issuers-config" {
       {
         Sid = "GetCredentialIssuersConfig"
         Action = [
-          "ssm:GetParameter"
+          "ssm:GetParameter",
+          "ssm:GetParametersByPath"
         ]
         Effect   = "Allow"
         Resource = aws_ssm_parameter.credential-issuers-config.arn


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add missing ssm:GetParametersByPath action to the get-credential-issuers-config iam policy.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Because we now use the SSM powertools ssmProvider.getMultiple() method which uses the above action to read multiple params that follow a certain path structure from parameter store. This is used for our new individual cri config params that we store in SSM.

