### PR TITLE
BAU: Encapsulate shared attributes in vc_http_api claim

### DIFF
--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
@@ -36,6 +36,7 @@ public class SharedAttributesHandler
     public static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
     public static final int BAD_REQUEST = 400;
     public static final int OK = 200;
+    public static final String VC_HTTP_API_CLAIM = "vc_http_api";
     private final UserIdentityService userIdentityService;
     private final ObjectMapper mapper = new ObjectMapper();
     private final JWSSigner signer;
@@ -92,7 +93,8 @@ public class SharedAttributesHandler
             SharedAttributesResponse sharedAttributesResponse)
             throws HttpResponseExceptionWithErrorBody {
         try {
-            return JwtHelper.createSignedJwtFromObject(sharedAttributesResponse, signer);
+            return JwtHelper.createSignedJwtFromObject(
+                    Map.of(VC_HTTP_API_CLAIM, sharedAttributesResponse), signer);
         } catch (JOSEException e) {
             LOGGER.error("Failed to sign Shared Attributes: {}", e.getMessage());
             throw new HttpResponseExceptionWithErrorBody(


### PR DESCRIPTION
**Companion PR for passport-back here: https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/91**
**Companion PR for CRI stub here: https://github.com/alphagov/di-ipv-stubs/pull/48**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Encapsulate shared attributes in vc_http_api claim

### Why did it change

In [RFC 0008](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0008-identity-ipv-sequence-diagram.md#authorize)
we stipulate that the shared attributes will be encapsulated in a top
level claim in the JWT called `vc_http_api`.

The KBV team has implemented this, and we should probably do the same
thing.

