### PR TITLE
PYI-677 Add permission for credential issuer to access JWT Signing Key

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -162,6 +162,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/sharedAttributesJwtSigningKeyId
       Events:
         IPVCoreAPI:
           Type: Api


### PR DESCRIPTION
This is needed by the credential issuer lambda to sign an auth jwt when
calling CRIs.

## Proposed changes
As above, we should rename this parameter to remove the `SharedAttributes` portion since it is used to signing other jwts (for example shared attributes and auth).
