### PR TITLE
PYIC-865: Use ES256 to sign JWTs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -52,12 +52,12 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub shared-attributes-${Environment}
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
-          SHARED_ATTRIBUTES_SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/sharedAttributesJwtSigningKeyId"
+          SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsTable
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/sharedAttributesJwtSigningKeyId
+            ParameterName: !Sub ${Environment}/core/self/signingKeyId
         - Statement:
           - Sid: kmsSigningKeyPermission
             Effect: Allow
@@ -193,7 +193,7 @@ Resources:
         Variables:
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
-          SHARED_ATTRIBUTES_SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/sharedAttributesJwtSigningKeyId"
+          SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub cri-return-${Environment}
       Policies:
@@ -204,7 +204,7 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/sharedAttributesJwtSigningKeyId
+            ParameterName: !Sub ${Environment}/core/self/signingKeyId
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
         - Statement:

--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -15,7 +15,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerRequestDto;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
-import uk.gov.di.ipv.core.library.helpers.KmsSigner;
+import uk.gov.di.ipv.core.library.helpers.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.CredentialIssuerService;
@@ -40,7 +40,8 @@ public class CredentialIssuerReturnHandler
     @ExcludeFromGeneratedCoverageReport
     public CredentialIssuerReturnHandler() {
         this.configurationService = new ConfigurationService();
-        JWSSigner signer = new KmsSigner(configurationService.getSharedAttributesSigningKeyId());
+        JWSSigner signer =
+                new KmsEs256Signer(configurationService.getSharedAttributesSigningKeyId());
 
         this.credentialIssuerService = new CredentialIssuerService(configurationService, signer);
     }

--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -40,8 +40,7 @@ public class CredentialIssuerReturnHandler
     @ExcludeFromGeneratedCoverageReport
     public CredentialIssuerReturnHandler() {
         this.configurationService = new ConfigurationService();
-        JWSSigner signer =
-                new KmsEs256Signer(configurationService.getSharedAttributesSigningKeyId());
+        JWSSigner signer = new KmsEs256Signer(configurationService.getSigningKeyId());
 
         this.credentialIssuerService = new CredentialIssuerService(configurationService, signer);
     }

--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
@@ -20,7 +20,7 @@ import uk.gov.di.ipv.core.library.domain.SharedAttributesResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.JwtHelper;
-import uk.gov.di.ipv.core.library.helpers.KmsSigner;
+import uk.gov.di.ipv.core.library.helpers.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
@@ -56,7 +56,7 @@ public class SharedAttributesHandler
     public SharedAttributesHandler() {
         ConfigurationService configurationService = new ConfigurationService();
         this.userIdentityService = new UserIdentityService(configurationService);
-        this.signer = new KmsSigner(configurationService.getSharedAttributesSigningKeyId());
+        this.signer = new KmsEs256Signer(configurationService.getSharedAttributesSigningKeyId());
     }
 
     @Override

--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
@@ -56,7 +56,7 @@ public class SharedAttributesHandler
     public SharedAttributesHandler() {
         ConfigurationService configurationService = new ConfigurationService();
         this.userIdentityService = new UserIdentityService(configurationService);
-        this.signer = new KmsEs256Signer(configurationService.getSharedAttributesSigningKeyId());
+        this.signer = new KmsEs256Signer(configurationService.getSigningKeyId());
     }
 
     @Override

--- a/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandlerTest.java
+++ b/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandlerTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.helpers.KmsSigner;
+import uk.gov.di.ipv.core.library.helpers.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.io.ByteArrayInputStream;
@@ -130,7 +130,7 @@ class SharedAttributesHandlerTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
     @Mock private Context context;
     @Mock private UserIdentityService userIdentityService;
-    @Mock private KmsSigner mockKmsSigner;
+    @Mock private KmsEs256Signer mockKmsSigner;
     private SharedAttributesHandler underTest;
 
     @BeforeEach

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/KmsEs256Signer.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/KmsEs256Signer.java
@@ -20,9 +20,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Set;
 
