### PR TITLE
BAU: Define common versions for libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,26 @@ spotless {
 		endWithNewline()
 	}
 }
+
+ext {
+	dependencyVersions = [
+		apacheHttpclient:'4.5.13',
+		awsJavaSdkDynamodb:'1.12.167',
+		awsJavaSdkSqs:'1.12.197',
+		awsLambdaJavaCore:'1.2.1',
+		awsLambdaJavaEvents:'3.11.0',
+		dynamodbEnhanced:'2.17.89',
+		gson:'2.8.9',
+		jackson:'2.13.2',
+		kms:'2.17.100',
+		lombok:'1.18.22',
+		nimbusdsOauth2OidcSdk:'9.27',
+		powertoolsParameters:'1.11.0',
+		powertoolsTracing:'1.12.0',
+		slf4j:'1.7.36'
+	]
+}
+
+subprojects {
+	task allDeps(type: DependencyReportTask) {}
+}

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -15,26 +15,24 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
-			"com.google.code.gson:gson:2.8.9",
-			"com.nimbusds:nimbus-jose-jwt:9.15.2",
-			'org.junit.jupiter:junit-jupiter:5.8.2',
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.2.0",
 			"org.mockito:mockito-junit-jupiter:4.2.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 }
 

--- a/lambdas/accesstoken/build.gradle
+++ b/lambdas/accesstoken/build.gradle
@@ -12,29 +12,29 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"org.apache.httpcomponents:httpclient:4.5.13",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	aspect 'software.amazon.lambda:powertools-tracing:1.11.0'
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
-	compileOnly 'org.projectlombok:lombok:1.18.22'
-	annotationProcessor 'org.projectlombok:lombok:1.18.22'
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 }
 

--- a/lambdas/credentialissuerconfig/build.gradle
+++ b/lambdas/credentialissuerconfig/build.gradle
@@ -12,19 +12,18 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"org.slf4j:slf4j-simple:1.7.32",
+	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			project(":lib")
 
-	aspect 'software.amazon.lambda:powertools-tracing:1.11.0'
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
-
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
 			project(":lib").sourceSets.test.output
 }
 

--- a/lambdas/credentialissuererror/build.gradle
+++ b/lambdas/credentialissuererror/build.gradle
@@ -12,17 +12,16 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.167",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			project(":lib")
 
-	aspect "software.amazon.lambda:powertools-tracing:1.12.0"
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
-
-	compileOnly "org.projectlombok:lombok:1.18.22"
-	annotationProcessor "org.projectlombok:lombok:1.18.22"
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.3.1",

--- a/lambdas/credentialissuerreturn/build.gradle
+++ b/lambdas/credentialissuerreturn/build.gradle
@@ -12,31 +12,30 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"org.apache.httpcomponents:httpclient:4.5.13",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	aspect 'software.amazon.lambda:powertools-tracing:1.11.0'
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
-	compileOnly 'org.projectlombok:lombok:1.18.22'
-	annotationProcessor 'org.projectlombok:lombok:1.18.22'
-
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0",
 			project(":lib").sourceSets.test.output
 }

--- a/lambdas/credentialissuerstart/build.gradle
+++ b/lambdas/credentialissuerstart/build.gradle
@@ -12,31 +12,30 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			'com.amazonaws:aws-java-sdk-dynamodb:1.12.167',
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			'com.nimbusds:oauth2-oidc-sdk:9.27',
-			'com.fasterxml.jackson.core:jackson-core:2.13.2',
-			'com.fasterxml.jackson.core:jackson-databind:2.13.2',
-			'com.fasterxml.jackson.core:jackson-annotations:2.13.2',
-			"org.apache.httpcomponents:httpclient:4.5.13",
-			'org.slf4j:slf4j-simple:1.7.36',
-			'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1',
-			'software.amazon.lambda:powertools-parameters:1.11.0',
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	aspect 'software.amazon.lambda:powertools-tracing:1.12.0'
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
-	compileOnly 'org.projectlombok:lombok:1.18.22'
-	annotationProcessor 'org.projectlombok:lombok:1.18.22'
-
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
-			'org.mockito:mockito-core:4.3.1',
-			'org.mockito:mockito-junit-jupiter:4.3.1',
-			'com.github.tomakehurst:wiremock-jre8:2.32.0',
-			'uk.org.webcompere:system-stubs-jupiter:2.0.1',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.32.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
+			"org.mockito:mockito-core:4.3.1",
+			"org.mockito:mockito-junit-jupiter:4.3.1",
+			"uk.org.webcompere:system-stubs-jupiter:2.0.1",
 			project(":lib").sourceSets.test.output
 }
 

