### PR TITLE
PYI-556: Update lambda to retrieve details of credentials from the dyanmoDB

### DIFF
--- a/lambdas/issuedcredentials/src/main/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandler.java
+++ b/lambdas/issuedcredentials/src/main/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandler.java
@@ -54,13 +54,9 @@ public class IssuedCredentialsHandler
         }
 
         Map<String, String> credentials =
-                userIdentityService.getUserIssuedCredentials(ipvSessionId);
+                userIdentityService.getUserIssuedDebugCredentials(ipvSessionId);
 
-        // This is here to allow us to test the functionality with core-front in the short term.
-        // When ready, we can switch to returning the credentials retrieved above.
-        Map<String, String> stubCredentials = getStubCredentials();
-
-        return ApiGatewayResponseGenerator.proxyJsonResponse(OK, stubCredentials);
+        return ApiGatewayResponseGenerator.proxyJsonResponse(OK, credentials);
     }
 
     public static Map<String, String> getStubCredentials() {

--- a/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
+++ b/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.issuedcredentials.IssuedCredentialsHandler.getStubCredentials;
 
 @ExtendWith(MockitoExtension.class)
 public class IssuedCredentialsHandlerTest {
@@ -37,7 +36,7 @@ public class IssuedCredentialsHandlerTest {
                         "criOne", "credential issued by criOne",
                         "criTwo", "credential issued by criTwo",
                         "criThree", "credential issued by criThree");
-        when(mockUserIdentityService.getUserIssuedCredentials(ipvSessionId))
+        when(mockUserIdentityService.getUserIssuedDebugCredentials(ipvSessionId))
                 .thenReturn(userIssuedCredentials);
         IssuedCredentialsHandler issuedCredentialsHandler =
                 new IssuedCredentialsHandler(mockUserIdentityService, mockConfigurationService);
@@ -46,8 +45,7 @@ public class IssuedCredentialsHandlerTest {
                 issuedCredentialsHandler.handleRequest(event, mockContext);
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(gson.toJson(getStubCredentials()), response.getBody());
-        //        assertEquals(gson.toJson(userIssuedCredentials), response.getBody());
+        assertEquals(gson.toJson(userIssuedCredentials), response.getBody());
     }
 
     @Test

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 			"com.fasterxml.jackson.core:jackson-core:2.13.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
 			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
+			"com.google.code.gson:gson:2.8.9",
 			"org.apache.httpcomponents:httpclient:4.5.13",
 			"org.apache.commons:commons-lang3:3.5",
 			"org.slf4j:slf4j-simple:1.7.32",

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/DebugCredentialAttributes.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/DebugCredentialAttributes.java
@@ -1,27 +1,16 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class DebugCredentialAttributes {
     private String ipvSessionId;
     private String dateCreated;
 
     public DebugCredentialAttributes(String ipvSessionId, String dateCreated) {
         this.ipvSessionId = ipvSessionId;
-        this.dateCreated = dateCreated;
-    }
-
-    public String getIpvSessionId() {
-        return ipvSessionId;
-    }
-
-    public void setIpvSessionId(String ipvSessionId) {
-        this.ipvSessionId = ipvSessionId;
-    }
-
-    public String getDateCreated() {
-        return dateCreated;
-    }
-
-    public void setDateCreated(String dateCreated) {
         this.dateCreated = dateCreated;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/DebugCredentialAttributes.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/DebugCredentialAttributes.java
@@ -1,0 +1,27 @@
+package uk.gov.di.ipv.core.library.domain;
+
+public class DebugCredentialAttributes {
+    private String ipvSessionId;
+    private String dateCreated;
+
+    public DebugCredentialAttributes(String ipvSessionId, String dateCreated) {
+        this.ipvSessionId = ipvSessionId;
+        this.dateCreated = dateCreated;
+    }
+
+    public String getIpvSessionId() {
+        return ipvSessionId;
+    }
+
+    public void setIpvSessionId(String ipvSessionId) {
+        this.ipvSessionId = ipvSessionId;
+    }
+
+    public String getDateCreated() {
+        return dateCreated;
+    }
+
+    public void setDateCreated(String dateCreated) {
+        this.dateCreated = dateCreated;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIssuedDebugCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIssuedDebugCredential.java
@@ -1,9 +1,13 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.Map;
 
+@Getter
+@Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserIssuedDebugCredential {
 
@@ -13,21 +17,5 @@ public class UserIssuedDebugCredential {
     public UserIssuedDebugCredential(DebugCredentialAttributes attributes) {
         this.attributes = attributes;
         this.gpg45Score = null;
-    }
-
-    public DebugCredentialAttributes getAttributes() {
-        return attributes;
-    }
-
-    public void setAttributes(DebugCredentialAttributes attributes) {
-        this.attributes = attributes;
-    }
-
-    public Map<String, String> getGpg45Score() {
-        return gpg45Score;
-    }
-
-    public void setGpg45Score(Map<String, String> gpg45Score) {
-        this.gpg45Score = gpg45Score;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIssuedDebugCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIssuedDebugCredential.java
@@ -1,0 +1,33 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserIssuedDebugCredential {
+
+    DebugCredentialAttributes attributes;
+    private Map<String, String> gpg45Score;
+
+    public UserIssuedDebugCredential(DebugCredentialAttributes attributes) {
+        this.attributes = attributes;
+        this.gpg45Score = null;
+    }
+
+    public DebugCredentialAttributes getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(DebugCredentialAttributes attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, String> getGpg45Score() {
+        return gpg45Score;
+    }
+
+    public void setGpg45Score(Map<String, String> gpg45Score) {
+        this.gpg45Score = gpg45Score;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -1,14 +1,24 @@
 package uk.gov.di.ipv.core.library.service;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.DebugCredentialAttributes;
+import uk.gov.di.ipv.core.library.domain.UserIssuedDebugCredential;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class UserIdentityService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserIdentityService.class);
+    private static final String GPG45_SCORE_PARAM_NAME = "gpg45Score";
+
     private final ConfigurationService configurationService;
     private final DataStore<UserIssuedCredentialsItem> dataStore;
 
@@ -37,5 +47,41 @@ public class UserIdentityService {
         return credentialIssuerItem.stream()
                 .map(ciItem -> Map.entry(ciItem.getCredentialIssuer(), ciItem.getCredential()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public Map<String, String> getUserIssuedDebugCredentials(String ipvSessionId) {
+        List<UserIssuedCredentialsItem> credentialIssuerItems = dataStore.getItems(ipvSessionId);
+        Map<String, String> userIssuedDebugCredentials = new HashMap<>();
+
+        Gson gson = new Gson();
+        credentialIssuerItems.forEach(
+                criItem -> {
+                    DebugCredentialAttributes attributes =
+                            new DebugCredentialAttributes(
+                                    criItem.getIpvSessionId(), criItem.getDateCreated().toString());
+                    UserIssuedDebugCredential debugCredential =
+                            new UserIssuedDebugCredential(attributes);
+
+                    Map<String, Object> credentialJson;
+                    try {
+                        credentialJson = gson.fromJson(criItem.getCredential(), Map.class);
+
+                        if (credentialJson.containsKey(GPG45_SCORE_PARAM_NAME)) {
+                            debugCredential.setGpg45Score(
+                                    gson.fromJson(
+                                            credentialJson.get(GPG45_SCORE_PARAM_NAME).toString(),
+                                            Map.class));
+                        }
+                    } catch (JsonSyntaxException e) {
+                        LOGGER.error("Failed to parse credential JSON for the debug page");
+                    }
+
+                    String debugCredentialJson = gson.toJson(debugCredential);
+
+                    userIssuedDebugCredentials.put(
+                            criItem.getCredentialIssuer(), debugCredentialJson);
+                });
+
+        return userIssuedDebugCredentials;
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -54,6 +54,102 @@ class UserIdentityServiceTest {
         assertEquals("Test credential 2", credentials.get("FraudIssuer"));
     }
 
+    @Test
+    void shouldReturnDebugCredentialsFromDataStore() {
+        List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
+                List.of(
+                        createUserIssuedCredentialsItem(
+                                "ipv-session-id-1",
+                                "PassportIssuer",
+                                "{ \"gpg45Score\": { \"verification\": \"2\"} }",
+                                LocalDateTime.parse("2022-01-25T12:28:56.414849")),
+                        createUserIssuedCredentialsItem(
+                                "ipv-session-id-1",
+                                "FraudIssuer",
+                                "{ \"gpg45Score\": { \"activity\": \"1\"} }",
+                                LocalDateTime.parse("2022-01-25T12:28:56.414849")));
+
+        when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
+
+        Map<String, String> credentials =
+                userIdentityService.getUserIssuedDebugCredentials("ipv-session-id-1");
+
+        assertEquals(
+                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"},\"gpg45Score\":{\"verification\":2.0}}",
+                credentials.get("PassportIssuer"));
+        assertEquals(
+                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"},\"gpg45Score\":{\"activity\":1.0}}",
+                credentials.get("FraudIssuer"));
+    }
+
+    @Test
+    void shouldReturnDebugCredentialsFromDataStoreWhenMissingAGpg45Score() {
+        List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
+                List.of(
+                        createUserIssuedCredentialsItem(
+                                "ipv-session-id-1",
+                                "PassportIssuer",
+                                "{ \"test\": \"test-value\"}",
+                                LocalDateTime.parse("2022-01-25T12:28:56.414849")),
+                        createUserIssuedCredentialsItem(
+                                "ipv-session-id-1",
+                                "FraudIssuer",
+                                "{ \"test\": \"test-value\"}",
+                                LocalDateTime.parse("2022-01-25T12:28:56.414849")));
+
+        when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
+
+        Map<String, String> credentials =
+                userIdentityService.getUserIssuedDebugCredentials("ipv-session-id-1");
+
+        assertEquals(
+                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"}}",
+                credentials.get("PassportIssuer"));
+        assertEquals(
+                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"}}",
+                credentials.get("FraudIssuer"));
+    }
+
+    @Test
+    void shouldReturnDebugCredentialsEvenIfFailingToParseCredentialJson() {
+        List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
+                List.of(
+                        createUserIssuedCredentialsItem(
+                                "ipv-session-id-1",
+                                "PassportIssuer",
+                                "invalid-json",
+                                LocalDateTime.parse("2022-01-25T12:28:56.414849")));
+
+        when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
+
+        Map<String, String> credentials =
+                userIdentityService.getUserIssuedDebugCredentials("ipv-session-id-1");
+
+        assertEquals(
+                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"}}",
+                credentials.get("PassportIssuer"));
+    }
+
+    @Test
+    void shouldReturnDebugCredentialsEvenIfFailingToParseGpg45ScoreParamFromJson() {
+        List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
+                List.of(
+                        createUserIssuedCredentialsItem(
+                                "ipv-session-id-1",
+                                "PassportIssuer",
+                                "{ \"gpg45Score\": \"invalid gpg45 json\" }",
+                                LocalDateTime.parse("2022-01-25T12:28:56.414849")));
+
+        when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
+
+        Map<String, String> credentials =
+                userIdentityService.getUserIssuedDebugCredentials("ipv-session-id-1");
+
+        assertEquals(
+                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"}}",
+                credentials.get("PassportIssuer"));
+    }
+
     private UserIssuedCredentialsItem createUserIssuedCredentialsItem(
             String ipvSessionId,
             String credentialIssuer,


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Retrieve credentials from DynamoDB.
- Parse the credentials string into JSON and retrieve the gpg45Score field if it exists.
- Construct a new JSON object to be returned to core-front with basic credential details
- Added new unit tests for new service method
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Core-front will use these debug credentials to display an indication of which credentials have been gathered duing their current user journey. This lambda will return a few minimal non-protective fields from the credentials that are mapped to their current ipv-session-id.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-556](https://govukverify.atlassian.net/browse/PYI-556)


