### PR TITLE
BAU: Add missing kms permissions needed to write onto the audit event queue

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -220,6 +220,13 @@ Resources:
               - 'kms:sign'
             Resource:
               - !ImportValue SigningKeyArn
+          - Sid: kmsAuditEventQueueEncryptionKeyPermission
+            Effect: Allow
+            Action:
+              - 'kms:Decrypt'
+              - 'kms:GenerateDataKey'
+            Resource:
+              - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
         IPVCoreInternalAPI:
           Type: Api


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add missing kms permissions for the kms encryption key that needs to be applied to the lambda for writing to the audit event queue.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Without these permissions the lambda will fail to write to the SQS queue
<!-- Describe the reason these changes were made - the "why" -->

