### PR TITLE
PYIC-794: Set the user starting state depending on journey type

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -193,6 +193,7 @@ public class DataStoreIpvSessionIT {
                 "test-client-id",
                 "https//example.com",
                 "test-state",
-                "test-scope");
+                "test-scope",
+                false);
     }
 }

--- a/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
+++ b/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
@@ -176,7 +176,12 @@ class SessionEndHandlerTest {
 
         ClientSessionDetailsDto clientSessionDetailsDto =
                 new ClientSessionDetailsDto(
-                        "code", "test-client-id", "https://example.com", "openid", "test-state");
+                        "code",
+                        "test-client-id",
+                        "https://example.com",
+                        "openid",
+                        "test-state",
+                        false);
         item.setClientSessionDetails(clientSessionDetailsDto);
 
         return item;
@@ -184,6 +189,6 @@ class SessionEndHandlerTest {
 
     private ClientSessionDetailsDto generateValidClientSessionDetailsDto() {
         return new ClientSessionDetailsDto(
-                "code", "test-client-id", "https://example.com", "openid", "test-state");
+                "code", "test-client-id", "https://example.com", "openid", "test-state", false);
     }
 }

--- a/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
+++ b/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
@@ -54,7 +54,8 @@ class IpvSessionStartHandlerTest {
                         "test-client",
                         "https://example.com",
                         "test-scope",
-                        "test-state");
+                        "test-state",
+                        false);
         event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
 
         APIGatewayProxyResponseEvent response =
@@ -105,7 +106,12 @@ class IpvSessionStartHandlerTest {
 
         ClientSessionDetailsDto clientSessionDetailsDto =
                 new ClientSessionDetailsDto(
-                        null, "test-client-id", "https://example.com", "test-scope", "test-state");
+                        null,
+                        "test-client-id",
+                        "https://example.com",
+                        "test-scope",
+                        "test-state",
+                        false);
         event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
 
         APIGatewayProxyResponseEvent response =
@@ -130,7 +136,8 @@ class IpvSessionStartHandlerTest {
                         null,
                         "https://example.com",
                         "test-scope",
-                        "test-state");
+                        "test-state",
+                        false);
         event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
 
         APIGatewayProxyResponseEvent response =
@@ -151,7 +158,12 @@ class IpvSessionStartHandlerTest {
 
         ClientSessionDetailsDto clientSessionDetailsDto =
                 new ClientSessionDetailsDto(
-                        "test-response-type", "test-client-id", null, "test-scope", "test-state");
+                        "test-response-type",
+                        "test-client-id",
+                        null,
+                        "test-scope",
+                        "test-state",
+                        false);
         event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
 
         APIGatewayProxyResponseEvent response =
@@ -176,7 +188,8 @@ class IpvSessionStartHandlerTest {
                         "test-client-id",
                         "https://example.com",
                         null,
-                        "test-state");
+                        "test-state",
+                        false);
         event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
 
         APIGatewayProxyResponseEvent response =
@@ -201,7 +214,8 @@ class IpvSessionStartHandlerTest {
                         "test-client-id",
                         "https://example.com",
                         "test-scope",
-                        null);
+                        null,
+                        false);
         event.setBody(objectMapper.writeValueAsString(clientSessionDetailsDto));
 
         APIGatewayProxyResponseEvent response =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
@@ -11,16 +11,23 @@ public class ClientSessionDetailsDto {
     String redirectUri;
     String scope;
     String state;
+    boolean isDebugJourney;
 
     public ClientSessionDetailsDto() {}
 
     public ClientSessionDetailsDto(
-            String responseType, String clientId, String redirectUri, String scope, String state) {
+            String responseType,
+            String clientId,
+            String redirectUri,
+            String scope,
+            String state,
+            boolean isDebugJourney) {
         this.responseType = responseType;
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.scope = scope;
         this.state = state;
+        this.isDebugJourney = isDebugJourney;
     }
 
     public String getResponseType() {
@@ -61,5 +68,13 @@ public class ClientSessionDetailsDto {
 
     public void setState(String state) {
         this.state = state;
+    }
+
+    public boolean isDebugJourney() {
+        return isDebugJourney;
+    }
+
+    public void setDebugJourney(boolean debugJourney) {
+        isDebugJourney = debugJourney;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -37,11 +37,18 @@ public class IpvSessionService {
     }
 
     public String generateIpvSession(ClientSessionDetailsDto clientSessionDetailsDto) {
+
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
+
+        String userState =
+                clientSessionDetailsDto.isDebugJourney()
+                        ? UserStates.DEBUG_PAGE.toString()
+                        : UserStates.INITIAL_IPV_JOURNEY.toString();
+        ipvSessionItem.setUserState(userState);
+
         dataStore.create(ipvSessionItem);
 
         return ipvSessionItem.getIpvSessionId();

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -63,7 +63,8 @@ class IpvSessionServiceTest {
                                 "test-client",
                                 "http://example.come",
                                 "test-scope",
-                                "test-state"));
+                                "test-state",
+                                false));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -72,6 +73,33 @@ class IpvSessionServiceTest {
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
 
         assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
+        assertEquals(
+                UserStates.INITIAL_IPV_JOURNEY.toString(),
+                ipvSessionItemArgumentCaptor.getValue().getUserState());
+    }
+
+    @Test
+    void shouldCreateSessionItemForDebugJourney() {
+        String ipvSessionID =
+                ipvSessionService.generateIpvSession(
+                        new ClientSessionDetailsDto(
+                                "jwt",
+                                "test-client",
+                                "http://example.come",
+                                "test-scope",
+                                "test-state",
+                                true));
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockDataStore).create(ipvSessionItemArgumentCaptor.capture());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
+
+        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
+        assertEquals(
+                UserStates.DEBUG_PAGE.toString(),
+                ipvSessionItemArgumentCaptor.getValue().getUserState());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add a new field to clientSessionDetailsDto to track which type of journey the user is currently doing. If the user is doing a debug journey then their starting state will be DEBUG_PAGE and for a real journey it will be INITIAL_IPV_JOURNEY.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
For a debug journey the starting state needs to be DEBUG_PAGE and for that journey the user will always remain in that state and always be redirected back to the core-front debug page.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-794](https://govukverify.atlassian.net/browse/PYIC-794)

