### PR TITLE
BAU: Update start session request to receive client auth params in request body

### DIFF
--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -81,3 +81,19 @@ region = "eu-west-2"
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = "Environment=\"dev-kerrr\""
 
+[dev-ianj.deploy.parameters]
+stack_name = "ipv-core-back-dev-ianj"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ianj-core-back-stack"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-ianj\""
+
+[dev-derrenw.deploy.parameters]
+stack_name = "ipv-core-back-dev-derrenw"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "derrenw-core-back-stack"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-derrenw\""
+

--- a/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
+++ b/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
@@ -4,7 +4,8 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.util.StringUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,14 +13,11 @@ import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
-import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 public class IpvSessionStartHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -27,11 +25,6 @@ public class IpvSessionStartHandler
     private static final Logger LOGGER =
             LoggerFactory.getLogger(IpvSessionStartHandler.class.getName());
     private static final String IPV_SESSION_ID_KEY = "ipvSessionId";
-    private static final String RESPONSE_TYPE_PARAM = "response_type";
-    private static final String CLIENT_ID_PARAM = "client_id";
-    private static final String REDIRECT_URI_PARAM = "redirect_uri";
-    private static final String SCOPE_PARAM = "scope";
-    private static final String STATE_PARAM = "state";
 
     private final ConfigurationService configurationService;
 
@@ -54,76 +47,20 @@ public class IpvSessionStartHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
+            ObjectMapper objectMapper = new ObjectMapper();
             ClientSessionDetailsDto clientSessionDetails =
-                    getClientSessionDetails(input.getQueryStringParameters());
+                    objectMapper.readValue(input.getBody(), ClientSessionDetailsDto.class);
 
             String ipvSessionId = ipvSessionService.generateIpvSession(clientSessionDetails);
 
             Map<String, String> response = Map.of(IPV_SESSION_ID_KEY, ipvSessionId);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, response);
-        } catch (HttpResponseExceptionWithErrorBody e) {
-            LOGGER.error("Ipv session generation failed", e);
+        } catch (IllegalArgumentException | JsonProcessingException e) {
+            LOGGER.error(
+                    "Failed to parse the request body into a ClientSessionDetailsDto object", e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getResponseCode(), e.getErrorBody());
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_REQUEST);
         }
-    }
-
-    private ClientSessionDetailsDto getClientSessionDetails(
-            Map<String, String> queryStringParameters) throws HttpResponseExceptionWithErrorBody {
-        if (Objects.isNull(queryStringParameters) || queryStringParameters.isEmpty()) {
-            LOGGER.warn("Missing client session details in request query parameters");
-            throw new HttpResponseExceptionWithErrorBody(
-                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_QUERY_PARAMETERS);
-        }
-
-        String responseType = queryStringParameters.get(RESPONSE_TYPE_PARAM);
-        String clientId = queryStringParameters.get(CLIENT_ID_PARAM);
-        String redirectUri = queryStringParameters.get(REDIRECT_URI_PARAM);
-        String scope = queryStringParameters.get(SCOPE_PARAM);
-        String state = queryStringParameters.get(STATE_PARAM);
-
-        Optional<ErrorResponse> error =
-                validateClientSessionDetails(responseType, clientId, redirectUri, scope, state);
-
-        if (error.isPresent()) {
-            throw new HttpResponseExceptionWithErrorBody(HttpStatus.SC_BAD_REQUEST, error.get());
-        }
-
-        return new ClientSessionDetailsDto(responseType, clientId, redirectUri, scope, state);
-    }
-
-    private Optional<ErrorResponse> validateClientSessionDetails(
-            String responseType, String clientId, String redirectUri, String scope, String state) {
-        boolean isInvalid = false;
-        if (StringUtils.isBlank(responseType)) {
-            LOGGER.warn("Missing response_type query parameter");
-            isInvalid = true;
-        }
-
-        if (StringUtils.isBlank(clientId)) {
-            LOGGER.warn("Missing client_id query parameter");
-            isInvalid = true;
-        }
-
-        if (StringUtils.isBlank(redirectUri)) {
-            LOGGER.warn("Missing redirect_uri query parameter");
-            isInvalid = true;
-        }
-
-        if (StringUtils.isBlank(scope)) {
-            LOGGER.warn("Missing scope query parameter");
-            isInvalid = true;
-        }
-
-        if (StringUtils.isBlank(state)) {
-            LOGGER.warn("Missing state query parameter");
-            isInvalid = true;
-        }
-
-        if (isInvalid) {
-            return Optional.of(ErrorResponse.MISSING_QUERY_PARAMETERS);
-        }
-        return Optional.empty();
     }
 }

