### PR TITLE
BAU: Increase Lambda RAM and change architecture to arm64 on all Lambdas.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -47,8 +47,8 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/accesstoken
       Architectures:
-        - x86_64
-      MemorySize: 512
+        - arm64
+      MemorySize: 4096
       Tracing: Active
       Environment:
         Variables:
@@ -84,8 +84,8 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/sessionend
       Architectures:
-        - x86_64
-      MemorySize: 512
+        - arm64
+      MemorySize: 4096
       Tracing: Active
       Environment:
         Variables:
@@ -120,8 +120,8 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/sessionstart
       Architectures:
-        - x86_64
-      MemorySize: 512
+        - arm64
+      MemorySize: 4096
       Tracing: Active
       Environment:
         Variables:
@@ -151,8 +151,8 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/credentialissuerreturn
       Architectures:
-        - x86_64
-      MemorySize: 512
+        - arm64
+      MemorySize: 4096
       Tracing: Active
       Environment:
         Variables:
@@ -209,7 +209,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/credentialissuerstart
       Architectures:
-        - x86_64
+        - arm64
       MemorySize: 3008
       Tracing: Active
       Environment:
@@ -259,7 +259,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/credentialissuererror
       Architectures:
-        - x86_64
+        - arm64
       MemorySize: 3008
       Tracing: Active
       Environment:
@@ -290,8 +290,8 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/useridentity
       Architectures:
-        - x86_64
-      MemorySize: 512
+        - arm64
+      MemorySize: 4096
       Tracing: Active
       Environment:
         Variables:
@@ -324,8 +324,8 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/credentialissuerconfig
       Architectures:
-        - x86_64
-      MemorySize: 512
+        - arm64
+      MemorySize: 4096
       Tracing: Active
       Environment:
         Variables:
@@ -355,8 +355,8 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/issuedcredentials
       Architectures:
-        - x86_64
-      MemorySize: 512
+        - arm64
+      MemorySize: 4096
       Tracing: Active
       Environment:
         Variables:
@@ -386,8 +386,8 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/journeyengine
       Architectures:
-        - x86_64
-      MemorySize: 512
+        - arm64
+      MemorySize: 4096
       Tracing: Active
       Environment:
         Variables:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
We spoke about increasing the RAM from 512 to 4096mb. This increases the RAM and uses the arm64 architecture (graviton)

<!-- Describe the changes in detail - the "what"-->

### Why did it change
To try and decrease the response times of our Lambdas