### PR TITLE
PYI-724 Grand permission to kms signing key

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -42,6 +42,13 @@ Resources:
             TableName: !Ref UserIssuedCredentialsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/sharedAttributesJwtSigningKeyId
+        - Statement:
+          - Sid: kmsSigningKeyPermission
+            Effect: Allow
+            Action:
+              - 'kms:sign'
+            Resource:
+              - "arn:aws:kms:eu-west-2:130355686670:key/3efe7d7f-5a08-4ea3-90c3-11b24ec3b375"
       Events:
         IPVCoreAPI:
           Type: Api
@@ -181,6 +188,13 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/sharedAttributesJwtSigningKeyId
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
+        - Statement:
+          - Sid: kmsSigningKeyPermission
+            Effect: Allow
+            Action:
+              - 'kms:sign'
+            Resource:
+              - "arn:aws:kms:eu-west-2:130355686670:key/3efe7d7f-5a08-4ea3-90c3-11b24ec3b375"
       Events:
         IPVCoreAPI:
           Type: Api


### PR DESCRIPTION
The SharedAttributes and CredentialIssuers lambdas need access to the
jwt signing key we store in KMS. At present this KMS key isn't generated
via code so it is temporarily being hard-coded until we manage it in
code and can use a CloudFormation output to reference it.

Co-authored-by: Tom Withers
<thomas.withers@digital.cabinet-office.gov.uk>
Co-authored-by: Dan Pomfret
<daniel.pomfret@digital.cabinet-office.gov.uk>

### What changed
Now we have multiple dev environments for each dev it is not managable to edit the kms key policy manually each time. This adds the permission to call `kms:sign` on our jwt signing key to the Iam role assigned to the Shared Attributes and CredentialIssuers lambda.

We need to dynamically reference the key arn in future, this is dependent upon managing the key in CF.

### Issue tracking
- [PYI-724](https://govukverify.atlassian.net/browse/PYI-724)