--- a/lambdas/issuedcredentials/build.gradle
+++ b/lambdas/issuedcredentials/build.gradle
@@ -12,15 +12,15 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
+	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			project(":lib")
 
-	aspect 'software.amazon.lambda:powertools-tracing:1.11.0'
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
-	testImplementation 'com.google.code.gson:gson:2.8.9',
-			'org.junit.jupiter:junit-jupiter:5.8.2',
-			'org.mockito:mockito-junit-jupiter:4.2.0'
+	testImplementation "com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
+			"org.mockito:mockito-junit-jupiter:4.2.0"
 }
 
 java {

--- a/lambdas/journeyengine/build.gradle
+++ b/lambdas/journeyengine/build.gradle
@@ -11,11 +11,11 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
+	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			project(":lib")
 
-	aspect "software.amazon.lambda:powertools-tracing:1.11.0"
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",

--- a/lambdas/sessionend/build.gradle
+++ b/lambdas/sessionend/build.gradle
@@ -12,30 +12,30 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"org.apache.httpcomponents:httpclient:4.5.13",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	aspect 'software.amazon.lambda:powertools-tracing:1.11.0'
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
-	compileOnly 'org.projectlombok:lombok:1.18.22'
-	annotationProcessor 'org.projectlombok:lombok:1.18.22'
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 }
 

--- a/lambdas/sessionstart/build.gradle
+++ b/lambdas/sessionstart/build.gradle
@@ -12,30 +12,30 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"org.apache.httpcomponents:httpclient:4.5.13",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	aspect 'software.amazon.lambda:powertools-tracing:1.11.0'
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
-	compileOnly 'org.projectlombok:lombok:1.18.22'
-	annotationProcessor 'org.projectlombok:lombok:1.18.22'
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0",
 			project(":lib").sourceSets.test.output
 }

--- a/lambdas/useridentity/build.gradle
+++ b/lambdas/useridentity/build.gradle
@@ -12,30 +12,30 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			"com.nimbusds:oauth2-oidc-sdk:9.3.1",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"org.apache.httpcomponents:httpclient:4.5.13",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
 			project(":lib")
 
-	aspect 'software.amazon.lambda:powertools-tracing:1.11.0'
+	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
-	compileOnly 'org.projectlombok:lombok:1.18.22'
-	annotationProcessor 'org.projectlombok:lombok:1.18.22'
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -13,31 +13,31 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
-			"com.amazonaws:aws-lambda-java-events:3.11.0",
-			"com.amazonaws:aws-java-sdk-dynamodb:1.12.122",
-			"com.amazonaws:aws-java-sdk-sqs:1.12.197",
-			"com.nimbusds:oauth2-oidc-sdk:9.25",
-			"com.fasterxml.jackson.core:jackson-core:2.13.0",
-			"com.fasterxml.jackson.core:jackson-databind:2.13.0",
-			"com.fasterxml.jackson.core:jackson-annotations:2.13.0",
-			"com.google.code.gson:gson:2.8.9",
-			"org.apache.httpcomponents:httpclient:4.5.13",
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.fasterxml.jackson.core:jackson-annotations:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-core:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.core:jackson-databind:$rootProject.ext.dependencyVersions.jackson",
+			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.apache.commons:commons-lang3:3.5",
-			"org.slf4j:slf4j-simple:1.7.32",
-			"software.amazon.awssdk:dynamodb-enhanced:2.17.89",
-			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0",
-			"software.amazon.lambda:powertools-parameters:1.8.0",
-			"software.amazon.awssdk:kms:2.17.100"
+			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
+			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.awssdk:kms:$rootProject.ext.dependencyVersions.kms",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters"
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2',
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.31.0",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",
 			"org.mockito:mockito-junit-jupiter:4.1.0",
-			"com.github.tomakehurst:wiremock-jre8:2.31.0",
 			"uk.org.webcompere:system-stubs-jupiter:1.1.0"
 
-	compileOnly 'org.projectlombok:lombok:1.18.22'
-	annotationProcessor 'org.projectlombok:lombok:1.18.22'
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 }
 
 java {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Define common versions for libs

### Why did it change

We were using different versions of the same libs in different lambdas.

This defines a structure in the root project where we can define the
versions we want to use and then pull them in in the sub projects.

This makes it easy to bump all versions in case of a security issue, as
well as ensuring consistency to help diagnose weird bugs.

This also sorts all the dependencies to scratch an itch.
