### PR TITLE
PYIC-992: Validate verifiable credential JWT received from CRIs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -319,6 +319,7 @@ Resources:
         Variables:
           CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsTable.Arn]]
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub cri-return-${Environment}
@@ -326,6 +327,8 @@ Resources:
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref UserIssuedCredentialsTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:

--- a/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
+++ b/lambdas/credentialissuerconfig/src/test/java/uk/gov/di/ipv/core/credentialisserconfig/CredentialIssuerConfigHandlerTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PUBLIC_JWK;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerConfigHandlerTest {
@@ -37,7 +38,9 @@ class CredentialIssuerConfigHandlerTest {
                             URI.create("test1credentialUrl"),
                             URI.create("test1AuthorizeUrl"),
                             "ipv-core",
-                            EC_PUBLIC_JWK),
+                            EC_PUBLIC_JWK,
+                            RSA_ENCRYPTION_PUBLIC_JWK,
+                            "test-audience"),
                     new CredentialIssuerConfig(
                             "test2",
                             "Any",
@@ -45,7 +48,9 @@ class CredentialIssuerConfigHandlerTest {
                             URI.create("test2credentialUrl"),
                             URI.create("test2AuthorizeUrl"),
                             "ipv-core",
-                            EC_PUBLIC_JWK));
+                            EC_PUBLIC_JWK,
+                            RSA_ENCRYPTION_PUBLIC_JWK,
+                            "test-audience"));
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/lambdas/credentialissuerreturn/build.gradle
+++ b/lambdas/credentialissuerreturn/build.gradle
@@ -37,7 +37,8 @@ dependencies {
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
 			"com.github.tomakehurst:wiremock-jre8:2.31.0",
-			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
+			"uk.org.webcompere:system-stubs-jupiter:1.1.0",
+			project(":lib").sourceSets.test.output
 }
 
 java {

--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -77,7 +77,7 @@ public class CredentialIssuerReturnHandler
                     credentialIssuerService.exchangeCodeForToken(request, credentialIssuerConfig);
             String verifiableCredential =
                     credentialIssuerService.getVerifiableCredential(
-                            accessToken, credentialIssuerConfig, request.getIpvSessionId());
+                            accessToken, credentialIssuerConfig);
 
             auditService.sendAuditEvent(
                     AuditEventTypes.IPV_CREDENTIAL_RECEIVED_AND_SIGNATURE_CHECKED);

--- a/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
+++ b/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerReturnHandlerTest {
@@ -71,7 +72,9 @@ class CredentialIssuerReturnHandlerTest {
                         new URI("http://www.example.com/credential"),
                         new URI("http://www.example.com/authorize"),
                         "ipv-core",
-                        "{}");
+                        "{}",
+                        RSA_ENCRYPTION_PUBLIC_JWK,
+                        "test-audience");
     }
 
     @Test