--- a/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
+++ b/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 class IpvSessionStartHandlerTest {
 
     @Mock private Context mockContext;
-
     @Mock private IpvSessionService mockIpvSessionService;
     @Mock private ConfigurationService mockConfigurationService;
 
@@ -88,6 +87,123 @@ class IpvSessionStartHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         event.setBody("invalid-body");
+
+        APIGatewayProxyResponseEvent response =
+                ipvSessionStartHandler.handleRequest(event, mockContext);
+
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.INVALID_SESSION_REQUEST.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400IfMissingResponseTypeParameter() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        ClientSessionDetailsDto clientSessionDetailsDto =
+                new ClientSessionDetailsDto(
+                        null, "test-client", "https://example.com", "test-scope", "test-state");
+        event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
+
+        APIGatewayProxyResponseEvent response =
+                ipvSessionStartHandler.handleRequest(event, mockContext);
+
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.INVALID_SESSION_REQUEST.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400IfMissingClientIdParameter() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        ClientSessionDetailsDto clientSessionDetailsDto =
+                new ClientSessionDetailsDto(
+                        "test-response-type",
+                        null,
+                        "https://example.com",
+                        "test-scope",
+                        "test-state");
+        event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
+
+        APIGatewayProxyResponseEvent response =
+                ipvSessionStartHandler.handleRequest(event, mockContext);
+
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.INVALID_SESSION_REQUEST.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400IfMissingRedirectUriParameter() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        ClientSessionDetailsDto clientSessionDetailsDto =
+                new ClientSessionDetailsDto(
+                        "test-response-type", "test-client", null, "test-scope", "test-state");
+        event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
+
+        APIGatewayProxyResponseEvent response =
+                ipvSessionStartHandler.handleRequest(event, mockContext);
+
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.INVALID_SESSION_REQUEST.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400IfMissingScopeParameter() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        ClientSessionDetailsDto clientSessionDetailsDto =
+                new ClientSessionDetailsDto(
+                        "test-response-type",
+                        "test-client",
+                        "https://example.com",
+                        null,
+                        "test-state");
+        event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
+
+        APIGatewayProxyResponseEvent response =
+                ipvSessionStartHandler.handleRequest(event, mockContext);
+
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.INVALID_SESSION_REQUEST.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400IfMissingStateParameter() throws JsonProcessingException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        ClientSessionDetailsDto clientSessionDetailsDto =
+                new ClientSessionDetailsDto(
+                        "test-response-type",
+                        "test-client",
+                        "https://example.com",
+                        "test-scope",
+                        null);
+        event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
 
         APIGatewayProxyResponseEvent response =
                 ipvSessionStartHandler.handleRequest(event, mockContext);

--- a/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
+++ b/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
@@ -47,14 +48,14 @@ class IpvSessionStartHandlerTest {
         when(mockIpvSessionService.generateIpvSession(any())).thenReturn(ipvSessionId);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> queryStringParameters =
-                Map.of(
-                        "response_type", "test-response-type",
-                        "client_id", "test-client",
-                        "redirect_uri", "https://example.com",
-                        "scope", "test-scope",
-                        "state", "test-state");
-        event.setQueryStringParameters(queryStringParameters);
+        ClientSessionDetailsDto clientSessionDetailsDto =
+                new ClientSessionDetailsDto(
+                        "test-response-type",
+                        "test-client",
+                        "https://example.com",
+                        "test-scope",
+                        "test-state");
+        event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
 
         APIGatewayProxyResponseEvent response =
                 ipvSessionStartHandler.handleRequest(event, mockContext);
@@ -67,7 +68,7 @@ class IpvSessionStartHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfMissingQueryStringParameters() throws JsonProcessingException {
+    void shouldReturn400IfMissingBody() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         APIGatewayProxyResponseEvent response =
@@ -77,22 +78,16 @@ class IpvSessionStartHandlerTest {
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
         assertEquals(
-                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
+                ErrorResponse.INVALID_SESSION_REQUEST.getMessage(), responseBody.get("message"));
     }
 
     @Test
-    void shouldReturn400IfMissingResponseTypeParameter() throws JsonProcessingException {
+    void shouldReturn400IfInvalidBody() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
-        Map<String, String> queryStringParameters =
-                Map.of(
-                        "client_id", "test-client",
-                        "redirect_uri", "https://example.com",
-                        "scope", "test-scope",
-                        "state", "test-state");
-        event.setQueryStringParameters(queryStringParameters);
+        event.setBody("invalid-body");
 
         APIGatewayProxyResponseEvent response =
                 ipvSessionStartHandler.handleRequest(event, mockContext);
@@ -101,104 +96,8 @@ class IpvSessionStartHandlerTest {
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
         assertEquals(
-                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
-    }
-
-    @Test
-    void shouldReturn400IfMissingClientIdParameter() throws JsonProcessingException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> queryStringParameters =
-                Map.of(
-                        "responseType", "test-response-type",
-                        "redirect_uri", "https://example.com",
-                        "scope", "test-scope",
-                        "state", "test-state");
-        event.setQueryStringParameters(queryStringParameters);
-
-        APIGatewayProxyResponseEvent response =
-                ipvSessionStartHandler.handleRequest(event, mockContext);
-
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
-    }
-
-    @Test
-    void shouldReturn400IfMissingRedirectUriParameter() throws JsonProcessingException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> queryStringParameters =
-                Map.of(
-                        "responseType", "test-response-type",
-                        "client_id", "test-client",
-                        "scope", "test-scope",
-                        "state", "test-state");
-        event.setQueryStringParameters(queryStringParameters);
-
-        APIGatewayProxyResponseEvent response =
-                ipvSessionStartHandler.handleRequest(event, mockContext);
-
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
-    }
-
-    @Test
-    void shouldReturn400IfMissingScopeParameter() throws JsonProcessingException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> queryStringParameters =
-                Map.of(
-                        "responseType", "test-response-type",
-                        "client_id", "test-client",
-                        "redirect_uri", "https://example.com",
-                        "state", "test-state");
-        event.setQueryStringParameters(queryStringParameters);
-
-        APIGatewayProxyResponseEvent response =
-                ipvSessionStartHandler.handleRequest(event, mockContext);
-
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
-    }
-
-    @Test
-    void shouldReturn400IfMissingStateParameter() throws JsonProcessingException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> queryStringParameters =
-                Map.of(
-                        "responseType", "test-response-type",
-                        "client_id", "test-client",
-                        "redirect_uri", "https://example.com",
-                        "scope", "test-scope");
-        event.setQueryStringParameters(queryStringParameters);
-
-        APIGatewayProxyResponseEvent response =
-                ipvSessionStartHandler.handleRequest(event, mockContext);
-
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_QUERY_PARAMETERS.getCode(), responseBody.get("code"));
-        assertEquals(
-                ErrorResponse.MISSING_QUERY_PARAMETERS.getMessage(), responseBody.get("message"));
+                ErrorResponse.INVALID_SESSION_REQUEST.getMessage(), responseBody.get("message"));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -37,7 +37,8 @@ public enum ErrorResponse {
             1022,
             "Invalid ipv-session-id has been provided, could not record of that requested session"),
     FAILED_JOURNEY_ENGINE_STEP(1023, "Failed to execute journey engine step"),
