### PR TITLE
PYIC-1065: Lambda and API gateway logs to Splunk

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -30,16 +30,16 @@ Resources:
         DestinationArn: !GetAtt IPVCoreInternalAPILogGroup.Arn
         Format: >-
           {
-          "requestId":      "$context.requestId",
-          "ip":             "$context.identity.sourceIp",
-          "requestTime":    "$context.requestTime",
-          "httpMethod":     "$context.httpMethod",
-          "path":           "$context.path",
-          "routeKey":       "$context.routeKey",
-          "status":         "$context.status",
-          "protocol":       "$context.protocol",
+          "requestId":"$context.requestId",
+          "ip":"$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path":"$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
           "responseLatency":"$context.responseLatency",
-          "responseLength": "$context.responseLength"
+          "responseLength":"$context.responseLength"
           }
 
   IPVCoreInternalAPILogGroup:
@@ -69,16 +69,16 @@ Resources:
         DestinationArn: !GetAtt IPVCoreExternalAPILogGroup.Arn
         Format: >-
           {
-          "requestId":      "$context.requestId",
-          "ip":             "$context.identity.sourceIp",
-          "requestTime":    "$context.requestTime",
-          "httpMethod":     "$context.httpMethod",
-          "path":           "$context.path",
-          "routeKey":       "$context.routeKey",
-          "status":         "$context.status",
-          "protocol":       "$context.protocol",
+          "requestId":"$context.requestId",
+          "ip":"$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path":"$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
           "responseLatency":"$context.responseLatency",
-          "responseLength": "$context.responseLength"
+          "responseLength":"$context.responseLength"
           }
 
   IPVCoreExternalAPILogGroup:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -26,6 +26,34 @@ Resources:
           Name: "AWS::Include"
           Parameters:
             Location: "../openAPI/core-back-internal.yaml"
+      AccessLogSetting:
+        DestinationArn: !GetAtt IPVCoreInternalAPILogGroup.Arn
+        Format: >-
+          {
+          "requestId":      "$context.requestId",
+          "ip":             "$context.identity.sourceIp",
+          "requestTime":    "$context.requestTime",
+          "httpMethod":     "$context.httpMethod",
+          "path":           "$context.path",
+          "routeKey":       "$context.routeKey",
+          "status":         "$context.status",
+          "protocol":       "$context.protocol",
+          "responseLatency":"$context.responseLatency",
+          "responseLength": "$context.responseLength"
+          }
+
+  IPVCoreInternalAPILogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CoreBackInternal-API-GW-AccessLogs
+      RetentionInDays: 14
+
+  IPVCoreInternalAPILogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCoreInternalAPILogGroup
 
   IPVCoreExternalAPI:
     Type: AWS::Serverless::Api
@@ -37,6 +65,34 @@ Resources:
           Name: "AWS::Include"
           Parameters:
             Location: "../openAPI/core-back-external.yaml"
+      AccessLogSetting:
+        DestinationArn: !GetAtt IPVCoreExternalAPILogGroup.Arn
+        Format: >-
+          {
+          "requestId":      "$context.requestId",
+          "ip":             "$context.identity.sourceIp",
+          "requestTime":    "$context.requestTime",
+          "httpMethod":     "$context.httpMethod",
+          "path":           "$context.path",
+          "routeKey":       "$context.routeKey",
+          "status":         "$context.status",
+          "protocol":       "$context.protocol",
+          "responseLatency":"$context.responseLatency",
+          "responseLength": "$context.responseLength"
+          }
+
+  IPVCoreExternalAPILogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CoreBackExternal-API-GW-AccessLogs
+      RetentionInDays: 14
+
+  IPVCoreExternalAPILogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCoreExternalAPILogGroup
 
   IPVAccessTokenFunction:
     Type: AWS::Serverless::Function
@@ -75,6 +131,19 @@ Resources:
             Path: /token
             Method: POST
 
