### PR TITLE
PYIC-1148: Persist OAuth State in Session Table and validate state in Response when CRI Returns.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -319,15 +319,17 @@ Resources:
         Variables:
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
-          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub cri-return-${Environment}
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref UserIssuedCredentialsTable
         - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
+        - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
@@ -403,11 +405,13 @@ Resources:
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsTable.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
+          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsTable
         - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
+        - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/signingKeyId

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -178,7 +178,7 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub session-end-${Environment}
           AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AuthCodesTable.Arn]]
-          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBWritePolicy:
@@ -323,7 +323,7 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub cri-return-${Environment}
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref UserIssuedCredentialsTable
@@ -405,7 +405,7 @@ Resources:
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsTable.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsTable
@@ -487,7 +487,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub credential-issuer-error-${Environment}
-          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
@@ -703,7 +703,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub session-${Environment}
-          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           IPV_JOURNEY_CRI_START_URI: "/journey/cri/start/"
           IPV_JOURNEY_SESSION_END_URI: "/journey/session/end"
       Policies:

--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -85,6 +85,7 @@ public class CredentialIssuerReturnHandler
             var errorResponse = validate(request);
 
             if (errorResponse.isPresent()) {
+                LOGGER.error("Validation failed: {}", errorResponse.get().getMessage());
                 return ApiGatewayResponseGenerator.proxyJsonResponse(400, errorResponse.get());
             }
             CredentialIssuerConfig credentialIssuerConfig = getCredentialIssuerConfig(request);

--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.lambda.powertools.tracing.Tracing;
@@ -37,7 +38,6 @@ public class CredentialIssuerReturnHandler
 
     private final CredentialIssuerService credentialIssuerService;
     private final ConfigurationService configurationService;
-    private final IpvSessionService ipvSessionService;
     private final AuditService auditService;
     private final VerifiableCredentialJwtValidator verifiableCredentialJwtValidator;
     private final IpvSessionService ipvSessionService;
@@ -47,11 +47,9 @@ public class CredentialIssuerReturnHandler
             ConfigurationService configurationService,
             IpvSessionService ipvSessionService,
             AuditService auditService,
-            VerifiableCredentialJwtValidator verifiableCredentialJwtValidator,
-            IpvSessionService ipvSessionService) {
+            VerifiableCredentialJwtValidator verifiableCredentialJwtValidator) {
         this.credentialIssuerService = credentialIssuerService;
         this.configurationService = configurationService;
-        this.ipvSessionService = ipvSessionService;
         this.auditService = auditService;
         this.verifiableCredentialJwtValidator = verifiableCredentialJwtValidator;
         this.ipvSessionService = ipvSessionService;
@@ -66,7 +64,6 @@ public class CredentialIssuerReturnHandler
                         new KmsEs256Signer(configurationService.getSigningKeyId()));
         this.auditService =
                 new AuditService(AuditService.getDefaultSqsClient(), configurationService);
-        this.ipvSessionService = new IpvSessionService(configurationService);
         this.verifiableCredentialJwtValidator =
                 new VerifiableCredentialJwtValidator(configurationService.getAudienceForClients());
         this.ipvSessionService = new IpvSessionService(configurationService);

--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
@@ -26,12 +26,14 @@ import uk.gov.di.ipv.core.library.domain.SharedAttributes;
 import uk.gov.di.ipv.core.library.domain.SharedAttributesResponse;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.AuthorizationRequestHelper;
 import uk.gov.di.ipv.core.library.helpers.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -42,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
