### PR TITLE
BAU: Refactor Services and Handlers so that ConfigurationService is only instantiated once per handler.

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
 import java.net.URI;
@@ -32,6 +33,7 @@ public class AccessTokenHandler
 
     private final AccessTokenService accessTokenService;
     private final AuthorizationCodeService authorizationCodeService;
+    private final ConfigurationService configurationService;
 
     static {
         // Set the default synchronous HTTP client to UrlConnectionHttpClient
@@ -42,15 +44,18 @@ public class AccessTokenHandler
 
     public AccessTokenHandler(
             AccessTokenService accessTokenService,
-            AuthorizationCodeService authorizationCodeService) {
+            AuthorizationCodeService authorizationCodeService,
+            ConfigurationService configurationService) {
         this.accessTokenService = accessTokenService;
         this.authorizationCodeService = authorizationCodeService;
+        this.configurationService = configurationService;
     }
 
     @ExcludeFromGeneratedCoverageReport
     public AccessTokenHandler() {
-        this.accessTokenService = new AccessTokenService();
-        this.authorizationCodeService = new AuthorizationCodeService();
+        this.configurationService = new ConfigurationService();
+        this.accessTokenService = new AccessTokenService(configurationService);
+        this.authorizationCodeService = new AuthorizationCodeService(configurationService);
     }
 
     @Override

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
 import java.util.Map;
@@ -51,10 +52,15 @@ class AccessTokenHandlerTest {
         when(mockAccessTokenService.generateAccessToken(any())).thenReturn(tokenResponse);
 
         mockAuthorizationCodeService = mock(AuthorizationCodeService.class);
+        ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
 
         context = mock(Context.class);
 
-        handler = new AccessTokenHandler(mockAccessTokenService, mockAuthorizationCodeService);
+        handler =
+                new AccessTokenHandler(
+                        mockAccessTokenService,
+                        mockAuthorizationCodeService,
+                        mockConfigurationService);
     }
 
     @Test

--- a/lambdas/authorization/src/main/java/uk/gov/di/ipv/core/authorization/AuthorizationHandler.java
+++ b/lambdas/authorization/src/main/java/uk/gov/di/ipv/core/authorization/AuthorizationHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
 import java.util.Collections;
@@ -41,13 +42,19 @@ public class AuthorizationHandler
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
     }
 
+    private final ConfigurationService configurationService;
+
     @ExcludeFromGeneratedCoverageReport
     public AuthorizationHandler() {
-        this.authorizationCodeService = new AuthorizationCodeService();
+        this.configurationService = new ConfigurationService();
+        this.authorizationCodeService = new AuthorizationCodeService(configurationService);
     }
 
