### PR TITLE
PYIC-989: Update CredentialStartHandler to use configuration for issuer, audience, expirationTime, notBeforeTime, issueTime and redirectUri in the "request" JWT.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -261,6 +261,8 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/signingKeyId
         - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/coreFrontCallbackUrlValue
+        - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers

--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
@@ -101,7 +101,11 @@ public class CredentialIssuerStartHandler
                     AuthorizationRequestHelper.createJWTWithSharedClaims(
                             sharedAttributesResponse,
                             signer,
-                            credentialIssuerConfig.getIpvClientId());
+                            credentialIssuerConfig.getId(),
+                            credentialIssuerConfig.getIpvClientId(),
+                            credentialIssuerConfig.getAuthorizeUrl().toString(),
+                            configurationService.getIpvTokenTtl(),
+                            configurationService.getCoreFrontCallbackUrl());
         } catch (HttpResponseExceptionWithErrorBody exception) {
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     exception.getResponseCode(), exception.getErrorBody());

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -32,7 +32,8 @@ public enum ErrorResponse {
     MISSING_JOURNEY_STEP_URL_PATH_PARAM(1023, "Missing journeyStep url path parameter in request"),
     FAILED_TO_PARSE_ISSUED_CREDENTIALS(1024, "Failed to parse issued credentials"),
     CREDENTIAL_SUBJECT_MISSING(1025, "Credential subject missing from verified credential"),
-    INVALID_SESSION_REQUEST(1026, "Failed to parse the session start request");
+    INVALID_SESSION_REQUEST(1026, "Failed to parse the session start request"),
+    FAILED_TO_BUILD_CORE_FRONT_CALLBACK_URL(1027, "Failed to build Core Front Callback Url");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -220,4 +220,10 @@ public class ConfigurationService {
         return ssmProvider.get(
                 String.format("/%s/core/self/jwtTtlSeconds", System.getenv(ENVIRONMENT)));
     }
+
+    public String getCoreFrontCallbackUrl() {
+        return ssmProvider.get(
+                String.format(
+                        "/%s/core/self/coreFrontCallbackUrlValue", System.getenv(ENVIRONMENT)));
+    }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update CredentialStartHandler to use configuration for issuer, audience, expirationTime, notBeforeTime, issueTime and redirectUri in the "request" JWT.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-989](https://govukverify.atlassian.net/browse/PYIC-989)