### PR TITLE
PYIC-900: Store credentials within a vcs property

### DIFF
--- a/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
+++ b/lambdas/sharedattributes/src/main/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.SharedAttributes;
 import uk.gov.di.ipv.core.library.domain.SharedAttributesResponse;
+import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.JwtHelper;
@@ -79,11 +80,10 @@ public class SharedAttributesHandler
     @Tracing
     private SharedAttributesResponse getSharedAttributes(String ipvSessionId)
             throws HttpResponseExceptionWithErrorBody {
-        Map<String, String> credentials =
-                userIdentityService.getUserIssuedCredentials(ipvSessionId);
+        UserIdentity credentials = userIdentityService.getUserIssuedCredentials(ipvSessionId);
 
         List<SharedAttributes> sharedAttributes = new ArrayList<>();
-        for (String credential : credentials.values()) {
+        for (String credential : credentials.getVcs()) {
             try {
                 JsonNode credentialSubject =
                         mapper.readTree(SignedJWT.parse(credential).getPayload().toString())

--- a/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandlerTest.java
+++ b/lambdas/sharedattributes/src/test/java/uk/gov/di/ipv/core/sharedattributes/SharedAttributesHandlerTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.helpers.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
@@ -66,11 +67,12 @@ class SharedAttributesHandlerTest {
     void shouldExtractSessionIdFromHeaderAndReturnSharedAttributesAndStatusOK() throws Exception {
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
                 .thenReturn(
-                        Map.of(
-                                "CredentialIssuer1",
-                                generateVerifiableCredential(vcClaim(CREDENTIAL_ATTRIBUTES_1)),
-                                "CredentialIssuer2",
-                                generateVerifiableCredential(vcClaim(CREDENTIAL_ATTRIBUTES_2))));
+                        new UserIdentity(
+                                List.of(
+                                        generateVerifiableCredential(
+                                                vcClaim(CREDENTIAL_ATTRIBUTES_1)),
+                                        generateVerifiableCredential(
+                                                vcClaim(CREDENTIAL_ATTRIBUTES_2)))));
 
         List<Address> addressList = new ArrayList<>();
 
@@ -116,7 +118,7 @@ class SharedAttributesHandlerTest {
     @Test
     void shouldReturnOKIfZeroCredentialExists() {
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
-                .thenReturn(Collections.emptyMap());
+                .thenReturn(new UserIdentity(Collections.emptyList()));
 
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
@@ -129,10 +131,11 @@ class SharedAttributesHandlerTest {
     void shouldReturnOKIfCredentialExistsWithoutAnySharedAttributeFields() throws Exception {
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
                 .thenReturn(
-                        Map.of(
-                                "CredentialIssuer3",
-                                generateVerifiableCredential(
-                                        vcClaim(CREDENTIAL_ATTRIBUTES_WITHOUT_SHARED_ATTRIBUTES))));
+                        new UserIdentity(
+                                List.of(
+                                        generateVerifiableCredential(
+                                                vcClaim(
+                                                        CREDENTIAL_ATTRIBUTES_WITHOUT_SHARED_ATTRIBUTES)))));
 
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
@@ -169,11 +172,12 @@ class SharedAttributesHandlerTest {
     void shouldReturn500WhenUnableToSignSharedAttributes() throws Exception {
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
                 .thenReturn(
-                        Map.of(
-                                "CredentialIssuer1",
-                                generateVerifiableCredential(vcClaim(CREDENTIAL_ATTRIBUTES_1)),
-                                "CredentialIssuer2",
-                                generateVerifiableCredential(vcClaim(CREDENTIAL_ATTRIBUTES_2))));
+                        new UserIdentity(
+                                List.of(
+                                        generateVerifiableCredential(
+                                                vcClaim(CREDENTIAL_ATTRIBUTES_1)),
+                                        generateVerifiableCredential(
+                                                vcClaim(CREDENTIAL_ATTRIBUTES_2)))));
 
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
@@ -194,7 +198,7 @@ class SharedAttributesHandlerTest {
     @Test
     void shouldReturn500WhenUnableToParseCredentials() throws Exception {
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
-                .thenReturn(Map.of("CredentialIssuer1", "Not a verifiable credential"));
+                .thenReturn(new UserIdentity(List.of("Not a verifiable credential")));
 
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
@@ -217,7 +221,7 @@ class SharedAttributesHandlerTest {
         vcClaim.remove(VC_CREDENTIAL_SUBJECT);
 
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
-                .thenReturn(Map.of("CredentialIssuer1", generateVerifiableCredential(vcClaim)));
+                .thenReturn(new UserIdentity(List.of(generateVerifiableCredential(vcClaim))));
 
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setHeaders(Map.of("ipv-session-id", SESSION_ID));

--- a/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
+++ b/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
@@ -13,13 +13,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
-
-import java.util.Map;
 
 public class UserIdentityHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -73,10 +72,9 @@ public class UserIdentityHandler
                                 .toJSONObject());
             }
 
-            Map<String, String> credentials =
-                    userIdentityService.getUserIssuedCredentials(ipvSessionId);
+            UserIdentity userIdentity = userIdentityService.getUserIssuedCredentials(ipvSessionId);
 
-            return ApiGatewayResponseGenerator.proxyJsonResponse(HTTPResponse.SC_OK, credentials);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HTTPResponse.SC_OK, userIdentity);
         } catch (ParseException e) {
             LOGGER.error("Failed to parse access token");
             return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
+++ b/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
@@ -15,12 +15,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -45,17 +47,14 @@ class UserIdentityHandlerTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private UserIdentityHandler userInfoHandler;
-    private Map<String, String> userIssuedCredential;
+    private UserIdentity userIdentity;
     private Map<String, String> responseBody;
 
     @BeforeEach
     void setUp() {
-        userIssuedCredential = new HashMap<>();
         responseBody = new HashMap<>();
 
-        userIssuedCredential.put("id", "12345");
-        userIssuedCredential.put("type", "Test credential");
-        userIssuedCredential.put("foo", "bar");
+        userIdentity = new UserIdentity(List.of("12345", "Test credential", "bar"));
 
         userInfoHandler =
                 new UserIdentityHandler(
@@ -72,8 +71,7 @@ class UserIdentityHandlerTest {
 
         when(mockAccessTokenService.getIpvSessionIdByAccessToken(anyString()))
                 .thenReturn(TEST_IPV_SESSION_ID);
-        when(mockUserIdentityService.getUserIssuedCredentials(any()))
-                .thenReturn(userIssuedCredential);
+        when(mockUserIdentityService.getUserIssuedCredentials(any())).thenReturn(userIdentity);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
 
@@ -90,16 +88,15 @@ class UserIdentityHandlerTest {
 
         when(mockAccessTokenService.getIpvSessionIdByAccessToken(anyString()))
                 .thenReturn(TEST_IPV_SESSION_ID);
-        when(mockUserIdentityService.getUserIssuedCredentials(any()))
-                .thenReturn(userIssuedCredential);
+        when(mockUserIdentityService.getUserIssuedCredentials(any())).thenReturn(userIdentity);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
-        Map<String, Object> responseBody =
+        UserIdentity responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
-        assertEquals(userIssuedCredential.get("id"), responseBody.get("id"));
-        assertEquals(userIssuedCredential.get("type"), responseBody.get("type"));
-        assertEquals(userIssuedCredential.get("foo"), responseBody.get("foo"));
+        assertEquals(userIdentity.getVcs().get(0), responseBody.getVcs().get(0));
+        assertEquals(userIdentity.getVcs().get(1), responseBody.getVcs().get(1));
+        assertEquals(userIdentity.getVcs().get(2), responseBody.getVcs().get(2));
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -12,10 +12,15 @@ import java.util.List;
 @Setter
 @ExcludeFromGeneratedCoverageReport
 public class UserIdentity {
-    @JsonProperty private List<String> vcs;
+    @JsonProperty("https://vocab.sign-in.service.gov.uk/v1/credentials")
+    private List<String> vcs;
 
     @JsonCreator
-    public UserIdentity(@JsonProperty(value = "vcs", required = true) List<String> vcs) {
+    public UserIdentity(
+            @JsonProperty(
+                            value = "https://vocab.sign-in.service.gov.uk/v1/credentials",
+                            required = true)
+                    List<String> vcs) {
         this.vcs = vcs;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ExcludeFromGeneratedCoverageReport
+public class UserIdentity {
+    @JsonProperty private List<String> vcs;
+
+    @JsonCreator
+    public UserIdentity(@JsonProperty(value = "vcs", required = true) List<String> vcs) {
+        this.vcs = vcs;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.DebugCredentialAttributes;
+import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.domain.UserIssuedDebugCredential;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
@@ -47,12 +48,15 @@ public class UserIdentityService {
         this.dataStore = dataStore;
     }
 
-    public Map<String, String> getUserIssuedCredentials(String ipvSessionId) {
+    public UserIdentity getUserIssuedCredentials(String ipvSessionId) {
         List<UserIssuedCredentialsItem> credentialIssuerItem = dataStore.getItems(ipvSessionId);
 
-        return credentialIssuerItem.stream()
-                .map(ciItem -> Map.entry(ciItem.getCredentialIssuer(), ciItem.getCredential()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        List<String> vcJwts =
+                credentialIssuerItem.stream()
+                        .map(UserIssuedCredentialsItem::getCredential)
+                        .collect(Collectors.toList());
+
+        return new UserIdentity(vcJwts);
     }
 
     public Map<String, String> getUserIssuedDebugCredentials(String ipvSessionId) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 
@@ -53,11 +54,10 @@ class UserIdentityServiceTest {
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
-        Map<String, String> credentials =
-                userIdentityService.getUserIssuedCredentials("ipv-session-id-1");
+        UserIdentity credentials = userIdentityService.getUserIssuedCredentials("ipv-session-id-1");
 
-        assertEquals(SIGNED_VC_1, credentials.get("PassportIssuer"));
-        assertEquals(SIGNED_VC_2, credentials.get("FraudIssuer"));
+        assertEquals(SIGNED_VC_1, credentials.getVcs().get(0));
+        assertEquals(SIGNED_VC_2, credentials.getVcs().get(1));
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the user-identity lambda to return the list of VC's within an object under the "vcs" property.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To update the user-identity endpoint to start returning data in the format matching with the RFC spec.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-900](https://govukverify.atlassian.net/browse/PYIC-900)


