### PR TITLE
PYI-612: Use the correct key attribute

### DIFF
--- a/terraform/modules/parameters/shared-attributes.tf
+++ b/terraform/modules/parameters/shared-attributes.tf
@@ -1,6 +1,6 @@
 resource "aws_ssm_parameter" "shared_attributes_signing_cert" {
   name        = "/${var.environment}/ipv/core/sharedAttributes/signingCert"
-  description = "The IPV core's shared attributes signing certificate"
+  description = "The IPV core's shared attributes signing certificate - used by CRIs to validate the shared attributes JWT signature"
   type        = "String"
   value       = var.shared_attributes_signing_cert
 }
@@ -13,5 +13,5 @@ resource "aws_ssm_parameter" "shared_attributes_signing_key_id" {
   name        = "/${var.environment}/ipv/core/sharedAttributes/signingKeyId"
   description = "The IPV core's shared attributes KMS signing key ID"
   type        = "String"
-  value       = data.aws_kms_key.shared_attributes_signing.key_id
+  value       = data.aws_kms_key.shared_attributes_signing.id
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We need to use the id of the key, not the key_id we set in the data
resources. Currently it just sets the value of the parameter to the keys
alias. Confusing.

See the TF docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key#attributes-reference

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-612](https://govukverify.atlassian.net/browse/PYI-612)

