### PR TITLE
PYIC-1251 Add a Private API Gateway

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -25,12 +25,67 @@ Conditions:
       - !Ref ProvisionedConcurrentExecutions
       -  0
 
+  IsDevelopmentEnvironment: !Not
+    - !Or
+      - !Equals [ !Ref Environment, "build"]
+      - !Equals [ !Ref Environment, "staging"]
+      - !Equals [ !Ref Environment, "integration"]
+      - !Equals [ !Ref Environment, "production"]
+
 Resources:
 
   IPVCoreInternalAPI:
     Type: AWS::Serverless::Api
     Properties:
       Name: !Sub IPV Core Internal API Gateway ${Environment}
+      StageName: !Sub ${Environment}
+      DefinitionBody:
+        'Fn::Transform':
+          Name: "AWS::Include"
+          Parameters:
+            Location: "../openAPI/core-back-internal.yaml"
+      AccessLogSetting:
+        DestinationArn: !GetAtt IPVCoreInternalAPILogGroup.Arn
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip":"$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path":"$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLatency":"$context.responseLatency",
+          "responseLength":"$context.responseLength"
+          }
+
+  IPVCorePrivateAPI:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: !Sub IPV Core Private API Gateway ${Environment}
+      EndpointConfiguration:
+        Type: PRIVATE
+      Auth:
+        ResourcePolicy:
+          CustomStatements:
+            - Action: 'execute-api:Invoke'
+              Effect: Allow
+              Principal: '*'
+              Resource:
+                - 'execute-api:/*'
+            - Action: 'execute-api:Invoke'
+              Effect: Deny
+              Principal: '*'
+              Resource:
+                - 'execute-api:/*'
+              Condition:
+                StringNotEquals:
+                  'aws:SourceVpce': !If
+                    - IsDevelopmentEnvironment
+                    - !ImportValue "network-shared-development-ApiGatewayVpcEndpointId"
+                    - Fn::ImportValue:
+                        !Sub network-${Environment}-ApiGatewayVpcEndpointId"
       StageName: !Sub ${Environment}
       DefinitionBody:
         'Fn::Transform':
@@ -207,6 +262,13 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/session/end
             Method: POST
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
+            Path: /journey/session/end
+            Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
@@ -281,6 +343,13 @@ Resources:
           Properties:
             RestApiId:
               Ref: IPVCoreInternalAPI
+            Path: /session/start
+            Method: POST
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
             Path: /session/start
             Method: POST
       AutoPublishAlias: live
@@ -367,6 +436,13 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/return
             Method: POST
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
+            Path: /journey/cri/return
+            Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
@@ -451,6 +527,13 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /journey/cri/start/{criId}
             Method: POST
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
+            Path: /journey/cri/start/{criId}
+            Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
@@ -499,6 +582,13 @@ Resources:
           Properties:
             RestApiId:
               Ref: IPVCoreInternalAPI
+            Path: /journey/cri/error
+            Method: POST
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
             Path: /journey/cri/error
             Method: POST
       AutoPublishAlias: live
@@ -620,6 +710,13 @@ Resources:
               Ref: IPVCoreInternalAPI
             Path: /request-config
             Method: GET
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
+            Path: /request-config
+            Method: GET
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
@@ -668,6 +765,13 @@ Resources:
           Properties:
             RestApiId:
               Ref: IPVCoreInternalAPI
+            Path: /issued-credentials
+            Method: GET
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
             Path: /issued-credentials
             Method: GET
       AutoPublishAlias: live
@@ -720,6 +824,13 @@ Resources:
           Properties:
             RestApiId:
               Ref: IPVCoreInternalAPI
+            Path: /journey/{journeyStep}
+            Method: POST
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
             Path: /journey/{journeyStep}
             Method: POST
       AutoPublishAlias: live
@@ -800,6 +911,9 @@ Outputs:
     Export:
       Name: !Sub "${AWS::StackName}-IPVCoreInternalAPIGatewayID"
     Value: !Ref IPVCoreInternalAPI
+  IPVCorePrivateAPIGatewayID:
+    Description: Core Back Private API Gateway ID
+    Value: !Ref IPVCorePrivateAPI
   IPVCoreExternalAPIGatewayID:
     Description: Core Back External API Gateway ID
     Export:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -913,6 +913,8 @@ Outputs:
     Value: !Ref IPVCoreInternalAPI
   IPVCorePrivateAPIGatewayID:
     Description: Core Back Private API Gateway ID
+    Export:
+      Name: !Sub "${AWS::StackName}-IPVCorePrivateAPIGatewayID"
     Value: !Ref IPVCorePrivateAPI
   IPVCoreExternalAPIGatewayID:
     Description: Core Back External API Gateway ID

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -85,7 +85,7 @@ Resources:
                     - IsDevelopmentEnvironment
                     - !ImportValue "network-shared-development-ApiGatewayVpcEndpointId"
                     - Fn::ImportValue:
-                        !Sub network-${Environment}-ApiGatewayVpcEndpointId"
+                        !Sub networking-${Environment}-ApiGatewayVpcEndpointId"
       StageName: !Sub ${Environment}
       DefinitionBody:
         'Fn::Transform':


### PR DESCRIPTION
This adds a private API Gateway which can only be invoked via a VPC
Endpoint in the environment's VPC. This will replace the existing
"internal" core back API gateway which is public. In the interim this
new private API Gateway invokes the same lambdas on the same paths as
the existing public API Gateway.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
See above.

### What changed
See above.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To better secure the internal core-back lambdas behind a private API gateway.
<!-- Describe the reason these changes were made - the "why" -->


### Testing
This has been applied to my developer environment and seen working alongside https://github.com/alphagov/di-ipv-config/pull/568. This change should be a no-op until 

1. the aforementioned PR is merged,
2. private dns is enabled on the VPC Endpoint in the environment
3. core-front ECS task is updated to use the private API gateway invoke url. Important that unless we add a custom domain to soon-to-be-deprecated public "internal" api gateway then the environment breaks between steps 2 and 3 which is deemed ok because we will line up changes to minimise down time. The reason for this is available here: https://aws.amazon.com/premiumsupport/knowledge-center/api-gateway-vpc-connections/

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1251](https://govukverify.atlassian.net/browse/PYIC-1251)

### Update
The "network" stack has a slightly different name in the non-development environments.

```
GDS11321:di-ipv-core-front dan.worth$ for env in dev build int stag; do aws-vault exec di-ipv-${env} -- aws cloudformation list-exports --region eu-west-2 | jq '.Exports[] | select(.Name | contains("network")).Name' -r; done                                            
network-shared-development-ApiGatewayVpcEndpointId
networking-build-ApiGatewayVpcEndpointId
networking-integration-ApiGatewayVpcEndpointId
networking-staging-ApiGatewayVpcEndpointId
```