### PR TITLE
PYIC-1165 Disable Splunk Logs for Integration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -25,6 +25,9 @@ Conditions:
       - !Ref ProvisionedConcurrentExecutions
       -  0
 
+  SendLogsToSplunk: !Not
+    - !Equals [ !Ref Environment, integration ]
+
 Resources:
 
   IPVCoreInternalAPI:
@@ -60,6 +63,7 @@ Resources:
       RetentionInDays: 14
 
   IPVCoreInternalAPILogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -99,6 +103,7 @@ Resources:
       RetentionInDays: 14
 
   IPVCoreExternalAPILogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -155,6 +160,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVAccessTokenFunction}"
 
   IPVAccessTokenFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -210,6 +216,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVSessionEndFunction}"
 
   IPVSessionEndFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -276,6 +283,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVSessionStartFunction}"
 
   IPVSessionStartFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -353,6 +361,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVCriReturnFunction}"
 
   IPVCriReturnFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -422,6 +431,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVCredentialIssuerStartFunction}"
 
   IPVCredentialIssuerStartFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -472,6 +482,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVCredentialIssuerErrorFunction}"
 
   IPVCredentialIssuerErrorFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -525,6 +536,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVUserIdentityFunction}"
 
   IPVUserIdentityFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -575,6 +587,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVCredentialIssuerConfig}"
 
   IPVCredentialIssuerFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -625,6 +638,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVIssuedCredentials}"
 
   IPVIssuedCredentialsFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -677,6 +691,7 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${IPVJourneyEngineFunction}"
 
   IPVJourneyEngineFunctionLogGroupSubscriptionFilter:
+    Condition: SendLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"


### PR DESCRIPTION
Whilst Cyber permit out integration account to send logs to Splunk we're
going to temporarily disable trying to send them so we can deploy the
core-back stack and continue progress.

### Why did it change
Please see commit, we'll revert this once Cyber have enabled our integration account.