-import static com.nimbusds.jose.JWSAlgorithm.RS256;
+import static com.nimbusds.jose.JWSAlgorithm.ES256;
+import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_256;
 
-public class KmsSigner implements JWSSigner {
+public class KmsEs256Signer implements JWSSigner {
 
     private final AWSKMS kmsClient;
 
@@ -31,12 +32,12 @@ public class KmsSigner implements JWSSigner {
     private final String keyId;
 
     @ExcludeFromGeneratedCoverageReport
-    public KmsSigner(String keyId) {
+    public KmsEs256Signer(String keyId) {
         this.keyId = keyId;
         this.kmsClient = AWSKMSClientBuilder.defaultClient();
     }
 
-    public KmsSigner(String keyId, AWSKMS kmsClient) {
+    public KmsEs256Signer(String keyId, AWSKMS kmsClient) {
         this.keyId = keyId;
         this.kmsClient = kmsClient;
     }
@@ -46,15 +47,14 @@ public class KmsSigner implements JWSSigner {
         byte[] signingInputHash;
 
         try {
-            signingInputHash = MessageDigest.getInstance("SHA-256").digest(signingInput);
+            signingInputHash = MessageDigest.getInstance(SHA_256).digest(signingInput);
         } catch (NoSuchAlgorithmException e) {
             throw new JOSEException(e.getMessage());
         }
 
         SignRequest signRequest =
                 new SignRequest()
-                        .withSigningAlgorithm(
-                                SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256.toString())
+                        .withSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString())
                         .withKeyId(keyId)
                         .withMessage(ByteBuffer.wrap(signingInputHash))
                         .withMessageType(MessageType.DIGEST);
@@ -66,7 +66,7 @@ public class KmsSigner implements JWSSigner {
 
     @Override
     public Set<JWSAlgorithm> supportedJWSAlgorithms() {
-        return Set.of(RS256);
+        return Set.of(ES256);
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -162,8 +162,8 @@ public class ConfigurationService {
         return splitKey;
     }
 
-    public String getSharedAttributesSigningKeyId() {
-        return ssmProvider.get(System.getenv("SHARED_ATTRIBUTES_SIGNING_KEY_ID_PARAM"));
+    public String getSigningKeyId() {
+        return ssmProvider.get(System.getenv("SIGNING_KEY_ID_PARAM"));
     }
 
     public String getAudienceForClients() {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/KmsEs256SignerTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/KmsEs256SignerTest.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class KmsSignerTest {
+class KmsEs256SignerTest {
 
     public static final String KEY_ID = "test";
 
@@ -35,11 +35,11 @@ class KmsSignerTest {
 
         byte[] bytes = new byte[10];
         when(signResult.getSignature()).thenReturn(ByteBuffer.wrap(bytes));
-        KmsSigner kmsSigner = new KmsSigner(KEY_ID, kmsClient);
+        KmsEs256Signer kmsSigner = new KmsEs256Signer(KEY_ID, kmsClient);
 
         JSONObject jsonPayload = new JSONObject(Map.of("test", "test"));
 
-        JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
+        JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
         JWSObject jwsObject = new JWSObject(jwsHeader, new Payload(jsonPayload));
 
         jwsObject.sign(kmsSigner);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

[PYIC-865: Switch KmsSigner to ES256 and rename](https://github.com/alphagov/di-ipv-core-back/commit/cfa3b345a2f09d159aebf94532d77d90a2cb9e78)[](https://github.com/Wynndow) 

Change the KMS signer to use the ES256 JWS algorithm, rather than RS256.
This is so we stay in step with how we're signing in other parts of the
system. 
  
[PYIC-856: Rename sharedAttributeSigningKey to signingKey](https://github.com/alphagov/di-ipv-core-back/commit/0a078e8f546d615dc617e6873ded724cda7fb206) 

The same key is being used to sign the shared attributes JWT, as well as
the client auth JWT used on the token endpoint.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-865](https://govukverify.atlassian.net/browse/PYIC-865)