### PR TITLE
BAU: Improve logging for failed requests

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -71,7 +71,13 @@ public class CredentialIssuerService {
                         Objects.requireNonNullElse(
                                 errorResponse.getErrorObject(),
                                 new ErrorObject("unknown", "unknown"));
-                LOGGER.error("{}: {}", errorObject.getCode(), errorObject.getDescription());
+                LOGGER.error(
+                        "Failed to exchange token with credential issuer with ID '{}' at '{}'. Code: '{}', Description: {}, HttpStatus code: {}",
+                        config.getId(),
+                        config.getTokenUrl(),
+                        errorObject.getCode(),
+                        errorObject.getDescription(),
+                        errorObject.getHTTPStatusCode());
                 throw new CredentialIssuerException(
                         HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST);
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We had an issue with the wrong config being set for the credential
issuers. The 404 being returned in the httpResponse was causing the
error logging to just return "null: null". This adds some more details
to make it easier to work out what had gone wrong.

It's a bit wordy but it'll be helpful if things go wrong again.