### PR TITLE
PYIC-1181: Update session-end lambda to return the full redirect url with query params

### DIFF
--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/domain/ClientDetails.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/domain/ClientDetails.java
@@ -8,28 +8,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(Include.NON_EMPTY)
 public class ClientDetails {
     @JsonProperty private final String redirectUrl;
-    @JsonProperty private final String authCode;
-    @JsonProperty private final String state;
 
     @JsonCreator
-    public ClientDetails(
-            @JsonProperty(value = "redirectUrl", required = true) String redirectUrl,
-            @JsonProperty(value = "authCode", required = true) String authCode,
-            @JsonProperty(value = "state") String state) {
+    public ClientDetails(@JsonProperty(value = "redirectUrl", required = true) String redirectUrl) {
         this.redirectUrl = redirectUrl;
-        this.authCode = authCode;
-        this.state = state;
     }
 
     public String getRedirectUrl() {
         return redirectUrl;
-    }
-
-    public String getAuthCode() {
-        return authCode;
-    }
-
-    public String getState() {
-        return state;
     }
 }

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -160,11 +160,9 @@ components:
         client:
           type: object
           description: redirect to the oauth client, ending the session.
-          required: [ "callbackUrl", "authcode" ]
+          required: [ "callbackUrl" ]
           properties:
             callbackUrl:
-              type: string
-            authcode:
               type: string
       oneOf:
         - required: [ "page" ]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the session end lambda to return a fully defined redirect url with the query params.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We previously sent all the details back seperately  and had core-front stich it together into the redirect_uri. Now do this on the back-end which will make things easier when it comes to our error handling and have different things added onto the redirect uri as query params
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1181](https://govukverify.atlassian.net/browse/PYIC-1181)

