### PR TITLE
PYI-633: Add new ipvClientId property to CredentialIssuerConfig class…

### DIFF
--- a/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
+++ b/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
@@ -59,7 +59,8 @@ class CredentialIssuerHandlerTest {
                         "any",
                         new URI("http://www.example.com"),
                         new URI("http://www.example.com/credential"),
-                        new URI("http://www.example.com/authorize"));
+                        new URI("http://www.example.com/authorize"),
+                        "ipv-core");
     }
 
     @Test

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -34,13 +34,15 @@ class CredentialIssuerConfigHandlerTest {
                             "Any",
                             URI.create("test1TokenUrl"),
                             URI.create("test1credentialUrl"),
-                            URI.create("tesstAuthorizeUrl")),
+                            URI.create("tesstAuthorizeUrl"),
+                            "ipv-core"),
                     new CredentialIssuerConfig(
                             "test2",
                             "Any",
                             URI.create("test2TokenUrl"),
                             URI.create("test2credentialUrl"),
-                            URI.create("tesstAuthorizeUrl")));
+                            URI.create("tesstAuthorizeUrl"),
+                            "ipv-core"));
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Mock Context context;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -13,16 +13,23 @@ public class CredentialIssuerConfig {
     private URI tokenUrl;
     private URI credentialUrl;
     private URI authorizeUrl;
+    private String ipvClientId;
 
     public CredentialIssuerConfig() {}
 
     public CredentialIssuerConfig(
-            String id, String name, URI tokenUrl, URI credentialUrl, URI authorizeUrl) {
+            String id,
+            String name,
+            URI tokenUrl,
+            URI credentialUrl,
+            URI authorizeUrl,
+            String ipvClientId) {
         this.id = id;
         this.name = name;
         this.tokenUrl = tokenUrl;
         this.credentialUrl = credentialUrl;
         this.authorizeUrl = authorizeUrl;
+        this.ipvClientId = ipvClientId;
     }
 
     public String getId() {
@@ -43,6 +50,10 @@ public class CredentialIssuerConfig {
 
     public URI getAuthorizeUrl() {
         return authorizeUrl;
+    }
+
+    public String getIpvClientId() {
+        return ipvClientId;
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -1,11 +1,13 @@
 package uk.gov.di.ipv.core.library.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.net.URI;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@ExcludeFromGeneratedCoverageReport
 public class CredentialIssuerConfig {
 
     private String id;

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -99,7 +99,8 @@ class ConfigurationServiceTest {
                         "",
                         URI.create(TEST_TOKEN_URL),
                         URI.create(TEST_CREDENTIAL_URL),
-                        URI.create(TEST_CREDENTIAL_URL));
+                        URI.create(TEST_CREDENTIAL_URL),
+                        "ipv-core");
 
         assertEquals(expected.getTokenUrl(), result.getTokenUrl());
         assertEquals(expected.getCredentialUrl(), result.getCredentialUrl());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -288,6 +288,7 @@ class CredentialIssuerServiceTest {
                 "any",
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"),
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/credential"),
-                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/authorizeUrl"));
+                URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/authorizeUrl"),
+                "ipv-core");
     }
 }

--- a/terraform/modules/parameters/credential-issuers.tf
+++ b/terraform/modules/parameters/credential-issuers.tf
@@ -38,6 +38,14 @@ resource "aws_ssm_parameter" "credential_url" {
   overwrite = var.overwrite
 }
 
+resource "aws_ssm_parameter" "ipvClientId" {
+  for_each  = { for c in var.issuers : c.id => c }
+  name      = "/${var.environment}/ipv/core/credentialIssuers/${each.value.id}/ipvClientId"
+  type      = var.type
+  value     = each.value.ipvClientId
+  overwrite = var.overwrite
+}
+
 // Tempory until we move to SAM
 resource "aws_iam_policy" "credential_issuers_config" {
   name   = "${var.environment}-get-credential-issuers-config"


### PR DESCRIPTION
… and add to the credential issuers parameter store values

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add new ipvClientId field to the CredentialIssierConfig class
- Update tests to work with new property.
- Add new ipvClientId field to the terraform crendential issuer paramaters

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Allow the new field to be read in from SSM and passed back to core-front.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-633](https://govukverify.atlassian.net/browse/PYI-633)