--- a/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
+++ b/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
@@ -98,7 +98,7 @@ class CredentialIssuerReturnHandlerTest {
         when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
                 .thenReturn(new BearerAccessToken());
 
-        when(credentialIssuerService.getVerifiableCredential(any(), any(), any()))
+        when(credentialIssuerService.getVerifiableCredential(any(), any()))
                 .thenReturn(TEST_VERIFIABLE_CREDENTIAL);
 
         when(configurationService.getCredentialIssuer("PassportIssuer")).thenReturn(passportIssuer);
@@ -186,8 +186,7 @@ class CredentialIssuerReturnHandlerTest {
         when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
                 .thenReturn(accessToken);
 
-        when(credentialIssuerService.getVerifiableCredential(
-                        accessToken, passportIssuer, sessionId))
+        when(credentialIssuerService.getVerifiableCredential(accessToken, passportIssuer))
                 .thenReturn(TEST_VERIFIABLE_CREDENTIAL);
 
         when(configurationService.getCredentialIssuer("PassportIssuer")).thenReturn(passportIssuer);
@@ -254,7 +253,7 @@ class CredentialIssuerReturnHandlerTest {
             throws JsonProcessingException {
         when(credentialIssuerService.exchangeCodeForToken(any(), any()))
                 .thenReturn(new BearerAccessToken());
-        when(credentialIssuerService.getVerifiableCredential(any(), any(), any()))
+        when(credentialIssuerService.getVerifiableCredential(any(), any()))
                 .thenThrow(
                         new CredentialIssuerException(
                                 HTTPResponse.SC_SERVER_ERROR,

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -26,7 +26,6 @@ import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
-
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.library.dto;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.net.URI;
@@ -20,9 +21,12 @@ public class CredentialIssuerConfig {
     private URI authorizeUrl;
     private String ipvClientId;
     private String vcVerifyingPublicJwk;
+    private String jarEncryptionPublicJwk;
+    private String audienceForClients;
 
     public CredentialIssuerConfig() {}
 
+    @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public CredentialIssuerConfig(
             String id,
             String name,
@@ -30,7 +34,9 @@ public class CredentialIssuerConfig {
             URI credentialUrl,
             URI authorizeUrl,
             String ipvClientId,
-            String vcVerifyingPublicJwk) {
+            String vcVerifyingPublicJwk,
+            String jarEncryptionPublicJwk,
+            String audienceForClients) {
         this.id = id;
         this.name = name;
         this.tokenUrl = tokenUrl;
@@ -38,6 +44,8 @@ public class CredentialIssuerConfig {
         this.authorizeUrl = authorizeUrl;
         this.ipvClientId = ipvClientId;
         this.vcVerifyingPublicJwk = vcVerifyingPublicJwk;
+        this.jarEncryptionPublicJwk = jarEncryptionPublicJwk;
+        this.audienceForClients = audienceForClients;
     }
 
     public String getId() {
@@ -71,6 +79,19 @@ public class CredentialIssuerConfig {
 
     public ECKey getVcVerifyingPublicJwk() throws ParseException {
         return ECKey.parse(vcVerifyingPublicJwk);
+    }
+
+    @JsonGetter("jarEncryptionPublicJwk")
+    public String getJarEncryptionPublicJwkString() {
+        return jarEncryptionPublicJwk;
+    }
+
+    public RSAKey getJarEncryptionPublicJwk() throws ParseException {
+        return RSAKey.parse(jarEncryptionPublicJwk);
+    }
+
+    public String getAudienceForClients() {
+        return audienceForClients;
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
@@ -66,7 +66,7 @@ public class AuthorizationRequestHelper {
 
         JWTClaimsSet.Builder claimsSetBuilder =
                 new JWTClaimsSet.Builder(authClaimsSet)
-                        .audience(configurationService.getClientAudience(criId))
+                        .audience(credentialIssuerConfig.getAudienceForClients())
                         .issuer(configurationService.getAudienceForClients())
                         .issueTime(Date.from(now))
                         .expirationTime(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class RequestHelper {
 
     public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private RequestHelper() {}
 
@@ -23,7 +24,6 @@ public class RequestHelper {
         Map<String, String> map = parseRequestBody(request.getBody());
         getHeader(request.getHeaders(), IPV_SESSION_ID_HEADER)
                 .ifPresent(h -> map.put("ipv_session_id", h));
-        ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.convertValue(map, type);
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -84,7 +84,7 @@ public class CredentialIssuerService {
                     new ClientAuthClaims(
                             config.getIpvClientId(),
                             config.getIpvClientId(),
-                            configurationService.getClientAudience(config.getId()),
+                            config.getAudienceForClients(),
                             dateTime.plusSeconds(
                                             Long.parseLong(configurationService.getIpvTokenTtl()))
                                     .toEpochSecond(),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -5,9 +5,6 @@ import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.util.Base64URL;
-import com.nimbusds.jwt.JWTClaimNames;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
@@ -130,20 +127,10 @@ public class CredentialIssuerService {
     }
 
     public String getVerifiableCredential(
-            BearerAccessToken accessToken, CredentialIssuerConfig config, String subject) {
-        String requestJWT =
-                new PlainJWT(
-                                new JWTClaimsSet.Builder()
-                                        .claim(
-                                                JWTClaimNames.SUBJECT,
-                                                String.format("urn:uuid:%s", subject))
-                                        .build())
-                        .serialize();
-
+            BearerAccessToken accessToken, CredentialIssuerConfig config) {
         HTTPRequest credentialRequest =
                 new HTTPRequest(HTTPRequest.Method.POST, config.getCredentialUrl());
         credentialRequest.setAuthorization(accessToken.toAuthorizationHeader());
-        credentialRequest.setQuery(requestJWT);
 
         try {
             HTTPResponse response = credentialRequest.send();

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -2,9 +2,6 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.ECDSAVerifier;
-import com.nimbusds.jose.crypto.impl.ECDSA;
-import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
@@ -37,8 +34,6 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
-
-import static com.nimbusds.jose.JWSAlgorithm.ES256;
 
 public class CredentialIssuerService {
 
@@ -126,7 +121,7 @@ public class CredentialIssuerService {
         }
     }
 
-    public String getVerifiableCredential(
+    public SignedJWT getVerifiableCredential(
             BearerAccessToken accessToken, CredentialIssuerConfig config) {
         HTTPRequest credentialRequest =
                 new HTTPRequest(HTTPRequest.Method.POST, config.getCredentialUrl());
@@ -144,37 +139,13 @@ public class CredentialIssuerService {
                         ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
             }
 
-            SignedJWT verifiableCredential = (SignedJWT) response.getContentAsJWT();
-
-            // Signatures from AWS are in DER format. Nimbus needs then in concat format.
-            if (signatureIsDerFormat(verifiableCredential)) {
-                LOGGER.info("Transcoding signature");
-                verifiableCredential = transcodeSignature(verifiableCredential);
-            }
-
-            if (!verifiableCredential.verify(new ECDSAVerifier(config.getVcVerifyingPublicJwk()))) {
-                LOGGER.error("Verifiable credential signature not valid");
-                throw new CredentialIssuerException(
-                        HTTPResponse.SC_SERVER_ERROR,
-                        ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
-            }
-
-            return verifiableCredential.serialize();
+            return (SignedJWT) response.getContentAsJWT();
 
         } catch (IOException | ParseException e) {
             LOGGER.error("Error retrieving credential: {}", e.getMessage());
             throw new CredentialIssuerException(
                     HTTPResponse.SC_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
-        } catch (JOSEException e) {
-            LOGGER.error("JOSE exception when verifying signature: {}", e.getMessage());
-            throw new CredentialIssuerException(
-                    HTTPResponse.SC_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
-        } catch (java.text.ParseException e) {
-            LOGGER.error("Error parsing credential issuer public JWK: {}", e.getMessage());
-            throw new CredentialIssuerException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_PARSE_JWK);
         }
     }
 
@@ -195,21 +166,5 @@ public class CredentialIssuerService {
             throw new CredentialIssuerException(
                     HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_SAVE_CREDENTIAL);
         }
-    }
-
-    private SignedJWT transcodeSignature(SignedJWT vc)
-            throws JOSEException, java.text.ParseException {
-        Base64URL transcodedSignatureBase64 =
-                Base64URL.encode(
-                        ECDSA.transcodeSignatureToConcat(
-                                vc.getSignature().decode(),
-                                ECDSA.getSignatureByteArrayLength(ES256)));
-        String[] jwtParts = vc.serialize().split("\\.");
-        return SignedJWT.parse(
-                String.format("%s.%s.%s", jwtParts[0], jwtParts[1], transcodedSignatureBase64));
-    }
-
-    private boolean signatureIsDerFormat(SignedJWT signedJWT) throws JOSEException {
-        return signedJWT.getSignature().decode().length != ECDSA.getSignatureByteArrayLength(ES256);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidator.java
@@ -1,0 +1,125 @@
+package uk.gov.di.ipv.core.library.validation;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.proc.SimpleSecurityContext;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimNames;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.core.library.domain.CredentialIssuerException;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static com.nimbusds.jose.JWSAlgorithm.ES256;
+
+public class VerifiableCredentialJwtValidator {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(VerifiableCredentialJwtValidator.class);
+    public static final String VC_CLAIM_NAME = "vc";
+
+    private final String audience;
+
+    public VerifiableCredentialJwtValidator(String audience) {
+        this.audience = audience;
+    }
+
+    public void validate(
+            SignedJWT verifiableCredential,
+            CredentialIssuerConfig credentialIssuerConfig,
+            String userId)
+            throws CredentialIssuerException {
+        validateSignature(verifiableCredential, credentialIssuerConfig);
+        validateClaimsSet(verifiableCredential, credentialIssuerConfig, userId);
+    }
+
+    private void validateSignature(
+            SignedJWT verifiableCredential, CredentialIssuerConfig credentialIssuerConfig) {
+
+        SignedJWT concatSignatureVerifiableCredential;
+        try {
+            concatSignatureVerifiableCredential =
+                    signatureIsDerFormat(verifiableCredential)
+                            ? transcodeSignature(verifiableCredential)
+                            : verifiableCredential;
+        } catch (JOSEException | ParseException e) {
+            LOGGER.error("Error transcoding signature: '{}'", e.getMessage());
+            throw new CredentialIssuerException(
+                    HTTPResponse.SC_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
+        }
+
+        try {
+            ECDSAVerifier verifier =
+                    new ECDSAVerifier(credentialIssuerConfig.getVcVerifyingPublicJwk());
+            if (!concatSignatureVerifiableCredential.verify(verifier)) {
+                LOGGER.error("Verifiable credential signature not valid");
+                throw new CredentialIssuerException(
+                        HTTPResponse.SC_SERVER_ERROR,
+                        ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
+            }
+        } catch (JOSEException e) {
+            LOGGER.error("JOSE exception when verifying signature: '{}'", e.getMessage());
+            throw new CredentialIssuerException(
+                    HTTPResponse.SC_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
+        } catch (ParseException e) {
+            LOGGER.error("Error parsing credential issuer public JWK: '{}'", e.getMessage());
+            throw new CredentialIssuerException(
+                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_PARSE_JWK);
+        }
+    }
+
+    private SignedJWT transcodeSignature(SignedJWT vc) throws JOSEException, ParseException {
+        LOGGER.info("Transcoding signature");
+        Base64URL transcodedSignatureBase64 =
+                Base64URL.encode(
+                        ECDSA.transcodeSignatureToConcat(
+                                vc.getSignature().decode(),
+                                ECDSA.getSignatureByteArrayLength(ES256)));
+
+        Base64URL[] jwtParts = vc.getParsedParts();
+        return new SignedJWT(jwtParts[0], jwtParts[1], transcodedSignatureBase64);
+    }
+
+    private boolean signatureIsDerFormat(SignedJWT signedJWT) throws JOSEException {
+        return signedJWT.getSignature().decode().length != ECDSA.getSignatureByteArrayLength(ES256);
+    }
+
+    private void validateClaimsSet(
+            SignedJWT verifiableCredential,
+            CredentialIssuerConfig credentialIssuerConfig,
+            String userId) {
+        DefaultJWTClaimsVerifier<SimpleSecurityContext> verifier =
+                new DefaultJWTClaimsVerifier<>(
+                        new JWTClaimsSet.Builder()
+                                .issuer(credentialIssuerConfig.getAudienceForClients())
+                                .audience(audience)
+                                .subject(userId)
+                                .build(),
+                        new HashSet<>(
+                                Arrays.asList(
+                                        JWTClaimNames.EXPIRATION_TIME,
+                                        JWTClaimNames.NOT_BEFORE,
+                                        VC_CLAIM_NAME)));
+
+        try {
+            verifier.verify(verifiableCredential.getJWTClaimsSet(), null);
+        } catch (BadJWTException | ParseException e) {
+            LOGGER.error("Verifiable credential claims set not valid: '{}'", e.getMessage());
+            throw new CredentialIssuerException(
+                    HTTPResponse.SC_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
+        }
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
@@ -42,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
@@ -93,6 +92,7 @@ class AuthorizationRequestHelperTest {
             throws JOSEException, ParseException, HttpResponseExceptionWithErrorBody {
         setupCredentialIssuerConfigMock();
         setupConfigurationServiceMock();
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(AUDIENCE);
 
         SignedJWT result =
                 AuthorizationRequestHelper.createSignedJWT(
@@ -209,7 +209,6 @@ class AuthorizationRequestHelperTest {
         when(configurationService.getCoreFrontCallbackUrl()).thenReturn(CORE_FRONT_CALLBACK_URL);
         when(configurationService.getIpvTokenTtl()).thenReturn(IPV_TOKEN_TTL);
         when(configurationService.getAudienceForClients()).thenReturn(IPV_ISSUER);
-        when(configurationService.getClientAudience(anyString())).thenReturn(AUDIENCE);
     }
 
     private PrivateKey getEncryptionPrivateKey()

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -43,12 +43,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PUBLIC_JWK;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_VC_1;
 
 @WireMockTest
@@ -73,7 +73,6 @@ class CredentialIssuerServiceTest {
     @Test
     void validTokenResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
-        when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -103,7 +102,6 @@ class CredentialIssuerServiceTest {
     @Test
     void tokenErrorResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
-        when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         var errorJson =
                 "{ \"error\": \"invalid_request\", \"error_description\": \"Request was missing the 'redirect_uri' parameter.\", \"error_uri\": \"See the full API docs at https://authorization-server.com/docs/access_token\"}";
         stubFor(
@@ -137,7 +135,6 @@ class CredentialIssuerServiceTest {
     @Test
     void invalidHeaderThrowsCredentialIssuerException(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
-        when(mockConfigurationService.getClientAudience(anyString())).thenReturn("test-audience");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -349,7 +346,9 @@ class CredentialIssuerServiceTest {
                                         + wmRuntimeInfo.getHttpPort()
                                         + "/authorizeUrl"),
                         "ipv-core",
-                        "NOT A KEY");
+                        "NOT A KEY",
+                        RSA_ENCRYPTION_PUBLIC_JWK,
+                        "test-audience");
         ;
 
         BearerAccessToken accessToken = new BearerAccessToken();
@@ -400,7 +399,9 @@ class CredentialIssuerServiceTest {
                         "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/credentials/issue"),
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/authorizeUrl"),
                 "ipv-core",
-                EC_PUBLIC_JWK);
+                EC_PUBLIC_JWK,
+                RSA_ENCRYPTION_PUBLIC_JWK,
+                "test-audience");
     }
 
     private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -229,7 +229,7 @@ class CredentialIssuerServiceTest {
 
         String credential =
                 credentialIssuerService.getVerifiableCredential(
-                        accessToken, credentialIssuerConfig, "subject");
+                        accessToken, credentialIssuerConfig);
 
         assertEquals(SIGNED_VC_1, credential);
 
@@ -267,7 +267,7 @@ class CredentialIssuerServiceTest {
 
         String credential =
                 credentialIssuerService.getVerifiableCredential(
-                        accessToken, credentialIssuerConfig, "subject");
+                        accessToken, credentialIssuerConfig);
 
         assertEquals(SIGNED_VC_1, credential);
     }
@@ -292,7 +292,7 @@ class CredentialIssuerServiceTest {
                         CredentialIssuerException.class,
                         () ->
                                 credentialIssuerService.getVerifiableCredential(
-                                        accessToken, credentialIssuerConfig, "subject"));
+                                        accessToken, credentialIssuerConfig));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
         assertEquals(ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER, thrown.getErrorResponse());
@@ -316,7 +316,7 @@ class CredentialIssuerServiceTest {
                         CredentialIssuerException.class,
                         () ->
                                 credentialIssuerService.getVerifiableCredential(
-                                        accessToken, credentialIssuerConfig, "subject"));
+                                        accessToken, credentialIssuerConfig));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
         assertEquals(
@@ -358,7 +358,7 @@ class CredentialIssuerServiceTest {
                         CredentialIssuerException.class,
                         () ->
                                 credentialIssuerService.getVerifiableCredential(
-                                        accessToken, credentialIssuerConfig, "subject"));
+                                        accessToken, credentialIssuerConfig));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
         assertEquals(ErrorResponse.FAILED_TO_PARSE_JWK, thrown.getErrorResponse());
@@ -383,7 +383,7 @@ class CredentialIssuerServiceTest {
                         CredentialIssuerException.class,
                         () ->
                                 credentialIssuerService.getVerifiableCredential(
-                                        accessToken, credentialIssuerConfig, "subject"));
+                                        accessToken, credentialIssuerConfig));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
         assertEquals(ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER, thrown.getErrorResponse());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidatorTest.java
@@ -1,0 +1,308 @@
+package uk.gov.di.ipv.core.library.validation;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.CredentialIssuerException;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+
+import java.security.KeyFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PUBLIC_JWK;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PUBLIC_JWK_2;
+
+@ExtendWith(MockitoExtension.class)
+class VerifiableCredentialJwtValidatorTest {
+
+    public static final String AUDIENCE = "https://example.com/audience";
+    public static final String ISSUER = "https://example.com/issuer";
+    public static final String SUBJECT = "https://example.com/subject";
+
+    private final ECDSASigner signer = getSigner();
+
+    @Mock CredentialIssuerConfig credentialIssuerConfig;
+
+    public VerifiableCredentialJwtValidatorTest() throws Exception {}
+
+    @Test
+    void doesNotThrowIfValidJwt() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(ISSUER);
+
+        SignedJWT signedJWT = getValidSignedJwt();
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        assertDoesNotThrow(() -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
+    }
+
+    @Test
+    void shouldHandleDerEncodedSignatures() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(ISSUER);
+
+        SignedJWT signedJWT = getValidSignedJwt();
+        Base64URL derSignature =
+                Base64URL.encode(ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode()));
+        SignedJWT derSignedJwt =
+                new SignedJWT(
+                        signedJWT.getHeader().toBase64URL(),
+                        signedJWT.getPayload().toBase64URL(),
+                        derSignature);
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        assertDoesNotThrow(() -> validator.validate(derSignedJwt, credentialIssuerConfig, SUBJECT));
+    }
+
+    @Test
+    void throwsIfSignatureIsInvalid() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK_2));
+
+        SignedJWT signedJWT = getValidSignedJwt();
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        CredentialIssuerException exception =
+                assertThrows(
+                        CredentialIssuerException.class,
+                        () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
+                exception.getErrorResponse());
+    }
+
+    @Test
+    void throwsIfCanNotParseVerifyingPublicKey() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenThrow(new ParseException("Nope", 0));
+
+        SignedJWT signedJWT = getValidSignedJwt();
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        CredentialIssuerException exception =
+                assertThrows(
+                        CredentialIssuerException.class,
+                        () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
+        assertEquals(ErrorResponse.FAILED_TO_PARSE_JWK, exception.getErrorResponse());
+    }
+
+    @Test
+    void throwsIfIssuerDoesNotMatch() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn("THIS IS WRONG");
+
+        SignedJWT signedJWT = getValidSignedJwt();
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        CredentialIssuerException exception =
+                assertThrows(
+                        CredentialIssuerException.class,
+                        () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
+                exception.getErrorResponse());
+    }
+
+    @Test
+    void throwsIfAudienceDoesNotMatch() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(ISSUER);
+
+        SignedJWT signedJWT = getValidSignedJwt();
+
+        VerifiableCredentialJwtValidator validator =
+                new VerifiableCredentialJwtValidator("THIS IS THE WRONG AUDIENCE");
+
+        CredentialIssuerException exception =
+                assertThrows(
+                        CredentialIssuerException.class,
+                        () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
+                exception.getErrorResponse());
+    }
+
+    @Test
+    void throwsIfSubjectDoesNotMatch() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(ISSUER);
+
+        SignedJWT signedJWT = getValidSignedJwt();
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        CredentialIssuerException exception =
+                assertThrows(
+                        CredentialIssuerException.class,
+                        () ->
+                                validator.validate(
+                                        signedJWT,
+                                        credentialIssuerConfig,
+                                        "THIS IS THE WRONG SUBJECT"));
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
+                exception.getErrorResponse());
+    }
+
+    @Test
+    void throwsIfExpired() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(ISSUER);
+
+        Instant now = Instant.now();
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build(),
+                        new JWTClaimsSet.Builder()
+                                .issuer(ISSUER)
+                                .subject(SUBJECT)
+                                .audience(AUDIENCE)
+                                .expirationTime(new Date(now.minusSeconds(60).toEpochMilli()))
+                                .notBeforeTime(new Date(now.toEpochMilli()))
+                                .claim("vc", new Object())
+                                .build());
+
+        signedJWT.sign(signer);
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        CredentialIssuerException exception =
+                assertThrows(
+                        CredentialIssuerException.class,
+                        () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
+                exception.getErrorResponse());
+    }
+
+    @Test
+    void throwsIfNotBeforeIsInTheFuture() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(ISSUER);
+
+        Instant now = Instant.now();
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build(),
+                        new JWTClaimsSet.Builder()
+                                .issuer(ISSUER)
+                                .subject(SUBJECT)
+                                .audience(AUDIENCE)
+                                .expirationTime(new Date(now.plusSeconds(60).toEpochMilli()))
+                                .notBeforeTime(new Date(now.plusSeconds(100).toEpochMilli()))
+                                .claim("vc", new Object())
+                                .build());
+
+        signedJWT.sign(signer);
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        CredentialIssuerException exception =
+                assertThrows(
+                        CredentialIssuerException.class,
+                        () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
+                exception.getErrorResponse());
+    }
+
+    @Test
+    void throwsIfVcClaimIsMissing() throws Exception {
+        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
+                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
+        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(ISSUER);
+
+        Instant now = Instant.now();
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build(),
+                        new JWTClaimsSet.Builder()
+                                .issuer(ISSUER)
+                                .subject(SUBJECT)
+                                .audience(AUDIENCE)
+                                .expirationTime(new Date(now.plusSeconds(60).toEpochMilli()))
+                                .notBeforeTime(new Date(now.toEpochMilli()))
+                                .build());
+
+        signedJWT.sign(signer);
+
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+
+        CredentialIssuerException exception =
+                assertThrows(
+                        CredentialIssuerException.class,
+                        () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
+                exception.getErrorResponse());
+    }
+
+    private ECDSASigner getSigner() throws Exception {
+        return new ECDSASigner(
+                KeyFactory.getInstance("EC")
+                        .generatePrivate(
+                                new PKCS8EncodedKeySpec(
+                                        Base64.getDecoder().decode(EC_PRIVATE_KEY))),
+                Curve.P_256);
+    }
+
+    private SignedJWT getValidSignedJwt() throws Exception {
+        Instant now = Instant.now();
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build(),
+                        new JWTClaimsSet.Builder()
+                                .issuer(ISSUER)
+                                .subject(SUBJECT)
+                                .audience(AUDIENCE)
+                                .expirationTime(new Date(now.plusSeconds(60).toEpochMilli()))
+                                .notBeforeTime(new Date(now.toEpochMilli()))
+                                .claim("vc", new Object())
+                                .build());
+
+        signedJWT.sign(signer);
+        return signedJWT;
+    }
+}


### PR DESCRIPTION
**This should not be merged before https://github.com/alphagov/di-ipv-core-back/pull/270**

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Validate verifiable credential JWT received from CRIs

### Why did it change

[PYIC-992: Include enc key and audience in CRI config object](https://github.com/alphagov/di-ipv-core-back/commit/259b6db6c7b881a3122603617381810e383234d0) 

Add a credential issuers public encryption key and audience to the
CredentialIssuerConfig object.

We had these configuration details of CRIs defined separately. This is
most likely as they had been newly added. This refactors the object so
they are deserialized and available on the object with just one call the
parameter store.
  
[PYIC-992: Make ObjectMapper static field on RequestHelper](https://github.com/alphagov/di-ipv-core-back/commit/dadc6b1ba825306788d1dd854e6e7740246b07b9) 

An object mapper is a heavy object. We probably shouldn't be using it at
all in Lambda world. By moving it to a static field we can reduce its
impact but just creating it once, rather than every time the request
helper is called.
  
[PYIC-992: Don't send plain JWT to VC endpoint](https://github.com/alphagov/di-ipv-core-back/commit/7cca6f2eb0fed6b41912624e07af37d538b02773) 

Previously we were sending the subject of the VC to the credential
issues in a plain JWT, when requesting the VC.

We now send the subject in the JAR when we start the journey. We can
remove the plain JWT cruft.
  
[PYIC-922: Validate VC JWTs in new Verifier](https://github.com/alphagov/di-ipv-core-back/commit/3bf0296f04308d8bc73cbbfafbcf989cdda4fa1e) 

Adds a new class specifically for validating JWTs received from CRIs.
This moves the existing signature checking logic from credential issuer
service into this class, and extends it with a check of the claims it
should contain.
  
[PYIC-922: Fetch userId from session to validate VC JWT subject](https://github.com/alphagov/di-ipv-core-back/commit/ad346492f1092cadaa3105ef168223804d14d0d6) 

We are storing the userID received from orch in the JAR they send us in
the session table. This is the value that's used as the subject when
making requests to CRIs. This is then passed back to us as the subject
of the VC JWT.

This pulls that value from the session and validates subject in the JWT
using it.

This also DRYs up the CRI return lambda tests a bunch.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-992](https://govukverify.atlassian.net/browse/PYIC-992)