### PR TITLE
PYIC-974: Load params from the JAR and store in the back-end sessions

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -180,6 +180,11 @@ public class DataStoreIpvSessionIT {
 
     private ClientSessionDetailsDto generateClientSessionDetails() {
         return new ClientSessionDetailsDto(
-                "test-response-type", "test-client-id", "https//example.com", "test-state", false);
+                "test-response-type",
+                "test-client-id",
+                "https//example.com",
+                "test-state",
+                "test-user-id",
+                false);
     }
 }

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -110,9 +110,6 @@ public class DataStoreIpvSessionIT {
         assertEquals(
                 ipvSessionItem.getClientSessionDetails().getState(),
                 clientSessionDetailsDto.getState());
-        assertEquals(
-                ipvSessionItem.getClientSessionDetails().getScope(),
-                clientSessionDetailsDto.getScope());
     }
 
     @Test
@@ -143,9 +140,6 @@ public class DataStoreIpvSessionIT {
         assertEquals(
                 ipvSessionItem.getClientSessionDetails().getState(),
                 result.getClientSessionDetails().getState());
-        assertEquals(
-                ipvSessionItem.getClientSessionDetails().getScope(),
-                result.getClientSessionDetails().getScope());
     }
 
     @Test
@@ -182,19 +176,10 @@ public class DataStoreIpvSessionIT {
         assertEquals(
                 ipvSessionItem.getClientSessionDetails().getState(),
                 result.getClientSessionDetails().getState());
-        assertEquals(
-                ipvSessionItem.getClientSessionDetails().getScope(),
-                result.getClientSessionDetails().getScope());
     }
 
     private ClientSessionDetailsDto generateClientSessionDetails() {
         return new ClientSessionDetailsDto(
-                "test-response-type",
-                "test-client-id",
-                "https//example.com",
-                "test-state",
-                "test-scope",
-                false,
-                null);
+                "test-response-type", "test-client-id", "https//example.com", "test-state", false);
     }
 }

--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
@@ -119,9 +119,6 @@ public class SessionEndHandler
                     AuthRequestValidator.REDIRECT_URI_PARAM,
                     Collections.singletonList(clientSessionDetailsDto.getRedirectUri()));
             authParams.put(
-                    AuthRequestValidator.SCOPE_PARAM,
-                    Collections.singletonList(clientSessionDetailsDto.getScope()));
-            authParams.put(
                     AuthRequestValidator.STATE_PARAM,
                     Collections.singletonList(clientSessionDetailsDto.getState()));
 

--- a/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
+++ b/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
@@ -197,7 +197,12 @@ class SessionEndHandlerTest {
 
         ClientSessionDetailsDto clientSessionDetailsDto =
                 new ClientSessionDetailsDto(
-                        "code", "test-client-id", "https://example.com", "test-state", false);
+                        "code",
+                        "test-client-id",
+                        "https://example.com",
+                        "test-state",
+                        "test-user-id",
+                        false);
         item.setClientSessionDetails(clientSessionDetailsDto);
 
         return item;
@@ -205,6 +210,11 @@ class SessionEndHandlerTest {
 
     private ClientSessionDetailsDto generateValidClientSessionDetailsDto() {
         return new ClientSessionDetailsDto(
-                "code", "test-client-id", "https://example.com", "test-state", false);
+                "code",
+                "test-client-id",
+                "https://example.com",
+                "test-state",
+                "test-user-id",
+                false);
     }
 }

--- a/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
+++ b/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
@@ -197,13 +197,7 @@ class SessionEndHandlerTest {
 
         ClientSessionDetailsDto clientSessionDetailsDto =
                 new ClientSessionDetailsDto(
-                        "code",
-                        "test-client-id",
-                        "https://example.com",
-                        "openid",
-                        "test-state",
-                        false,
-                        null);
+                        "code", "test-client-id", "https://example.com", "test-state", false);
         item.setClientSessionDetails(clientSessionDetailsDto);
 
         return item;
@@ -211,12 +205,6 @@ class SessionEndHandlerTest {
 
     private ClientSessionDetailsDto generateValidClientSessionDetailsDto() {
         return new ClientSessionDetailsDto(
-                "code",
-                "test-client-id",
-                "https://example.com",
-                "openid",
-                "test-state",
-                false,
-                null);
+                "code", "test-client-id", "https://example.com", "test-state", false);
     }
 }

--- a/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
+++ b/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
@@ -153,6 +153,7 @@ public class IpvSessionStartHandler
                 clientId,
                 claimsSet.getStringClaim("redirect_uri"),
                 claimsSet.getStringClaim("state"),
+                claimsSet.getSubject(),
                 isDebugJourney);
     }
 

