### PR TITLE
Add old original api gateway output to fix the param store stack

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -393,6 +393,10 @@ Resources:
           KeyType: "HASH"
 
 Outputs:
+  IPVCoreAPIGatewayID:
+    Description: Core Back API Gateway ID
+      Name: !Sub "${AWS::StackName}-IPVCoreAPIGatewayID"
+    Value: !Ref IPVCoreInternalAPI
   IPVCoreInternalAPIGatewayID:
     Description: Core Back Internal API Gateway ID
     Export:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add old api gateway id in order to fix the param store stack.

This is a temporary change in order to allow the ipv-core-back-{env} stack to be deployed. This param will be removed after that and the param store stack will be updated.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Cloudformation does not allow us to change the outputs since they are used by the paramter-store stack.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-790](https://govukverify.atlassian.net/browse/PYI-790)

