### PR TITLE
Fix param name

### DIFF
--- a/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
+++ b/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
@@ -39,7 +39,7 @@ public class IpvSessionStartHandler
             LoggerFactory.getLogger(IpvSessionStartHandler.class.getName());
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final String IPV_SESSION_ID_KEY = "ipvSessionId";
-    private static final String CLIENT_ID_PARAM_KEY = "client_id";
+    private static final String CLIENT_ID_PARAM_KEY = "clientId";
     private static final String REQUEST_PARAM_KEY = "request";
     private static final String IS_DEBUG_JOURNEY_PARAM_KEY = "isDebugJourney";
 

--- a/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
+++ b/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
@@ -100,7 +100,7 @@ class IpvSessionStartHandlerTest {
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams =
-                Map.of("client_id", "test-client", "request", signedJWT.serialize());
+                Map.of("clientId", "test-client", "request", signedJWT.serialize());
         event.setBody(objectMapper.writeValueAsString(sessionParams));
 
         APIGatewayProxyResponseEvent response =
@@ -171,7 +171,7 @@ class IpvSessionStartHandlerTest {
     void shouldReturn400IfMissingRequestParameter() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
-        Map<String, Object> sessionParams = Map.of("client_id", "test-client");
+        Map<String, Object> sessionParams = Map.of("clientId", "test-client");
 
         event.setBody(objectMapper.writeValueAsString(sessionParams));
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Fix the clientId param name that core-front sends to the session start lambda
<!-- Describe the changes in detail - the "what"-->

