### PR TITLE
BAU: Fix /token body params being passed into client authentication method

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -77,7 +77,7 @@ public class AccessTokenHandler
                         validationResult.getError().toJSONObject());
             }
 
-            tokenRequestValidator.authenticateClient(input.getBody(), input.getPathParameters());
+            tokenRequestValidator.authenticateClient(input.getBody());
 
             AuthorizationCodeGrant authorizationGrant =
                     (AuthorizationCodeGrant) tokenRequest.getAuthorizationGrant();

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
@@ -204,7 +204,7 @@ class AccessTokenHandlerTest {
 
         doThrow(new ClientAuthenticationException("error"))
                 .when(mockTokenRequestValidator)
-                .authenticateClient(any(), any());
+                .authenticateClient(any());
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
@@ -226,7 +226,7 @@ class AccessTokenHandlerTest {
 
         doThrow(new ClientAuthenticationException("error"))
                 .when(mockTokenRequestValidator)
-                .authenticateClient(any(), any());
+                .authenticateClient(any());
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.core.library.domain.ConfigurationServicePublicKeySelector;
 import uk.gov.di.ipv.core.library.exceptions.ClientAuthenticationException;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.time.OffsetDateTime;
@@ -36,8 +37,8 @@ public class TokenRequestValidator {
         this.verifier = getClientAuthVerifier(configurationService);
     }
 
-    public void authenticateClient(String requestBody, Map<String, String> queryParams)
-            throws ClientAuthenticationException {
+    public void authenticateClient(String requestBody) throws ClientAuthenticationException {
+        Map<String, String> queryParams = RequestHelper.parseRequestBody(requestBody);
         if (queryParams.containsKey(CLIENT_ASSERTION_PARAM)) {
             authenticateClientWithJwt(requestBody);
         } else {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidatorTest.java
@@ -77,8 +77,7 @@ class TokenRequestValidatorTest {
                 getValidQueryParams(generateClientAssertion(getValidClaimsSetValues()));
         assertDoesNotThrow(
                 () -> {
-                    validator.authenticateClient(
-                            queryMapToString(validQueryParams), validQueryParams);
+                    validator.authenticateClient(queryMapToString(validQueryParams));
                 });
     }
 
@@ -100,8 +99,7 @@ class TokenRequestValidatorTest {
                         ClientAuthenticationException.class,
                         () -> {
                             validator.authenticateClient(
-                                    queryMapToString(invalidSignatureQueryParams),
-                                    invalidSignatureQueryParams);
+                                    queryMapToString(invalidSignatureQueryParams));
                         });
 
         assertTrue(exception.getMessage().contains("InvalidClientException: Bad JWT signature"));
@@ -121,8 +119,7 @@ class TokenRequestValidatorTest {
                         ClientAuthenticationException.class,
                         () -> {
                             validator.authenticateClient(
-                                    queryMapToString(differentIssuerAndSubjectQueryParams),
-                                    differentIssuerAndSubjectQueryParams);
+                                    queryMapToString(differentIssuerAndSubjectQueryParams));
                         });
 
         assertTrue(
@@ -147,8 +144,7 @@ class TokenRequestValidatorTest {
                         ClientAuthenticationException.class,
                         () -> {
                             validator.authenticateClient(
-                                    queryMapToString(wrongAudienceQueryParams),
-                                    wrongAudienceQueryParams);
+                                    queryMapToString(wrongAudienceQueryParams));
                         });
 
         assertTrue(
@@ -173,8 +169,7 @@ class TokenRequestValidatorTest {
                 assertThrows(
                         ClientAuthenticationException.class,
                         () -> {
-                            validator.authenticateClient(
-                                    queryMapToString(expiredQueryParams), expiredQueryParams);
+                            validator.authenticateClient(queryMapToString(expiredQueryParams));
                         });
 
         assertTrue(exception.getMessage().contains("Expired JWT"));
@@ -199,8 +194,7 @@ class TokenRequestValidatorTest {
                 assertThrows(
                         ClientAuthenticationException.class,
                         () -> {
-                            validator.authenticateClient(
-                                    queryMapToString(expiredQueryParams), expiredQueryParams);
+                            validator.authenticateClient(queryMapToString(expiredQueryParams));
                         });
         assertTrue(
                 exception
@@ -216,7 +210,7 @@ class TokenRequestValidatorTest {
 
         assertDoesNotThrow(
                 () -> {
-                    validator.authenticateClient(queryMapToString(params), params);
+                    validator.authenticateClient(queryMapToString(params));
                 });
     }
 
@@ -229,8 +223,7 @@ class TokenRequestValidatorTest {
 
         assertDoesNotThrow(
                 () -> {
-                    validator.authenticateClient(
-                            queryMapToString(validQueryParams), validQueryParams);
+                    validator.authenticateClient(queryMapToString(validQueryParams));
                 });
     }
 
@@ -246,8 +239,7 @@ class TokenRequestValidatorTest {
                         ClientAuthenticationException.class,
                         () -> {
                             validator.authenticateClient(
-                                    queryMapToString(missingClientAssertionParams),
-                                    missingClientAssertionParams);
+                                    queryMapToString(missingClientAssertionParams));
                         });
 
         assertEquals(
@@ -263,8 +255,7 @@ class TokenRequestValidatorTest {
                 assertThrows(
                         ClientAuthenticationException.class,
                         () -> {
-                            validator.authenticateClient(
-                                    queryMapToString(missingClientIdParams), missingClientIdParams);
+                            validator.authenticateClient(queryMapToString(missingClientIdParams));
                         });
 
         assertEquals(


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Use the request body to retrieve the /token form-url-endoded values being passed into the request
<!-- Describe the changes in detail - the "what"-->

