### PR TITLE
PYI-785: Update journeyEngine lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -333,6 +333,8 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub session-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          IPV_JOURNEY_CRI_START_URI: "/journey/cri/start/"
+          IPV_JOURNEY_SESSION_END_URI: "/journey/session/end"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -331,13 +331,20 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
+          POWERTOOLS_SERVICE_NAME: !Sub session-${Environment}
+          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionsTable
       Events:
         IPVCoreInternalAPI:
           Type: Api
           Properties:
             RestApiId:
               Ref: IPVCoreInternalAPI
-            Path: /event/journey/{journeyId}
+            Path: /journey/{journeyStep}
             Method: POST
 
   UserIssuedCredentialsTable:

--- a/lambdas/journeyengine/build.gradle
+++ b/lambdas/journeyengine/build.gradle
@@ -12,12 +12,14 @@ repositories {
 
 dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0"
+			"com.amazonaws:aws-lambda-java-events:3.11.0",
+			project(":lib")
 
 	aspect "software.amazon.lambda:powertools-tracing:1.11.0"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
-			"org.mockito:mockito-core:4.1.0"
+			"org.mockito:mockito-core:4.1.0",
+			"org.mockito:mockito-junit-jupiter:4.1.0"
 }
 
 java {

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -39,9 +39,6 @@ public class JourneyEngineHandler
 
     private static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
     private static final String JOURNEY_STEP_PARAM = "journeyStep";
-
-    private static final String START_CRI_JOURNEY_URI_PATH = "/journey/cri/start/";
-    private static final String END_JOURNEY_URI_PATH = "/journey/session/end";
     private static final String UK_PASSPORT_CRI_ID = "ukPassport";
     private static final String ADDRESS_CRI_ID = "address";
     private static final String KBV_CRI_ID = "kbv";
@@ -106,6 +103,9 @@ public class JourneyEngineHandler
 
     private JourneyEngineResult executeJourneyEvent(
             String journeyStep, IpvSessionItem ipvSessionItem) throws JourneyEngineException {
+        String criStartUri = configurationService.getIpvJourneyCriStartUri();
+        String journeyEndUri = configurationService.getIpvJourneySessionEnd();
+
         String currentUserState = ipvSessionItem.getUserState();
         UserStates currentUserStateValue = UserStates.fromValue(currentUserState);
 
@@ -130,18 +130,15 @@ public class JourneyEngineHandler
                 break;
             case TRANSITION_PAGE_1:
                 updateUserState(CRI_UK_PASSPORT, ipvSessionItem);
-                builder.setJourneyResponse(
-                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + UK_PASSPORT_CRI_ID));
+                builder.setJourneyResponse(new JourneyResponse(criStartUri + UK_PASSPORT_CRI_ID));
                 break;
             case CRI_UK_PASSPORT:
                 updateUserState(CRI_ADDRESS, ipvSessionItem);
-                builder.setJourneyResponse(
-                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + ADDRESS_CRI_ID));
+                builder.setJourneyResponse(new JourneyResponse(criStartUri + ADDRESS_CRI_ID));
                 break;
             case CRI_ADDRESS:
                 updateUserState(CRI_KBV, ipvSessionItem);
-                builder.setJourneyResponse(
-                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + KBV_CRI_ID));
+                builder.setJourneyResponse(new JourneyResponse(criStartUri + KBV_CRI_ID));
                 break;
             case CRI_KBV:
                 updateUserState(TRANSITION_PAGE_2, ipvSessionItem);
@@ -149,16 +146,15 @@ public class JourneyEngineHandler
                 break;
             case TRANSITION_PAGE_2:
                 updateUserState(CRI_FRAUD, ipvSessionItem);
-                builder.setJourneyResponse(
-                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + FRAUD_CRI_ID));
+                builder.setJourneyResponse(new JourneyResponse(criStartUri + FRAUD_CRI_ID));
                 break;
             case CRI_FRAUD:
                 updateUserState(CRI_ACTIVITY_HISTORY, ipvSessionItem);
                 builder.setJourneyResponse(
-                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + ACTIVITY_HISTORY_CRI_ID));
+                        new JourneyResponse(criStartUri + ACTIVITY_HISTORY_CRI_ID));
                 break;
             case CRI_ACTIVITY_HISTORY:
-                builder.setJourneyResponse(new JourneyResponse(END_JOURNEY_URI_PATH));
+                builder.setJourneyResponse(new JourneyResponse(journeyEndUri));
                 break;
             case DEBUG_PAGE:
                 builder.setPageResponse(new PageResponse(DEBUG_PAGE.value));

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -4,25 +4,176 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.lambda.powertools.tracing.Tracing;
+import uk.gov.di.ipv.core.journeyengine.domain.JourneyEngineResult;
+import uk.gov.di.ipv.core.journeyengine.domain.JourneyResponse;
+import uk.gov.di.ipv.core.journeyengine.domain.PageResponse;
+import uk.gov.di.ipv.core.journeyengine.exceptions.JourneyEngineException;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.UserStates;
+import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
+import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
-import java.util.logging.Logger;
+import java.util.List;
+
+import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_ACTIVITY_HISTORY;
+import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_ADDRESS;
+import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_FRAUD;
+import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_KBV;
+import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_UK_PASSPORT;
+import static uk.gov.di.ipv.core.library.domain.UserStates.DEBUG_PAGE;
+import static uk.gov.di.ipv.core.library.domain.UserStates.TRANSITION_PAGE_1;
+import static uk.gov.di.ipv.core.library.domain.UserStates.TRANSITION_PAGE_2;
 
 public class JourneyEngineHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(JourneyEngineHandler.class.getName());
 
-    private static final Logger LOGGER = Logger.getLogger(JourneyEngineHandler.class.getName());
-    private static final String JOURNEY_ID_PARAM = "journeyId";
+    private static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
+    private static final String JOURNEY_STEP_PARAM = "journeyStep";
+
+    private static final String START_CRI_JOURNEY_URI_PATH = "/journey/cri/start/";
+    private static final String END_JOURNEY_URI_PATH = "/journey/session/end";
+    private static final String UK_PASSPORT_CRI_ID = "ukPassport";
+    private static final String ADDRESS_CRI_ID = "address";
+    private static final String KBV_CRI_ID = "kbv";
+    private static final String FRAUD_CRI_ID = "fraud";
+    private static final String ACTIVITY_HISTORY_CRI_ID = "activityHistory";
+
+    private static final List<String> VALID_JOURNEY_STEPS = List.of("next");
+
+    private final IpvSessionService ipvSessionService;
+    private final ConfigurationService configurationService;
+
+    public JourneyEngineHandler(
+            IpvSessionService ipvSessionService, ConfigurationService configurationService) {
+        this.ipvSessionService = ipvSessionService;
+        this.configurationService = configurationService;
+    }
+
+    @ExcludeFromGeneratedCoverageReport
+    public JourneyEngineHandler() {
+        this.configurationService = new ConfigurationService();
+        this.ipvSessionService = new IpvSessionService(configurationService);
+    }
 
     @Override
     @Tracing
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LOGGER.info("Hello world!");
+        String journeyStep = input.getPathParameters().get(JOURNEY_STEP_PARAM);
 
-        String journeyId = input.getPathParameters().get(JOURNEY_ID_PARAM);
-        LOGGER.info(journeyId);
+        var ipvSessionId =
+                RequestHelper.getHeaderByKey(input.getHeaders(), IPV_SESSION_ID_HEADER_KEY);
 
