### PR TITLE
PYIC-1217: Send userId from session in JAR

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -400,9 +400,12 @@ Resources:
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsTable.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/signingKeyId
         - SSMParameterReadPolicy:

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
@@ -42,13 +42,10 @@ public class AuthorizationRequestHelper {
             SharedAttributesResponse sharedClaims,
             JWSSigner signer,
             CredentialIssuerConfig credentialIssuerConfig,
-            ConfigurationService configurationService)
+            ConfigurationService configurationService,
+            String userId)
             throws HttpResponseExceptionWithErrorBody {
         Instant now = Instant.now();
-
-        String ipvClientId = credentialIssuerConfig.getIpvClientId();
-
-        ClientID clientID = new ClientID(ipvClientId);
 
         String criId = credentialIssuerConfig.getId();
 
@@ -59,7 +56,9 @@ public class AuthorizationRequestHelper {
                 new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build();
 
         JWTClaimsSet authClaimsSet =
-                new AuthorizationRequest.Builder(ResponseType.CODE, clientID)
+                new AuthorizationRequest.Builder(
+                                ResponseType.CODE,
+                                new ClientID(credentialIssuerConfig.getIpvClientId()))
                         .redirectionURI(redirectionURI)
                         .state(new State("read"))
                         .build()
@@ -77,7 +76,7 @@ public class AuthorizationRequestHelper {
                                                         configurationService.getIpvTokenTtl()),
                                                 ChronoUnit.SECONDS)))
                         .notBeforeTime(Date.from(now))
-                        .subject(ipvClientId);
+                        .subject(userId);
 
         if (Objects.nonNull(sharedClaims)) {
             claimsSetBuilder.claim(SHARED_CLAIMS, sharedClaims);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
@@ -62,6 +62,7 @@ class AuthorizationRequestHelperTest {
     public static final String IPV_TOKEN_TTL = "900";
     public static final String CORE_FRONT_CALLBACK_URL = "callbackUri";
     public static final String CRI_ID = "cri_id";
+    public static final String TEST_USER_ID = "test-user-id";
 
     private final SharedAttributesResponse sharedClaims =
             new SharedAttributesResponse(
@@ -95,10 +96,14 @@ class AuthorizationRequestHelperTest {
 
         SignedJWT result =
                 AuthorizationRequestHelper.createSignedJWT(
-                        sharedClaims, signer, credentialIssuerConfig, configurationService);
+                        sharedClaims,
+                        signer,
+                        credentialIssuerConfig,
+                        configurationService,
+                        TEST_USER_ID);
 
         assertEquals(IPV_ISSUER, result.getJWTClaimsSet().getIssuer());
-        assertEquals(IPV_CLIENT_ID_VALUE, result.getJWTClaimsSet().getSubject());
+        assertEquals(TEST_USER_ID, result.getJWTClaimsSet().getSubject());
         assertEquals(AUDIENCE, result.getJWTClaimsSet().getAudience().get(0));
         assertEquals(sharedClaims, result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
         assertEquals(
@@ -117,7 +122,7 @@ class AuthorizationRequestHelperTest {
 
         SignedJWT result =
                 AuthorizationRequestHelper.createSignedJWT(
-                        null, signer, credentialIssuerConfig, configurationService);
+                        null, signer, credentialIssuerConfig, configurationService, TEST_USER_ID);
         assertNull(result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
     }
 
@@ -134,14 +139,15 @@ class AuthorizationRequestHelperTest {
                                         null,
                                         jwsSigner,
                                         credentialIssuerConfig,
-                                        configurationService));
+                                        configurationService,
+                                        TEST_USER_ID));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to sign Shared Attributes", exception.getErrorReason());
     }
 
     @Test
     void shouldThrowExceptionWhenUnableToBuildRedirectionUri() {
-        setupCredentialIssuerConfigMock();
+        when(credentialIssuerConfig.getId()).thenReturn(CRI_ID);
         when(configurationService.getCoreFrontCallbackUrl()).thenReturn("[[]]]][[[");
 
         HttpResponseExceptionWithErrorBody exception =
@@ -152,7 +158,8 @@ class AuthorizationRequestHelperTest {
                                         null,
                                         jwsSigner,
                                         credentialIssuerConfig,
-                                        configurationService));
+                                        configurationService,
+                                        TEST_USER_ID));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to build Core Front Callback Url", exception.getErrorReason());
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Send userId from session in JAR

### Why did it change

We need to be setting the subject of the signed JWT sent in the JAR as
the user ID received from the orchestrator.

This pulls it from the session store and sets it as the subject.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1217](https://govukverify.atlassian.net/browse/PYIC-1217)

