### PR TITLE
BAU: Remove Optionals from configuration service

### DIFF
--- a/lambdas/credentialissuer/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandler.java
+++ b/lambdas/credentialissuer/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerHandler.java
@@ -38,14 +38,7 @@ public class CredentialIssuerHandler
     @ExcludeFromGeneratedCoverageReport
     public CredentialIssuerHandler() {
         this.configurationService = new ConfigurationService();
-        JWSSigner signer =
-                new KmsSigner(
-                        configurationService
-                                .getSharedAttributesSigningKeyId()
-                                .orElseThrow(
-                                        () ->
-                                                new IllegalArgumentException(
-                                                        "The shared attributes signing key id is not set in parameter store")));
+        JWSSigner signer = new KmsSigner(configurationService.getSharedAttributesSigningKeyId());
 
         this.credentialIssuerService = new CredentialIssuerService(configurationService, signer);
     }

--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
@@ -48,14 +48,7 @@ public class SharedAttributesHandler
     public SharedAttributesHandler() {
         ConfigurationService configurationService = new ConfigurationService();
         this.userIdentityService = new UserIdentityService(configurationService);
-        this.signer =
-                new KmsSigner(
-                        configurationService
-                                .getSharedAttributesSigningKeyId()
-                                .orElseThrow(
-                                        () ->
-                                                new IllegalArgumentException(
-                                                        "The shared attributes signing key id is not set in parameter store")));
+        this.signer = new KmsSigner(configurationService.getSharedAttributesSigningKeyId());
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -34,6 +34,7 @@ public class ConfigurationService {
     private static final String CLIENT_REDIRECT_URL_SEPARATOR = ",";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationService.class);
+    public static final String ENVIRONMENT = "ENVIRONMENT";
 
     private final SSMProvider ssmProvider;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -162,7 +163,7 @@ public class ConfigurationService {
                 ssmProvider.get(
                         String.format(
                                 "/%s/core/clients/%s/validRedirectUrls",
-                                System.getenv("ENVIRONMENT"), clientId));
+                                System.getenv(ENVIRONMENT), clientId));
 
         return Arrays.asList(redirectUrlStrings.split(CLIENT_REDIRECT_URL_SEPARATOR));
     }
@@ -171,36 +172,34 @@ public class ConfigurationService {
         return getCertificateFromStore(
                 String.format(
                         "/%s/core/clients/%s/publicCertificateForCoreToVerify",
-                        System.getenv("ENVIRONMENT"), clientId));
+                        System.getenv(ENVIRONMENT), clientId));
     }
 
     public String getClientIssuer(String clientId) {
         return getParameterFromStore(
-                String.format(
-                        "/%s/core/clients/%s/issuer", System.getenv("ENVIRONMENT"), clientId));
+                String.format("/%s/core/clients/%s/issuer", System.getenv(ENVIRONMENT), clientId));
     }
 
     public String getClientAudience(String clientId) {
         return getParameterFromStore(
                 String.format(
-                        "/%s/core/clients/%s/audience", System.getenv("ENVIRONMENT"), clientId));
+                        "/%s/core/clients/%s/audience", System.getenv(ENVIRONMENT), clientId));
     }
 
     public String getClientSubject(String clientId) {
         return getParameterFromStore(
-                String.format(
-                        "/%s/core/clients/%s/subject", System.getenv("ENVIRONMENT"), clientId));
+                String.format("/%s/core/clients/%s/subject", System.getenv(ENVIRONMENT), clientId));
     }
 
     public String getClientTokenTtl(String clientId) {
         return getParameterFromStore(
                 String.format(
-                        "/%s/core/clients/%s/tokenTtl", System.getenv("ENVIRONMENT"), clientId));
+                        "/%s/core/clients/%s/tokenTtl", System.getenv(ENVIRONMENT), clientId));
     }
 
     public String getIpvTokenTtl() {
         return getParameterFromStore(
-                String.format("/%s/core/self/jwtTtlSeconds", System.getenv("ENVIRONMENT")));
+                String.format("/%s/core/self/jwtTtlSeconds", System.getenv(ENVIRONMENT)));
     }
 
     private Certificate getCertificateFromStore(String parameterName) throws CertificateException {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -153,28 +153,18 @@ public class ConfigurationService {
         return splitKey;
     }
 
-    public Optional<String> getSharedAttributesSigningKeyId() {
-        return Optional.ofNullable(
-                ssmProvider.get(System.getenv("SHARED_ATTRIBUTES_SIGNING_KEY_ID_PARAM")));
+    public String getSharedAttributesSigningKeyId() {
+        return ssmProvider.get(System.getenv("SHARED_ATTRIBUTES_SIGNING_KEY_ID_PARAM"));
     }
 
     public List<String> getClientRedirectUrls(String clientId) {
-        Optional<String> redirectUrlStrings =
-                Optional.ofNullable(
-                        ssmProvider.get(
-                                String.format(
-                                        "/%s/core/clients/%s/validRedirectUrls",
-                                        System.getenv("ENVIRONMENT"), clientId)));
+        String redirectUrlStrings =
+                ssmProvider.get(
+                        String.format(
+                                "/%s/core/clients/%s/validRedirectUrls",
+                                System.getenv("ENVIRONMENT"), clientId));
 
-        return Arrays.asList(
-                redirectUrlStrings
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                String.format(
-                                                        "Client redirect URLs are not set in parameter store for client ID '%s'",
-                                                        clientId)))
-                        .split(CLIENT_REDIRECT_URL_SEPARATOR));
+        return Arrays.asList(redirectUrlStrings.split(CLIENT_REDIRECT_URL_SEPARATOR));
     }
 
     public Certificate getClientCertificate(String clientId) throws CertificateException {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -223,23 +223,6 @@ class ConfigurationServiceTest {
     }
 
     @Test
-    void shouldThrowIfNoRedirectUrlsFound() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/clients/aClientId/validRedirectUrls")).thenReturn(null);
-
-        IllegalArgumentException exception =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> configurationService.getClientRedirectUrls("aClientId"));
-
-        assertTrue(
-                exception
-                        .getMessage()
-                        .contains(
-                                "Client redirect URLs are not set in parameter store for client ID 'aClientId'"));
-    }
-
-    @Test
     void shouldReturnValidClientCertificateForAuth() throws CertificateException {
         environmentVariables.set("ENVIRONMENT", "test");
         when(ssmProvider.get("/test/core/clients/aClientId/publicCertificateForCoreToVerify"))


### PR DESCRIPTION
## Proposed changes

### Why did it change

The ssmProvider doesn't return null if it can't find a parameter.
Instead, it will throw a `ParameterNotFoundException` which is a run
time exception.

