### PR TITLE
PYIC-1277: Update journey engine to handle cri error responses

### DIFF
--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -150,7 +150,7 @@ public class JourneyEngineHandler
                         updateUserState(CRI_ADDRESS, ipvSessionItem);
                         builder.setJourneyResponse(
                                 new JourneyResponse(criStartUri + ADDRESS_CRI_ID));
-                    } else if (journeyStep.equals(ERROR_STEP)) {
+                    } else {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     }
@@ -159,7 +159,7 @@ public class JourneyEngineHandler
                     if (journeyStep.equals(NEXT_STEP)) {
                         updateUserState(CRI_FRAUD, ipvSessionItem);
                         builder.setJourneyResponse(new JourneyResponse(criStartUri + FRAUD_CRI_ID));
-                    } else if (journeyStep.equals(ERROR_STEP)) {
+                    } else {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     }
@@ -168,7 +168,7 @@ public class JourneyEngineHandler
                     if (journeyStep.equals(NEXT_STEP)) {
                         updateUserState(PRE_KBV_TRANSITION_PAGE, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PRE_KBV_TRANSITION_PAGE.value));
-                    } else if (journeyStep.equals(ERROR_STEP)) {
+                    } else {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     }
@@ -181,7 +181,7 @@ public class JourneyEngineHandler
                     if (journeyStep.equals(NEXT_STEP)) {
                         updateUserState(IPV_SUCCESS_PAGE, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(IPV_SUCCESS_PAGE.value));
-                    } else if (journeyStep.equals(ERROR_STEP)) {
+                    } else {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     }

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -116,6 +116,7 @@ public class JourneyEngineHandler
         }
     }
 
+    @SuppressWarnings("java:S3776") // Cognitive complexity rule
     @Tracing
     private JourneyEngineResult executeJourneyEvent(
             String journeyStep, IpvSessionItem ipvSessionItem) throws JourneyEngineException {
@@ -150,27 +151,33 @@ public class JourneyEngineHandler
                         updateUserState(CRI_ADDRESS, ipvSessionItem);
                         builder.setJourneyResponse(
                                 new JourneyResponse(criStartUri + ADDRESS_CRI_ID));
-                    } else {
+                    } else if (journeyStep.equals(ERROR_STEP)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
+                    } else {
+                        handleInvalidJourneyStep(journeyStep, CRI_UK_PASSPORT.value);
                     }
                     break;
                 case CRI_ADDRESS:
                     if (journeyStep.equals(NEXT_STEP)) {
                         updateUserState(CRI_FRAUD, ipvSessionItem);
                         builder.setJourneyResponse(new JourneyResponse(criStartUri + FRAUD_CRI_ID));
-                    } else {
+                    } else if (journeyStep.equals(ERROR_STEP)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
+                    } else {
+                        handleInvalidJourneyStep(journeyStep, CRI_ADDRESS.value);
                     }
                     break;
                 case CRI_FRAUD:
                     if (journeyStep.equals(NEXT_STEP)) {
                         updateUserState(PRE_KBV_TRANSITION_PAGE, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PRE_KBV_TRANSITION_PAGE.value));
-                    } else {
+                    } else if (journeyStep.equals(ERROR_STEP)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
+                    } else {
+                        handleInvalidJourneyStep(journeyStep, CRI_FRAUD.value);
                     }
                     break;
                 case PRE_KBV_TRANSITION_PAGE:
@@ -181,9 +188,11 @@ public class JourneyEngineHandler
                     if (journeyStep.equals(NEXT_STEP)) {
                         updateUserState(IPV_SUCCESS_PAGE, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(IPV_SUCCESS_PAGE.value));
-                    } else {
+                    } else if (journeyStep.equals(ERROR_STEP)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
+                    } else {
+                        handleInvalidJourneyStep(journeyStep, CRI_KBV.value);
                     }
                     break;
                 case IPV_SUCCESS_PAGE:
@@ -194,6 +203,7 @@ public class JourneyEngineHandler
                     builder.setPageResponse(new PageResponse(DEBUG_PAGE.value));
                     break;
                 default:
+                    LOGGER.info("Unknown current user state: {}", currentUserState);
                     updateUserState(CRI_ERROR, ipvSessionItem);
                     builder.setPageResponse(
                             new PageResponse(PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE.value));
@@ -205,6 +215,18 @@ public class JourneyEngineHandler
             throw new JourneyEngineException(
                     "Unknown user state, failed to execute journey engine step.");
         }
+    }
+
+    private void handleInvalidJourneyStep(String journeyStep, String currentUserState)
+            throws JourneyEngineException {
+        LOGGER.error(
+                "Invalid jourey step provided: {} for the current user state: {}",
+                journeyStep,
+                currentUserState);
+        throw new JourneyEngineException(
+                String.format(
+                        "Invalid journey step provided: %s for the current user status: %s",
+                        journeyStep, currentUserState));
     }
 
     @Tracing

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -32,10 +32,11 @@ import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_FRAUD;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_KBV;
 import static uk.gov.di.ipv.core.library.domain.UserStates.CRI_UK_PASSPORT;
 import static uk.gov.di.ipv.core.library.domain.UserStates.DEBUG_PAGE;
