### PR TITLE
PYIC-1276: Update criError lambda to send audit event and return error journey step

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -566,11 +566,22 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub credential-issuer-error-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
+        - Statement:
+            - Sid: kmsAuditEventQueueEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
         IPVCoreInternalAPI:
           Type: Api

--- a/lambdas/credentialissuererror/build.gradle
+++ b/lambdas/credentialissuererror/build.gradle
@@ -13,6 +13,7 @@ repositories {
 dependencies {
 
 	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",

--- a/lambdas/credentialissuererror/src/main/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandler.java
+++ b/lambdas/credentialissuererror/src/main/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandler.java
@@ -31,11 +31,13 @@ public class CredentialIssuerErrorHandler
 
     private static final List<String> ALLOWED_OAUTH_ERROR_CODES =
             Arrays.asList(
-                    OAuth2Error.SERVER_ERROR_CODE,
                     OAuth2Error.INVALID_REQUEST_CODE,
-                    OAuth2Error.INVALID_REQUEST_OBJECT_CODE,
-                    OAuth2Error.INVALID_GRANT_CODE,
-                    OAuth2Error.INVALID_CLIENT_CODE);
+                    OAuth2Error.UNAUTHORIZED_CLIENT_CODE,
+                    OAuth2Error.ACCESS_DENIED_CODE,
+                    OAuth2Error.UNSUPPORTED_RESPONSE_TYPE_CODE,
+                    OAuth2Error.INVALID_SCOPE_CODE,
+                    OAuth2Error.SERVER_ERROR_CODE,
+                    OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE);
 
     private final ConfigurationService configurationService;
     private final AuditService auditService;
@@ -65,7 +67,7 @@ public class CredentialIssuerErrorHandler
                 credentialIssuerErrorDto.getCredentialIssuerId());
 
         if (!ALLOWED_OAUTH_ERROR_CODES.contains(credentialIssuerErrorDto.getError())) {
-            LOGGER.error("Unknown Oauth error code recieved");
+            LOGGER.error("Unknown Oauth error code received");
         }
         LOGGER.error("Error code: {}", credentialIssuerErrorDto.getError());
         LOGGER.error(credentialIssuerErrorDto.getErrorDescription());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the CriError lambda to send an AuditEventTypes.IPV_CRI_AUTH_RESPONSE_RECEIVED audit event and then return a error journey step response.

Also updated the lambda permissions to allow write permission to the audit sqs queue
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The journey engine will be updated to handle the new /journey/error step being returned here and will be able to render the correct error page for this scenario.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1276](https://govukverify.atlassian.net/browse/PYIC-1276)

