### PR TITLE
BAU: Provisioned concurrency for lambdas

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -11,6 +11,15 @@ Parameters:
   Environment:
     Type: String
 
+Mappings:
+  ProvisionedConcurrency:
+    dev:
+      executions: 0
+    build:
+      executions: 0
+    staging:
+      executions: 1
+
 Resources:
 
   IPVCoreInternalAPI:
@@ -72,6 +81,9 @@ Resources:
             RestApiId: !Ref IPVCoreInternalAPI
             Path: /shared-attributes
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVAccessTokenFunction:
     Type: AWS::Serverless::Function
@@ -109,6 +121,9 @@ Resources:
             RestApiId: !Ref IPVCoreExternalAPI
             Path: /token
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVSessionEndFunction:
     Type: AWS::Serverless::Function
@@ -145,6 +160,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/session/end
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVSessionStartFunction:
     Type: AWS::Serverless::Function
@@ -176,6 +194,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /session/start
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVCriReturnFunction:
     Type: AWS::Serverless::Function
@@ -222,6 +243,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/return
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVCredentialIssuerStartFunction:
     Type: AWS::Serverless::Function
@@ -253,6 +277,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/start/{criId}
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVCredentialIssuerErrorFunction:
     Type: AWS::Serverless::Function
@@ -284,6 +311,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/error
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVUserIdentityFunction:
     Type: AWS::Serverless::Function
@@ -318,6 +348,9 @@ Resources:
               Ref: IPVCoreExternalAPI
             Path: /user-identity
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVCredentialIssuerConfig:
     Type: AWS::Serverless::Function
@@ -349,6 +382,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /request-config
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVIssuedCredentials:
     Type: AWS::Serverless::Function
@@ -380,6 +416,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /issued-credentials
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   IPVJourneyEngineFunction:
     Type: AWS::Serverless::Function
@@ -413,6 +452,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/{journeyStep}
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !FindInMap [ProvisionedConcurrency, !Ref Environment, executions ]
 
   UserIssuedCredentialsTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds the ability to set provisioned concurrency on a per env basis.

With SAM templates you need to set the AutoPublishAlias value to be able
to use ProvisionedConcurrencyConfig.

AutoPublishAlias will set up a version and an alias for the lambda.
ProvisionedConcurrencyConfig is passed directly to the cloudforamtion
Alias resource created by the AutoPublishAlias.

https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html