### PR TITLE
BAU: Correct the claim name for the VCs list

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Setter
 @ExcludeFromGeneratedCoverageReport
 public class UserIdentity {
-    @JsonProperty("https://vocab.sign-in.service.gov.uk/v1/credentials")
+    @JsonProperty("https://vocab.account.gov.uk/v1/credentialJWT")
     private List<String> vcs;
 
     @JsonProperty private String sub;
@@ -23,9 +23,7 @@ public class UserIdentity {
 
     @JsonCreator
     public UserIdentity(
-            @JsonProperty(
-                            value = "https://vocab.sign-in.service.gov.uk/v1/credentials",
-                            required = true)
+            @JsonProperty(value = "https://vocab.account.gov.uk/v1/credentialJWT", required = true)
                     List<String> vcs,
             @JsonProperty(value = "sub", required = true) String sub,
             @JsonProperty(value = "vot", required = true) String vot,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated the claim name of the list of VC returned in the User Identity json, returned from IPV Core.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

The user identity json has defined claim names. We were using an out of date version.

see: https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0014-identity-ipv-core-oauth-profile.md
