### PR TITLE
BAU: fix incorrect integration http method type on shared attributes

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -97,7 +97,7 @@ paths:
               schema:
                 type: "string"
       x-amazon-apigateway-integration:
-        httpMethod: "GET"
+        httpMethod: "POST"
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVSharedAttributesFunction.Arn}/invocations
         passthroughBehavior: "when_no_match"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Change back integration http method type back to a POST for the shared attributes lambda.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Accidental change back to a GET during the previous PR.