--- a/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
+++ b/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
@@ -5,8 +5,10 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
@@ -37,6 +39,9 @@ public class IpvSessionStartHandler
             LoggerFactory.getLogger(IpvSessionStartHandler.class.getName());
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final String IPV_SESSION_ID_KEY = "ipvSessionId";
+    private static final String CLIENT_ID_PARAM_KEY = "client_id";
+    private static final String REQUEST_PARAM_KEY = "request";
+    private static final String IS_DEBUG_JOURNEY_PARAM_KEY = "isDebugJourney";
 
     private final ConfigurationService configurationService;
     private final IpvSessionService ipvSessionService;
@@ -72,34 +77,37 @@ public class IpvSessionStartHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
-            ClientSessionDetailsDto clientSessionDetails =
-                    objectMapper.readValue(input.getBody(), ClientSessionDetailsDto.class);
+            Map<String, String> sessionParams =
+                    objectMapper.readValue(input.getBody(), new TypeReference<>() {});
 
-            Optional<ErrorResponse> error = validateClientSessionDetails(clientSessionDetails);
+            Optional<ErrorResponse> error = validateSessionParams(sessionParams);
 
             if (error.isPresent()) {
-                LOGGER.error("Validation of the client session details failed");
+                LOGGER.error(
+                        "Validation of the client session params failed because: {}",
+                        error.get().getMessage());
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         HttpStatus.SC_BAD_REQUEST, error.get());
             }
 
-            if (StringUtils.isNotBlank(clientSessionDetails.getRequest())) {
-                SignedJWT signedJWT = decryptRequest(clientSessionDetails.getRequest());
-                jarValidator.validateRequestJwt(signedJWT, clientSessionDetails.getClientId());
-            }
+            SignedJWT signedJWT = decryptRequest(sessionParams.get(REQUEST_PARAM_KEY));
+            JWTClaimsSet claimsSet =
+                    jarValidator.validateRequestJwt(
+                            signedJWT, sessionParams.get(CLIENT_ID_PARAM_KEY));
 
-            String ipvSessionId = ipvSessionService.generateIpvSession(clientSessionDetails);
+            ClientSessionDetailsDto clientSessionDetailsDto =
+                    generateClientSessionDetails(
+                            claimsSet,
+                            sessionParams.get(CLIENT_ID_PARAM_KEY),
+                            Boolean.parseBoolean(sessionParams.get(IS_DEBUG_JOURNEY_PARAM_KEY)));
+
+            String ipvSessionId = ipvSessionService.generateIpvSession(clientSessionDetailsDto);
 
             auditService.sendAuditEvent(AuditEventTypes.IPV_JOURNEY_START);
 
             Map<String, String> response = Map.of(IPV_SESSION_ID_KEY, ipvSessionId);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, response);
-        } catch (IllegalArgumentException | JsonProcessingException e) {
-            LOGGER.error(
-                    "Failed to parse the request body into a ClientSessionDetailsDto object", e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_REQUEST);
         } catch (ParseException e) {
             LOGGER.error("Failed to parse the decrypted JWE because: {}", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
@@ -112,34 +120,23 @@ public class IpvSessionStartHandler
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            LOGGER.error("Failed to parse request body into map because: {}", e.getMessage());
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_REQUEST);
         }
     }
 
