### PR TITLE
PYIC-1254 Remove Unused Internal API

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -34,32 +34,6 @@ Conditions:
 
 Resources:
 
-  IPVCoreInternalAPI:
-    Type: AWS::Serverless::Api
-    Properties:
-      Name: !Sub IPV Core Internal API Gateway ${Environment}
-      StageName: !Sub ${Environment}
-      DefinitionBody:
-        'Fn::Transform':
-          Name: "AWS::Include"
-          Parameters:
-            Location: "../openAPI/core-back-internal.yaml"
-      AccessLogSetting:
-        DestinationArn: !GetAtt IPVCoreInternalAPILogGroup.Arn
-        Format: >-
-          {
-          "requestId":"$context.requestId",
-          "ip":"$context.identity.sourceIp",
-          "requestTime":"$context.requestTime",
-          "httpMethod":"$context.httpMethod",
-          "path":"$context.path",
-          "routeKey":"$context.routeKey",
-          "status":"$context.status",
-          "protocol":"$context.protocol",
-          "responseLatency":"$context.responseLatency",
-          "responseLength":"$context.responseLength"
-          }
-
   IPVCorePrivateAPI:
     Type: AWS::Serverless::Api
     Properties:
@@ -88,7 +62,7 @@ Resources:
                         !Sub "networking-${Environment}-ApiGatewayVpcEndpointId"
       StageName: !Sub ${Environment}
       AccessLogSetting:
-        DestinationArn: !GetAtt IPVCoreInternalAPILogGroup.Arn
+        DestinationArn: !GetAtt IPVCorePrivateAPILogGroup.Arn
         Format: >-
           {
           "requestId":"$context.requestId",
@@ -103,18 +77,18 @@ Resources:
           "responseLength":"$context.responseLength"
           }
 
-  IPVCoreInternalAPILogGroup:
+  IPVCorePrivateAPILogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CoreBackInternal-API-GW-AccessLogs
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-CoreBackPrivate-API-GW-AccessLogs
       RetentionInDays: 14
 
-  IPVCoreInternalAPILogGroupSubscriptionFilter:
+  IPVCorePrivateAPILogGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
-      LogGroupName: !Ref IPVCoreInternalAPILogGroup
+      LogGroupName: !Ref IPVCorePrivateAPILogGroup
 
   IPVCoreExternalAPI:
     Type: AWS::Serverless::Api
@@ -250,13 +224,6 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
-        IPVCoreInternalAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCoreInternalAPI
-            Path: /journey/session/end
-            Method: POST
         IPVCorePrivateAPI:
           Type: Api
           Properties:
@@ -333,13 +300,6 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
-        IPVCoreInternalAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCoreInternalAPI
-            Path: /session/start
-            Method: POST
         IPVCorePrivateAPI:
           Type: Api
           Properties:
@@ -424,13 +384,6 @@ Resources:
             Resource:
               - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
-        IPVCoreInternalAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCoreInternalAPI
-            Path: /journey/cri/return
-            Method: POST
         IPVCorePrivateAPI:
           Type: Api
           Properties:
@@ -515,13 +468,6 @@ Resources:
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
       Events:
-        IPVCoreInternalAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCoreInternalAPI
-            Path: /journey/cri/start/{criId}
-            Method: POST
         IPVCorePrivateAPI:
           Type: Api
           Properties:
@@ -572,13 +518,6 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
       Events:
-        IPVCoreInternalAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCoreInternalAPI
-            Path: /journey/cri/error
-            Method: POST
         IPVCorePrivateAPI:
           Type: Api
           Properties:
@@ -698,13 +637,6 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
       Events:
-        IPVCoreInternalAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCoreInternalAPI
-            Path: /request-config
-            Method: GET
         IPVCorePrivateAPI:
           Type: Api
           Properties:
@@ -755,13 +687,6 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Ref UserIssuedCredentialsTable
       Events:
-        IPVCoreInternalAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCoreInternalAPI
-            Path: /issued-credentials
-            Method: GET
         IPVCorePrivateAPI:
           Type: Api
           Properties:
@@ -814,13 +739,6 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
       Events:
-        IPVCoreInternalAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCoreInternalAPI
-            Path: /journey/{journeyStep}
-            Method: POST
         IPVCorePrivateAPI:
           Type: Api
           Properties:
@@ -901,11 +819,6 @@ Resources:
           KeyType: "HASH"
 
 Outputs:
-  IPVCoreInternalAPIGatewayID:
-    Description: Core Back Internal API Gateway ID
-    Export:
-      Name: !Sub "${AWS::StackName}-IPVCoreInternalAPIGatewayID"
-    Value: !Ref IPVCoreInternalAPI
   IPVCorePrivateAPIGatewayID:
     Description: Core Back Private API Gateway ID
     Export:


### PR DESCRIPTION
The internal API Gateway which was actually public has been replaced
with a private API Gateway. This commit removes the unused API Gateway,
its log group and the events connected with the core-back lambdas.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Removed the "internal" API Gateway which is no longer used. Removed the exported output `ipv-core-back-<environment>-IPVCoreInternalAPIGatewayID` which was no longer being used, as shown below:

```
GDS11321:di-ipv-core-back dan.worth$ for name in $(aws-vault exec di-ipv-int -- aws cloudformation list-exports --region eu-west-2 | jq '.Exports[].Name' -r); do if aws-vault exec di-ipv-int -- aws cloudformation list-imports --export-name "$name" --region eu-west-2 > /dev/null 2>&1 ; then echo "${name} USED"; else echo "${name} NOT-USED"; fi; done | sort -k2 | column -t
CoreEncryptionKeyId                                    NOT-USED
ipv-core-back-integration-IPVCoreInternalAPIGatewayID  NOT-USED
AuditEventQueueEncryptionKeyArn                        USED
AuditEventQueueName                                    USED
AuditEventQueueUrl                                     USED
CoreEncryptionKeyArn                                   USED
SigningKeyArn                                          USED
SigningKeyId                                           USED
core-front-integration-IPVCoreFrontGatewayID           USED
ipv-core-back-integration-IPVCoreExternalAPIGatewayID  USED
ipv-core-back-integration-IPVCorePrivateAPIGatewayID   USED
networking-integration-ApiGatewayVpcEndpointId         USED
```

This has been applied to my developer environment and a manual journey was successful. The template correctly validates
```
GDS11321:deploy dan.worth$ aws-vault exec di-ipv-dev -- sam validate
2022-05-24 08:50:52 Loading policies from IAM...
2022-05-24 08:50:55 Finished loading policies from IAM.
/Users/dan.worth/projects/gds/di-ipv-core-back/deploy/template.yaml is a valid SAM Template

```

Created a log group for the new private API Gateway and deleted the old one. The new log group is succesfully connected to the private API gateway as shown below
```
GDS11321:~ dan.worth$ aws-vault exec di-ipv-dev -- awslogs get /aws/apigateway/ipv-core-back-dev-danw-CoreBackPrivate-API-GW-AccessLogs --aws-region eu-west-2 -S
/aws/apigateway/ipv-core-back-dev-danw-CoreBackPrivate-API-GW-AccessLogs { "requestId":"134a9460-050f-4b36-8e49-79713d997af3", "ip":"10.120.10.10", "requestTime":"24/May/2022:07:43:42 +0000", "httpMethod":"POST", "path":"/dev-danw/session/start", "routeKey":"-", "status":"200", "protocol":"HTTP/1.1", "responseLatency":"6135", "responseLength":"55" }

```
<!-- Describe the changes in detail - the "what"-->

### Why did it change
It was no longer needed.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1254](https://govukverify.atlassian.net/browse/PYIC-1254)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


