### PR TITLE
PYIC-1202: Add new sub property to user identity response

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -418,8 +418,6 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/coreFrontCallbackUrl
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/coreVtmClaim
-        - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
@@ -535,6 +533,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub user-identity-${Environment}
           ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AccessTokensTable.Arn]]
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
+          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBReadPolicy:
@@ -543,6 +542,8 @@ Resources:
             TableName: !Ref UserIssuedCredentialsTable
         - DynamoDBCrudPolicy:
             TableName: !Ref AccessTokensTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:

--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
@@ -24,7 +24,6 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.SharedAttributes;
 import uk.gov.di.ipv.core.library.domain.SharedAttributesResponse;
-import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
@@ -170,10 +169,10 @@ public class CredentialIssuerStartHandler
     @Tracing
     private SharedAttributesResponse getSharedAttributes(String ipvSessionId)
             throws HttpResponseExceptionWithErrorBody {
-        UserIdentity credentials = userIdentityService.getUserIssuedCredentials(ipvSessionId);
+        List<String> credentials = userIdentityService.getUserIssuedCredentials(ipvSessionId);
 
         List<SharedAttributes> sharedAttributes = new ArrayList<>();
-        for (String credential : credentials.getVcs()) {
+        for (String credential : credentials) {
             try {
                 JsonNode credentialSubject =
                         mapper.readTree(SignedJWT.parse(credential).getPayload().toString())

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -22,8 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.UserIdentity;
-import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -51,7 +49,6 @@ import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -155,18 +152,13 @@ class CredentialIssuerStartHandlerTest {
         when(configurationService.getIpvTokenTtl()).thenReturn("900");
         when(configurationService.getCoreFrontCallbackUrl()).thenReturn("callbackUrl");
         when(configurationService.getAudienceForClients()).thenReturn(IPV_ISSUER);
+        when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(SESSION_ID))
                 .thenReturn(
-                        new UserIdentity(
-                                List.of(
-                                        generateVerifiableCredential(
-                                                vcClaim(CREDENTIAL_ATTRIBUTES_1)),
-                                        generateVerifiableCredential(
-                                                vcClaim(CREDENTIAL_ATTRIBUTES_2))),
-                                VectorOfTrust.P2.toString(),
-                                VTM));
-        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(mockIpvSessionItem);
-        when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
+                        List.of(
+                                generateVerifiableCredential(vcClaim(CREDENTIAL_ATTRIBUTES_1)),
+                                generateVerifiableCredential(vcClaim(CREDENTIAL_ATTRIBUTES_2))));
 
         APIGatewayProxyRequestEvent input = createRequestEvent(emptyMap(), emptyMap());
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -15,6 +15,8 @@ public class UserIdentity {
     @JsonProperty("https://vocab.sign-in.service.gov.uk/v1/credentials")
     private List<String> vcs;
 
+    @JsonProperty private String sub;
+
     @JsonProperty private String vot;
 
     @JsonProperty private String vtm;
@@ -25,20 +27,28 @@ public class UserIdentity {
                             value = "https://vocab.sign-in.service.gov.uk/v1/credentials",
                             required = true)
                     List<String> vcs,
+            @JsonProperty(value = "sub", required = true) String sub,
             @JsonProperty(value = "vot", required = true) String vot,
             @JsonProperty(value = "vtm", required = true) String vtm) {
         this.vcs = vcs;
+        this.sub = sub;
         this.vot = vot;
         this.vtm = vtm;
     }
 
     public static class Builder {
         private List<String> vcs;
+        private String sub;
         private String vot;
         private String vtm;
 
         public Builder setVcs(List<String> vcs) {
             this.vcs = vcs;
+            return this;
+        }
+
+        public Builder setSub(String sub) {
+            this.sub = sub;
             return this;
         }
 
@@ -53,7 +63,7 @@ public class UserIdentity {
         }
 
         public UserIdentity build() {
-            return new UserIdentity(vcs, vot, vtm);
+            return new UserIdentity(vcs, sub, vot, vtm);
         }
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -59,7 +59,15 @@ public class UserIdentityService {
         this.dataStore = dataStore;
     }
 
-    public UserIdentity getUserIssuedCredentials(String ipvSessionId) {
+    public List<String> getUserIssuedCredentials(String ipvSessionId) {
+        List<UserIssuedCredentialsItem> credentialIssuerItems = dataStore.getItems(ipvSessionId);
+
+        return credentialIssuerItems.stream()
+                .map(UserIssuedCredentialsItem::getCredential)
+                .collect(Collectors.toList());
+    }
+
+    public UserIdentity generateUserIdentity(String ipvSessionId, String sub) {
         List<UserIssuedCredentialsItem> credentialIssuerItems = dataStore.getItems(ipvSessionId);
 
         List<String> vcJwts =
@@ -71,7 +79,12 @@ public class UserIdentityService {
 
         String vtm = configurationService.getCoreVtmClaim();
 
-        return new UserIdentity.Builder().setVcs(vcJwts).setVot(vot).setVtm(vtm).build();
+        return new UserIdentity.Builder()
+                .setVcs(vcJwts)
+                .setSub(sub)
+                .setVot(vot)
+                .setVtm(vtm)
+                .build();
     }
 
     public Map<String, String> getUserIssuedDebugCredentials(String ipvSessionId) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -235,6 +235,23 @@ class UserIdentityServiceTest {
         assertEquals("mock-vtm-claim", credentials.getVtm());
     }
 
+    @Test
+    void shouldReturnListOfVcsForSharedAttributes() {
+        List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
+                List.of(
+                        createUserIssuedCredentialsItem(
+                                "ipv-session-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                        createUserIssuedCredentialsItem(
+                                "ipv-session-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()));
+
+        when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
+
+        List<String> vcList = userIdentityService.getUserIssuedCredentials("ipv-session-id-1");
+
+        assertEquals(SIGNED_VC_1, vcList.get(0));
+        assertEquals(SIGNED_VC_2, vcList.get(1));
+    }
+
     private UserIssuedCredentialsItem createUserIssuedCredentialsItem(
             String ipvSessionId,
             String credentialIssuer,

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -51,10 +51,12 @@ class UserIdentityServiceTest {
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
-        UserIdentity credentials = userIdentityService.getUserIssuedCredentials("ipv-session-id-1");
+        UserIdentity credentials =
+                userIdentityService.generateUserIdentity("ipv-session-id-1", "test-sub");
 
         assertEquals(SIGNED_VC_1, credentials.getVcs().get(0));
         assertEquals(SIGNED_VC_2, credentials.getVcs().get(1));
+        assertEquals("test-sub", credentials.getSub());
     }
 
     @Test
@@ -171,7 +173,8 @@ class UserIdentityServiceTest {
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
-        UserIdentity credentials = userIdentityService.getUserIssuedCredentials("ipv-session-id-1");
+        UserIdentity credentials =
+                userIdentityService.generateUserIdentity("ipv-session-id-1", "test-sub");
 
         assertEquals(VectorOfTrust.P2.toString(), credentials.getVot());
     }
@@ -187,9 +190,20 @@ class UserIdentityServiceTest {
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
-        UserIdentity credentials = userIdentityService.getUserIssuedCredentials("ipv-session-id-1");
+        UserIdentity credentials =
+                userIdentityService.generateUserIdentity("ipv-session-id-1", "test-sub");
 
         assertEquals(VectorOfTrust.P0.toString(), credentials.getVot());
+    }
+
+    @Test
+    void shouldSetsubClaimOnUserIdentity() {
+        when(mockConfigurationService.getCoreVtmClaim()).thenReturn("mock-vtm-claim");
+
+        UserIdentity credentials =
+                userIdentityService.generateUserIdentity("ipv-session-id-1", "test-sub");
+
+        assertEquals("test-sub", credentials.getSub());
     }
 
     @Test
@@ -205,7 +219,8 @@ class UserIdentityServiceTest {
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
-        UserIdentity credentials = userIdentityService.getUserIssuedCredentials("ipv-session-id-1");
+        UserIdentity credentials =
+                userIdentityService.generateUserIdentity("ipv-session-id-1", "test-sub");
 
         assertEquals(VectorOfTrust.P0.toString(), credentials.getVot());
     }
@@ -214,7 +229,8 @@ class UserIdentityServiceTest {
     void shouldSetVtmClaimOnUserIdentity() {
         when(mockConfigurationService.getCoreVtmClaim()).thenReturn("mock-vtm-claim");
 
-        UserIdentity credentials = userIdentityService.getUserIssuedCredentials("ipv-session-id-1");
+        UserIdentity credentials =
+                userIdentityService.generateUserIdentity("ipv-session-id-1", "test-sub");
 
         assertEquals("mock-vtm-claim", credentials.getVtm());
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Load the user-id value from the Sessions DynamoDB table and set it as the "sub" property on the userIdentity response.

Refactor the criStart lambda to no longer construct a UserIdentiy object and remove he unnessary lambda ssm policy for the vtm claim param
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The sub value being returned needs to be same the sub value received during the orc JAR, which the value of has been stored in Session DynamoDB table.

The refactor will clean up what the CriStart lambda actually needs from the UserIdenity service and means we can remove an unnecessary lambda SSM read policy permission.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1202](https://govukverify.atlassian.net/browse/PYIC-1202)
