### PR TITLE
PYI-677 Permit ipv-credential-issuer lambda access to jwtTtlSeconds

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -165,6 +165,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/sharedAttributesJwtSigningKeyId
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
       Events:
         IPVCoreAPI:
           Type: Api


### PR DESCRIPTION


## Proposed changes
This is required so the ipv-credential-issuers lambda can validate the auth jwt. Example of current error that this solves:
```
ipv-credential-issuer-dev-danw is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:eu-west-2:130355686670:parameter/dev-danw/core/self/jwtTtlSeconds
```