### PR TITLE
PYIC-826: Use SigningKeyArn output variable in SAM template for the CriReturn lambda permissions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -210,7 +210,7 @@ Resources:
             Action:
               - 'kms:sign'
             Resource:
-              - "arn:aws:kms:eu-west-2:130355686670:key/3efe7d7f-5a08-4ea3-90c3-11b24ec3b375"
+              - !ImportValue SigningKeyArn
       Events:
         IPVCoreInternalAPI:
           Type: Api


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Used the SigningKeyArn output variable from concourse to set the correct KMS permission on the CriReturn lambda.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The kms signing key has been updated so the old hard coded arn value is no longer valid and the lambda is currently running in to a permission denied error when trying to use the new KMS signing key.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-826](https://govukverify.atlassian.net/browse/PYIC-826)