-        return null;
+        if (ipvSessionId == null || ipvSessionId.isEmpty()) {
+            LOGGER.warn("User credentials could not be retrieved. No session ID received.");
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
+        }
+
+        IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
+
+        if (ipvSessionItem == null) {
+            LOGGER.warn("Failed to find ipv-session");
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_ID);
+        }
+        try {
+            JourneyEngineResult journeyEngineResult =
+                    executeJourneyEvent(journeyStep, ipvSessionItem);
+
+            if (journeyEngineResult.getJourneyResponse() != null) {
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        HttpStatus.SC_OK, journeyEngineResult.getJourneyResponse());
+            } else {
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        HttpStatus.SC_OK, journeyEngineResult.getPageResponse());
+            }
+        } catch (JourneyEngineException e) {
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_JOURNEY_ENGINE_STEP);
+        }
+    }
+
+    private JourneyEngineResult executeJourneyEvent(
+            String journeyStep, IpvSessionItem ipvSessionItem) throws JourneyEngineException {
+        String currentUserState = ipvSessionItem.getUserState();
+        UserStates currentUserStateValue = UserStates.fromValue(currentUserState);
+
+        JourneyEngineResult.Builder builder = new JourneyEngineResult.Builder();
+
+        if (currentUserStateValue == null) {
+            LOGGER.warn("Unknown user state: {}", currentUserState);
+            throw new JourneyEngineException(
+                    "Unknown user state, failed to execute journey engine step.");
+        }
+
+        if (!VALID_JOURNEY_STEPS.contains(journeyStep)) {
+            LOGGER.warn("Unknown journey step: {}", journeyStep);
+            throw new JourneyEngineException(
+                    "Invalid journey step provided, failed to execute journey engine step.");
+        }
+
+        switch (currentUserStateValue) {
+            case INITIAL_IPV_JOURNEY:
+                updateUserState(TRANSITION_PAGE_1, ipvSessionItem);
+                builder.setPageResponse(new PageResponse(TRANSITION_PAGE_1.value));
+                break;
+            case TRANSITION_PAGE_1:
+                updateUserState(CRI_UK_PASSPORT, ipvSessionItem);
+                builder.setJourneyResponse(
+                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + UK_PASSPORT_CRI_ID));
+                break;
+            case CRI_UK_PASSPORT:
+                updateUserState(CRI_ADDRESS, ipvSessionItem);
+                builder.setJourneyResponse(
+                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + ADDRESS_CRI_ID));
+                break;
+            case CRI_ADDRESS:
+                updateUserState(CRI_KBV, ipvSessionItem);
+                builder.setJourneyResponse(
+                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + KBV_CRI_ID));
+                break;
+            case CRI_KBV:
+                updateUserState(TRANSITION_PAGE_2, ipvSessionItem);
+                builder.setPageResponse(new PageResponse(TRANSITION_PAGE_2.value));
+                break;
+            case TRANSITION_PAGE_2:
+                updateUserState(CRI_FRAUD, ipvSessionItem);
+                builder.setJourneyResponse(
+                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + FRAUD_CRI_ID));
+                break;
+            case CRI_FRAUD:
+                updateUserState(CRI_ACTIVITY_HISTORY, ipvSessionItem);
+                builder.setJourneyResponse(
+                        new JourneyResponse(START_CRI_JOURNEY_URI_PATH + ACTIVITY_HISTORY_CRI_ID));
+                break;
+            case CRI_ACTIVITY_HISTORY:
+                builder.setJourneyResponse(new JourneyResponse(END_JOURNEY_URI_PATH));
+                break;
+            case DEBUG_PAGE:
+                builder.setPageResponse(new PageResponse(DEBUG_PAGE.value));
+                break;
+        }
+
+        return builder.build();
+    }
+
+    private void updateUserState(UserStates updatedStateValue, IpvSessionItem previosSessionItem) {
+        IpvSessionItem updatedIpvSessionItem = new IpvSessionItem();
+        updatedIpvSessionItem.setIpvSessionId(previosSessionItem.getIpvSessionId());
+        updatedIpvSessionItem.setCreationDateTime(previosSessionItem.getCreationDateTime());
+        updatedIpvSessionItem.setUserState(updatedStateValue.value);
+
+        ipvSessionService.updateIpvSession(updatedIpvSessionItem);
     }
 }

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyEngineResult.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyEngineResult.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.core.journeyengine.domain;
+
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class JourneyEngineResult {
+    private final PageResponse pageResponse;
+    private final JourneyResponse journeyResponse;
+
+    public JourneyEngineResult(PageResponse pageResponse, JourneyResponse journeyResponse) {
+        this.pageResponse = pageResponse;
+        this.journeyResponse = journeyResponse;
+    }
+
+    public PageResponse getPageResponse() {
+        return pageResponse;
+    }
+
+    public JourneyResponse getJourneyResponse() {
+        return journeyResponse;
+    }
+
+    public static class Builder {
+        private PageResponse pageResponse;
+        private JourneyResponse journeyResponse;
+
+        public Builder setPageResponse(PageResponse pageResponse) {
+            this.pageResponse = pageResponse;
+            return this;
+        }
+
+        public Builder setJourneyResponse(JourneyResponse journeyResponse) {
+            this.journeyResponse = journeyResponse;
+            return this;
+        }
+
+        public JourneyEngineResult build() {
+            return new JourneyEngineResult(pageResponse, journeyResponse);
+        }
+    }
+}

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyResponse.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyResponse.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.core.journeyengine.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class JourneyResponse {
+    @JsonProperty private final String journey;
+
+    @JsonCreator
+    public JourneyResponse(@JsonProperty(value = "journey", required = true) String journey) {
+        this.journey = journey;
+    }
+
+    public String getJourney() {
+        return journey;
+    }
+}

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/PageResponse.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/PageResponse.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.core.journeyengine.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class PageResponse {
+    @JsonProperty private final String page;
+
+    @JsonCreator
+    public PageResponse(@JsonProperty(value = "page", required = true) String page) {
+        this.page = page;
+    }
+
+    public String getPage() {
+        return page;
+    }
+}

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/exceptions/JourneyEngineException.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/exceptions/JourneyEngineException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.journeyengine.exceptions;
+
+public class JourneyEngineException extends Exception {
+    public JourneyEngineException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -190,6 +190,8 @@ class JourneyEngineHandlerTest {
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setUserState(UserStates.TRANSITION_PAGE_1.value);
 
+        when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -222,6 +224,8 @@ class JourneyEngineHandlerTest {
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.value);
 
+        when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -253,6 +257,8 @@ class JourneyEngineHandlerTest {
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.value);
 
+        when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -316,6 +322,8 @@ class JourneyEngineHandlerTest {
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setUserState(UserStates.TRANSITION_PAGE_2.value);
 
+        when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -347,6 +355,8 @@ class JourneyEngineHandlerTest {
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setUserState(UserStates.CRI_FRAUD.value);
 
+        when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -380,6 +390,8 @@ class JourneyEngineHandlerTest {
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ACTIVITY_HISTORY.value);
 
+        when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -3,35 +3,416 @@ package uk.gov.di.ipv.core.journeyengine;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.journeyengine.domain.JourneyResponse;
+import uk.gov.di.ipv.core.journeyengine.domain.PageResponse;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.UserStates;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
+import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
+import java.io.IOException;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class JourneyEngineHandlerTest {
     @Mock private Context mockContext;
+    @Mock private IpvSessionService mockIpvSessionService;
+    @Mock private ConfigurationService mockConfigurationService;
 
     private JourneyEngineHandler journeyEngineHandler;
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @BeforeEach
     void setUp() {
-        journeyEngineHandler = new JourneyEngineHandler();
+        journeyEngineHandler =
+                new JourneyEngineHandler(mockIpvSessionService, mockConfigurationService);
     }
 
     @Test
-    void shouldReturnNull() {
+    void shouldReturn400OnMissingIpvSessionIdHeader() throws IOException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyId", "next");
+        pathParameters.put("journeyStep", "next");
         event.setPathParameters(pathParameters);
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
-        assertNull(response);
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400WhenInvalidSessionIdProvided() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(null);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_SESSION_ID.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.INVALID_SESSION_ID.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn500WhenUnknownJourneyEngineStepProvided() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "invalid-step");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(500, response.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn500WhenUserIsInUnknownState() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState("INVALID-STATE");
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(500, response.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn1stTransitionPageResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.TRANSITION_PAGE_1.value,
+                sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("core:transitionPage1", pageResponse.getPage());
+    }
+
+    @Test
+    void shouldReturnCriUkPassportJourneyResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.TRANSITION_PAGE_1.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        JourneyResponse journeyResponse =
+                objectMapper.readValue(response.getBody(), JourneyResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.CRI_UK_PASSPORT.value, sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("/journey/cri/start/ukPassport", journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnCriAddressJourneyResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        JourneyResponse journeyResponse =
+                objectMapper.readValue(response.getBody(), JourneyResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(UserStates.CRI_ADDRESS.value, sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("/journey/cri/start/address", journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnCriKbvJourneyResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        JourneyResponse journeyResponse =
+                objectMapper.readValue(response.getBody(), JourneyResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(UserStates.CRI_KBV.value, sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("/journey/cri/start/kbv", journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturn2ndTransitionPageResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_KBV.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.TRANSITION_PAGE_2.value,
+                sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.TRANSITION_PAGE_2.value, pageResponse.getPage());
+    }
+
+    @Test
+    void shouldReturnCriFraudJourneyResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.TRANSITION_PAGE_2.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        JourneyResponse journeyResponse =
+                objectMapper.readValue(response.getBody(), JourneyResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(UserStates.CRI_FRAUD.value, sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("/journey/cri/start/fraud", journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnCriActivityHistoryJourneyResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_FRAUD.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        JourneyResponse journeyResponse =
+                objectMapper.readValue(response.getBody(), JourneyResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.CRI_ACTIVITY_HISTORY.value,
+                sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("/journey/cri/start/activityHistory", journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnEndSessionJourneyResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_ACTIVITY_HISTORY.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        JourneyResponse journeyResponse =
+                objectMapper.readValue(response.getBody(), JourneyResponse.class);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("/journey/session/end", journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnDebugPageResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.value);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.DEBUG_PAGE.value, pageResponse.getPage());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -32,7 +32,11 @@ public enum ErrorResponse {
     INVALID_JWT_AUDIENCE_PARAM(1019, "Invalid value for the audience of the client JWT provided"),
     CLIENT_JWT_EXPIRED(1020, "The provided client JWT has expired"),
     MAX_CLIENT_JWT_TTL_TIME_SURPASSED(
-            1021, "The client JWT expiry date has surpassed the maximum allowed ttl value");
+            1021, "The client JWT expiry date has surpassed the maximum allowed ttl value"),
+    INVALID_SESSION_ID(
+            1022,
+            "Invalid ipv-session-id has been provided, could not record of that requested session"),
+    FAILED_JOURNEY_ENGINE_STEP(1023, "Failed to execute journey engine step");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
@@ -1,7 +1,28 @@
 package uk.gov.di.ipv.core.library.domain;
 
 public enum UserStates {
-    INITIAL_IPV_JOURNEY,
-    DEBUG_PAGE,
-    TRANSITION_PAGE_1
+    DEBUG_PAGE("core:debugPage"),
+    INITIAL_IPV_JOURNEY("core:initalJourney"),
+    TRANSITION_PAGE_1("core:transitionPage1"),
+    TRANSITION_PAGE_2("core:transitionPage2"),
+    CRI_UK_PASSPORT("cri:ukPassport"),
+    CRI_ACTIVITY_HISTORY("cri:activityHistory"),
+    CRI_ADDRESS("cri:Address"),
+    CRI_FRAUD("cri:fraud"),
+    CRI_KBV("cri:kbv");
+
+    public final String value;
+
+    private UserStates(String value) {
+        this.value = value;
+    }
+
+    public static UserStates fromValue(String value) {
+        for (UserStates state : values()) {
+            if (state.value.equals(value)) {
+                return state;
+            }
+        }
+        return null;
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -85,6 +85,14 @@ public class ConfigurationService {
         return System.getenv("IPV_SESSIONS_TABLE_NAME");
     }
 
+    public String getIpvJourneyCriStartUri() {
+        return System.getenv("IPV_JOURNEY_CRI_START_URI");
+    }
+
+    public String getIpvJourneySessionEnd() {
+        return System.getenv("IPV_JOURNEY_SESSION_END_URI");
+    }
+
     public long getBearerAccessTokenTtl() {
         return Optional.ofNullable(System.getenv("BEARER_TOKEN_TTL"))
                 .map(Long::valueOf)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -38,7 +38,7 @@ public class IpvSessionService {
     public String generateIpvSession() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.value);
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         dataStore.create(ipvSessionItem);
 

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -102,7 +102,7 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVSharedAttributesFunction.Arn}/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
-  /event/journey/{journeyId}:
+  /journey/{journeyStep}:
     post:
       description: Called when the user selects a journey event.
       responses:
@@ -111,7 +111,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/eventResponse"
+                $ref: "#/components/schemas/journeyResponse"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
@@ -121,41 +121,37 @@ paths:
 
 components:
   schemas:
-    eventResponse:
+    journeyResponse:
       type: object
       properties:
         page:
           type: string
           description: pageId of page to be displayed
-        redirect:
+        journey:
+          type: string
+          description: journeyId of an journey to take
+        cri:
           type: object
-          description: one of three types of redirect; event, cri, or client
+          description: redirect to a cri (credential issuer)
+          required: [ "id", "authorizeUrl", "request" ]
           properties:
-            journey:
+            id:
               type: string
-              description: path of an journey event to redirect to.
-            cri:
-              type: object
-              description: redirect to a cri (credential issuer)
-              required: [ "id", "authorizeUrl" ]
-              properties:
-                id:
-                  type: string
-                authorizeUrl:
-                  type: string
-            client:
-              type: object
-              description: redirect to the oauth client, ending the session.
-              required: [ "callbackUrl", "authcode" ]
-              properties:
-                callbackUrl:
-                  type: string
-                authcode:
-                  type: string
-          oneOf:
-            - required: [ "client" ]
-            - required: [ "cri" ]
-            - required: [ "journey" ]
+            authorizeUrl:
+              type: string
+            request:
+              type: string
+        client:
+          type: object
+          description: redirect to the oauth client, ending the session.
+          required: [ "callbackUrl", "authcode" ]
+          properties:
+            callbackUrl:
+              type: string
+            authcode:
+              type: string
       oneOf:
         - required: [ "page" ]
-        - required: [ "redirect" ]
+        - required: [ "client" ]
+        - required: [ "cri" ]
+        - required: [ "journey" ]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update journey engine lambda to control the core-front next journey steps.

The lambda retrieves the current user state from their stored session, and then returns either a JourneyResponse or PageResponse depending on what the current user state is.

Update open-api spec to add new journey/{journeyStep} endpoint.

Add missing DynamoDB permission to the journey engine lambda.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
The lambda will be called by core-front in order to decide and control what core-front should be doing. It returns 2 types of events that controls wether core-front should render a new transition page, or should call a new core-back endpoint to start a new CRI journey.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-785](https://govukverify.atlassian.net/browse/PYI-785)

