### PR TITLE
PYI-702: Add new ipvClientJwtExpirationTime variable to the CredentialIssuerConfig class

### DIFF
--- a/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
+++ b/lambdas/credentialissuer/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandlerTest.java
@@ -60,7 +60,8 @@ class CredentialIssuerHandlerTest {
                         new URI("http://www.example.com"),
                         new URI("http://www.example.com/credential"),
                         new URI("http://www.example.com/authorize"),
-                        "ipv-core");
+                        "ipv-core",
+                        "900");
     }
 
     @Test

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -35,14 +35,16 @@ class CredentialIssuerConfigHandlerTest {
                             URI.create("test1TokenUrl"),
                             URI.create("test1credentialUrl"),
                             URI.create("tesstAuthorizeUrl"),
-                            "ipv-core"),
+                            "ipv-core",
+                            "900"),
                     new CredentialIssuerConfig(
                             "test2",
                             "Any",
                             URI.create("test2TokenUrl"),
                             URI.create("test2credentialUrl"),
                             URI.create("tesstAuthorizeUrl"),
-                            "ipv-core"));
+                            "ipv-core",
+                            "900"));
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Mock Context context;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -16,6 +16,7 @@ public class CredentialIssuerConfig {
     private URI credentialUrl;
     private URI authorizeUrl;
     private String ipvClientId;
+    private String ipvClientJwtTtl;
 
     public CredentialIssuerConfig() {}
 
@@ -25,13 +26,15 @@ public class CredentialIssuerConfig {
             URI tokenUrl,
             URI credentialUrl,
             URI authorizeUrl,
-            String ipvClientId) {
+            String ipvClientId,
+            String ipvClientJwtTtl) {
         this.id = id;
         this.name = name;
         this.tokenUrl = tokenUrl;
         this.credentialUrl = credentialUrl;
         this.authorizeUrl = authorizeUrl;
         this.ipvClientId = ipvClientId;
+        this.ipvClientJwtTtl = ipvClientJwtTtl;
     }
 
     public String getId() {
@@ -56,6 +59,10 @@ public class CredentialIssuerConfig {
 
     public String getIpvClientId() {
         return ipvClientId;
+    }
+
+    public String getIpvClientJwtTtl() {
+        return ipvClientJwtTtl;
     }
 
     @Override

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -104,7 +104,8 @@ class ConfigurationServiceTest {
                         URI.create(TEST_TOKEN_URL),
                         URI.create(TEST_CREDENTIAL_URL),
                         URI.create(TEST_CREDENTIAL_URL),
-                        "ipv-core");
+                        "ipv-core",
+                        "900");
 
         assertEquals(expected.getTokenUrl(), result.getTokenUrl());
         assertEquals(expected.getCredentialUrl(), result.getCredentialUrl());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -289,6 +289,7 @@ class CredentialIssuerServiceTest {
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"),
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/credential"),
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/authorizeUrl"),
-                "ipv-core");
+                "ipv-core",
+                "900");
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added new ipvClientJwtExpirationTime variable to the CredentialIssuerConfig class.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
New variable will be used when generating the ipv-core client JWT and setting its expiry time claim value.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-702](https://govukverify.atlassian.net/browse/PYI-702)

