### PR TITLE
BAU: Remove env from SQS queue name

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -211,9 +211,7 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
         - SQSSendMessagePolicy:
-            QueueName:
-              Fn::ImportValue:
-                !Sub ${Environment}AuditEventQueueName
+            QueueName: !ImportValue AuditEventQueueName
         - Statement:
           - Sid: kmsSigningKeyPermission
             Effect: Allow


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove env from SQS queue name

### Why did it change

The environment prefix has been removed from the SQS queue name. It was
making deploying a shared stack in the dev environment difficult due to
the exported values.

