### PR TITLE
PYIC-1198: Update Lambda infrastructure to allow sending messages to SQS

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -179,6 +179,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub session-end-${Environment}
           AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AuthCodesTable.Arn]]
           IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBWritePolicy:
             TableName: !Ref AuthCodesTable
@@ -188,6 +189,16 @@ Resources:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
               ParameterName: !Sub ${Environment}/core/*
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
+        - Statement:
+            - Sid: kmsAuditEventQueueEncryptionKeyPermission
+                Effect: Allow
+                Action:
+                  - 'kms:Decrypt'
+                  - 'kms:GenerateDataKey'
+                Resource:
+                  - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
         IPVCoreInternalAPI:
           Type: Api
@@ -388,6 +399,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub credential-issuer-start-${Environment}
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsTable.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsTable
@@ -403,6 +415,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
         - Statement:
             - Sid: kmsSigningKeyPermission
               Effect: Allow
@@ -410,6 +424,13 @@ Resources:
                 - 'kms:sign'
               Resource:
                 - !ImportValue SigningKeyArn
+            - Sid: kmsAuditEventQueueEncryptionKeyPermission
+                Effect: Allow
+                Action:
+                  - 'kms:Decrypt'
+                  - 'kms:GenerateDataKey'
+                Resource:
+                  - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
         IPVCoreInternalAPI:
           Type: Api
@@ -506,6 +527,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub user-identity-${Environment}
           ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AccessTokensTable.Arn]]
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsTable
@@ -513,6 +535,16 @@ Resources:
             TableName: !Ref UserIssuedCredentialsTable
         - DynamoDBCrudPolicy:
             TableName: !Ref AccessTokensTable
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
+        - Statement:
+            - Sid: kmsAuditEventQueueEncryptionKeyPermission
+                Effect: Allow
+                Action:
+                  - 'kms:Decrypt'
+                  - 'kms:GenerateDataKey'
+                Resource:
+                  - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
         IPVCoreExternalAPI:
           Type: Api


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Lambdas that need to send audit messages to SQS require permission to:
 * Send messags to SQS
 * Access the KMS to encrypt messages using Data Keys

They also need to know the URL of the audit event queue.

This commit adds permissions for the lambdas we are adding audit events to for now:
 * SessionEnd
 * CredentialIssuerStart
 * UserIdentity


<!-- Describe the changes in detail - the "what"-->

### Why did it change

We need to send audit messages.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1198](https://govukverify.atlassian.net/browse/PYIC-1198)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
