### PR TITLE
BAU: Get redirect url from config

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -336,6 +336,8 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
         - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/coreFrontCallbackUrl
+        - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/signingKeyId
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -72,6 +72,8 @@ class CredentialIssuerServiceTest {
     @Test
     void validTokenResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getCoreFrontCallbackUrl())
+                .thenReturn("http://www.example.com/redirect");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -102,6 +104,8 @@ class CredentialIssuerServiceTest {
     @Test
     void tokenErrorResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getCoreFrontCallbackUrl())
+                .thenReturn("http://www.example.com/redirect");
         var errorJson =
                 "{ \"error\": \"invalid_request\", \"error_description\": \"Request was missing the 'redirect_uri' parameter.\", \"error_uri\": \"See the full API docs at https://authorization-server.com/docs/access_token\"}";
         stubFor(
@@ -136,6 +140,8 @@ class CredentialIssuerServiceTest {
     @Test
     void invalidHeaderThrowsCredentialIssuerException(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
+        when(mockConfigurationService.getCoreFrontCallbackUrl())
+                .thenReturn("http://www.example.com/redirect");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -194,7 +200,6 @@ class CredentialIssuerServiceTest {
 
     @Test
     void expectedExceptionWhenSaveCredentials() {
-
         CredentialIssuerRequestDto credentialIssuerRequestDto =
                 new CredentialIssuerRequestDto(
                         "1234",
@@ -244,6 +249,7 @@ class CredentialIssuerServiceTest {
 
     @Test
     void getVerifiableCredentialThrowsIfResponseIsNotOk(WireMockRuntimeInfo wmRuntimeInfo) {
+
         stubFor(
                 post("/credentials/issue")
                         .willReturn(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When constructing the token exchange request, use the redirect url from config instead of the one passed from core-front.

### Why did it change

Core front was basing the value passed to core back on a url from its environment that was not correct. On reflection it seemed safer to construct that url in the back end.
