### PR TITLE
PYI-640: Use new parameter store config structure

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -34,14 +34,12 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
-          SHARED_ATTRIBUTES_SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/ipv/core/sharedAttributes/signingKeyId"
+          SHARED_ATTRIBUTES_SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/sharedAttributesJwtSigningKeyId"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsTable
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/sharedAttributes/*
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/sharedAttributes
+            ParameterName: !Sub ${Environment}/core/self/sharedAttributesJwtSigningKeyId
       Events:
         IPVCoreAPI:
           Type: Api
@@ -71,10 +69,6 @@ Resources:
             TableName: !Ref AccessTokensTable
         - DynamoDBCrudPolicy:
             TableName: !Ref AuthCodesTable
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers/*
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers
       Events:
         IPVCoreAPI:
           Type: Api
@@ -103,10 +97,6 @@ Resources:
             TableName: !Ref AuthCodesTable
         - DynamoDBReadPolicy:
             TableName: !Ref AuthCodesTable
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers/*
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers
       Events:
         IPVCoreAPI:
           Type: Api
@@ -136,10 +126,6 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers/*
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers
       Events:
         IPVCoreAPI:
           Type: Api
@@ -162,16 +148,15 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
-          ENVIRONMENT: !Sub "${Environment}"
-          CREDENTIAL_ISSUER_CONFIG_PARAMETER_STORE_KEY: !Sub "/${Environment}/credential-issuers-config"
+          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "${Environment}/core/credentialIssuers/"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref UserIssuedCredentialsTable
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers/*
+            ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers
+            ParameterName: !Sub ${Environment}/core/credentialIssuers
       Events:
         IPVCoreAPI:
           Type: Api
@@ -204,10 +189,6 @@ Resources:
             TableName: !Ref UserIssuedCredentialsTable
         - DynamoDBCrudPolicy:
             TableName: !Ref AccessTokensTable
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers/*
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers
       Events:
         IPVCoreAPI:
           Type: Api
@@ -230,12 +211,12 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
-          ENVIRONMENT: !Sub "${Environment}"
+          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "${Environment}/core/credentialIssuers/"
       Policies:
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers/*
+            ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers
+            ParameterName: !Sub ${Environment}/core/credentialIssuers
       Events:
         IPVCoreAPI:
           Type: Api
@@ -265,10 +246,6 @@ Resources:
             TableName: !Ref UserIssuedCredentialsTable
         - DynamoDBWritePolicy:
             TableName: !Ref UserIssuedCredentialsTable
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers/*
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/ipv/core/credentialIssuers
       Events:
         IPVCoreAPI:
           Type: Api

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -86,9 +86,8 @@ public class ConfigurationService {
     public CredentialIssuerConfig getCredentialIssuer(String credentialIssuerId) {
         Map<String, String> result =
                 ssmProvider.getMultiple(
-                        String.format(
-                                "/%s/ipv/core/credentialIssuers/%s",
-                                System.getenv("ENVIRONMENT"), credentialIssuerId));
+                        System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX")
+                                + credentialIssuerId);
         return new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
     }
 
@@ -97,10 +96,7 @@ public class ConfigurationService {
         Map<String, String> params =
                 ssmProvider
                         .recursive()
-                        .getMultiple(
-                                String.format(
-                                        "/%s/ipv/core/credentialIssuers",
-                                        System.getenv("ENVIRONMENT")));
+                        .getMultiple(System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX"));
 
         Map<String, Map<String, Object>> map = new HashMap<>();
         for (Entry<String, String> entry : params.entrySet()) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -84,11 +84,12 @@ class ConfigurationServiceTest {
 
     @Test
     void shouldGetCredentialIssuerFromParameterStore() {
-        environmentVariables.set("ENVIRONMENT", "dev");
+        environmentVariables.set(
+                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
 
         Map<String, String> credentialIssuerParameters =
                 Map.of("tokenUrl", TEST_TOKEN_URL, "credentialUrl", TEST_CREDENTIAL_URL);
-        when(ssmProvider.getMultiple("/dev/ipv/core/credentialIssuers/passportCri"))
+        when(ssmProvider.getMultiple("/dev/core/credentialIssuers/passportCri"))
                 .thenReturn(credentialIssuerParameters);
 
         CredentialIssuerConfig result = configurationService.getCredentialIssuer("passportCri");
@@ -110,7 +111,8 @@ class ConfigurationServiceTest {
     void shouldGetAllCredentialIssuersFromParameterStore()
             throws ParseCredentialIssuerConfigException {
 
-        environmentVariables.set("ENVIRONMENT", "dev");
+        environmentVariables.set(
+                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
         HashMap<String, String> response = new HashMap<>();
         response.put("passportCri/tokenUrl", "passportTokenUrl");
         response.put("passportCri/authorizeUrl", "passportAuthUrl");
@@ -122,7 +124,7 @@ class ConfigurationServiceTest {
         response.put("stubCri/name", "stubIssuer");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/ipv/core/credentialIssuers")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
         List<CredentialIssuerConfig> result = configurationService.getCredentialIssuers();
 
         assertEquals(2, result.size());
@@ -144,7 +146,8 @@ class ConfigurationServiceTest {
 
     @Test
     void shouldThrowExceptionWhenCriConfigIsIncorrect() {
-        environmentVariables.set("ENVIRONMENT", "dev");
+        environmentVariables.set(
+                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
         HashMap<String, String> response = new HashMap<>();
         response.put("incorrectPathName", "passportTokenUrl");
         response.put("passportCri/authorizeUrl", "passportAuthUrl");
@@ -152,7 +155,7 @@ class ConfigurationServiceTest {
         response.put("passportCri/name", "passportIssuer");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/ipv/core/credentialIssuers")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
         ParseCredentialIssuerConfigException exception =
                 assertThrows(
                         ParseCredentialIssuerConfigException.class,
@@ -166,7 +169,8 @@ class ConfigurationServiceTest {
     void shouldGetAllCredentialIssuersFromParameterStoreNewAndIgnoreInExistingFields()
             throws ParseCredentialIssuerConfigException {
 
-        environmentVariables.set("ENVIRONMENT", "dev");
+        environmentVariables.set(
+                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
         HashMap<String, String> response = new HashMap<>();
         response.put("passportCri/id", "passportCri");
         response.put("passportCri/tokenUrl", "passportTokenUrl");
@@ -176,7 +180,7 @@ class ConfigurationServiceTest {
         response.put("stubCri/ipclientid", "stubIpClient");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/ipv/core/credentialIssuers")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
         List<CredentialIssuerConfig> result = configurationService.getCredentialIssuers();
 
         Optional<CredentialIssuerConfig> passportIssuerConfig =


### PR DESCRIPTION
**Companion PR to do the restructuring: https://github.com/alphagov/di-ipv-config/pull/130**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The layout of the config in the parameter store has changed. This
updates the templates to reflect it.

It also updates the configuration service to format the location of each
individual credential issuers config with the new format.

Some lambdas also had permissions on params they didn't need, which have
been removed.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-640](https://govukverify.atlassian.net/browse/PYI-640)

