### PR TITLE
Remove validation for aud claim for cri jwt

### DIFF
--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -64,8 +64,7 @@ public class CredentialIssuerReturnHandler
                         new KmsEs256Signer(configurationService.getSigningKeyId()));
         this.auditService =
                 new AuditService(AuditService.getDefaultSqsClient(), configurationService);
-        this.verifiableCredentialJwtValidator =
-                new VerifiableCredentialJwtValidator(configurationService.getAudienceForClients());
+        this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator();
         this.ipvSessionService = new IpvSessionService(configurationService);
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidator.java
@@ -28,12 +28,6 @@ public class VerifiableCredentialJwtValidator {
             LoggerFactory.getLogger(VerifiableCredentialJwtValidator.class);
     public static final String VC_CLAIM_NAME = "vc";
 
-    private final String audience;
-
-    public VerifiableCredentialJwtValidator(String audience) {
-        this.audience = audience;
-    }
-
     public void validate(
             SignedJWT verifiableCredential,
             CredentialIssuerConfig credentialIssuerConfig,
@@ -104,7 +98,6 @@ public class VerifiableCredentialJwtValidator {
                 new DefaultJWTClaimsVerifier<>(
                         new JWTClaimsSet.Builder()
                                 .issuer(credentialIssuerConfig.getAudienceForClients())
-                                .audience(audience)
                                 .subject(userId)
                                 .build(),
                         new HashSet<>(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidatorTest.java
@@ -55,7 +55,7 @@ class VerifiableCredentialJwtValidatorTest {
 
         SignedJWT signedJWT = getValidSignedJwt();
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         assertDoesNotThrow(() -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
     }
@@ -75,7 +75,7 @@ class VerifiableCredentialJwtValidatorTest {
                         signedJWT.getPayload().toBase64URL(),
                         derSignature);
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         assertDoesNotThrow(() -> validator.validate(derSignedJwt, credentialIssuerConfig, SUBJECT));
     }
@@ -87,7 +87,7 @@ class VerifiableCredentialJwtValidatorTest {
 
         SignedJWT signedJWT = getValidSignedJwt();
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         CredentialIssuerException exception =
                 assertThrows(
@@ -106,7 +106,7 @@ class VerifiableCredentialJwtValidatorTest {
 
         SignedJWT signedJWT = getValidSignedJwt();
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         CredentialIssuerException exception =
                 assertThrows(
@@ -124,28 +124,7 @@ class VerifiableCredentialJwtValidatorTest {
 
         SignedJWT signedJWT = getValidSignedJwt();
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
-
-        CredentialIssuerException exception =
-                assertThrows(
-                        CredentialIssuerException.class,
-                        () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
-        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
-                exception.getErrorResponse());
-    }
-
-    @Test
-    void throwsIfAudienceDoesNotMatch() throws Exception {
-        when(credentialIssuerConfig.getVcVerifyingPublicJwk())
-                .thenReturn(ECKey.parse(EC_PUBLIC_JWK));
-        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(ISSUER);
-
-        SignedJWT signedJWT = getValidSignedJwt();
-
-        VerifiableCredentialJwtValidator validator =
-                new VerifiableCredentialJwtValidator("THIS IS THE WRONG AUDIENCE");
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         CredentialIssuerException exception =
                 assertThrows(
@@ -165,7 +144,7 @@ class VerifiableCredentialJwtValidatorTest {
 
         SignedJWT signedJWT = getValidSignedJwt();
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         CredentialIssuerException exception =
                 assertThrows(
@@ -202,7 +181,7 @@ class VerifiableCredentialJwtValidatorTest {
 
         signedJWT.sign(signer);
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         CredentialIssuerException exception =
                 assertThrows(
@@ -235,7 +214,7 @@ class VerifiableCredentialJwtValidatorTest {
 
         signedJWT.sign(signer);
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         CredentialIssuerException exception =
                 assertThrows(
@@ -267,7 +246,7 @@ class VerifiableCredentialJwtValidatorTest {
 
         signedJWT.sign(signer);
 
-        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator(AUDIENCE);
+        VerifiableCredentialJwtValidator validator = new VerifiableCredentialJwtValidator();
 
         CredentialIssuerException exception =
                 assertThrows(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Removed the validation check for the aud claim on the JWT we get back from a CRI. Ipv-core isn't the only audience of this JWT so it doesn't need to be ther.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
I mistakenly added this requirement to a ticket so it was added in some recent validation changes we made.

**We will want to stop sending the aud claim from our passport and cri stubs, but everything should still work with them sending a value. For now we are just ignoring it, and will remove it later**
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

