### PR TITLE
PYIC-1031: Use new audience config value for JWT audience claim values

### DIFF
--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
@@ -105,7 +105,7 @@ public class CredentialIssuerStartHandler
                             signer,
                             credentialIssuerConfig.getId(),
                             credentialIssuerConfig.getIpvClientId(),
-                            credentialIssuerConfig.getTokenUrl().toString(),
+                            configurationService.getClientAudience(credentialIssuerConfig.getId()),
                             configurationService.getIpvTokenTtl(),
                             configurationService.getCoreFrontCallbackUrl());
 

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -50,6 +50,7 @@ import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.credentialissuer.CredentialIssuerStartHandler.SHARED_CLAIMS;
@@ -70,6 +71,7 @@ class CredentialIssuerStartHandlerTest {
     public static final String CRI_TOKEN_URL = "http://www.example.com";
     public static final String CRI_CREDENTIAL_URL = "http://www.example.com/credential";
     public static final String CRI_AUTHORIZE_URL = "http://www.example.com/authorize";
+    public static final String CRI_AUDIENCE = "http://www.example.com/audience";
     public static final String IPV_CLIENT_ID = "ipv-core";
     public static final String SESSION_ID = "the-session-id";
 
@@ -131,6 +133,7 @@ class CredentialIssuerStartHandlerTest {
         when(configurationService.getCoreFrontCallbackUrl()).thenReturn("callbackUrl");
         when(configurationService.getEncryptionPublicKey(CRI_ID))
                 .thenReturn(getEncryptionPublicKey());
+        when(configurationService.getClientAudience(anyString())).thenReturn(CRI_AUDIENCE);
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
                 .thenReturn(
                         new UserIdentity(
@@ -184,7 +187,7 @@ class CredentialIssuerStartHandlerTest {
         assertEquals(IPV_CLIENT_ID, signedJWT.getJWTClaimsSet().getClaim("client_id"));
         assertEquals(IPV_CLIENT_ID, signedJWT.getJWTClaimsSet().getIssuer());
         assertEquals(IPV_CLIENT_ID, signedJWT.getJWTClaimsSet().getSubject());
-        assertEquals(CRI_TOKEN_URL, signedJWT.getJWTClaimsSet().getAudience().get(0));
+        assertEquals(CRI_AUDIENCE, signedJWT.getJWTClaimsSet().getAudience().get(0));
 
         assertEquals(3, claimsSet.get(SHARED_CLAIMS).size());
         JsonNode vcAttributes = claimsSet.get(SHARED_CLAIMS);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -212,7 +212,8 @@ public class ConfigurationService {
     public String getClientAudience(String clientId) {
         return ssmProvider.get(
                 String.format(
-                        "/%s/core/clients/%s/audience", System.getenv(ENVIRONMENT), clientId));
+                        "/%s/core/credentialIssuers/%s/audienceForClients",
+                        System.getenv(ENVIRONMENT), clientId));
     }
 
     public String getClientSubject(String clientId) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -83,7 +83,7 @@ public class CredentialIssuerService {
                     new ClientAuthClaims(
                             config.getIpvClientId(),
                             config.getIpvClientId(),
-                            config.getTokenUrl().toString(),
+                            configurationService.getClientAudience(config.getId()),
                             dateTime.plusSeconds(
                                             Long.parseLong(configurationService.getIpvTokenTtl()))
                                     .toEpochSecond());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -243,7 +243,8 @@ class ConfigurationServiceTest {
     void shouldReturnClientAudience() {
         environmentVariables.set("ENVIRONMENT", "test");
         String clientIssuer = "aClientAudience";
-        when(ssmProvider.get("/test/core/clients/aClientId/audience")).thenReturn(clientIssuer);
+        when(ssmProvider.get("/test/core/credentialIssuers/aClientId/audienceForClients"))
+                .thenReturn(clientIssuer);
         assertEquals(clientIssuer, configurationService.getClientAudience("aClientId"));
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -72,6 +73,7 @@ class CredentialIssuerServiceTest {
     @Test
     void validTokenResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -101,6 +103,7 @@ class CredentialIssuerServiceTest {
     @Test
     void tokenErrorResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         var errorJson =
                 "{ \"error\": \"invalid_request\", \"error_description\": \"Request was missing the 'redirect_uri' parameter.\", \"error_uri\": \"See the full API docs at https://authorization-server.com/docs/access_token\"}";
         stubFor(
@@ -134,6 +137,7 @@ class CredentialIssuerServiceTest {
     @Test
     void invalidHeaderThrowsCredentialIssuerException(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         stubFor(
                 post("/token")
                         .willReturn(


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
User new config SSM value for the audience claim value on both the JAR request and the token client_assertion JWT.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The audience claim value should be unique for each cri so we now load this value for each cri and environment from SSM. 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1031](https://govukverify.atlassian.net/browse/PYIC-1031)


