### PR TITLE
PYIC-1128: Add audit event for IPV_CRI_AUTH_RESPONSE_RECEIVED

### DIFF
--- a/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
+++ b/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
@@ -102,6 +102,8 @@ class CredentialIssuerReturnHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
 
+        verify(auditService).sendAuditEvent(AuditEventTypes.IPV_CRI_AUTH_RESPONSE_RECEIVED);
+
         verify(auditService)
                 .sendAuditEvent(AuditEventTypes.IPV_CREDENTIAL_RECEIVED_AND_SIGNATURE_CHECKED);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added audit event, IPV_CRI_AUTH_RESPONSE_RECEIVED, to the CredentialIssuerReturn Lambda.

### Why did it change

We need to send audit events to the audit system.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1128](https://govukverify.atlassian.net/browse/PYIC-1128)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
