### PR TITLE
PYI-677 ipv-credential-issuers needs the ENVIRONMENT set

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -155,6 +155,7 @@ Resources:
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
           SHARED_ATTRIBUTES_SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/sharedAttributesJwtSigningKeyId"
+          ENVIRONMENT: !Sub "${Environment}"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref UserIssuedCredentialsTable


### PR DESCRIPTION
The ipv-credential-issuers lambda needs the `ENVIRONMENT` variable set
to pull the correct parameters from SSM Parameter Store.


## Proposed changes
The `ENVIRONMENT` variable is used to find the correct `jwtTtlSeconds` parameter in SSM here: https://github.com/alphagov/di-ipv-core-back/blob/60bc073fecc978470f21418294525169bb374a14/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java#L213

## Future Work
I think this highlights the case where we are sharing the `ConfigurationService` across lambdas and so any lambda can call the public methods without that specific lambda's configuration being correctly set (the mocked out tests will pass but things fail after deployment). Something to think about for the future.
