### PR TITLE
PYI-671: Validate redirect URLs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -100,7 +100,7 @@ Resources:
         - DynamoDBReadPolicy:
             TableName: !Ref AuthCodesTable
         - SSMParameterReadPolicy:
-              ParameterName: !Sub ${Environment}/core/self/audienceForClients
+              ParameterName: !Sub ${Environment}/core/*
       Events:
         IPVCoreAPI:
           Type: Api

--- a/lambdas/authorization/src/main/java/uk/gov/di/ipv/core/authorization/AuthorizationHandler.java
+++ b/lambdas/authorization/src/main/java/uk/gov/di/ipv/core/authorization/AuthorizationHandler.java
@@ -5,48 +5,43 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Identifier;
-import com.nimbusds.oauth2.sdk.util.StringUtils;
-import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
-import uk.gov.di.ipv.core.library.validation.ValidationResult;
+import uk.gov.di.ipv.core.library.validation.AuthRequestValidator;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class AuthorizationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationHandler.class);
 
     private final AuthorizationCodeService authorizationCodeService;
-
     private final ConfigurationService configurationService;
+    private final AuthRequestValidator authRequestValidator;
 
     @ExcludeFromGeneratedCoverageReport
     public AuthorizationHandler() {
         this.configurationService = new ConfigurationService();
         this.authorizationCodeService = new AuthorizationCodeService(configurationService);
+        this.authRequestValidator = new AuthRequestValidator(configurationService);
     }
 
     public AuthorizationHandler(
             AuthorizationCodeService authorizationCodeService,
-            ConfigurationService configurationService) {
+            ConfigurationService configurationService,
+            AuthRequestValidator authRequestValidator) {
         this.authorizationCodeService = authorizationCodeService;
         this.configurationService = configurationService;
+        this.authRequestValidator = authRequestValidator;
     }
 
     @Override
@@ -54,21 +49,11 @@ public class AuthorizationHandler
             APIGatewayProxyRequestEvent input, Context context) {
         Map<String, List<String>> queryStringParameters = getQueryStringParametersAsMap(input);
 
-        try {
-            ValidationResult<ErrorResponse> validationResult =
-                    validateRequest(queryStringParameters, input.getHeaders());
-            if (!validationResult.isValid()) {
-                LOGGER.error("Missing required query parameters for authorisation request");
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        HttpStatus.SC_BAD_REQUEST, validationResult.getError());
-            }
-            AuthenticationRequest.parse(queryStringParameters);
-            LOGGER.info("Successfully parsed authentication request");
-        } catch (ParseException e) {
-            LOGGER.error("Authentication request could not be parsed", e);
+        var validationResult =
+                authRequestValidator.validateRequest(queryStringParameters, input.getHeaders());
+        if (!validationResult.isValid()) {
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_BAD_REQUEST,
-                    ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS);
+                    HttpStatus.SC_BAD_REQUEST, validationResult.getError());
         }
 
         AuthorizationCode authorizationCode = authorizationCodeService.generateAuthorizationCode();
@@ -93,19 +78,5 @@ public class AuthorizationHandler
                                     Map.Entry::getKey, entry -> List.of(entry.getValue())));
         }
         return Collections.emptyMap();
-    }
-
-    private ValidationResult<ErrorResponse> validateRequest(
-            Map<String, List<String>> queryStringParameters, Map<String, String> requestHeaders) {
-        if (Objects.isNull(queryStringParameters) || queryStringParameters.isEmpty()) {
-            return new ValidationResult<>(false, ErrorResponse.MISSING_QUERY_PARAMETERS);
-        }
-
-        String ipvSessionId =
-                RequestHelper.getHeaderByKey(requestHeaders, IPV_SESSION_ID_HEADER_KEY);
-        if (StringUtils.isBlank(ipvSessionId)) {
-            return new ValidationResult<>(false, ErrorResponse.MISSING_IPV_SESSION_ID);
-        }
-        return ValidationResult.createValidResult();
     }
 }

--- a/lambdas/authorization/src/test/java/uk/gov/di/ipv/core/authorization/AuthorizationHandlerTest.java
+++ b/lambdas/authorization/src/test/java/uk/gov/di/ipv/core/authorization/AuthorizationHandlerTest.java
@@ -3,47 +3,63 @@ package uk.gov.di.ipv.core.authorization;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
+import uk.gov.di.ipv.core.library.validation.AuthRequestValidator;
+import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class AuthorizationHandlerTest {
     private static final Map<String, String> TEST_EVENT_HEADERS = Map.of("ipv-session-id", "12345");
 
-    private final Context context = mock(Context.class);
-    private AuthorizationCodeService mockAuthorizationCodeService;
+    @Mock private Context context;
+    @Mock private AuthorizationCodeService mockAuthorizationCodeService;
+    @Mock private ConfigurationService mockConfigurationService;
+    @Mock private AuthRequestValidator mockAuthRequestValidator;
 
     private AuthorizationHandler handler;
     private AuthorizationCode authorizationCode;
 
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
     @BeforeEach
     void setUp() {
-        mockAuthorizationCodeService = mock(AuthorizationCodeService.class);
-        ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
-
         authorizationCode = new AuthorizationCode();
-        when(mockAuthorizationCodeService.generateAuthorizationCode())
-                .thenReturn(authorizationCode);
-        handler = new AuthorizationHandler(mockAuthorizationCodeService, mockConfigurationService);
+        handler =
+                new AuthorizationHandler(
+                        mockAuthorizationCodeService,
+                        mockConfigurationService,
+                        mockAuthRequestValidator);
     }
 
     @Test
-    void shouldReturn200OnSuccessfulOauthRequest() {
+    void shouldReturn200OnSuccessfulOauthRequest() throws JsonProcessingException {
+        when(mockAuthorizationCodeService.generateAuthorizationCode())
+                .thenReturn(authorizationCode);
+        when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
+                .thenReturn(ValidationResult.createValidResult());
+
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> params = new HashMap<>();
         params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
@@ -57,23 +73,7 @@ class AuthorizationHandlerTest {
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-    }
 
-    @Test
-    void shouldReturnAuthResponseOnSuccessfulOauthRequest() throws Exception {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> params = new HashMap<>();
-        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
-        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
-        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
-        params.put(OAuth2RequestParams.SCOPE, "openid");
-        event.setQueryStringParameters(params);
-
-        event.setHeaders(TEST_EVENT_HEADERS);
-
-        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
-
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Map<String, String>> responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
         Map<String, String> authCode = responseBody.get("code");
@@ -84,142 +84,27 @@ class AuthorizationHandlerTest {
     }
 
     @Test
-    void shouldReturn400OnMissingRedirectUriParam() throws Exception {
+    void shouldReturn400IfRequestFailsValidation() throws JsonProcessingException {
+        when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
+                .thenReturn(new ValidationResult<>(false, ErrorResponse.MISSING_QUERY_PARAMETERS));
+
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> params = new HashMap<>();
-        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
-        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
-        params.put(OAuth2RequestParams.SCOPE, "openid");
-        event.setQueryStringParameters(params);
+        event.setQueryStringParameters(new HashMap<>());
 
         event.setHeaders(TEST_EVENT_HEADERS);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
-
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
-                responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
-                responseBody.get("message"));
-    }
 
-    @Test
-    void shouldReturn400OnMissingClientIdParam() throws Exception {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> params = new HashMap<>();
-        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
-        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
-        params.put(OAuth2RequestParams.SCOPE, "openid");
-        event.setQueryStringParameters(params);
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
-        event.setHeaders(TEST_EVENT_HEADERS);
-
-        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
-                responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
-                responseBody.get("message"));
-    }
-
-    @Test
-    void shouldReturn400OnMissingResponseTypeParam() throws Exception {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> params = new HashMap<>();
-        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
-        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
-        params.put(OAuth2RequestParams.SCOPE, "openid");
-        event.setQueryStringParameters(params);
-
-        event.setHeaders(TEST_EVENT_HEADERS);
-
-        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
-                responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
-                responseBody.get("message"));
-    }
-
-    @Test
-    void shouldReturn400OnMissingScopeParam() throws Exception {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> params = new HashMap<>();
-        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
-        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
-        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
-        event.setQueryStringParameters(params);
-
-        event.setHeaders(TEST_EVENT_HEADERS);
-
-        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
-                responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
-                responseBody.get("message"));
-    }
-
-    @Test
-    void shouldReturn400OnMissingQueryParameters() throws Exception {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        event.setHeaders(TEST_EVENT_HEADERS);
-
-        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
         assertEquals(
                 ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
-    }
 
-    @Test
-    void shouldReturn400OnMissingSessionIdHeader() throws Exception {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> params = new HashMap<>();
-        params.put(OAuth2RequestParams.REDIRECT_URI, "http://example.com");
-        params.put(OAuth2RequestParams.CLIENT_ID, "12345");
-        params.put(OAuth2RequestParams.RESPONSE_TYPE, "code");
-        params.put(OAuth2RequestParams.SCOPE, "openid");
-        event.setQueryStringParameters(params);
-
-        event.setHeaders(Collections.emptyMap());
-
-        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map responseBody = objectMapper.readValue(response.getBody(), Map.class);
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), responseBody.get("message"));
+        verify(mockAuthorizationCodeService, never())
+                .persistAuthorizationCode(anyString(), anyString());
     }
 }

--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
@@ -51,7 +51,7 @@ public class SharedAttributesHandler
         this.signer =
                 new KmsSigner(
                         configurationService
-                                .getShareAttributesSigningKeyId()
+                                .getSharedAttributesSigningKeyId()
                                 .orElseThrow(
                                         () ->
                                                 new IllegalArgumentException(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -24,7 +24,9 @@ public enum ErrorResponse {
     FAILED_TO_PARSE_CREDENTIAL_ISSUER_CONFIG(
             1014, "Failed to parse credential issuers config to credential issuers object"),
     FAILED_TO_GET_SHARED_ATTRIBUTES(1015, "Failed to get Shared Attributes"),
-    FAILED_TO_SIGN_SHARED_ATTRIBUTES(1016, "Failed to sign Shared Attributes");
+    FAILED_TO_SIGN_SHARED_ATTRIBUTES(1016, "Failed to sign Shared Attributes"),
+    INVALID_REDIRECT_URL(1017, "Provided redirect URL is not in those configured for client"),
+    INVALID_REQUEST_PARAM(1018, "Invalid request param");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/AuthRequestValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/AuthRequestValidator.java
@@ -1,0 +1,100 @@
+package uk.gov.di.ipv.core.library.validation;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class AuthRequestValidator {
+
+    public static final String CLIENT_ID_PARAM = "client_id";
+    public static final String REDIRECT_URI_PARAM = "redirect_uri";
+    private static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthRequestValidator.class);
+
+    private final ConfigurationService configurationService;
+
+    public AuthRequestValidator(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public ValidationResult<ErrorResponse> validateRequest(
+            Map<String, List<String>> queryStringParameters, Map<String, String> requestHeaders) {
+        if (queryStringParamsMissing(queryStringParameters)) {
+            LOGGER.error("Missing required query parameters for authorisation request");
+            return new ValidationResult<>(false, ErrorResponse.MISSING_QUERY_PARAMETERS);
+        }
+
+        if (sessionIdMissing(requestHeaders)) {
+            LOGGER.error("Missing IPV session ID from headers");
+            return new ValidationResult<>(false, ErrorResponse.MISSING_IPV_SESSION_ID);
+        }
+
+        if (unableToParseQueryStrings(queryStringParameters)) {
+            return new ValidationResult<>(
+                    false, ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS);
+        }
+
+        var errorResult = validateRedirectUrl(queryStringParameters);
+        if (errorResult.isPresent()) {
+            return new ValidationResult<>(false, errorResult.get());
+        }
+
+        return ValidationResult.createValidResult();
+    }
+
+    private boolean queryStringParamsMissing(Map<String, List<String>> queryStringParameters) {
+        return Objects.isNull(queryStringParameters) || queryStringParameters.isEmpty();
+    }
+
+    private boolean sessionIdMissing(Map<String, String> requestHeaders) {
+        return StringUtils.isBlank(
+                RequestHelper.getHeaderByKey(requestHeaders, IPV_SESSION_ID_HEADER_KEY));
+    }
+
+    private boolean unableToParseQueryStrings(Map<String, List<String>> queryStringParameters) {
+        try {
+            AuthenticationRequest.parse(queryStringParameters);
+            LOGGER.info("Successfully parsed authentication request");
+            return false;
+        } catch (ParseException e) {
+            LOGGER.error("Authentication request could not be parsed", e);
+            return true;
+        }
+    }
+
+    private Optional<ErrorResponse> validateRedirectUrl(
+            Map<String, List<String>> queryStringParameters) {
+        try {
+            String redirectUrl = getOnlyValueOrThrow(queryStringParameters.get(REDIRECT_URI_PARAM));
+            String clientId = getOnlyValueOrThrow(queryStringParameters.get(CLIENT_ID_PARAM));
+            List<String> clientRedirectUrls = configurationService.getClientRedirectUrls(clientId);
+
+            if (!clientRedirectUrls.contains(redirectUrl)) {
+                LOGGER.error("Invalid redirect URL for client_id {}: '{}'", clientId, redirectUrl);
+                return Optional.of(ErrorResponse.INVALID_REDIRECT_URL);
+            }
+            return Optional.empty();
+        } catch (IllegalArgumentException e) {
+            LOGGER.error(e.getMessage());
+            return Optional.of(ErrorResponse.INVALID_REQUEST_PARAM);
+        }
+    }
+
+    private String getOnlyValueOrThrow(List<String> container) {
+        if (container.size() != 1) {
+            throw new IllegalArgumentException(
+                    String.format("Container must have exactly one element: %s", container));
+        }
+        return container.get(0);
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/validation/AuthRequestValidationTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/validation/AuthRequestValidationTest.java
@@ -1,0 +1,134 @@
+package uk.gov.di.ipv.core.library.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthRequestValidationTest {
+
+    @Mock private ConfigurationService mockConfigurationService;
+
+    private static final String REDIRECT_URI_PARAM = "redirect_uri";
+    private static final String CLIENT_ID_PARAM = "client_id";
+    private static final String RESPONSE_TYPE_PARAM = "response_type";
+    private static final String SCOPE_PARAM = "scope";
+    private static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
+
+    private static final Map<String, String> REQUEST_HEADERS =
+            Map.of(IPV_SESSION_ID_HEADER, "12345");
+    private static final Map<String, List<String>> VALID_QUERY_STRING_PARAMS =
+            Map.of(
+                    REDIRECT_URI_PARAM, List.of("http://example.com"),
+                    CLIENT_ID_PARAM, List.of("12345"),
+                    RESPONSE_TYPE_PARAM, List.of("code"),
+                    SCOPE_PARAM, List.of("openid"));
+
+    private AuthRequestValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new AuthRequestValidator(mockConfigurationService);
+    }
+
+    @Test
+    void validateRequestReturnsValidResultForValidRequest() {
+        when(mockConfigurationService.getClientRedirectUrls("12345"))
+                .thenReturn(List.of("http://example.com"));
+
+        var validationResult =
+                validator.validateRequest(VALID_QUERY_STRING_PARAMS, REQUEST_HEADERS);
+
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void validateRequestReturnsErrorResponseForNullParams() {
+        var validationResult = validator.validateRequest(null, REQUEST_HEADERS);
+
+        assertFalse(validationResult.isValid());
+        assertEquals(
+                ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(),
+                validationResult.getError().getCode());
+        assertEquals(
+                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(),
+                validationResult.getError().getMessage());
+    }
+
+    @Test
+    void validateRequestReturnsErrorResponseForEmptyParameters() {
+        var validationResult = validator.validateRequest(Collections.emptyMap(), REQUEST_HEADERS);
+
+        assertFalse(validationResult.isValid());
+        assertEquals(
+                ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(),
+                validationResult.getError().getCode());
+        assertEquals(
+                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(),
+                validationResult.getError().getMessage());
+    }
+
+    @Test
+    void validateRequestReturnsErrorResponseForMissingSessionId() {
+        var validationResult =
+                validator.validateRequest(VALID_QUERY_STRING_PARAMS, Collections.emptyMap());
+
+        assertFalse(validationResult.isValid());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getCode(),
+                validationResult.getError().getCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                validationResult.getError().getMessage());
+    }
+
+    @Test
+    void validateRequestReturnsErrorResponseForBlankSessionId() {
+        var validationResult =
+                validator.validateRequest(
+                        VALID_QUERY_STRING_PARAMS, Map.of(IPV_SESSION_ID_HEADER, ""));
+
+        assertFalse(validationResult.isValid());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getCode(),
+                validationResult.getError().getCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                validationResult.getError().getMessage());
+    }
+
+    @Test
+    void validateRequestReturnsErrorIfMissingParams() {
+        var paramsToTest =
+                List.of(REDIRECT_URI_PARAM, CLIENT_ID_PARAM, RESPONSE_TYPE_PARAM, SCOPE_PARAM);
+        for (String paramToTest : paramsToTest) {
+            var invalidQueryStringParams = new HashMap<>(VALID_QUERY_STRING_PARAMS);
+            invalidQueryStringParams.remove(paramToTest);
+
+            ValidationResult<ErrorResponse> validationResult =
+                    validator.validateRequest(invalidQueryStringParams, REQUEST_HEADERS);
+
+            assertFalse(validationResult.isValid());
+            assertEquals(
+                    ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getCode(),
+                    validationResult.getError().getCode());
+            assertEquals(
+                    ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS.getMessage(),
+                    validationResult.getError().getMessage());
+        }
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We've added configuration for each client the core talks to which
includes the valid redirect URLs. This consumes that config and
validates incoming requests on the authorize endpoint.

The changes to the configuration service expect the URLs to be a comma
separated list.

This refactors all the validation logic from the authorize endpoint into
a separate validator class to keep the handler cleaner.

### Why did it change

Security.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-671](https://govukverify.atlassian.net/browse/PYI-671)
