### PR TITLE
PYIC-1090: Add audit event for IPV_REDIRECT_TO_CRI

### DIFF
--- a/lambdas/credentialissuerstart/build.gradle
+++ b/lambdas/credentialissuerstart/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
 			"com.amazonaws:aws-lambda-java-events:3.11.0",
 			'com.amazonaws:aws-java-sdk-dynamodb:1.12.167',
+			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
 			'com.nimbusds:oauth2-oidc-sdk:9.27',
 			'com.fasterxml.jackson.core:jackson-core:2.13.2',
 			'com.fasterxml.jackson.core:jackson-databind:2.13.2',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added audit event, IPV_REDIRECT_TO_CRI, to the CredentialIssuerStart Lambda.

### Why did it change

We need to send audit events to the audit system.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1090](https://govukverify.atlassian.net/browse/PYIC-1090)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
