### PR TITLE
PYIC-825: Wrap cri and client response values in a cri or client prop…

### DIFF
--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import software.amazon.lambda.powertools.tracing.Tracing;
+import uk.gov.di.ipv.core.credentialissuer.domain.CriDetails;
 import uk.gov.di.ipv.core.credentialissuer.domain.CriResponse;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -54,9 +55,10 @@ public class CredentialIssuerStartHandler
 
         CriResponse criResponse =
                 new CriResponse(
-                        credentialIssuerConfig.getId(),
-                        credentialIssuerConfig.getIpvClientId(),
-                        credentialIssuerConfig.getAuthorizeUrl().toString());
+                        new CriDetails(
+                                credentialIssuerConfig.getId(),
+                                credentialIssuerConfig.getIpvClientId(),
+                                credentialIssuerConfig.getAuthorizeUrl().toString()));
 
         return ApiGatewayResponseGenerator.proxyJsonResponse(200, criResponse);
     }

--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/domain/CriDetails.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/domain/CriDetails.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.core.credentialissuer.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CriDetails {
+    @JsonProperty private final String id;
+
+    @JsonProperty private final String ipvClientId;
+
+    @JsonProperty private final String authorizeUrl;
+
+    @JsonCreator
+    public CriDetails(
+            @JsonProperty(value = "id", required = true) String id,
+            @JsonProperty(value = "ipvClientId", required = true) String ipvClientId,
+            @JsonProperty(value = "authorizeUrl", required = true) String authorizeUrl) {
+        this.id = id;
+        this.ipvClientId = ipvClientId;
+        this.authorizeUrl = authorizeUrl;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIpvClientId() {
+        return ipvClientId;
+    }
+
+    public String getAuthorizeUrl() {
+        return authorizeUrl;
+    }
+}

--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/domain/CriResponse.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/domain/CriResponse.java
@@ -4,31 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CriResponse {
-    @JsonProperty private final String id;
-
-    @JsonProperty private final String ipvClientId;
-
-    @JsonProperty private final String authorizeUrl;
+    @JsonProperty private final CriDetails cri;
 
     @JsonCreator
-    public CriResponse(
-            @JsonProperty(value = "id", required = true) String id,
-            @JsonProperty(value = "ipvClientId", required = true) String ipvClientId,
-            @JsonProperty(value = "authorizeUrl", required = true) String authorizeUrl) {
-        this.id = id;
-        this.ipvClientId = ipvClientId;
-        this.authorizeUrl = authorizeUrl;
+    public CriResponse(@JsonProperty(value = "cri", required = true) CriDetails cri) {
+        this.cri = cri;
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public String getAuthorizeUrl() {
-        return authorizeUrl;
-    }
-
-    public String getIpvClientId() {
-        return ipvClientId;
+    public CriDetails getCri() {
+        return cri;
     }
 }

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -87,7 +87,7 @@ class CredentialIssuerStartHandlerTest {
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
 
-        Map responseBody = getResponseBodyAsMap(response);
+        Map responseBody = getResponseBodyAsMap(response).get("cri");
 
         assertEquals(CRI_ID, responseBody.get("id"));
         assertEquals(IPV_CLIENT_ID, responseBody.get("ipvClientId"));
@@ -96,8 +96,8 @@ class CredentialIssuerStartHandlerTest {
         verifyNoInteractions(context);
     }
 
-    private Map getResponseBodyAsMap(APIGatewayProxyResponseEvent response)
-            throws JsonProcessingException {
+    private Map<String, Map<String, String>> getResponseBodyAsMap(
+            APIGatewayProxyResponseEvent response) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.readValue(response.getBody(), Map.class);
     }

--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.validation.AuthRequestValidator;
+import uk.gov.di.ipv.core.sessionend.domain.ClientDetails;
 import uk.gov.di.ipv.core.sessionend.domain.ClientResponse;
 
 import java.util.Collections;
@@ -95,8 +96,9 @@ public class SessionEndHandler
 
         ClientResponse clientResponse =
                 new ClientResponse(
-                        ipvSessionItem.getClientSessionDetails().getRedirectUri(),
-                        authorizationCode.getValue());
+                        new ClientDetails(
+                                ipvSessionItem.getClientSessionDetails().getRedirectUri(),
+                                authorizationCode.getValue()));
 
         return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, clientResponse);
     }

--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/domain/ClientDetails.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/domain/ClientDetails.java
@@ -1,0 +1,25 @@
+package uk.gov.di.ipv.core.sessionend.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ClientDetails {
+    @JsonProperty private String redirectUrl;
+    @JsonProperty private String authCode;
+
+    @JsonCreator
+    public ClientDetails(
+            @JsonProperty(value = "redirectUrl", required = true) String redirectUrl,
+            @JsonProperty(value = "authCode", required = true) String authCode) {
+        this.redirectUrl = redirectUrl;
+        this.authCode = authCode;
+    }
+
+    public String getRedirectUrl() {
+        return redirectUrl;
+    }
+
+    public String getAuthCode() {
+        return authCode;
+    }
+}

--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/domain/ClientResponse.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/domain/ClientResponse.java
@@ -6,22 +6,14 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 
 @ExcludeFromGeneratedCoverageReport
 public class ClientResponse {
-    @JsonProperty private String redirectUrl;
-    @JsonProperty private String authCode;
+    @JsonProperty private ClientDetails client;
 
     @JsonCreator
-    public ClientResponse(
-            @JsonProperty(value = "redirectUrl", required = true) String redirectUrl,
-            @JsonProperty(value = "authCode", required = true) String authCode) {
-        this.redirectUrl = redirectUrl;
-        this.authCode = authCode;
+    public ClientResponse(@JsonProperty(value = "client", required = true) ClientDetails client) {
+        this.client = client;
     }
 
-    public String getRedirectUrl() {
-        return redirectUrl;
-    }
-
-    public String getAuthCode() {
-        return authCode;
+    public ClientDetails getClient() {
+        return client;
     }
 }

--- a/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
+++ b/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
@@ -88,9 +88,11 @@ class SessionEndHandlerTest {
 
         verify(mockAuthorizationCodeService)
                 .persistAuthorizationCode(
-                        responseBody.getAuthCode(), "12345", responseBody.getRedirectUrl());
-        assertEquals(authorizationCode.toString(), responseBody.getAuthCode());
-        assertEquals("https://example.com", responseBody.getRedirectUrl());
+                        responseBody.getClient().getAuthCode(),
+                        "12345",
+                        responseBody.getClient().getRedirectUrl());
+        assertEquals(authorizationCode.toString(), responseBody.getClient().getAuthCode());
+        assertEquals("https://example.com", responseBody.getClient().getRedirectUrl());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the CriResponse and ClientResponse objects to have a top level "cri" or "client" property to store the details underneath.
<!-- Describe the changes in detail - the "what"-->

### Why
This will make it easier for core-front to determine what type of response is being returned.



