### PR TITLE
BAU: Turn on provisioned concurrency in all deploys

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -72,6 +72,9 @@ Resources:
             RestApiId: !Ref IPVCoreInternalAPI
             Path: /shared-attributes
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVAccessTokenFunction:
     Type: AWS::Serverless::Function
@@ -109,6 +112,9 @@ Resources:
             RestApiId: !Ref IPVCoreExternalAPI
             Path: /token
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVSessionEndFunction:
     Type: AWS::Serverless::Function
@@ -145,6 +151,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/session/end
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVSessionStartFunction:
     Type: AWS::Serverless::Function
@@ -176,6 +185,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /session/start
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVCriReturnFunction:
     Type: AWS::Serverless::Function
@@ -222,6 +234,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/return
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVCredentialIssuerStartFunction:
     Type: AWS::Serverless::Function
@@ -253,6 +268,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/start/{criId}
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVCredentialIssuerErrorFunction:
     Type: AWS::Serverless::Function
@@ -284,6 +302,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/error
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVUserIdentityFunction:
     Type: AWS::Serverless::Function
@@ -318,6 +339,9 @@ Resources:
               Ref: IPVCoreExternalAPI
             Path: /user-identity
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVCredentialIssuerConfig:
     Type: AWS::Serverless::Function
@@ -349,6 +373,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /request-config
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVIssuedCredentials:
     Type: AWS::Serverless::Function
@@ -380,6 +407,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /issued-credentials
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   IPVJourneyEngineFunction:
     Type: AWS::Serverless::Function
@@ -413,6 +443,9 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/{journeyStep}
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
 
   UserIssuedCredentialsTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
This is a temporary measure to get things working for the show and tell.
I'll revert it after and then we can work out a more targeted way of
applying it.
