### PR TITLE
BAU: Transcode AWS signatures

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.core.library.service;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimNames;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;
@@ -37,6 +39,8 @@ import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
+
+import static com.nimbusds.jose.JWSAlgorithm.ES256;
 
 public class CredentialIssuerService {
 
@@ -152,6 +156,12 @@ public class CredentialIssuerService {
             }
 
             SignedJWT verifiableCredential = (SignedJWT) response.getContentAsJWT();
+
+            if (config.getId().equals("ukPassport")) {
+                LOGGER.info("Transcoding ukPassport signature");
+                verifiableCredential = transcodeSignature(verifiableCredential);
+            }
+
             if (!verifiableCredential.verify(new ECDSAVerifier(config.getVcVerifyingPublicJwk()))) {
                 LOGGER.error("Verifiable credential signature not valid");
                 LOGGER.error(verifiableCredential.serialize());
@@ -197,5 +207,17 @@ public class CredentialIssuerService {
             throw new CredentialIssuerException(
                     HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_SAVE_CREDENTIAL);
         }
+    }
+
+    private SignedJWT transcodeSignature(SignedJWT vc)
+            throws JOSEException, java.text.ParseException {
+        Base64URL transcodedSignatureBase64 =
+                Base64URL.encode(
+                        ECDSA.transcodeSignatureToConcat(
+                                vc.getSignature().decode(),
+                                ECDSA.getSignatureByteArrayLength(ES256)));
+        String[] jwtParts = vc.serialize().split("\\.");
+        return SignedJWT.parse(
+                String.format("%s.%s.%s", jwtParts[0], jwtParts[1], transcodedSignatureBase64));
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes


### Why did it change

Passport CRI is the only CRI that uses AWS to sign VCs.

The signatures from AWS need to be transcoded (from DER to R+S format)
for the nimbus libs to be able to verify it.