-    public AuthorizationHandler(AuthorizationCodeService authorizationCodeService) {
+    public AuthorizationHandler(
+            AuthorizationCodeService authorizationCodeService,
+            ConfigurationService configurationService) {
         this.authorizationCodeService = authorizationCodeService;
+        this.configurationService = configurationService;
     }
 
     @Override

--- a/lambdas/authorization/src/test/java/uk/gov/di/ipv/core/authorization/AuthorizationHandlerTest.java
+++ b/lambdas/authorization/src/test/java/uk/gov/di/ipv/core/authorization/AuthorizationHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,12 +34,12 @@ class AuthorizationHandlerTest {
     @BeforeEach
     void setUp() {
         mockAuthorizationCodeService = mock(AuthorizationCodeService.class);
+        ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
 
         authorizationCode = new AuthorizationCode();
         when(mockAuthorizationCodeService.generateAuthorizationCode())
                 .thenReturn(authorizationCode);
-
-        handler = new AuthorizationHandler(mockAuthorizationCodeService);
+        handler = new AuthorizationHandler(mockAuthorizationCodeService, mockConfigurationService);
     }
 
     @Test

--- a/lambdas/credentialissuer/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandler.java
+++ b/lambdas/credentialissuer/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandler.java
@@ -42,8 +42,8 @@ public class CredentialIssuerHandler
 
     @ExcludeFromGeneratedCoverageReport
     public CredentialIssuerHandler() {
-        this.credentialIssuerService = new CredentialIssuerService();
         this.configurationService = new ConfigurationService();
+        this.credentialIssuerService = new CredentialIssuerService(configurationService);
     }
 
     @Override

--- a/lambdas/issuedcredentials/src/main/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandler.java
+++ b/lambdas/issuedcredentials/src/main/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.util.Collections;
@@ -33,13 +34,18 @@ public class IssuedCredentialsHandler
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
     }
 
-    public IssuedCredentialsHandler(UserIdentityService userIdentityService) {
+    private final ConfigurationService configurationService;
+
+    public IssuedCredentialsHandler(
+            UserIdentityService userIdentityService, ConfigurationService configurationService) {
         this.userIdentityService = userIdentityService;
+        this.configurationService = configurationService;
     }
 
     @ExcludeFromGeneratedCoverageReport
     public IssuedCredentialsHandler() {
-        this.userIdentityService = new UserIdentityService();
+        this.configurationService = new ConfigurationService();
+        this.userIdentityService = new UserIdentityService(configurationService);
     }
 
     @Override

--- a/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
+++ b/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.util.Map;
@@ -21,6 +22,7 @@ public class IssuedCredentialsHandlerTest {
 
     @Mock private Context mockContext;
     @Mock private UserIdentityService mockUserIdentityService;
+    @Mock private ConfigurationService mockConfigurationService;
 
     private final Gson gson = new Gson();
 
@@ -38,7 +40,7 @@ public class IssuedCredentialsHandlerTest {
         when(mockUserIdentityService.getUserIssuedCredentials(ipvSessionId))
                 .thenReturn(userIssuedCredentials);
         IssuedCredentialsHandler issuedCredentialsHandler =
-                new IssuedCredentialsHandler(mockUserIdentityService);
+                new IssuedCredentialsHandler(mockUserIdentityService, mockConfigurationService);
 
         APIGatewayProxyResponseEvent response =
                 issuedCredentialsHandler.handleRequest(event, mockContext);
@@ -53,7 +55,7 @@ public class IssuedCredentialsHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of());
         IssuedCredentialsHandler issuedCredentialsHandler =
-                new IssuedCredentialsHandler(mockUserIdentityService);
+                new IssuedCredentialsHandler(mockUserIdentityService, mockConfigurationService);
 
         APIGatewayProxyResponseEvent response =
                 issuedCredentialsHandler.handleRequest(event, mockContext);
@@ -66,7 +68,7 @@ public class IssuedCredentialsHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(IssuedCredentialsHandler.IPV_SESSION_ID_HEADER_KEY, ""));
         IssuedCredentialsHandler issuedCredentialsHandler =
-                new IssuedCredentialsHandler(mockUserIdentityService);
+                new IssuedCredentialsHandler(mockUserIdentityService, mockConfigurationService);
 
         APIGatewayProxyResponseEvent response =
                 issuedCredentialsHandler.handleRequest(event, mockContext);

--- a/lambdas/session/src/main/java/uk/gov/di/ipv/core/session/IpvSessionHandler.java
+++ b/lambdas/session/src/main/java/uk/gov/di/ipv/core/session/IpvSessionHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.http.HttpStatus;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -27,6 +28,7 @@ public class IpvSessionHandler
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public IpvSessionHandler() {
         this.configurationService = new ConfigurationService();
         this.ipvSessionService = new IpvSessionService(configurationService);

--- a/lambdas/session/src/main/java/uk/gov/di/ipv/core/session/IpvSessionHandler.java
+++ b/lambdas/session/src/main/java/uk/gov/di/ipv/core/session/IpvSessionHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.http.HttpStatus;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
 import java.util.Map;
@@ -14,6 +15,8 @@ public class IpvSessionHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final String IPV_SESSION_ID_KEY = "ipvSessionId";
+
+    private final ConfigurationService configurationService;
 
     private final IpvSessionService ipvSessionService;
 
@@ -25,11 +28,14 @@ public class IpvSessionHandler
     }
 
     public IpvSessionHandler() {
-        this.ipvSessionService = new IpvSessionService();
+        this.configurationService = new ConfigurationService();
+        this.ipvSessionService = new IpvSessionService(configurationService);
     }
 
-    public IpvSessionHandler(IpvSessionService ipvSessionService) {
+    public IpvSessionHandler(
+            IpvSessionService ipvSessionService, ConfigurationService configurationService) {
         this.ipvSessionService = ipvSessionService;
+        this.configurationService = configurationService;
     }
 
     @Override

--- a/lambdas/session/src/test/java/uk/gov/di/ipv/core/session/IpvSessionHandlerTest.java
+++ b/lambdas/session/src/test/java/uk/gov/di/ipv/core/session/IpvSessionHandlerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
 import java.util.Map;
@@ -26,6 +27,7 @@ class IpvSessionHandlerTest {
     @Mock private Context mockContext;
 
     @Mock private IpvSessionService mockIpvSessionService;
+    @Mock private ConfigurationService mockConfigurationService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final String testUserId = UUID.randomUUID().toString();
@@ -34,7 +36,7 @@ class IpvSessionHandlerTest {
 
     @BeforeEach
     void setUp() {
-        ipvSessionHandler = new IpvSessionHandler(mockIpvSessionService);
+        ipvSessionHandler = new IpvSessionHandler(mockIpvSessionService, mockConfigurationService);
     }
 
     @Test

--- a/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
+++ b/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.util.Map;
@@ -35,16 +36,22 @@ public class UserIdentityHandler
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
     }
 
+    private final ConfigurationService configurationService;
+
     public UserIdentityHandler(
-            UserIdentityService userIdentityService, AccessTokenService accessTokenService) {
+            UserIdentityService userIdentityService,
+            AccessTokenService accessTokenService,
+            ConfigurationService configurationService) {
         this.userIdentityService = userIdentityService;
         this.accessTokenService = accessTokenService;
+        this.configurationService = configurationService;
     }
 
     @ExcludeFromGeneratedCoverageReport
     public UserIdentityHandler() {
-        this.userIdentityService = new UserIdentityService();
-        this.accessTokenService = new AccessTokenService();
+        this.configurationService = new ConfigurationService();
+        this.userIdentityService = new UserIdentityService(configurationService);
+        this.accessTokenService = new AccessTokenService(configurationService);
     }
 
     @Override

--- a/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
+++ b/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.util.Collections;
@@ -39,6 +40,8 @@ class UserIdentityHandlerTest {
 
     @Mock private AccessTokenService mockAccessTokenService;
 
+    @Mock private ConfigurationService mockConfigurationService;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private UserIdentityHandler userInfoHandler;
@@ -54,7 +57,9 @@ class UserIdentityHandlerTest {
         userIssuedCredential.put("type", "Test credential");
         userIssuedCredential.put("foo", "bar");
 
-        userInfoHandler = new UserIdentityHandler(mockUserIdentityService, mockAccessTokenService);
+        userInfoHandler =
+                new UserIdentityHandler(
+                        mockUserIdentityService, mockAccessTokenService, mockConfigurationService);
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -7,7 +7,6 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.net.URI;
 import java.util.List;
@@ -16,7 +15,7 @@ import java.util.stream.Collectors;
 public class DataStore<T> {
 
     private static final String LOCALHOST_URI = "http://localhost:4567";
-    private static ConfigurationService configurationService;
+    private static boolean isRunningLocally;
 
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
     private final String tableName;
@@ -26,18 +25,15 @@ public class DataStore<T> {
             String tableName,
             Class<T> typeParameterClass,
             DynamoDbEnhancedClient dynamoDbEnhancedClient,
-            ConfigurationService configurationService) {
+            boolean isRunningLocally) {
         this.tableName = tableName;
         this.typeParameterClass = typeParameterClass;
         this.dynamoDbEnhancedClient = dynamoDbEnhancedClient;
-        DataStore.configurationService = configurationService;
+        DataStore.isRunningLocally = isRunningLocally;
     }
 
     public static DynamoDbEnhancedClient getClient() {
-        DynamoDbClient client =
-                configurationService.isRunningLocally()
-                        ? createLocalDbClient()
-                        : DynamoDbClient.create();
+        DynamoDbClient client = isRunningLocally ? createLocalDbClient() : DynamoDbClient.create();
 
         return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class DataStore<T> {
 
     private static final String LOCALHOST_URI = "http://localhost:4567";
+    private static ConfigurationService configurationService;
 
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
     private final String tableName;
@@ -24,15 +25,17 @@ public class DataStore<T> {
     public DataStore(
             String tableName,
             Class<T> typeParameterClass,
-            DynamoDbEnhancedClient dynamoDbEnhancedClient) {
+            DynamoDbEnhancedClient dynamoDbEnhancedClient,
+            ConfigurationService configurationService) {
         this.tableName = tableName;
         this.typeParameterClass = typeParameterClass;
         this.dynamoDbEnhancedClient = dynamoDbEnhancedClient;
+        DataStore.configurationService = configurationService;
     }
 
     public static DynamoDbEnhancedClient getClient() {
         DynamoDbClient client =
-                new ConfigurationService().isRunningLocally()
+                configurationService.isRunningLocally()
                         ? createLocalDbClient()
                         : DynamoDbClient.create();
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -21,13 +21,14 @@ public class AccessTokenService {
     private final ConfigurationService configurationService;
 
     @ExcludeFromGeneratedCoverageReport
-    public AccessTokenService() {
-        this.configurationService = new ConfigurationService();
+    public AccessTokenService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         this.dataStore =
                 new DataStore<>(
-                        configurationService.getAccessTokensTableName(),
+                        this.configurationService.getAccessTokensTableName(),
                         AccessTokenItem.class,
-                        DataStore.getClient());
+                        DataStore.getClient(),
+                        configurationService);
     }
 
     public AccessTokenService(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -28,7 +28,7 @@ public class AccessTokenService {
                         this.configurationService.getAccessTokensTableName(),
                         AccessTokenItem.class,
                         DataStore.getClient(),
-                        configurationService);
+                        this.configurationService.isRunningLocally());
     }
 
     public AccessTokenService(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
@@ -12,13 +12,14 @@ public class AuthorizationCodeService {
     private final ConfigurationService configurationService;
 
     @ExcludeFromGeneratedCoverageReport
-    public AuthorizationCodeService() {
-        this.configurationService = new ConfigurationService();
+    public AuthorizationCodeService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         this.dataStore =
                 new DataStore<>(
-                        configurationService.getAuthCodesTableName(),
+                        this.configurationService.getAuthCodesTableName(),
                         AuthorizationCodeItem.class,
-                        DataStore.getClient());
+                        DataStore.getClient(),
+                        configurationService);
     }
 
     public AuthorizationCodeService(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
@@ -19,7 +19,7 @@ public class AuthorizationCodeService {
                         this.configurationService.getAuthCodesTableName(),
                         AuthorizationCodeItem.class,
                         DataStore.getClient(),
-                        configurationService);
+                        this.configurationService.isRunningLocally());
     }
 
     public AuthorizationCodeService(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -31,13 +31,14 @@ public class CredentialIssuerService {
     private final ConfigurationService configurationService;
 
     @ExcludeFromGeneratedCoverageReport
-    public CredentialIssuerService() {
-        this.configurationService = new ConfigurationService();
+    public CredentialIssuerService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         this.dataStore =
                 new DataStore<>(
-                        configurationService.getUserIssuedCredentialTableName(),
+                        this.configurationService.getUserIssuedCredentialTableName(),
                         UserIssuedCredentialsItem.class,
-                        DataStore.getClient());
+                        DataStore.getClient(),
+                        configurationService);
     }
 
     // used for testing

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -38,7 +38,7 @@ public class CredentialIssuerService {
                         this.configurationService.getUserIssuedCredentialTableName(),
                         UserIssuedCredentialsItem.class,
                         DataStore.getClient(),
-                        configurationService);
+                        this.configurationService.isRunningLocally());
     }
 
     // used for testing

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -13,13 +13,14 @@ public class IpvSessionService {
     private final ConfigurationService configurationService;
 
     @ExcludeFromGeneratedCoverageReport
-    public IpvSessionService() {
-        this.configurationService = new ConfigurationService();
+    public IpvSessionService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         dataStore =
                 new DataStore<>(
-                        configurationService.getIpvSessionTableName(),
+                        this.configurationService.getIpvSessionTableName(),
                         IpvSessionItem.class,
-                        DataStore.getClient());
+                        DataStore.getClient(),
+                        configurationService);
     }
 
     public IpvSessionService(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -20,7 +20,7 @@ public class IpvSessionService {
                         this.configurationService.getIpvSessionTableName(),
                         IpvSessionItem.class,
                         DataStore.getClient(),
-                        configurationService);
+                        this.configurationService.isRunningLocally());
     }
 
     public IpvSessionService(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -13,13 +13,14 @@ public class UserIdentityService {
     private final DataStore<UserIssuedCredentialsItem> dataStore;
 
     @ExcludeFromGeneratedCoverageReport
-    public UserIdentityService() {
-        this.configurationService = new ConfigurationService();
+    public UserIdentityService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         this.dataStore =
                 new DataStore<>(
-                        configurationService.getUserIssuedCredentialTableName(),
+                        this.configurationService.getUserIssuedCredentialTableName(),
                         UserIssuedCredentialsItem.class,
-                        DataStore.getClient());
+                        DataStore.getClient(),
+                        configurationService);
     }
 
     public UserIdentityService(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -20,7 +20,7 @@ public class UserIdentityService {
                         this.configurationService.getUserIssuedCredentialTableName(),
                         UserIssuedCredentialsItem.class,
                         DataStore.getClient(),
-                        configurationService);
+                        this.configurationService.isRunningLocally());
     }
 
     public UserIdentityService(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
@@ -16,7 +16,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
-import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.util.stream.Stream;
 
@@ -35,7 +34,6 @@ class DataStoreTest {
     @Mock private DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
     @Mock private DynamoDbTable<AuthorizationCodeItem> mockDynamoDbTable;
     @Mock private PageIterable<AuthorizationCodeItem> mockPageIterable;
-    @Mock private ConfigurationService mockConfigurationService;
 
     private AuthorizationCodeItem authorizationCodeItem;
     private DataStore<AuthorizationCodeItem> dataStore;
@@ -55,7 +53,7 @@ class DataStoreTest {
                         TEST_TABLE_NAME,
                         AuthorizationCodeItem.class,
                         mockDynamoDbEnhancedClient,
-                        mockConfigurationService);
+                        false);
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.util.stream.Stream;
 
@@ -34,6 +35,7 @@ class DataStoreTest {
     @Mock private DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
     @Mock private DynamoDbTable<AuthorizationCodeItem> mockDynamoDbTable;
     @Mock private PageIterable<AuthorizationCodeItem> mockPageIterable;
+    @Mock private ConfigurationService mockConfigurationService;
 
     private AuthorizationCodeItem authorizationCodeItem;
     private DataStore<AuthorizationCodeItem> dataStore;
@@ -50,7 +52,10 @@ class DataStoreTest {
 
         dataStore =
                 new DataStore<>(
-                        TEST_TABLE_NAME, AuthorizationCodeItem.class, mockDynamoDbEnhancedClient);
+                        TEST_TABLE_NAME,
+                        AuthorizationCodeItem.class,
+                        mockDynamoDbEnhancedClient,
+                        mockConfigurationService);
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Refactor Services and Handlers so that ConfigurationService is only instantiated once per handler.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

This reduces the number of times we instantiate Configuration Service - in some cases 6 instantiations for one lambda call.