### PR TITLE
Pyic 1100

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -173,6 +173,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/signingKeyId
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/audienceForClients
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -224,6 +226,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/signingKeyId
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/audienceForClients
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/coreFrontCallbackUrl
         - SSMParameterReadPolicy:

--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
@@ -105,6 +105,7 @@ public class CredentialIssuerStartHandler
                             signer,
                             credentialIssuerConfig.getId(),
                             credentialIssuerConfig.getIpvClientId(),
+                            configurationService.getAudienceForClients(),
                             configurationService.getClientAudience(credentialIssuerConfig.getId()),
                             configurationService.getIpvTokenTtl(),
                             configurationService.getCoreFrontCallbackUrl());

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -71,6 +71,7 @@ class CredentialIssuerStartHandlerTest {
     public static final String CRI_TOKEN_URL = "http://www.example.com";
     public static final String CRI_CREDENTIAL_URL = "http://www.example.com/credential";
     public static final String CRI_AUTHORIZE_URL = "http://www.example.com/authorize";
+    public static final String IPV_ISSUER = "http://www.example.com/issuer";
     public static final String CRI_AUDIENCE = "http://www.example.com/audience";
     public static final String IPV_CLIENT_ID = "ipv-core";
     public static final String SESSION_ID = "the-session-id";
@@ -133,6 +134,7 @@ class CredentialIssuerStartHandlerTest {
         when(configurationService.getCoreFrontCallbackUrl()).thenReturn("callbackUrl");
         when(configurationService.getEncryptionPublicKey(CRI_ID))
                 .thenReturn(getEncryptionPublicKey());
+        when(configurationService.getAudienceForClients()).thenReturn(IPV_ISSUER);
         when(configurationService.getClientAudience(anyString())).thenReturn(CRI_AUDIENCE);
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
                 .thenReturn(
@@ -185,7 +187,7 @@ class CredentialIssuerStartHandlerTest {
         JsonNode claimsSet = objectMapper.readTree(signedJWT.getJWTClaimsSet().toString());
 
         assertEquals(IPV_CLIENT_ID, signedJWT.getJWTClaimsSet().getClaim("client_id"));
-        assertEquals(IPV_CLIENT_ID, signedJWT.getJWTClaimsSet().getIssuer());
+        assertEquals(IPV_ISSUER, signedJWT.getJWTClaimsSet().getIssuer());
         assertEquals(IPV_CLIENT_ID, signedJWT.getJWTClaimsSet().getSubject());
         assertEquals(CRI_AUDIENCE, signedJWT.getJWTClaimsSet().getAudience().get(0));
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
@@ -41,6 +41,7 @@ public class AuthorizationRequestHelper {
             JWSSigner signer,
             String criId,
             String ipvClientId,
+            String issuer,
             String audience,
             String ipvTokenTtl,
             String coreFrontCallbackUrl)
@@ -64,7 +65,7 @@ public class AuthorizationRequestHelper {
         JWTClaimsSet.Builder claimsSetBuilder =
                 new JWTClaimsSet.Builder(authClaimsSet)
                         .audience(audience)
-                        .issuer(ipvClientId)
+                        .issuer(issuer)
                         .issueTime(Date.from(now))
                         .expirationTime(
                                 Date.from(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -81,8 +81,8 @@ public class CredentialIssuerService {
             OffsetDateTime dateTime = OffsetDateTime.now();
             ClientAuthClaims clientAuthClaims =
                     new ClientAuthClaims(
-                            config.getIpvClientId(),
-                            config.getIpvClientId(),
+                            configurationService.getAudienceForClients(),
+                            configurationService.getAudienceForClients(),
                             configurationService.getClientAudience(config.getId()),
                             dateTime.plusSeconds(
                                             Long.parseLong(configurationService.getIpvTokenTtl()))

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
@@ -52,6 +52,7 @@ class AuthorizationRequestHelperTest {
 
     public static final String CLIENT_ID_FIELD = "client_id";
     public static final String IPV_CLIENT_ID_VALUE = "testClientId";
+    public static final String IPV_ISSUER = "http://example.com/issuer";
     public static final String AUDIENCE = "Audience";
     public static final String IPV_TOKEN_TTL = "900";
     public static final String CORE_FRONT_CALLBACK_URL = "callbackUri";
@@ -86,11 +87,12 @@ class AuthorizationRequestHelperTest {
                         signer,
                         CRI_ID,
                         IPV_CLIENT_ID_VALUE,
+                        IPV_ISSUER,
                         AUDIENCE,
                         IPV_TOKEN_TTL,
                         CORE_FRONT_CALLBACK_URL);
 
-        assertEquals(IPV_CLIENT_ID_VALUE, result.getJWTClaimsSet().getIssuer());
+        assertEquals(IPV_ISSUER, result.getJWTClaimsSet().getIssuer());
         assertEquals(IPV_CLIENT_ID_VALUE, result.getJWTClaimsSet().getSubject());
         assertEquals(AUDIENCE, result.getJWTClaimsSet().getAudience().get(0));
         assertEquals(sharedClaims, result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
@@ -111,6 +113,7 @@ class AuthorizationRequestHelperTest {
                         signer,
                         CRI_ID,
                         IPV_CLIENT_ID_VALUE,
+                        IPV_ISSUER,
                         AUDIENCE,
                         IPV_TOKEN_TTL,
                         CORE_FRONT_CALLBACK_URL);
@@ -128,6 +131,7 @@ class AuthorizationRequestHelperTest {
                                         jwsSigner,
                                         CRI_ID,
                                         IPV_CLIENT_ID_VALUE,
+                                        IPV_ISSUER,
                                         AUDIENCE,
                                         IPV_TOKEN_TTL,
                                         CORE_FRONT_CALLBACK_URL));
@@ -146,6 +150,7 @@ class AuthorizationRequestHelperTest {
                                         jwsSigner,
                                         CRI_ID,
                                         IPV_CLIENT_ID_VALUE,
+                                        IPV_ISSUER,
                                         AUDIENCE,
                                         IPV_TOKEN_TTL,
                                         "[[]]]][[["));

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -73,6 +73,7 @@ class CredentialIssuerServiceTest {
     @Test
     void validTokenResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getAudienceForClients()).thenReturn("test-issuer");
         when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         stubFor(
                 post("/token")
@@ -103,6 +104,7 @@ class CredentialIssuerServiceTest {
     @Test
     void tokenErrorResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getAudienceForClients()).thenReturn("test-issuer");
         when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         var errorJson =
                 "{ \"error\": \"invalid_request\", \"error_description\": \"Request was missing the 'redirect_uri' parameter.\", \"error_uri\": \"See the full API docs at https://authorization-server.com/docs/access_token\"}";
@@ -137,6 +139,7 @@ class CredentialIssuerServiceTest {
     @Test
     void invalidHeaderThrowsCredentialIssuerException(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getAudienceForClients()).thenReturn("test-issuer");
         when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         stubFor(
                 post("/token")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Use the correct SSM parameter when setting the iss claim of the JAR going to the CRI's.

Use the correct SSM parameter when setting the iss & sub claims of the client auth JWT on the /token request to a CRI

Add new SSM read permissions to the criStart and criReturn lambdas for the above SSM params.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The expected iss claim for ipv-core has changed so this ensure we are using the correct SSM params for these claim values when sending JWT's to a CRI.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1100](https://govukverify.atlassian.net/browse/PYIC-1100)