-import static uk.gov.di.ipv.core.library.domain.UserStates.IPV_ERROR_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.IPV_IDENTITY_START_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.IPV_SUCCESS_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.PRE_KBV_TRANSITION_PAGE;
+import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_TECHNICAL_ERROR_PAGE;
+import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE;
 
 public class JourneyEngineHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -151,7 +152,7 @@ public class JourneyEngineHandler
                                 new JourneyResponse(criStartUri + ADDRESS_CRI_ID));
                     } else if (journeyStep.equals(ERROR_STEP)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
-                        builder.setPageResponse(new PageResponse(IPV_ERROR_PAGE.value));
+                        builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     }
                     break;
                 case CRI_ADDRESS:
@@ -160,7 +161,7 @@ public class JourneyEngineHandler
                         builder.setJourneyResponse(new JourneyResponse(criStartUri + FRAUD_CRI_ID));
                     } else if (journeyStep.equals(ERROR_STEP)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
-                        builder.setPageResponse(new PageResponse(IPV_ERROR_PAGE.value));
+                        builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     }
                     break;
                 case CRI_FRAUD:
@@ -169,7 +170,7 @@ public class JourneyEngineHandler
                         builder.setPageResponse(new PageResponse(PRE_KBV_TRANSITION_PAGE.value));
                     } else if (journeyStep.equals(ERROR_STEP)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
-                        builder.setPageResponse(new PageResponse(IPV_ERROR_PAGE.value));
+                        builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     }
                     break;
                 case PRE_KBV_TRANSITION_PAGE:
@@ -182,7 +183,7 @@ public class JourneyEngineHandler
                         builder.setPageResponse(new PageResponse(IPV_SUCCESS_PAGE.value));
                     } else if (journeyStep.equals(ERROR_STEP)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
-                        builder.setPageResponse(new PageResponse(IPV_ERROR_PAGE.value));
+                        builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     }
                     break;
                 case IPV_SUCCESS_PAGE:
@@ -194,7 +195,8 @@ public class JourneyEngineHandler
                     break;
                 default:
                     updateUserState(CRI_ERROR, ipvSessionItem);
-                    builder.setPageResponse(new PageResponse(IPV_ERROR_PAGE.value));
+                    builder.setPageResponse(
+                            new PageResponse(PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE.value));
             }
 
             return builder.build();

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -313,7 +313,7 @@ class JourneyEngineHandlerTest {
                 UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
+        assertEquals(UserStates.PYI_TECHNICAL_ERROR_PAGE.value, pageResponse.getPage());
     }
 
     @Test
@@ -378,7 +378,7 @@ class JourneyEngineHandlerTest {
                 UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
+        assertEquals(UserStates.PYI_TECHNICAL_ERROR_PAGE.value, pageResponse.getPage());
     }
 
     @Test
@@ -475,7 +475,7 @@ class JourneyEngineHandlerTest {
                 UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
+        assertEquals(UserStates.PYI_TECHNICAL_ERROR_PAGE.value, pageResponse.getPage());
     }
 
     @Test
@@ -541,7 +541,7 @@ class JourneyEngineHandlerTest {
                 UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
+        assertEquals(UserStates.PYI_TECHNICAL_ERROR_PAGE.value, pageResponse.getPage());
     }
 
     @Test

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -286,6 +286,37 @@ class JourneyEngineHandlerTest {
     }
 
     @Test
+    void shouldReturnCriErrorPageResponseIfPassportCriFails() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "error");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
+    }
+
+    @Test
     void shouldReturnCriFraudJourneyResponseWhenRequired() throws IOException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
@@ -317,6 +348,37 @@ class JourneyEngineHandlerTest {
 
         assertEquals(200, response.getStatusCode());
         assertEquals("/journey/cri/start/fraud", journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnCriErrorPageResponseIfAddressCriFails() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "error");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.toString());
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
     }
 
     @Test
@@ -386,6 +448,37 @@ class JourneyEngineHandlerTest {
     }
 
     @Test
+    void shouldReturnCriErrorPageResponseIfFraudCriFails() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "error");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
+    }
+
+    @Test
     void shouldReturnIpvSuccessPageResponseWhenRequired() throws IOException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
@@ -418,6 +511,37 @@ class JourneyEngineHandlerTest {
 
         assertEquals(200, response.getStatusCode());
         assertEquals(UserStates.IPV_SUCCESS_PAGE.value, pageResponse.getPage());
+    }
+
+    @Test
+    void shouldReturnCriErrorPageResponseIfKbvCriFails() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "error");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
     }
 
     @Test
@@ -488,13 +612,15 @@ class JourneyEngineHandlerTest {
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ERROR.toString());
 
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
-        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+        JourneyResponse journeyResponse =
+                objectMapper.readValue(response.getBody(), JourneyResponse.class);
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(UserStates.IPV_ERROR_PAGE.value, pageResponse.getPage());
+        assertEquals("/journey/session/end", journeyResponse.getJourney());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
@@ -12,7 +12,9 @@ public enum UserStates {
     CRI_FRAUD("cri-fraud"),
     CRI_KBV("cri-kbv"),
     CRI_ERROR("cri-error"),
-    IPV_ERROR_PAGE("page-ipv-error");
+    IPV_ERROR_PAGE("page-ipv-error"),
+    PYI_TECHNICAL_ERROR_PAGE("pyi-technical"),
+    PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE("pyi-technical-unrecoverable");
 
     public final String value;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the journey engine to now handle /journey/error journey steps and render the recoverable error page
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This now means we can control how to handle these error scenarios through the journey engine. In the future the big benefit will be that we can now handle these error scenarios by potentially attempting alternative CRI routes where possible.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1277](https://govukverify.atlassian.net/browse/PYIC-1277)


