### PR TITLE
PYIC-816: Update session start lambda to read client auth details from request body

### DIFF
--- a/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
+++ b/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
@@ -4,6 +4,8 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -12,13 +14,11 @@ import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
-import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 public class IpvSessionStartHandler
@@ -27,11 +27,6 @@ public class IpvSessionStartHandler
     private static final Logger LOGGER =
             LoggerFactory.getLogger(IpvSessionStartHandler.class.getName());
     private static final String IPV_SESSION_ID_KEY = "ipvSessionId";
-    private static final String RESPONSE_TYPE_PARAM = "response_type";
-    private static final String CLIENT_ID_PARAM = "client_id";
-    private static final String REDIRECT_URI_PARAM = "redirect_uri";
-    private static final String SCOPE_PARAM = "scope";
-    private static final String STATE_PARAM = "state";
 
     private final ConfigurationService configurationService;
 
@@ -54,75 +49,61 @@ public class IpvSessionStartHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
+            ObjectMapper objectMapper = new ObjectMapper();
             ClientSessionDetailsDto clientSessionDetails =
-                    getClientSessionDetails(input.getQueryStringParameters());
+                    objectMapper.readValue(input.getBody(), ClientSessionDetailsDto.class);
+
+            Optional<ErrorResponse> error = validateClientSessionDetails(clientSessionDetails);
+
+            if (error.isPresent()) {
+                LOGGER.error("Validation of the client session details failed");
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        HttpStatus.SC_BAD_REQUEST, error.get());
+            }
 
             String ipvSessionId = ipvSessionService.generateIpvSession(clientSessionDetails);
 
             Map<String, String> response = Map.of(IPV_SESSION_ID_KEY, ipvSessionId);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, response);
-        } catch (HttpResponseExceptionWithErrorBody e) {
-            LOGGER.error("Ipv session generation failed", e);
+        } catch (IllegalArgumentException | JsonProcessingException e) {
+            LOGGER.error(
+                    "Failed to parse the request body into a ClientSessionDetailsDto object", e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getResponseCode(), e.getErrorBody());
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_REQUEST);
         }
-    }
-
-    private ClientSessionDetailsDto getClientSessionDetails(
-            Map<String, String> queryStringParameters) throws HttpResponseExceptionWithErrorBody {
-        if (Objects.isNull(queryStringParameters) || queryStringParameters.isEmpty()) {
-            LOGGER.warn("Missing client session details in request query parameters");
-            throw new HttpResponseExceptionWithErrorBody(
-                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_QUERY_PARAMETERS);
-        }
-
-        String responseType = queryStringParameters.get(RESPONSE_TYPE_PARAM);
-        String clientId = queryStringParameters.get(CLIENT_ID_PARAM);
-        String redirectUri = queryStringParameters.get(REDIRECT_URI_PARAM);
-        String scope = queryStringParameters.get(SCOPE_PARAM);
-        String state = queryStringParameters.get(STATE_PARAM);
-
-        Optional<ErrorResponse> error =
-                validateClientSessionDetails(responseType, clientId, redirectUri, scope, state);
-
-        if (error.isPresent()) {
-            throw new HttpResponseExceptionWithErrorBody(HttpStatus.SC_BAD_REQUEST, error.get());
-        }
-
-        return new ClientSessionDetailsDto(responseType, clientId, redirectUri, scope, state);
     }
 
     private Optional<ErrorResponse> validateClientSessionDetails(
-            String responseType, String clientId, String redirectUri, String scope, String state) {
+            ClientSessionDetailsDto clientSessionDetailsDto) {
         boolean isInvalid = false;
-        if (StringUtils.isBlank(responseType)) {
+        if (StringUtils.isBlank(clientSessionDetailsDto.getResponseType())) {
             LOGGER.warn("Missing response_type query parameter");
             isInvalid = true;
         }
 
-        if (StringUtils.isBlank(clientId)) {
+        if (StringUtils.isBlank(clientSessionDetailsDto.getClientId())) {
             LOGGER.warn("Missing client_id query parameter");
             isInvalid = true;
         }
 
-        if (StringUtils.isBlank(redirectUri)) {
+        if (StringUtils.isBlank(clientSessionDetailsDto.getRedirectUri())) {
             LOGGER.warn("Missing redirect_uri query parameter");
             isInvalid = true;
         }
 
-        if (StringUtils.isBlank(scope)) {
+        if (StringUtils.isBlank(clientSessionDetailsDto.getScope())) {
             LOGGER.warn("Missing scope query parameter");
             isInvalid = true;
         }
 
-        if (StringUtils.isBlank(state)) {
+        if (StringUtils.isBlank(clientSessionDetailsDto.getState())) {
             LOGGER.warn("Missing state query parameter");
             isInvalid = true;
         }
 
         if (isInvalid) {
-            return Optional.of(ErrorResponse.MISSING_QUERY_PARAMETERS);
+            return Optional.of(ErrorResponse.INVALID_SESSION_REQUEST);
         }
         return Optional.empty();
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -31,7 +31,8 @@ public enum ErrorResponse {
     FAILED_JOURNEY_ENGINE_STEP(1022, "Failed to execute journey engine step"),
     MISSING_JOURNEY_STEP_URL_PATH_PARAM(1023, "Missing journeyStep url path parameter in request"),
     FAILED_TO_PARSE_ISSUED_CREDENTIALS(1024, "Failed to parse issued credentials"),
-    CREDENTIAL_SUBJECT_MISSING(1025, "Credential subject missing from verified credential");
+    CREDENTIAL_SUBJECT_MISSING(1025, "Credential subject missing from verified credential"),
+    INVALID_SESSION_REQUEST(1026, "Failed to parse the session start request");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
@@ -15,8 +15,8 @@ public class ClientSessionDetailsDto {
     public ClientSessionDetailsDto() {}
 
     public ClientSessionDetailsDto(
-            String reseponseType, String clientId, String redirectUri, String scope, String state) {
-        this.responseType = reseponseType;
+            String responseType, String clientId, String redirectUri, String scope, String state) {
+        this.responseType = responseType;
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.scope = scope;


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the start session endpoint to receive the client connection details in the request body rather than as query params.
<!-- Describe the changes in detail - the "what"-->
Simplifies the request and simplifies the construction of the dto object.
### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-816](https://govukverify.atlassian.net/browse/PYIC-816)

