### PR TITLE
PYI-686: Load the Certificate, Issuer, Audience and Subject for Client Authentication from the Parameter Store.

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -177,16 +177,39 @@ public class ConfigurationService {
                         .split(CLIENT_REDIRECT_URL_SEPARATOR));
     }
 
-    public Certificate getClientCertificateForAuth(String clientId) throws CertificateException {
+    public Certificate getClientCertificate(String clientId) throws CertificateException {
         return getCertificateFromStore(
                 String.format(
                         "/%s/core/clients/%s/publicCertificateForCoreToVerify",
                         System.getenv("ENVIRONMENT"), clientId));
     }
 
-    private Certificate getCertificateFromStore(String parameteraName) throws CertificateException {
-        byte[] binaryCertificate =
-                Base64.getDecoder().decode(getParameterFromStore(parameteraName));
+    public String getClientIssuer(String clientId) {
+        return getParameterFromStore(
+                String.format(
+                        "/%s/core/clients/%s/issuer", System.getenv("ENVIRONMENT"), clientId));
+    }
+
+    public String getClientAudience(String clientId) {
+        return getParameterFromStore(
+                String.format(
+                        "/%s/core/clients/%s/audience", System.getenv("ENVIRONMENT"), clientId));
+    }
+
+    public String getClientSubject(String clientId) {
+        return getParameterFromStore(
+                String.format(
+                        "/%s/core/clients/%s/subject", System.getenv("ENVIRONMENT"), clientId));
+    }
+
+    public String getClientTokenTtl(String clientId) {
+        return getParameterFromStore(
+                String.format(
+                        "/%s/core/clients/%s/tokenTtl", System.getenv("ENVIRONMENT"), clientId));
+    }
+
+    private Certificate getCertificateFromStore(String parameterName) throws CertificateException {
+        byte[] binaryCertificate = Base64.getDecoder().decode(getParameterFromStore(parameterName));
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         return factory.generateCertificate(new ByteArrayInputStream(binaryCertificate));
     }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -240,13 +240,45 @@ class ConfigurationServiceTest {
     }
 
     @Test
-    void shouldReturnValidCertificateForAuth() throws CertificateException {
+    void shouldReturnValidClientCertificateForAuth() throws CertificateException {
         environmentVariables.set("ENVIRONMENT", "test");
         when(ssmProvider.get("/test/core/clients/aClientId/publicCertificateForCoreToVerify"))
                 .thenReturn(TEST_CERT);
 
-        X509Certificate underTest =
-                (X509Certificate) configurationService.getClientCertificateForAuth("aClientId");
-        assertEquals("C=GB,CN=cri-uk-passport-back", underTest.getIssuerX500Principal().getName());
+        X509Certificate result =
+                (X509Certificate) configurationService.getClientCertificate("aClientId");
+        assertEquals("C=GB,CN=cri-uk-passport-back", result.getIssuerX500Principal().getName());
+    }
+
+    @Test
+    void shouldReturnClientIssuer() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        String clientIssuer = "aClientIssuer";
+        when(ssmProvider.get("/test/core/clients/aClientId/issuer")).thenReturn(clientIssuer);
+        assertEquals(clientIssuer, configurationService.getClientIssuer("aClientId"));
+    }
+
+    @Test
+    void shouldReturnClientAudience() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        String clientIssuer = "aClientAudience";
+        when(ssmProvider.get("/test/core/clients/aClientId/audience")).thenReturn(clientIssuer);
+        assertEquals(clientIssuer, configurationService.getClientAudience("aClientId"));
+    }
+
+    @Test
+    void shouldReturnClientSubject() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        String clientIssuer = "aClientSubject";
+        when(ssmProvider.get("/test/core/clients/aClientId/subject")).thenReturn(clientIssuer);
+        assertEquals(clientIssuer, configurationService.getClientSubject("aClientId"));
+    }
+
+    @Test
+    void shouldReturnClientTokenTtl() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        String clientIssuer = "aClientTokenTtl";
+        when(ssmProvider.get("/test/core/clients/aClientId/tokenTtl")).thenReturn(clientIssuer);
+        assertEquals(clientIssuer, configurationService.getClientTokenTtl("aClientId"));
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added method to configuration service to retrieve the Certificate, Issuer, Audience and Subject for Client Authentication from the Parameter Store.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-686](https://govukverify.atlassian.net/browse/PYI-686)