+  IPVAccessTokenFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVAccessTokenFunction}"
+
+  IPVAccessTokenFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVAccessTokenFunctionLogGroup
+
   IPVSessionEndFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -111,6 +180,19 @@ Resources:
             Path: /journey/session/end
             Method: POST
 
+  IPVSessionEndFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVSessionEndFunction}"
+
+  IPVSessionEndFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVSessionEndFunctionLogGroup
+
   IPVSessionStartFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -141,6 +223,19 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /session/start
             Method: POST
+
+  IPVSessionStartFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVSessionStartFunction}"
+
+  IPVSessionStartFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVSessionStartFunctionLogGroup
 
   IPVCriReturnFunction:
     Type: AWS::Serverless::Function
@@ -198,6 +293,19 @@ Resources:
             Path: /journey/cri/return
             Method: POST
 
+  IPVCriReturnFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVCriReturnFunction}"
+
+  IPVCriReturnFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCriReturnFunctionLogGroup
+
   IPVCredentialIssuerStartFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -246,6 +354,19 @@ Resources:
             Path: /journey/cri/start/{criId}
             Method: POST
 
+  IPVCredentialIssuerStartFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVCredentialIssuerStartFunction}"
+
+  IPVCredentialIssuerStartFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCredentialIssuerStartFunctionLogGroup
+
   IPVCredentialIssuerErrorFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -276,6 +397,19 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/error
             Method: POST
+
+  IPVCredentialIssuerErrorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVCredentialIssuerErrorFunction}"
+
+  IPVCredentialIssuerErrorFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCredentialIssuerErrorFunctionLogGroup
 
   IPVUserIdentityFunction:
     Type: AWS::Serverless::Function
@@ -311,6 +445,19 @@ Resources:
             Path: /user-identity
             Method: GET
 
+  IPVUserIdentityFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVUserIdentityFunction}"
+
+  IPVUserIdentityFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVUserIdentityFunctionLogGroup
+
   IPVCredentialIssuerConfig:
     Type: AWS::Serverless::Function
     Properties:
@@ -342,6 +489,19 @@ Resources:
             Path: /request-config
             Method: GET
 
+  IPVCredentialIssuerFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVCredentialIssuerConfig}"
+
+  IPVCredentialIssuerFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVCredentialIssuerFunctionLogGroup
+
   IPVIssuedCredentials:
     Type: AWS::Serverless::Function
     Properties:
@@ -372,6 +532,19 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /issued-credentials
             Method: GET
+
+  IPVIssuedCredentialsFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVIssuedCredentials}"
+
+  IPVIssuedCredentialsFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVIssuedCredentialsFunctionLogGroup
 
   IPVJourneyEngineFunction:
     Type: AWS::Serverless::Function
@@ -405,6 +578,19 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/{journeyStep}
             Method: POST
+
+  IPVJourneyEngineFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${IPVJourneyEngineFunction}"
+
+  IPVJourneyEngineFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref IPVJourneyEngineFunctionLogGroup
 
   UserIssuedCredentialsTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add CloudFormation resources to start sending our lambda application
logs and API gateway access logs to Splunk.

### Why did it change

For the API gateway logs I've reused the JSON format we have defined for
the core-front Fargate API gateway logs, for consistency. The only
difference is the addition of `responseLatency` which could be helpful
when looking at slow lambdas.

For the lambdas I've explicitly declared a log group resource even
though lambda creates one for you. This is because the lambda created
log groups will store messages indefinitely by default. You can change
this by declaring the log group yourself. As long as the name is the
same as the log group lambda creates and writes to, the function should
write to this new log group. It will be interesting to see if these log
groups deploy cleanly, considering they already exist...

The subscription filters are taking the logs from the newly created log
groups and sending them to Cyber's Centralised Security Logging Service
(CSLS) Kinesis data stream. This is the recommended way of getting our
logs to Splunk. See here for more details:
https://github.com/alphagov/centralised-security-logging-service

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1065](https://govukverify.atlassian.net/browse/PYIC-1065)
