### PR TITLE
BAU: Wrap shared attributes vc_http_api claim in claims claim

### DIFF
--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
@@ -37,6 +37,7 @@ public class SharedAttributesHandler
     public static final int BAD_REQUEST = 400;
     public static final int OK = 200;
     public static final String VC_HTTP_API_CLAIM = "vc_http_api";
+    public static final String CLAIMS_CLAIM = "claims";
     private final UserIdentityService userIdentityService;
     private final ObjectMapper mapper = new ObjectMapper();
     private final JWSSigner signer;
@@ -60,6 +61,7 @@ public class SharedAttributesHandler
         try {
             String ipvSessionId = getIpvSessionId(input.getHeaders());
             SharedAttributesResponse sharedAttributesResponse = getSharedAttributes(ipvSessionId);
+
             SignedJWT signedJWT = signSharedAttributesResponse(sharedAttributesResponse);
 
             return ApiGatewayResponseGenerator.proxyJoseResponse(OK, signedJWT.serialize());
@@ -94,7 +96,8 @@ public class SharedAttributesHandler
             throws HttpResponseExceptionWithErrorBody {
         try {
             return JwtHelper.createSignedJwtFromObject(
-                    Map.of(VC_HTTP_API_CLAIM, sharedAttributesResponse), signer);
+                    Map.of(CLAIMS_CLAIM, Map.of(VC_HTTP_API_CLAIM, sharedAttributesResponse)),
+                    signer);
         } catch (JOSEException e) {
             LOGGER.error("Failed to sign Shared Attributes: {}", e.getMessage());
             throw new HttpResponseExceptionWithErrorBody(

--- a/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandlerTest.java
+++ b/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandlerTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.sharedattributes.SharedAttributesHandler.CLAIMS_CLAIM;
 import static uk.gov.di.ipv.core.sharedattributes.SharedAttributesHandler.VC_HTTP_API_CLAIM;
 
 @ExtendWith(MockitoExtension.class)
@@ -120,8 +121,10 @@ class SharedAttributesHandlerTest {
         JsonNode claimsSet = objectMapper.readTree(signedJWT.getJWTClaimsSet().toString());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(4, claimsSet.get(VC_HTTP_API_CLAIM).size());
-        JsonNode vcAttributes = claimsSet.get(VC_HTTP_API_CLAIM);
+        assertEquals(1, claimsSet.get(CLAIMS_CLAIM).size());
+        JsonNode claims = claimsSet.get(CLAIMS_CLAIM);
+        assertEquals(4, claims.get(VC_HTTP_API_CLAIM).size());
+        JsonNode vcAttributes = claims.get(VC_HTTP_API_CLAIM);
 
         assertEquals(2, (vcAttributes.get("names")).size());
 
@@ -182,8 +185,10 @@ class SharedAttributesHandlerTest {
         JsonNode claimsSet = objectMapper.readTree(signedJWT.getJWTClaimsSet().toString());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(4, claimsSet.get(VC_HTTP_API_CLAIM).size());
-        JsonNode vcAttributes = claimsSet.get(VC_HTTP_API_CLAIM);
+        assertEquals(1, claimsSet.get(CLAIMS_CLAIM).size());
+        JsonNode claims = claimsSet.get(CLAIMS_CLAIM);
+        assertEquals(4, claims.get(VC_HTTP_API_CLAIM).size());
+        JsonNode vcAttributes = claims.get(VC_HTTP_API_CLAIM);
         assertEquals(0, vcAttributes.get("names").size());
         assertEquals(0, vcAttributes.get("dateOfBirths").size());
         assertEquals(0, vcAttributes.get("addresses").size());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

RFC 0008 actually specifies that the custom vc_http_api claim should be
nested under a top level claim in the JWT called `claims`.

This is to keep in line with the OIDC spec which we're sort of
following. https://openid.net/specs/openid-connect-core-1_0.html#RequestObject

This is quite a naive approach and there are probably better ways to do
it using objects from the OIDC library. This implementation is probably
going to change again though as we need to start encrypting these shared
attributes, so I'm delaying that until then.

### Why did it change

To meet the spec we've laid out.
