### PR TITLE
Fix incorect SSM var name for kms key id

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -221,6 +221,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/audienceForClients
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/jarKmsEncryptionKeyId
         - Statement:
             - Sid: jarKmsEncryptionKeyPermission
               Effect: Allow

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -177,7 +177,7 @@ public class ConfigurationService {
     public String getJarKmsEncryptionKeyId() {
         return ssmProvider.get(
                 String.format(
-                        "/%s/core/self/jarKmsEncryptionPublicKey", System.getenv(ENVIRONMENT)));
+                        "/%s/core/self/jarKmsEncryptionKeyId", System.getenv(ENVIRONMENT)));
     }
 
     public String getAudienceForClients() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated to use the correct SSM param name for the kms key id for the ipv-core JAR decryption.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Previously used the wrong SSM param name