-    private Optional<ErrorResponse> validateClientSessionDetails(
-            ClientSessionDetailsDto clientSessionDetailsDto) {
+    private Optional<ErrorResponse> validateSessionParams(Map<String, String> sessionParams) {
         boolean isInvalid = false;
-        if (StringUtils.isBlank(clientSessionDetailsDto.getResponseType())) {
-            LOGGER.warn("Missing response_type query parameter");
-            isInvalid = true;
-        }
 
-        if (StringUtils.isBlank(clientSessionDetailsDto.getClientId())) {
+        if (StringUtils.isBlank(sessionParams.get(CLIENT_ID_PARAM_KEY))) {
             LOGGER.warn("Missing client_id query parameter");
             isInvalid = true;
         }
 
-        if (StringUtils.isBlank(clientSessionDetailsDto.getRedirectUri())) {
-            LOGGER.warn("Missing redirect_uri query parameter");
-            isInvalid = true;
-        }
-
-        if (StringUtils.isBlank(clientSessionDetailsDto.getScope())) {
-            LOGGER.warn("Missing scope query parameter");
-            isInvalid = true;
-        }
-
-        if (StringUtils.isBlank(clientSessionDetailsDto.getState())) {
-            LOGGER.warn("Missing state query parameter");
+        if (StringUtils.isBlank(sessionParams.get(REQUEST_PARAM_KEY))) {
+            LOGGER.warn("Missing request query parameter");
             isInvalid = true;
         }
 
@@ -147,6 +144,16 @@ public class IpvSessionStartHandler
             return Optional.of(ErrorResponse.INVALID_SESSION_REQUEST);
         }
         return Optional.empty();
+    }
+
+    private ClientSessionDetailsDto generateClientSessionDetails(
+            JWTClaimsSet claimsSet, String clientId, boolean isDebugJourney) throws ParseException {
+        return new ClientSessionDetailsDto(
+                claimsSet.getStringClaim("response_type"),
+                clientId,
+                claimsSet.getStringClaim("redirect_uri"),
+                claimsSet.getStringClaim("state"),
+                isDebugJourney);
     }
 
     private SignedJWT decryptRequest(String jarString)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
@@ -9,10 +9,8 @@ public class ClientSessionDetailsDto {
     String responseType;
     String clientId;
     String redirectUri;
-    String scope;
     String state;
     boolean isDebugJourney;
-    String request;
 
     public ClientSessionDetailsDto() {}
 
@@ -20,17 +18,13 @@ public class ClientSessionDetailsDto {
             String responseType,
             String clientId,
             String redirectUri,
-            String scope,
             String state,
-            boolean isDebugJourney,
-            String request) {
+            boolean isDebugJourney) {
         this.responseType = responseType;
         this.clientId = clientId;
         this.redirectUri = redirectUri;
-        this.scope = scope;
         this.state = state;
         this.isDebugJourney = isDebugJourney;
-        this.request = request;
     }
 
     public String getResponseType() {
@@ -57,14 +51,6 @@ public class ClientSessionDetailsDto {
         this.redirectUri = redirectUri;
     }
 
-    public String getScope() {
-        return scope;
-    }
-
-    public void setScope(String scope) {
-        this.scope = scope;
-    }
-
     public String getState() {
         return state;
     }
@@ -79,13 +65,5 @@ public class ClientSessionDetailsDto {
 
     public void setIsDebugJourney(boolean isDebugJourney) {
         this.isDebugJourney = isDebugJourney;
-    }
-
-    public String getRequest() {
-        return request;
-    }
-
-    public void setRequest(String request) {
-        this.request = request;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
@@ -10,6 +10,7 @@ public class ClientSessionDetailsDto {
     String clientId;
     String redirectUri;
     String state;
+    String userId;
     boolean isDebugJourney;
 
     public ClientSessionDetailsDto() {}
@@ -19,11 +20,13 @@ public class ClientSessionDetailsDto {
             String clientId,
             String redirectUri,
             String state,
+            String userId,
             boolean isDebugJourney) {
         this.responseType = responseType;
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.state = state;
+        this.userId = userId;
         this.isDebugJourney = isDebugJourney;
     }
 
@@ -57,6 +60,14 @@ public class ClientSessionDetailsDto {
 
     public void setState(String state) {
         this.state = state;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 
     public boolean getIsDebugJourney() {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -59,13 +59,7 @@ class IpvSessionServiceTest {
         String ipvSessionID =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
-                                "jwt",
-                                "test-client",
-                                "http://example.come",
-                                "test-scope",
-                                "test-state",
-                                false,
-                                null));
+                                "jwt", "test-client", "http://example.come", "test-state", false));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -84,13 +78,7 @@ class IpvSessionServiceTest {
         String ipvSessionID =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
-                                "jwt",
-                                "test-client",
-                                "http://example.come",
-                                "test-scope",
-                                "test-state",
-                                true,
-                                null));
+                                "jwt", "test-client", "http://example.come", "test-state", true));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -59,7 +59,12 @@ class IpvSessionServiceTest {
         String ipvSessionID =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
-                                "jwt", "test-client", "http://example.come", "test-state", false));
+                                "jwt",
+                                "test-client",
+                                "http://example.come",
+                                "test-state",
+                                "test-user-id",
+                                false));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -78,7 +83,12 @@ class IpvSessionServiceTest {
         String ipvSessionID =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
-                                "jwt", "test-client", "http://example.come", "test-state", true));
+                                "jwt",
+                                "test-client",
+                                "http://example.come",
+                                "test-state",
+                                "test-user-id",
+                                true));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated session start lambda to only need to accept the "request", "client_id" and "isDebugJourney" params from the request body being sent front front. The previous params are now being retrieved out of the decrypted JAR and stored in the back-end session from there.

Also store the subject of the jar with the rest of the session data to be used later for validation purposes and used during the SessionEnd lambda
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We now will receive various Oauth params from within the decrypted JAR rather than query params.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-974](https://govukverify.atlassian.net/browse/PYIC-974)