@@ -111,31 +114,12 @@ public class CredentialIssuerStartHandler
 
         try {
             String ipvSessionId = getIpvSessionId(input.getHeaders());
+            UUID oauthState = UUID.randomUUID();
+            JWEObject jweObject = signEncryptJar(credentialIssuerConfig, ipvSessionId, oauthState);
 
-            SignedJWT signedJWT =
-                    AuthorizationRequestHelper.createSignedJWT(
-                            getSharedAttributes(ipvSessionId),
-                            signer,
-                            credentialIssuerConfig,
-                            configurationService,
-                            ipvSessionService
-                                    .getIpvSession(ipvSessionId)
-                                    .getClientSessionDetails()
-                                    .getUserId());
+            CriResponse criResponse = getCriResponse(credentialIssuerConfig, jweObject);
 
-            RSAEncrypter rsaEncrypter =
-                    new RSAEncrypter(credentialIssuerConfig.getJarEncryptionPublicJwk());
-
-            JWEObject jweObject =
-                    AuthorizationRequestHelper.createJweObject(rsaEncrypter, signedJWT);
-
-            CriResponse criResponse =
-                    new CriResponse(
-                            new CriDetails(
-                                    credentialIssuerConfig.getId(),
-                                    credentialIssuerConfig.getIpvClientId(),
-                                    credentialIssuerConfig.getAuthorizeUrl().toString(),
-                                    jweObject.serialize()));
+            persistOauthState(ipvSessionId, credentialIssuerConfig.getId(), oauthState);
 
             auditService.sendAuditEvent(AuditEventTypes.IPV_REDIRECT_TO_CRI);
 
@@ -152,6 +136,50 @@ public class CredentialIssuerStartHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         }
+    }
+
+    private CriResponse getCriResponse(
+            CredentialIssuerConfig credentialIssuerConfig, JWEObject jweObject) {
+        return new CriResponse(
+                new CriDetails(
+                        credentialIssuerConfig.getId(),
+                        credentialIssuerConfig.getIpvClientId(),
+                        credentialIssuerConfig.getAuthorizeUrl().toString(),
+                        jweObject.serialize()));
+    }
+
+    private JWEObject signEncryptJar(
+            CredentialIssuerConfig credentialIssuerConfig, String ipvSessionId, UUID oauthState)
+            throws HttpResponseExceptionWithErrorBody, ParseException, JOSEException {
+        SharedAttributesResponse sharedAttributesResponse = getSharedAttributes(ipvSessionId);
+        SignedJWT signedJWT =
+                getSignedJWT(
+                        credentialIssuerConfig,
+                        oauthState,
+                        sharedAttributesResponse,
+                        ipvSessionService
+                                .getIpvSession(ipvSessionId)
+                                .getClientSessionDetails()
+                                .getUserId());
+
+        RSAEncrypter rsaEncrypter =
+                new RSAEncrypter(credentialIssuerConfig.getJarEncryptionPublicJwk());
+        return AuthorizationRequestHelper.createJweObject(rsaEncrypter, signedJWT);
+    }
+
+    private SignedJWT getSignedJWT(
+            CredentialIssuerConfig credentialIssuerConfig,
+            UUID oauthState,
+            SharedAttributesResponse sharedAttributesResponse,
+            String userId)
+            throws HttpResponseExceptionWithErrorBody {
+        return AuthorizationRequestHelper.createSignedJWT(
+                sharedAttributesResponse,
+                signer,
+                credentialIssuerConfig,
+                configurationService,
+                oauthState,
+                userId);
     }
 
     @Tracing
@@ -209,5 +237,14 @@ public class CredentialIssuerStartHandler
                     BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
         }
         return ipvSessionId;
+    }
+
+    @Tracing
+    private void persistOauthState(String ipvSessionId, String criId, UUID oauthState) {
+        IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
+        CredentialIssuerSessionDetailsDto credentialIssuerSessionDetailsDto =
+                new CredentialIssuerSessionDetailsDto(criId, oauthState.toString());
+        ipvSessionItem.setCredentialIssuerSessionDetails(credentialIssuerSessionDetailsDto);
+        ipvSessionService.updateIpvSession(ipvSessionItem);
     }
 }

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -27,7 +27,6 @@ import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
-import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -80,6 +79,7 @@ class CredentialIssuerStartHandlerTest {
     public static final String SESSION_ID = "the-session-id";
     public static final String VTM = "http://www.example.com/vtm";
     public static final String TEST_USER_ID = "test-user-id";
+    public static final String OAUTH_STATE = "test-state";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -87,7 +87,6 @@ class CredentialIssuerStartHandlerTest {
     @Mock private ConfigurationService configurationService;
     @Mock private UserIdentityService userIdentityService;
     @Mock private AuditService mockAuditService;
-    @Mock private IpvSessionService ipvSessionService;
     @Mock private IpvSessionService mockIpvSessionService;
     @Mock private IpvSessionItem mockIpvSessionItem;
 
@@ -127,7 +126,7 @@ class CredentialIssuerStartHandlerTest {
                         "code",
                         "test-client-id",
                         "https://example.com/redirect",
-                        "test-state",
+                        OAUTH_STATE,
                         TEST_USER_ID,
                         false);
     }
@@ -169,7 +168,6 @@ class CredentialIssuerStartHandlerTest {
                                 VTM));
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
-        mockGetIPVSessionItem();
 
         APIGatewayProxyRequestEvent input = createRequestEvent(emptyMap(), emptyMap());
 
