### PR TITLE
PYIC-1091: Add audit event for IPV_VC_RECEIVED

### DIFF
--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -79,6 +79,8 @@ public class CredentialIssuerReturnHandler
             auditService.sendAuditEvent(
                     AuditEventTypes.IPV_CREDENTIAL_RECEIVED_AND_SIGNATURE_CHECKED);
 
+            auditService.sendAuditEvent(AuditEventTypes.IPV_VC_RECEIVED);
+
             credentialIssuerService.persistUserCredentials(verifiableCredential, request);
 
             JourneyResponse journeyResponse = new JourneyResponse(NEXT_JOURNEY_STEP_URI);

--- a/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
+++ b/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
@@ -105,6 +105,8 @@ class CredentialIssuerReturnHandlerTest {
         verify(auditService)
                 .sendAuditEvent(AuditEventTypes.IPV_CREDENTIAL_RECEIVED_AND_SIGNATURE_CHECKED);
 
+        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_VC_RECEIVED);
+
         Integer statusCode = response.getStatusCode();
         Map responseBody = getResponseBodyAsMap(response);
         assertEquals(HTTPResponse.SC_OK, statusCode);


### PR DESCRIPTION
## Proposed changes

### What changed

Add an audit event `IPV_VC_RECEIVED` when a VC has been retrieved in the CredentialIssuerReturn lambda. This is in addition to the existing event `IPV_CREDENTIAL_RECEIVED_AND_SIGNATURE_CHECKED`. This is likely to be removed int he future, but we will send both for now.

At this stage we are only recording the event itself, with not payload. We will do that later when we have more details.

### Why did it change

We need to send audit events to the audit system.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1091](https://govukverify.atlassian.net/browse/PYIC-1091)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
