### PR TITLE
Pyi 783/store user session

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -1,0 +1,102 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+plugins {
+	id "java"
+	id "application"
+	id "idea"
+	id "org.sonarqube"
+	id "jacoco"
+	id "com.diffplug.spotless"
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
+			"com.amazonaws:aws-lambda-java-events:3.11.0",
+			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
+			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
+			"com.fasterxml.jackson.core:jackson-core:2.13.0",
+			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
+			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
+			"org.slf4j:slf4j-simple:1.7.32",
+			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
+			"software.amazon.lambda:powertools-parameters:1.8.0",
+			"com.google.code.gson:gson:2.8.9",
+			"com.nimbusds:nimbus-jose-jwt:9.15.2",
+			'org.junit.jupiter:junit-jupiter:5.8.2',
+			project(":lib")
+
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+			"org.mockito:mockito-core:4.2.0",
+			"org.mockito:mockito-junit-jupiter:4.2.0",
+			"com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_11
+	targetCompatibility = JavaVersion.VERSION_11
+}
+
+test {
+	useJUnitPlatform ()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required.set(true)
+	}
+}
+
+sourceSets {
+	integrationTest {
+		java {
+			srcDir 'src/integration-test/java'
+		}
+		resources {
+			srcDir 'src/integration-test/resources'
+		}
+		runtimeClasspath += sourceSets.main.runtimeClasspath
+		runtimeClasspath += sourceSets.test.runtimeClasspath
+		compileClasspath += sourceSets.main.compileClasspath
+		compileClasspath += sourceSets.test.compileClasspath
+	}
+}
+
+task intTest(type: Test) {
+	useJUnitPlatform()
+	testClassesDirs = sourceSets.integrationTest.output.classesDirs
+	classpath += sourceSets.integrationTest.runtimeClasspath
+	reports.junitXml.getOutputLocation().set(file("${project.buildDir}/int-test-results"))
+	reports.html.getOutputLocation().set(file("${project.buildDir}/int-test-reports"))
+	include 'uk/gov/di/ipv/core/integrationtest/**'
+}
+
+tasks.withType(Test) {
+	testLogging {
+		events TestLogEvent.FAILED,
+				TestLogEvent.PASSED,
+				TestLogEvent.SKIPPED
+
+		exceptionFormat TestExceptionFormat.FULL
+		showExceptions true
+		showCauses true
+		showStackTraces true
+
+		afterSuite { suite, result ->
+			if (!suite.parent) {
+				def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+				def startItem = '|  ', endItem = '  |'
+				def repeatLength = startItem.length() + output.length() + endItem.length()
+				println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+			}
+		}
+	}
+}

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -6,9 +6,9 @@ import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.KeyAttribute;
 import com.amazonaws.services.dynamodbv2.document.Table;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ public class DataStoreIpvSessionIT {
 
     private static final String IPV_SESSION_ID = "ipvSessionId";
     private static final String USER_STATE = "userState";
-    private static final String creationDateTime = "creationDateTime";
+    private static final String CREATION_DATE_TIME = "creationDateTime";
     private static final List<String> createdItemIds = new ArrayList<>();
 
     private static DataStore<IpvSessionItem> ipvSessionItemDataStore;
@@ -48,7 +48,10 @@ public class DataStoreIpvSessionIT {
 
         ipvSessionItemDataStore =
                 new DataStore<>(
-                        ipvSessionsTableName, IpvSessionItem.class, DataStore.getClient(false), false);
+                        ipvSessionsTableName,
+                        IpvSessionItem.class,
+                        DataStore.getClient(false),
+                        false);
 
         AmazonDynamoDB independentClient =
                 AmazonDynamoDBClient.builder().withRegion("eu-west-2").build();
@@ -81,21 +84,48 @@ public class DataStoreIpvSessionIT {
         Item savedPassportCheck =
                 tableTestHarness.getItem(IPV_SESSION_ID, ipvSessionItem.getIpvSessionId());
 
-        assertEquals(ipvSessionItem.getIpvSessionId(), savedPassportCheck.get("test"));
-
-//        String attributesJson =
-//                OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(ATTRIBUTES_PARAM));
-//        PassportAttributes savedPassportAttributes =
-//                OBJECT_MAPPER.readValue(attributesJson, PassportAttributes.class);
-//        assertEquals(
-//                passportCheckDao.getAttributes().toString(), savedPassportAttributes.toString());
-//
-//        String gpg45ScoreJson =
-//                OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(GPG45_SCORE_PARAM));
-//        PassportGpg45Score savedPassportGpg45Score =
-//                OBJECT_MAPPER.readValue(gpg45ScoreJson, PassportGpg45Score.class);
-//        assertEquals(
-//                passportCheckDao.getGpg45Score().toString(), savedPassportGpg45Score.toString());
+        assertEquals(ipvSessionItem.getIpvSessionId(), savedPassportCheck.get(IPV_SESSION_ID));
+        assertEquals(ipvSessionItem.getUserState(), savedPassportCheck.get(USER_STATE));
+        assertEquals(
+                ipvSessionItem.getCreationDateTime(), savedPassportCheck.get(CREATION_DATE_TIME));
     }
 
+    @Test
+    void shouldReadIpvSessionFromTable() throws JsonProcessingException {
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+
+        Item item = Item.fromJSON(OBJECT_MAPPER.writeValueAsString(ipvSessionItem));
+        tableTestHarness.putItem(item);
+
+        IpvSessionItem result = ipvSessionItemDataStore.getItem(ipvSessionItem.getIpvSessionId());
+
+        assertEquals(ipvSessionItem.getIpvSessionId(), result.getIpvSessionId());
+        assertEquals(ipvSessionItem.getUserState(), result.getUserState());
+        assertEquals(ipvSessionItem.getCreationDateTime(), result.getCreationDateTime());
+    }
+
+    @Test
+    void shouldUpdateIpvSessionInTable() throws JsonProcessingException {
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+
+        Item item = Item.fromJSON(OBJECT_MAPPER.writeValueAsString(ipvSessionItem));
+        tableTestHarness.putItem(item);
+
+        IpvSessionItem updatedIpvSessionItem = new IpvSessionItem();
+        updatedIpvSessionItem.setIpvSessionId(ipvSessionItem.getIpvSessionId());
+        updatedIpvSessionItem.setCreationDateTime(ipvSessionItem.getCreationDateTime());
+        updatedIpvSessionItem.setUserState(UserStates.DEBUG_PAGE.toString());
+
+        IpvSessionItem result = ipvSessionItemDataStore.update(updatedIpvSessionItem);
+
+        assertEquals(updatedIpvSessionItem.getIpvSessionId(), result.getIpvSessionId());
+        assertEquals(updatedIpvSessionItem.getUserState(), result.getUserState());
+        assertEquals(updatedIpvSessionItem.getCreationDateTime(), result.getCreationDateTime());
+    }
 }

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -1,0 +1,101 @@
+package uk.gov.di.ipv.core.integrationtest;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.KeyAttribute;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.core.library.domain.UserStates;
+import uk.gov.di.ipv.core.library.persistence.DataStore;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataStoreIpvSessionIT {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataStoreIpvSessionIT.class);
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private static final String IPV_SESSION_ID = "ipvSessionId";
+    private static final String USER_STATE = "userState";
+    private static final String creationDateTime = "creationDateTime";
+    private static final List<String> createdItemIds = new ArrayList<>();
+
+    private static DataStore<IpvSessionItem> ipvSessionItemDataStore;
+    private static Table tableTestHarness;
+
+    @BeforeAll
+    public static void setUp() {
+        String ipvSessionsTableName = System.getenv("IPV_SESSIONS_TABLE_NAME");
+        if (ipvSessionsTableName == null) {
+            throw new IllegalArgumentException(
+                    "The environment variable 'IPV_SESSIONS_TABLE_NAME' must be provided to run this test");
+        }
+
+        ipvSessionItemDataStore =
+                new DataStore<>(
+                        ipvSessionsTableName, IpvSessionItem.class, DataStore.getClient(false), false);
+
+        AmazonDynamoDB independentClient =
+                AmazonDynamoDBClient.builder().withRegion("eu-west-2").build();
+        DynamoDB testClient = new DynamoDB(independentClient);
+        tableTestHarness = testClient.getTable(ipvSessionsTableName);
+    }
+
+    @AfterAll
+    public static void deleteTestItems() {
+        for (String id : createdItemIds) {
+            try {
+                tableTestHarness.deleteItem(new KeyAttribute(IPV_SESSION_ID, id));
+            } catch (Exception e) {
+                LOGGER.warn(
+                        String.format(
+                                "Failed to delete test data with %s of %s", IPV_SESSION_ID, id));
+            }
+        }
+    }
+
+    @Test
+    void shouldPutIpvSessionIntoTable() {
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+
+        ipvSessionItemDataStore.create(ipvSessionItem);
+
+        Item savedPassportCheck =
+                tableTestHarness.getItem(IPV_SESSION_ID, ipvSessionItem.getIpvSessionId());
+
+        assertEquals(ipvSessionItem.getIpvSessionId(), savedPassportCheck.get("test"));
+
+//        String attributesJson =
+//                OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(ATTRIBUTES_PARAM));
+//        PassportAttributes savedPassportAttributes =
+//                OBJECT_MAPPER.readValue(attributesJson, PassportAttributes.class);
+//        assertEquals(
+//                passportCheckDao.getAttributes().toString(), savedPassportAttributes.toString());
+//
+//        String gpg45ScoreJson =
+//                OBJECT_MAPPER.writeValueAsString(savedPassportCheck.get(GPG45_SCORE_PARAM));
+//        PassportGpg45Score savedPassportGpg45Score =
+//                OBJECT_MAPPER.readValue(gpg45ScoreJson, PassportGpg45Score.class);
+//        assertEquals(
+//                passportCheckDao.getGpg45Score().toString(), savedPassportGpg45Score.toString());
+    }
+
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.domain;
+
+public enum UserStates {
+    INITIAL_IPV_JOURNEY,
+    DEBUG_PAGE,
+    TRANSITION_PAGE_1
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 @DynamoDbBean
 public class IpvSessionItem {
     private String ipvSessionId;
+    private String userState;
     private String creationDateTime;
 
     @DynamoDbPartitionKey
@@ -15,6 +16,14 @@ public class IpvSessionItem {
 
     public void setIpvSessionId(String ipvSessionId) {
         this.ipvSessionId = ipvSessionId;
+    }
+
+    public String getUserState() {
+        return userState;
+    }
+
+    public void setUserState(String userState) {
+        this.userState = userState;
     }
 
     public String getCreationDateTime() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.service;
 
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.UserStates;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 
@@ -30,12 +31,21 @@ public class IpvSessionService {
         this.configurationService = configurationService;
     }
 
+    public IpvSessionItem getIpvSession(String ipvSessionId) {
+        return dataStore.getItem(ipvSessionId);
+    }
+
     public String generateIpvSession() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         dataStore.create(ipvSessionItem);
 
         return ipvSessionItem.getIpvSessionId();
+    }
+
+    public void updateIpvSession(IpvSessionItem updatedIpvSessionItem) {
+        dataStore.update(updatedIpvSessionItem);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -6,12 +6,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.UserStates;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+
+import java.util.Date;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class IpvSessionServiceTest {
@@ -28,6 +33,27 @@ class IpvSessionServiceTest {
     }
 
     @Test
+    void shouldReturnSessionItem() {
+        String ipvSessionID = UUID.randomUUID().toString();
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(ipvSessionID);
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+
+        when(mockDataStore.getItem(ipvSessionID)).thenReturn(ipvSessionItem);
+
+        IpvSessionItem result = ipvSessionService.getIpvSession(ipvSessionID);
+
+        ArgumentCaptor<String> ipvSessionIDArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockDataStore).getItem(ipvSessionIDArgumentCaptor.capture());
+        assertEquals(ipvSessionID, ipvSessionIDArgumentCaptor.getValue());
+        assertEquals(ipvSessionItem.getIpvSessionId(), result.getIpvSessionId());
+        assertEquals(ipvSessionItem.getUserState(), result.getUserState());
+        assertEquals(ipvSessionItem.getCreationDateTime(), result.getCreationDateTime());
+    }
+
+    @Test
     void shouldCreateSessionItem() {
         String ipvSessionID = ipvSessionService.generateIpvSession();
 
@@ -38,5 +64,17 @@ class IpvSessionServiceTest {
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
 
         assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
+    }
+
+    @Test
+    void shouldUpdateSessionItem() {
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+
+        ipvSessionService.updateIpvSession(ipvSessionItem);
+
+        verify(mockDataStore).update(ipvSessionItem);
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,5 @@ include "lib",
 		"lambdas:session",
 		"lambdas:useridentity",
 		"lambdas:sharedattributes",
-		"lambdas:journeyengine"
+		"lambdas:journeyengine",
+		"integration-test"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the IpvSessionService class to retrieve and update IpvSessions in DynamoDB. Also added a new "userState" field to the session object.

Added integration tests for storing IpvSessionItems using the DataStore.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The new IpvSessionService methods will be used by the new journey engine in order to track and update the current users state.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-783](https://govukverify.atlassian.net/browse/PYI-783)