@@ -273,12 +271,6 @@ class CredentialIssuerStartHandlerTest {
         Map responseBody = getResponseBodyAsMap(response);
         assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
         assertEquals(errorResponse.getCode(), responseBody.get("code"));
-    }
-
-    private void mockGetIPVSessionItem() {
-        IpvSessionItem value = new IpvSessionItem();
-        value.setClientSessionDetails(new ClientSessionDetailsDto());
-        when(ipvSessionService.getIpvSession(SESSION_ID)).thenReturn(value);
     }
 
     private ECPrivateKey getSigningPrivateKey()

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -27,6 +27,7 @@ import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -86,6 +87,7 @@ class CredentialIssuerStartHandlerTest {
     @Mock private ConfigurationService configurationService;
     @Mock private UserIdentityService userIdentityService;
     @Mock private AuditService mockAuditService;
+    @Mock private IpvSessionService ipvSessionService;
     @Mock private IpvSessionService mockIpvSessionService;
     @Mock private IpvSessionItem mockIpvSessionItem;
 
@@ -167,6 +169,7 @@ class CredentialIssuerStartHandlerTest {
                                 VTM));
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
+        mockGetIPVSessionItem();
 
         APIGatewayProxyRequestEvent input = createRequestEvent(emptyMap(), emptyMap());
 