-    MISSING_JOURNEY_STEP_URL_PATH_PARAM(1024, "Missing journeyStep url path parameter in request");
+    MISSING_JOURNEY_STEP_URL_PATH_PARAM(1024, "Missing journeyStep url path parameter in request"),
+    INVALID_SESSION_REQUEST(1025, "Failed to parse the session start request");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.core.library.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
@@ -17,11 +15,7 @@ public class ClientSessionDetailsDto {
     public ClientSessionDetailsDto() {}
 
     public ClientSessionDetailsDto(
-            String responseType,
-            String clientId,
-            String redirectUri,
-            String scope,
-            String state) {
+            String responseType, String clientId, String redirectUri, String scope, String state) {
         this.responseType = responseType;
         this.clientId = clientId;
         this.redirectUri = redirectUri;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
@@ -8,21 +8,20 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @ExcludeFromGeneratedCoverageReport
 @DynamoDbBean
 public class ClientSessionDetailsDto {
-    @JsonProperty String responseType;
-    @JsonProperty String clientId;
-    @JsonProperty String redirectUri;
-    @JsonProperty String scope;
-    @JsonProperty String state;
+    String responseType;
+    String clientId;
+    String redirectUri;
+    String scope;
+    String state;
 
     public ClientSessionDetailsDto() {}
 
-    @JsonCreator
     public ClientSessionDetailsDto(
-            @JsonProperty(value = "responseType", required = true) String responseType,
-            @JsonProperty(value = "clientId", required = true) String clientId,
-            @JsonProperty(value = "redirectUri", required = true) String redirectUri,
-            @JsonProperty(value = "scope", required = true) String scope,
-            @JsonProperty(value = "state", required = true) String state) {
+            String responseType,
+            String clientId,
+            String redirectUri,
+            String scope,
+            String state) {
         this.responseType = responseType;
         this.clientId = clientId;
         this.redirectUri = redirectUri;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
@@ -1,22 +1,29 @@
 package uk.gov.di.ipv.core.library.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @ExcludeFromGeneratedCoverageReport
 @DynamoDbBean
 public class ClientSessionDetailsDto {
-    String responseType;
-    String clientId;
-    String redirectUri;
-    String scope;
-    String state;
+    @JsonProperty String responseType;
+    @JsonProperty String clientId;
+    @JsonProperty String redirectUri;
+    @JsonProperty String scope;
+    @JsonProperty String state;
 
     public ClientSessionDetailsDto() {}
 
+    @JsonCreator
     public ClientSessionDetailsDto(
-            String reseponseType, String clientId, String redirectUri, String scope, String state) {
-        this.responseType = reseponseType;
+            @JsonProperty(value = "responseType", required = true) String responseType,
+            @JsonProperty(value = "clientId", required = true) String clientId,
+            @JsonProperty(value = "redirectUri", required = true) String redirectUri,
+            @JsonProperty(value = "scope", required = true) String scope,
+            @JsonProperty(value = "state", required = true) String state) {
+        this.responseType = responseType;
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.scope = scope;


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the start session endpoint to receive the client connection details in the request body rather than as query params,
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Simplifies the request and simplifies the construction of the dto object.
<!-- Describe the reason these changes were made - the "why" -->
