### PR TITLE
Fix authorize endpoint to use correct Oauth Nimbus parse method

### DIFF
--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,9 +77,9 @@ public class SessionEndHandler
                     HttpStatus.SC_BAD_REQUEST, validationResult.getError());
         }
 
-        AuthenticationRequest authenticationRequest;
+        AuthorizationRequest authorizationRequest;
         try {
-            authenticationRequest = AuthenticationRequest.parse(authParameters);
+            authorizationRequest = AuthorizationRequest.parse(authParameters);
         } catch (ParseException e) {
             LOGGER.error("Authentication request could not be parsed", e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
@@ -92,7 +92,7 @@ public class SessionEndHandler
         authorizationCodeService.persistAuthorizationCode(
                 authorizationCode.getValue(),
                 ipvSessionId,
-                authenticationRequest.getRedirectionURI().toString());
+                authorizationRequest.getRedirectionURI().toString());
 
         ClientResponse clientResponse =
                 new ClientResponse(

--- a/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
+++ b/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
@@ -129,24 +129,17 @@ class SessionEndHandlerTest {
         when(mockSessionService.getIpvSession(anyString())).thenReturn(generateIpvSessionItem());
 
         List<String> paramsToRemove =
-                List.of(
-                        OAuth2RequestParams.REDIRECT_URI,
-                        OAuth2RequestParams.CLIENT_ID,
-                        OAuth2RequestParams.RESPONSE_TYPE,
-                        OAuth2RequestParams.SCOPE);
+                List.of(OAuth2RequestParams.CLIENT_ID, OAuth2RequestParams.RESPONSE_TYPE);
         for (String param : paramsToRemove) {
             IpvSessionItem item = generateIpvSessionItem();
             ClientSessionDetailsDto clientSessionDetailsDto =
                     generateValidClientSessionDetailsDto();
-            if (param.equals(OAuth2RequestParams.REDIRECT_URI)) {
-                clientSessionDetailsDto.setRedirectUri(null);
-            } else if (param.equals(OAuth2RequestParams.CLIENT_ID)) {
+            if (param.equals(OAuth2RequestParams.CLIENT_ID)) {
                 clientSessionDetailsDto.setClientId(null);
             } else if (param.equals(OAuth2RequestParams.RESPONSE_TYPE)) {
                 clientSessionDetailsDto.setResponseType(null);
-            } else if (param.equals(OAuth2RequestParams.SCOPE)) {
-                clientSessionDetailsDto.setScope(null);
             }
+
             item.setClientSessionDetails(clientSessionDetailsDto);
 
             when(mockSessionService.getIpvSession(anyString())).thenReturn(item);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Change the /session/end lambda to use the correct Oauth AuthorizationRequest.parse method instead of the incorrect OIDC parse method.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Was previously using the incorrect parse method that caused the incoming request to need to be an OIDC request rather than regular Oauth.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-837](https://govukverify.atlassian.net/browse/PYIC-837)
