### PR TITLE
PYIC-917: Give CRI return lambda SQS write permissions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -210,6 +210,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/signingKeyId
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
+        - SQSSendMessagePolicy:
+            QueueName:
+              Fn::ImportValue:
+                !Sub ${Environment}AuditEventQueueName
         - Statement:
           - Sid: kmsSigningKeyPermission
             Effect: Allow


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Give CRI return lambda SQS write permissions

### Why did it change

For slice 2 we need to send an audit event from core-back when it
receives a VC and verifies its signature. It will send the audit event
to an SQS queue that has been created. This adds the permissions to
write to that queue.

We will need to also configure the lambda with the details of the SQS
queue - it's URL probably but maybe it's ARN. We will wait until we know
what the library that does the writing need before adding it.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-917](https://govukverify.atlassian.net/browse/PYIC-917)
