### PR TITLE
PYIC-1089: Add SQS queue URL env var

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -233,6 +233,7 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub session-start-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt SessionsTable.Arn]]
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable


### PR DESCRIPTION
The Lambda need to know the URL of the SQS Queue, passed in the SQS_AUDIT_EVENT_QUEUE_URL env var. Add it.
