### PR TITLE
PYI-638: Fix shared attributes deserializer by not looking for names …

### DIFF
--- a/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandlerTest.java
+++ b/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandlerTest.java
@@ -48,8 +48,10 @@ class SharedAttributesHandlerTest {
             Map.of(
                     "attributes",
                     Map.of(
-                            "names",
-                            Map.of("givenNames", List.of("John", "H"), "familyName", "Watson"),
+                            "givenNames",
+                            List.of("John", "H"),
+                            "familyName",
+                            "Watson",
                             "dateOfBirth",
                             "2021-03-01",
                             "address",
@@ -69,8 +71,10 @@ class SharedAttributesHandlerTest {
             Map.of(
                     "attributes",
                     Map.of(
-                            "names",
-                            Map.of("givenNames", List.of("Sherlock"), "familyName", "Holmes"),
+                            "givenNames",
+                            List.of("Sherlock"),
+                            "familyName",
+                            "Holmes",
                             "dateOfBirth",
                             "1991-03-01",
                             "address",

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedAttributesDeserializer.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedAttributesDeserializer.java
@@ -38,16 +38,22 @@ public class SharedAttributesDeserializer extends StdDeserializer<SharedAttribut
             return SharedAttributes.empty();
         }
 
-        JsonNode names = attributes.get("names");
-        if (names != null) {
-            List<String> givenNames = new ArrayList<>();
-            for (JsonNode name : names.get("givenNames")) {
+        List<String> givenNames = new ArrayList<>();
+        JsonNode givenNamesNode = attributes.get("givenNames");
+        if (givenNamesNode != null) {
+            for (JsonNode name : givenNamesNode) {
                 givenNames.add(name.asText());
             }
-            JsonNode familyName = names.get("familyName");
-            if (familyName != null) {
-                sharedAttributesBuilder.setName(new Name(givenNames, familyName.asText()));
-            }
+        }
+
+        JsonNode familyNameNode = attributes.get("familyName");
+        String familName = null;
+        if (familyNameNode != null) {
+            familName = familyNameNode.asText();
+        }
+
+        if (!givenNames.isEmpty() || familName != null) {
+            sharedAttributesBuilder.setName(new Name(givenNames, familName));
         }
 
         JsonNode dateOfBirth = attributes.get("dateOfBirth");


### PR DESCRIPTION
…attribute

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated shared attributes deserialiser to not expect the name properties to be under a "names" field.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The cri response does not structure the names properties under a "names" field so the current deserialising fails.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-638](https://govukverify.atlassian.net/browse/PYI-638)
