### PR TITLE
PYIC-828: Give sessionEnd lambda permission to read from sessions dynamodb table

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -127,11 +127,14 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub session-end-${Environment}
           AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AuthCodesTable.Arn]]
+          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
       Policies:
         - DynamoDBWritePolicy:
             TableName: !Ref AuthCodesTable
         - DynamoDBReadPolicy:
             TableName: !Ref AuthCodesTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
               ParameterName: !Sub ${Environment}/core/*
       Events:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add missing env variable for the sessions dynamodb table name, and give lambda read permission to the table.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The sessionEnd lambda needs to perform a read request to the sessions table to get the orc client connection details stored in the back-end session object.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-828](https://govukverify.atlassian.net/browse/PYIC-828)
