### PR TITLE
BAU: Remove cred issuer config prefix trailing slash

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -148,7 +148,7 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers/"
+          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
       Policies:
         - DynamoDBCrudPolicy:
@@ -211,7 +211,7 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers/"
+          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
       Policies:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -86,8 +86,10 @@ public class ConfigurationService {
     public CredentialIssuerConfig getCredentialIssuer(String credentialIssuerId) {
         Map<String, String> result =
                 ssmProvider.getMultiple(
-                        System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX")
-                                + credentialIssuerId);
+                        String.format(
+                                "%s/%s",
+                                System.getenv("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX"),
+                                credentialIssuerId));
         return new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -85,7 +85,7 @@ class ConfigurationServiceTest {
     @Test
     void shouldGetCredentialIssuerFromParameterStore() {
         environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
+                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers");
 
         Map<String, String> credentialIssuerParameters =
                 Map.of("tokenUrl", TEST_TOKEN_URL, "credentialUrl", TEST_CREDENTIAL_URL);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The trailing slash was causing the result of `ssmProvider.getMultiple()`
to have the keys not have the expected slashes separating the path
parts.

Removing it re-establishes the previous behaviour.
