### PR TITLE
Update timestamp field in message payload to be an int

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEvent.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEvent.java
@@ -8,14 +8,14 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @ExcludeFromGeneratedCoverageReport
 @Getter
 public class AuditEvent {
-    @JsonProperty private long timestamp;
+    @JsonProperty private int timestamp;
 
     @JsonProperty("event_name")
     private AuditEventTypes event;
 
     @JsonCreator
     public AuditEvent(
-            @JsonProperty(value = "timestamp", required = true) long timestamp,
+            @JsonProperty(value = "timestamp", required = true) int timestamp,
             @JsonProperty(value = "event_name", required = true) AuditEventTypes event) {
         this.timestamp = timestamp;
         this.event = event;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -38,7 +38,7 @@ public class AuditService {
     }
 
     private String generateMessageBody(AuditEventTypes eventType) throws JsonProcessingException {
-        AuditEvent auditEvent = new AuditEvent(Instant.now().getEpochSecond(), eventType);
+        AuditEvent auditEvent = new AuditEvent((int) Instant.now().getEpochSecond(), eventType);
 
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.writeValueAsString(auditEvent);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the AutitEvent timestamp field to be an int instead of long to match with the TxMA spec.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To match the expected spec from TxMA.
<!-- Describe the reason these changes were made - the "why" -->

