### PR TITLE
PYIC-875: Return state with client response

### DIFF
--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
@@ -98,7 +98,8 @@ public class SessionEndHandler
                 new ClientResponse(
                         new ClientDetails(
                                 ipvSessionItem.getClientSessionDetails().getRedirectUri(),
-                                authorizationCode.getValue()));
+                                authorizationCode.getValue(),
+                                ipvSessionItem.getClientSessionDetails().getState()));
 
         return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, clientResponse);
     }

--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/domain/ClientDetails.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/domain/ClientDetails.java
@@ -1,18 +1,24 @@
 package uk.gov.di.ipv.core.sessionend.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonInclude(Include.NON_EMPTY)
 public class ClientDetails {
     @JsonProperty private String redirectUrl;
     @JsonProperty private String authCode;
+    @JsonProperty private String state;
 
     @JsonCreator
     public ClientDetails(
             @JsonProperty(value = "redirectUrl", required = true) String redirectUrl,
-            @JsonProperty(value = "authCode", required = true) String authCode) {
+            @JsonProperty(value = "authCode", required = true) String authCode,
+            @JsonProperty(value = "state") String state) {
         this.redirectUrl = redirectUrl;
         this.authCode = authCode;
+        this.state = state;
     }
 
     public String getRedirectUrl() {
@@ -21,5 +27,9 @@ public class ClientDetails {
 
     public String getAuthCode() {
         return authCode;
+    }
+
+    public String getState() {
+        return state;
     }
 }

--- a/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
+++ b/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
@@ -26,6 +26,7 @@ public class IpvSessionStartHandler
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(IpvSessionStartHandler.class.getName());
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final String IPV_SESSION_ID_KEY = "ipvSessionId";
 
     private final ConfigurationService configurationService;
@@ -49,7 +50,6 @@ public class IpvSessionStartHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
             ClientSessionDetailsDto clientSessionDetails =
                     objectMapper.readValue(input.getBody(), ClientSessionDetailsDto.class);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return the value for state provided in an initial auth request.

### Why did it change

The Oauth spec states that if a value for state is sent in the
authentication request, we should return in in the response. See here:
https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2

We currently validate the presence of the state value when we receive an
auth request from a client so we should always have one to return.
However, it is optional according to the spec, so this change will allow
for a missing value.

The auth teams client validates that the state received in the response
is the same as that sent in the initial auth request. We need to return
it to allow this to happen.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-875](https://govukverify.atlassian.net/browse/PYIC-875)
