### PR TITLE
BAU: Fix debug page to show evidence.

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIssuedDebugCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIssuedDebugCredential.java
@@ -12,10 +12,10 @@ import java.util.Map;
 public class UserIssuedDebugCredential {
 
     DebugCredentialAttributes attributes;
-    private Map<String, Object> gpg45Score;
+    private Map<String, Object> evidence;
 
     public UserIssuedDebugCredential(DebugCredentialAttributes attributes) {
         this.attributes = attributes;
-        this.gpg45Score = null;
+        this.evidence = null;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -76,8 +76,7 @@ public class UserIdentityService {
                             LOGGER.error("Evidence not found in verifiable credential");
                         } else {
                             JSONArray evidenceArray = ((JSONArray) vcClaim.get(VC_EVIDENCE));
-                            debugCredential.setGpg45Score(
-                                    (Map<String, Object>) evidenceArray.get(0));
+                            debugCredential.setEvidence((Map<String, Object>) evidenceArray.get(0));
                         }
                     } catch (ParseException e) {
                         LOGGER.error("Failed to parse credential JSON for the debug page");

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -81,10 +81,10 @@ class UserIdentityServiceTest {
                 userIdentityService.getUserIssuedDebugCredentials("ipv-session-id-1");
 
         assertEquals(
-                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"},\"gpg45Score\":{\"strength\":4,\"validity\":2,\"type\":\"CriStubCheck\"}}",
+                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"},\"evidence\":{\"strength\":4,\"validity\":2,\"type\":\"CriStubCheck\"}}",
                 credentials.get("PassportIssuer"));
         assertEquals(
-                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"},\"gpg45Score\":{\"Gpg45\":\"Score\"}}",
+                "{\"attributes\":{\"ipvSessionId\":\"ipv-session-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"},\"evidence\":{\"Gpg45\":\"Score\"}}",
                 credentials.get("FraudIssuer"));
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
The debug page currently doesn't render the evidence block due to core-back returning the old 'gpgScore' rather than 'evidence'. This should fix that.