### PR TITLE
PYIC-1171 Add Provisioned Concurrency

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -13,6 +13,17 @@ Globals:
 Parameters:
   Environment:
     Type: String
+  ProvisionedConcurrentExecutions:
+    Type: Number
+    Description: >-
+      The number of lambda execution environments to keep permanently ready to reduce cold starts.
+    Default: 0
+
+Conditions:
+  AddProvisionedConcurrency: !Not
+    - !Equals
+      - !Ref ProvisionedConcurrentExecutions
+      -  0
 
 Resources:
 
@@ -130,6 +141,12 @@ Resources:
             RestApiId: !Ref IPVCoreExternalAPI
             Path: /token
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVAccessTokenFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -179,6 +196,12 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/session/end
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVSessionEndFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -239,6 +262,12 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /session/start
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVSessionStartFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -310,6 +339,12 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/return
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVCriReturnFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -373,6 +408,12 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/start/{criId}
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVCredentialIssuerStartFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -417,6 +458,12 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/error
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVCredentialIssuerErrorFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -464,6 +511,12 @@ Resources:
               Ref: IPVCoreExternalAPI
             Path: /user-identity
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVUserIdentityFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -508,6 +561,12 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /request-config
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVCredentialIssuerFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -552,6 +611,12 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /issued-credentials
             Method: GET
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVIssuedCredentialsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -598,6 +663,12 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/{journeyStep}
             Method: POST
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        !If
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - !Ref AWS::NoValue
 
   IPVJourneyEngineFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -18,7 +18,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVAccessTokenFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVAccessTokenFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
 
 
@@ -38,5 +38,5 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVUserIdentityFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVUserIdentityFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -19,7 +19,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVCredentialIssuerConfig.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVCredentialIssuerConfig.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
   /issued-credentials:
@@ -35,7 +35,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVIssuedCredentials.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVIssuedCredentials.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
   /session/start:
@@ -51,7 +51,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVSessionStartFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVSessionStartFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
   /journey/cri/return:
@@ -67,7 +67,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVCriReturnFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVCriReturnFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
   /journey/cri/error:
@@ -83,7 +83,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVCredentialIssuerErrorFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVCredentialIssuerErrorFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
   /journey/session/end:
@@ -99,7 +99,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVSessionEndFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVSessionEndFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
   /journey/{journeyStep}:
@@ -115,7 +115,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVJourneyEngineFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVJourneyEngineFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
   /journey/cri/start/{criId}:
@@ -131,7 +131,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVCredentialIssuerStartFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVCredentialIssuerStartFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
 


### PR DESCRIPTION
This adds a parameter named `ProvisionedConcurrentExecutions` to the CFN
template. When this is set to a value greater than 0 each Core Back
lambda will be provisioned that number of concurrent executions as a
means to reduce the impact of cold starts. The default value is 0 (this will help 
the roll out of this change to existing stacks).

This will permit turning on and adjusting provisioned concurrent
executions via CloudFormation update-stack operations.

In order to enable provisioned concurrent executions it is necessary to
also enable and create an alias and update the API Gateway invocation
mappings to reference the alias `live` in the lambda arns.


## Proposed changes
Please see above commit message. This is very much the M in MVP. It will allow the setting of provisioned concurrency via the `aws cloudformation` cli or via CloudFormation in the console by adjusting a stack parameter.

### Testing
I have applied this to my dev environment `dev-danw` and it worked as expected. I was able to adjust the provisioned concurrency using the following update-stack command (this example disables the concurrent executions, but passing a non-zero value enabled it to that value).
```
GDS11321:di-ipv-core-back dan.worth$ aws-vault exec di-ipv-dev -- aws cloudformation update-stack \
  --stack-name ipv-core-back-dev-danw \
  --use-previous-template \
  --parameters ParameterKey=ProvisionedConcurrentExecutions,ParameterValue=0 \ 
     ParameterKey=Environment,UsePreviousValue=true \
 --region eu-west-2 \
 --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND
```

### Why did it change
Enabling provisioned concurrency helps reduce the impact of cold-starts.

### Issue tracking

- [PYIC-1171](https://govukverify.atlassian.net/browse/PYIC-1171)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

