### PR TITLE
PYIC-403 journey engine returns an error page when cri/error status received

### DIFF
--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -28,10 +28,12 @@ import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_ACTIVITY_HISTORY;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_ADDRESS;
+import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_ERROR;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_FRAUD;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_KBV;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_UK_PASSPORT;
 import static uk.gov.di.ipv.core.library.domain.UserStates.DEBUG_PAGE;
+import static uk.gov.di.ipv.core.library.domain.UserStates.IPV_ERROR_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.TRANSITION_PAGE_1;
 import static uk.gov.di.ipv.core.library.domain.UserStates.TRANSITION_PAGE_2;
 
@@ -166,6 +168,9 @@ public class JourneyEngineHandler
                     break;
                 case DEBUG_PAGE:
                     builder.setPageResponse(new PageResponse(DEBUG_PAGE.value));
+                    break;
+                case CRI_ERROR:
+                    builder.setPageResponse(new PageResponse(IPV_ERROR_PAGE.value));
                     break;
             }
 

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_ACTIVITY_HISTORY;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_ADDRESS;
-import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_ERROR;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_FRAUD;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_KBV;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_UK_PASSPORT;

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyEngineResult.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyEngineResult.java
@@ -40,4 +40,3 @@ public class JourneyEngineResult {
         }
     }
 }
-

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyEngineResult.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyEngineResult.java
@@ -40,3 +40,4 @@ public class JourneyEngineResult {
         }
     }
 }
+

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -472,4 +472,29 @@ class JourneyEngineHandlerTest {
         assertEquals(200, response.getStatusCode());
         assertEquals(UserStates.DEBUG_PAGE.value, pageResponse.getPage());
     }
+
+    @Test
+    void shouldReturnErrorPageResponseWhenRequired() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "next");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_ERROR.toString());
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
@@ -9,7 +9,9 @@ public enum UserStates {
     CRI_ACTIVITY_HISTORY("cri-activityHistory"),
     CRI_ADDRESS("cri-Address"),
     CRI_FRAUD("cri-fraud"),
-    CRI_KBV("cri-kbv");
+    CRI_KBV("cri-kbv"),
+    CRI_ERROR("cri-error"),
+    IPV_ERROR_PAGE("page-ipv-error");
 
     public final String value;
 


### PR DESCRIPTION
### What changed
The journey engine should return an error page when in   cri/error state . This would have been raised by the new lambda that will deal with errors & would have set the state   cri/error state .

- [PYIC-403](https://govukverify.atlassian.net/browse/PYIC-403)

