### PR TITLE
PYIC-1089: Add audit event for IPV_JOURNEY_START

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -246,6 +246,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jarKmsEncryptionKeyId
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
         - Statement:
             - Sid: jarKmsEncryptionKeyPermission
               Effect: Allow

--- a/lambdas/sessionstart/build.gradle
+++ b/lambdas/sessionstart/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
 			"com.amazonaws:aws-lambda-java-events:3.11.0",
 			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
+			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
 			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
 			"com.fasterxml.jackson.core:jackson-core:2.13.0",
 			"com.fasterxml.jackson.core:jackson-databind:2.13.0",

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventTypes.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventTypes.java
@@ -5,4 +5,10 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @ExcludeFromGeneratedCoverageReport
 public enum AuditEventTypes {
     IPV_CREDENTIAL_RECEIVED_AND_SIGNATURE_CHECKED,
+    IPV_JOURNEY_START,
+    IPV_REDIRECT_TO_CRI,
+    IPV_VC_RECEIVED,
+    IPV_JOURNEY_END,
+    IPV_IDENTITY_ISSUED,
+    IPV_CRI_AUTH_RESPONSE_RECEIVED
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added audit event, IPV_JOURNEY_START, to the IpvSessionStart Lambda.
Updated AuditEventType enum for all known core audit events. 

### Why did it change

We need to send audit events to the audit system.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1089](https://govukverify.atlassian.net/browse/PYIC-1089)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
