### PR TITLE
Revert the iss and sub claims on the token client auth request jwt

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -81,8 +81,8 @@ public class CredentialIssuerService {
             OffsetDateTime dateTime = OffsetDateTime.now();
             ClientAuthClaims clientAuthClaims =
                     new ClientAuthClaims(
-                            configurationService.getAudienceForClients(),
-                            configurationService.getAudienceForClients(),
+                            config.getIpvClientId(),
+                            config.getIpvClientId(),
                             configurationService.getClientAudience(config.getId()),
                             dateTime.plusSeconds(
                                             Long.parseLong(configurationService.getIpvTokenTtl()))

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -73,7 +73,6 @@ class CredentialIssuerServiceTest {
     @Test
     void validTokenResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
-        when(mockConfigurationService.getAudienceForClients()).thenReturn("test-issuer");
         when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         stubFor(
                 post("/token")
@@ -104,7 +103,6 @@ class CredentialIssuerServiceTest {
     @Test
     void tokenErrorResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
-        when(mockConfigurationService.getAudienceForClients()).thenReturn("test-issuer");
         when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         var errorJson =
                 "{ \"error\": \"invalid_request\", \"error_description\": \"Request was missing the 'redirect_uri' parameter.\", \"error_uri\": \"See the full API docs at https://authorization-server.com/docs/access_token\"}";
@@ -139,7 +137,6 @@ class CredentialIssuerServiceTest {
     @Test
     void invalidHeaderThrowsCredentialIssuerException(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
-        when(mockConfigurationService.getAudienceForClients()).thenReturn("test-issuer");
         when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         stubFor(
                 post("/token")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Revert the iss and sub claims back to the original valyes. There are some unexpected behaviour with the nimbus PrivateKeyJWT that we are using to send the JWT. It is using the sub claim to store the clientId value as well causing a mismatch in the cri's.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Reverted back to the original values for now which should still work for the cris.
<!-- Describe the reason these changes were made - the "why" -->