@@ -270,6 +273,12 @@ class CredentialIssuerStartHandlerTest {
         Map responseBody = getResponseBodyAsMap(response);
         assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
         assertEquals(errorResponse.getCode(), responseBody.get("code"));
+    }
+
+    private void mockGetIPVSessionItem() {
+        IpvSessionItem value = new IpvSessionItem();
+        value.setClientSessionDetails(new ClientSessionDetailsDto());
+        when(ipvSessionService.getIpvSession(SESSION_ID)).thenReturn(value);
     }
 
     private ECPrivateKey getSigningPrivateKey()

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -35,7 +35,9 @@ public enum ErrorResponse {
     INVALID_SESSION_REQUEST(1026, "Failed to parse the session start request"),
     FAILED_TO_BUILD_CORE_FRONT_CALLBACK_URL(1027, "Failed to build Core Front Callback Url"),
     FAILED_TO_ENCRYPT_JWT(1028, "Failed to encrypt JWT"),
-    FAILED_TO_GET_ENCRYPTION_PUBLIC_KEY(1029, "Failed to load Encryption Public Key");
+    FAILED_TO_GET_ENCRYPTION_PUBLIC_KEY(1029, "Failed to load Encryption Public Key"),
+    MISSING_OAUTH_STATE(1030, "Missing OAuth state in Response"),
+    INVALID_OAUTH_STATE(1031, "Invalid OAuth State");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
@@ -1,7 +1,9 @@
 package uk.gov.di.ipv.core.library.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+@ExcludeFromGeneratedCoverageReport
 public class CredentialIssuerRequestDto {
 
     private final String authorizationCode;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
@@ -12,15 +12,19 @@ public class CredentialIssuerRequestDto {
 
     private final String redirectUri;
 
+    private final String state;
+
     public CredentialIssuerRequestDto(
             @JsonProperty(value = "authorization_code") String authorizationCode,
             @JsonProperty(value = "credential_issuer_id") String credentialIssuerId,
             @JsonProperty(value = "ipv_session_id") String ipvSessionId,
-            @JsonProperty(value = "redirect_uri") String redirectUri) {
+            @JsonProperty(value = "redirect_uri") String redirectUri,
+            @JsonProperty(value = "state") String state) {
         this.authorizationCode = authorizationCode;
         this.credentialIssuerId = credentialIssuerId;
         this.ipvSessionId = ipvSessionId;
         this.redirectUri = redirectUri;
+        this.state = state;
     }
 
     public String getAuthorizationCode() {
@@ -37,5 +41,9 @@ public class CredentialIssuerRequestDto {
 
     public String getRedirectUri() {
         return redirectUri;
+    }
+
+    public String getState() {
+        return state;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerSessionDetailsDto.java
@@ -1,0 +1,35 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@DynamoDbBean
+public class CredentialIssuerSessionDetailsDto {
+    String criId;
+
+    String state;
+
+    public CredentialIssuerSessionDetailsDto() {}
+
+    public CredentialIssuerSessionDetailsDto(String criId, String state) {
+        this.criId = criId;
+        this.state = state;
+    }
+
+    public String getCriId() {
+        return criId;
+    }
+
+    public void setCriId(String criId) {
+        this.criId = criId;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Objects;
+import java.util.UUID;
 
 public class AuthorizationRequestHelper {
 
@@ -43,6 +44,7 @@ public class AuthorizationRequestHelper {
             JWSSigner signer,
             CredentialIssuerConfig credentialIssuerConfig,
             ConfigurationService configurationService,
+            UUID oauthState,
             String userId)
             throws HttpResponseExceptionWithErrorBody {
         Instant now = Instant.now();
@@ -60,7 +62,7 @@ public class AuthorizationRequestHelper {
                                 ResponseType.CODE,
                                 new ClientID(credentialIssuerConfig.getIpvClientId()))
                         .redirectionURI(redirectionURI)
-                        .state(new State("read"))
+                        .state(new State(oauthState.toString()))
                         .build()
                         .toJWTClaimsSet();
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -2,10 +2,12 @@ package uk.gov.di.ipv.core.library.persistence.item;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 
 @DynamoDbBean
+@ExcludeFromGeneratedCoverageReport
 public class IpvSessionItem {
     private String ipvSessionId;
     private String userState;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.library.persistence.item;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 
 @DynamoDbBean
 public class IpvSessionItem {
@@ -10,6 +11,7 @@ public class IpvSessionItem {
     private String userState;
     private String creationDateTime;
     private ClientSessionDetailsDto clientSessionDetails;
+    private CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {
@@ -42,5 +44,14 @@ public class IpvSessionItem {
 
     public void setClientSessionDetails(ClientSessionDetailsDto clientSessionDetails) {
         this.clientSessionDetails = clientSessionDetails;
+    }
+
+    public void setCredentialIssuerSessionDetails(
+            CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails) {
+        this.credentialIssuerSessionDetails = credentialIssuerSessionDetails;
+    }
+
+    public CredentialIssuerSessionDetailsDto getCredentialIssuerSessionDetails() {
+        return credentialIssuerSessionDetails;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -56,7 +56,6 @@ public class CredentialIssuerService {
                         isRunningLocally);
     }
 
-    // used for testing
     public CredentialIssuerService(
             DataStore<UserIssuedCredentialsItem> dataStore,
             ConfigurationService configurationService,

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
@@ -37,6 +37,7 @@ import java.text.ParseException;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -62,6 +63,7 @@ class AuthorizationRequestHelperTest {
     public static final String CORE_FRONT_CALLBACK_URL = "callbackUri";
     public static final String CRI_ID = "cri_id";
     public static final String TEST_USER_ID = "test-user-id";
+    public static final UUID OAUTH_STATE = UUID.randomUUID();
 
     private final SharedAttributesResponse sharedClaims =
             new SharedAttributesResponse(
@@ -100,12 +102,14 @@ class AuthorizationRequestHelperTest {
                         signer,
                         credentialIssuerConfig,
                         configurationService,
+                        OAUTH_STATE,
                         TEST_USER_ID);
 
         assertEquals(IPV_ISSUER, result.getJWTClaimsSet().getIssuer());
         assertEquals(TEST_USER_ID, result.getJWTClaimsSet().getSubject());
         assertEquals(AUDIENCE, result.getJWTClaimsSet().getAudience().get(0));
         assertEquals(sharedClaims, result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
+        assertEquals(OAUTH_STATE.toString(), result.getJWTClaimsSet().getClaim("state"));
         assertEquals(
                 IPV_CLIENT_ID_VALUE, result.getJWTClaimsSet().getClaims().get(CLIENT_ID_FIELD));
         assertEquals(
@@ -122,7 +126,7 @@ class AuthorizationRequestHelperTest {
 
         SignedJWT result =
                 AuthorizationRequestHelper.createSignedJWT(
-                        null, signer, credentialIssuerConfig, configurationService, TEST_USER_ID);
+                        null, signer, credentialIssuerConfig, configurationService, OAUTH_STATE, TEST_USER_ID);
         assertNull(result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
     }
 
@@ -140,6 +144,7 @@ class AuthorizationRequestHelperTest {
                                         jwsSigner,
                                         credentialIssuerConfig,
                                         configurationService,
+                                        OAUTH_STATE,
                                         TEST_USER_ID));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to sign Shared Attributes", exception.getErrorReason());
@@ -159,6 +164,7 @@ class AuthorizationRequestHelperTest {
                                         jwsSigner,
                                         credentialIssuerConfig,
                                         configurationService,
+                                        OAUTH_STATE,
                                         TEST_USER_ID));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to build Core Front Callback Url", exception.getErrorReason());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
@@ -126,7 +126,12 @@ class AuthorizationRequestHelperTest {
 
         SignedJWT result =
                 AuthorizationRequestHelper.createSignedJWT(
-                        null, signer, credentialIssuerConfig, configurationService, OAUTH_STATE, TEST_USER_ID);
+                        null,
+                        signer,
+                        credentialIssuerConfig,
+                        configurationService,
+                        OAUTH_STATE,
+                        TEST_USER_ID);
         assertNull(result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -54,6 +54,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_VC_1;
 class CredentialIssuerServiceTest {
 
     private static final String TEST_IPV_SESSION_ID = UUID.randomUUID().toString();
+    public static final String OAUTH_STATE = "oauth-state";
 
     @Mock private DataStore<UserIssuedCredentialsItem> mockDataStore;
     @Mock private ConfigurationService mockConfigurationService;
@@ -84,7 +85,8 @@ class CredentialIssuerServiceTest {
                         "1234",
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
-                        "http://www.example.com/redirect");
+                        "http://www.example.com/redirect",
+                        OAUTH_STATE);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -115,7 +117,8 @@ class CredentialIssuerServiceTest {
                         "1234",
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
-                        "http://www.example.com/redirect");
+                        "http://www.example.com/redirect",
+                        OAUTH_STATE);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -146,7 +149,8 @@ class CredentialIssuerServiceTest {
                         "1234",
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
-                        "http://www.example.com/redirect");
+                        "http://www.example.com/redirect",
+                        OAUTH_STATE);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
         CredentialIssuerException exception =
@@ -171,7 +175,8 @@ class CredentialIssuerServiceTest {
                         "1234",
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
-                        "http://www.example.com/redirect");
+                        "http://www.example.com/redirect",
+                        OAUTH_STATE);
 
         credentialIssuerService.persistUserCredentials(SIGNED_VC_1, credentialIssuerRequestDto);
         verify(mockDataStore).create(userIssuedCredentialsItemCaptor.capture());
@@ -195,7 +200,8 @@ class CredentialIssuerServiceTest {
                         "1234",
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
-                        "http://www.example.com/redirect");
+                        "http://www.example.com/redirect",
+                        OAUTH_STATE);
 
         doThrow(new UnsupportedOperationException()).when(mockDataStore).create(any());
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Persist OAuth State in Session Table and send as claim inside JAR.
- Validate state returned from CRI against value stored in Session Table.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
We must protect the security of your users by preventing request forgery attacks. The first step is creating a unique session token that holds state (UUID). You later match this unique session token with the authentication response returned by the CRI to verify that the user is making the request and not a malicious attacker. These tokens are often referred to as cross-site request forgery ([CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery)) tokens.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1148](https://govukverify.atlassian.net/browse/PYIC-1148)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed