### PR TITLE
BAU: Update returned page-ids to match with front end 

### DIFF
--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -100,7 +100,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.value);
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -156,7 +156,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.value);
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -168,11 +168,11 @@ class JourneyEngineHandlerTest {
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(
-                UserStates.TRANSITION_PAGE_1.value,
+                UserStates.TRANSITION_PAGE_1.toString(),
                 sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("core:transitionPage1", pageResponse.getPage());
+        assertEquals(UserStates.TRANSITION_PAGE_1.value, pageResponse.getPage());
     }
 
     @Test
@@ -188,7 +188,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.TRANSITION_PAGE_1.value);
+        ipvSessionItem.setUserState(UserStates.TRANSITION_PAGE_1.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
@@ -203,7 +203,8 @@ class JourneyEngineHandlerTest {
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(
-                UserStates.CRI_UK_PASSPORT.value, sessionArgumentCaptor.getValue().getUserState());
+                UserStates.CRI_UK_PASSPORT.toString(),
+                sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
         assertEquals("/journey/cri/start/ukPassport", journeyResponse.getJourney());
@@ -222,7 +223,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.value);
+        ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
@@ -236,7 +237,8 @@ class JourneyEngineHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(UserStates.CRI_ADDRESS.value, sessionArgumentCaptor.getValue().getUserState());
+        assertEquals(
+                UserStates.CRI_ADDRESS.toString(), sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
         assertEquals("/journey/cri/start/address", journeyResponse.getJourney());
@@ -255,7 +257,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.value);
+        ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
@@ -269,7 +271,8 @@ class JourneyEngineHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(UserStates.CRI_KBV.value, sessionArgumentCaptor.getValue().getUserState());
+        assertEquals(
+                UserStates.CRI_KBV.toString(), sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
         assertEquals("/journey/cri/start/kbv", journeyResponse.getJourney());
@@ -288,7 +291,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.CRI_KBV.value);
+        ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -300,7 +303,7 @@ class JourneyEngineHandlerTest {
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(
-                UserStates.TRANSITION_PAGE_2.value,
+                UserStates.TRANSITION_PAGE_2.toString(),
                 sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
@@ -320,7 +323,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.TRANSITION_PAGE_2.value);
+        ipvSessionItem.setUserState(UserStates.TRANSITION_PAGE_2.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
@@ -334,7 +337,8 @@ class JourneyEngineHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(UserStates.CRI_FRAUD.value, sessionArgumentCaptor.getValue().getUserState());
+        assertEquals(
+                UserStates.CRI_FRAUD.toString(), sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
         assertEquals("/journey/cri/start/fraud", journeyResponse.getJourney());
@@ -353,7 +357,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.CRI_FRAUD.value);
+        ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
@@ -368,7 +372,7 @@ class JourneyEngineHandlerTest {
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(
-                UserStates.CRI_ACTIVITY_HISTORY.value,
+                UserStates.CRI_ACTIVITY_HISTORY.toString(),
                 sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
@@ -388,7 +392,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.CRI_ACTIVITY_HISTORY.value);
+        ipvSessionItem.setUserState(UserStates.CRI_ACTIVITY_HISTORY.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
@@ -416,7 +420,7 @@ class JourneyEngineHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
-        ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.value);
+        ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
@@ -1,28 +1,19 @@
 package uk.gov.di.ipv.core.library.domain;
 
 public enum UserStates {
-    DEBUG_PAGE("core:debugPage"),
-    INITIAL_IPV_JOURNEY("core:initalJourney"),
-    TRANSITION_PAGE_1("core:transitionPage1"),
-    TRANSITION_PAGE_2("core:transitionPage2"),
-    CRI_UK_PASSPORT("cri:ukPassport"),
-    CRI_ACTIVITY_HISTORY("cri:activityHistory"),
-    CRI_ADDRESS("cri:Address"),
-    CRI_FRAUD("cri:fraud"),
-    CRI_KBV("cri:kbv");
+    DEBUG_PAGE("page-ipv-debug"),
+    INITIAL_IPV_JOURNEY("page-ipv-start"),
+    TRANSITION_PAGE_1("page-cri-transition"),
+    TRANSITION_PAGE_2("page-cri-transition"),
+    CRI_UK_PASSPORT("cri-ukPassport"),
+    CRI_ACTIVITY_HISTORY("cri-activityHistory"),
+    CRI_ADDRESS("cri-Address"),
+    CRI_FRAUD("cri-fraud"),
+    CRI_KBV("cri-kbv");
 
     public final String value;
 
-    private UserStates(String value) {
+    UserStates(String value) {
         this.value = value;
-    }
-
-    public static UserStates fromValue(String value) {
-        for (UserStates state : values()) {
-            if (state.value.equals(value)) {
-                return state;
-            }
-        }
-        return null;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -38,7 +38,7 @@ public class IpvSessionService {
     public String generateIpvSession() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.value);
+        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         dataStore.create(ipvSessionItem);
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update core-back page id's to match up with core-front and use enum toString to store state value rather than the page id value.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Ensures that the correct page can be loaded and displayed on core-front. Also using the enum toString value will mean we can potentially reuse the same page-id's for different states.


