### PR TITLE
PYIC-1272: Update journey engine to call the session-end lambda after the error page.

### DIFF
--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -177,8 +177,8 @@ public class JourneyEngineHandler
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     } else if (journeyStep.equals(FAIL)) {
-                        updateUserState(PYI_KBV_FAIL, ipvSessionItem);
-                        builder.setPageResponse(new PageResponse(PYI_KBV_FAIL.value));
+                        updateUserState(PYI_NO_MATCH, ipvSessionItem);
+                        builder.setPageResponse(new PageResponse(PYI_NO_MATCH.value));
                     } else {
                         handleInvalidJourneyStep(journeyStep, CRI_FRAUD.value);
                     }
@@ -194,6 +194,10 @@ public class JourneyEngineHandler
                     } else if (journeyStep.equals(ERROR)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
+                    } else if (journeyStep.equals(FAIL)) {
+                        updateUserState(PYI_KBV_FAIL, ipvSessionItem);
+                        builder.setPageResponse(new PageResponse(PYI_KBV_FAIL.value));
+
                     } else {
                         handleInvalidJourneyStep(journeyStep, CRI_KBV.value);
                     }

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -39,6 +39,7 @@ import static uk.gov.di.ipv.core.library.domain.UserStates.DEBUG_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.IPV_IDENTITY_START_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.IPV_SUCCESS_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.PRE_KBV_TRANSITION_PAGE;
+import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_NO_MATCH;
 import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_TECHNICAL_ERROR_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE;
 
@@ -151,7 +152,7 @@ public class JourneyEngineHandler
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     } else if (journeyStep.equals(FAIL)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
-                        builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
+                        builder.setPageResponse(new PageResponse(PYI_NO_MATCH.value));
                     } else {
                         handleInvalidJourneyStep(journeyStep, CRI_UK_PASSPORT.value);
                     }
@@ -174,6 +175,9 @@ public class JourneyEngineHandler
                     } else if (journeyStep.equals(ERROR)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
+                    } else if (journeyStep.equals(FAIL)) {
+                        updateUserState(PYI_NO_MATCH, ipvSessionItem);
+                        builder.setPageResponse(new PageResponse(PYI_NO_MATCH.value));
                     } else {
                         handleInvalidJourneyStep(journeyStep, CRI_FRAUD.value);
                     }

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -39,6 +39,7 @@ import static uk.gov.di.ipv.core.library.domain.UserStates.DEBUG_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.IPV_IDENTITY_START_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.IPV_SUCCESS_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.PRE_KBV_TRANSITION_PAGE;
+import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_KBV_FAIL;
 import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_NO_MATCH;
 import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_TECHNICAL_ERROR_PAGE;
 import static uk.gov.di.ipv.core.library.domain.UserStates.PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE;
@@ -176,8 +177,8 @@ public class JourneyEngineHandler
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     } else if (journeyStep.equals(FAIL)) {
-                        updateUserState(PYI_NO_MATCH, ipvSessionItem);
-                        builder.setPageResponse(new PageResponse(PYI_NO_MATCH.value));
+                        updateUserState(PYI_KBV_FAIL, ipvSessionItem);
+                        builder.setPageResponse(new PageResponse(PYI_KBV_FAIL.value));
                     } else {
                         handleInvalidJourneyStep(journeyStep, CRI_FRAUD.value);
                     }

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -81,9 +81,6 @@ public class JourneyEngineHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(400, errorResponse.get());
         }
 
-        JourneyStep journeyStep =
-                JourneyStep.valueOf(input.getPathParameters().get(JOURNEY_STEP_PARAM));
-
         var ipvSessionId =
                 RequestHelper.getHeaderByKey(input.getHeaders(), IPV_SESSION_ID_HEADER_KEY);
 
@@ -101,6 +98,9 @@ public class JourneyEngineHandler
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_ID);
         }
         try {
+            JourneyStep journeyStep =
+                    getJourneyStep(input.getPathParameters().get(JOURNEY_STEP_PARAM));
+
             JourneyEngineResult journeyEngineResult =
                     executeJourneyEvent(journeyStep, ipvSessionItem);
 
@@ -130,8 +130,6 @@ public class JourneyEngineHandler
             UserStates currentUserStateValue = UserStates.valueOf(currentUserState);
 
             JourneyEngineResult.Builder builder = new JourneyEngineResult.Builder();
-
-            validateJourneyStep(journeyStep);
 
             switch (currentUserStateValue) {
                 case INITIAL_IPV_JOURNEY:
@@ -217,8 +215,8 @@ public class JourneyEngineHandler
         }
     }
 
-    private void validateJourneyStep(JourneyStep journeyStep) throws JourneyEngineException {
-        Arrays.stream(JourneyStep.values())
+    private JourneyStep getJourneyStep(String journeyStep) throws JourneyEngineException {
+        return Arrays.stream(JourneyStep.values())
                 .filter(step -> step.toString().equalsIgnoreCase(journeyStep.toString()))
                 .findFirst()
                 .orElseThrow(

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -52,7 +52,8 @@ public class JourneyEngineHandler
     private static final String KBV_CRI_ID = "kbv";
     private static final String FRAUD_CRI_ID = "fraud";
 
-    private static final List<String> VALID_JOURNEY_STEPS = List.of(NEXT_STEP, ERROR_STEP);
+    private static final List<String> VALID_JOURNEY_STEPS =
+            List.of(NEXT.toString(), ERROR.toString());
 
     private final IpvSessionService ipvSessionService;
     private final ConfigurationService configurationService;

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -221,7 +221,7 @@ public class JourneyEngineHandler
 
     private JourneyStep getJourneyStep(String journeyStep) throws JourneyEngineException {
         return Arrays.stream(JourneyStep.values())
-                .filter(step -> step.toString().equalsIgnoreCase(journeyStep.toString()))
+                .filter(step -> step.toString().equalsIgnoreCase(journeyStep))
                 .findFirst()
                 .orElseThrow(
                         () -> {

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyStep.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyStep.java
@@ -2,7 +2,8 @@ package uk.gov.di.ipv.core.journeyengine.domain;
 
 public enum JourneyStep {
     NEXT("next"),
-    ERROR("error");
+    ERROR("error"),
+    FAIL("fail");
 
     private final String step;
 

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyStep.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/domain/JourneyStep.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.core.journeyengine.domain;
+
+public enum JourneyStep {
+    NEXT("next"),
+    ERROR("error");
+
+    private final String step;
+
+    JourneyStep(String step) {
+        this.step = step;
+    }
+
+    @Override
+    public String toString() {
+        return step;
+    }
+}

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -33,6 +33,11 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JourneyEngineHandlerTest {
+    private static final String JOURNEY_STEP = "journeyStep";
+    private static final String FAIL = "fail";
+    private static final String NEXT = "next";
+    private static final String ERROR = "error";
+    private static final String INVALID_STEP = "invalid-step";
     @Mock private Context mockContext;
     @Mock private IpvSessionService mockIpvSessionService;
     @Mock private ConfigurationService mockConfigurationService;
@@ -92,7 +97,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         APIGatewayProxyResponseEvent response =
@@ -111,7 +116,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -133,7 +138,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "invalid-step");
+        pathParameters.put(JOURNEY_STEP, INVALID_STEP);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -161,7 +166,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -189,7 +194,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -221,7 +226,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -256,7 +261,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -290,7 +295,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "error");
+        pathParameters.put(JOURNEY_STEP, ERROR);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -321,7 +326,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -355,7 +360,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "error");
+        pathParameters.put(JOURNEY_STEP, ERROR);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -386,7 +391,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -418,7 +423,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -452,7 +457,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "error");
+        pathParameters.put(JOURNEY_STEP, ERROR);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -483,7 +488,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -518,7 +523,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "error");
+        pathParameters.put(JOURNEY_STEP, ERROR);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -549,7 +554,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -577,7 +582,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -602,7 +607,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "next");
+        pathParameters.put(JOURNEY_STEP, NEXT);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -629,7 +634,7 @@ class JourneyEngineHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "fail");
+        pathParameters.put(JOURNEY_STEP, FAIL);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -656,11 +661,11 @@ class JourneyEngineHandlerTest {
     }
 
     @Test
-    void shouldReturnPYIKbvErrorPageIfFraudCriVCValidationReturnsFail() throws IOException {
+    void shouldReturnPYINoMatchPageIfFraudCriVCValidationReturnsFail() throws IOException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put("journeyStep", "fail");
+        pathParameters.put(JOURNEY_STEP, FAIL);
         event.setPathParameters(pathParameters);
 
         event.setHeaders(Map.of("ipv-session-id", "1234"));
@@ -679,6 +684,41 @@ class JourneyEngineHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.PYI_NO_MATCH.toString(),
+                sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.PYI_NO_MATCH.value, pageResponse.getPage());
+    }
+
+    @Test
+    void shouldReturnPYIKbvFailPageIfKbvCriVCValidationReturnsFail() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put(JOURNEY_STEP, FAIL);
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
+
+        when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+
         assertEquals(
                 UserStates.PYI_KBV_FAIL.toString(),
                 sessionArgumentCaptor.getValue().getUserState());

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -625,7 +625,7 @@ class JourneyEngineHandlerTest {
     }
 
     @Test
-    void shouldReturnCriErrorPageResponseIfPassportCriReturnsFail() throws IOException {
+    void shouldReturnPYINoMatchPageIfPassportCriVCValidationReturnsFail() throws IOException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();
@@ -656,7 +656,7 @@ class JourneyEngineHandlerTest {
     }
 
     @Test
-    void shouldReturnPYINoMatchPageIfFraudVCValidationCriReturnsFail() throws IOException {
+    void shouldReturnPYIKbvErrorPageIfFraudCriVCValidationReturnsFail() throws IOException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         Map<String, String> pathParameters = new HashMap<>();

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -680,10 +680,10 @@ class JourneyEngineHandlerTest {
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(
-                UserStates.PYI_NO_MATCH.toString(),
+                UserStates.PYI_KBV_FAIL.toString(),
                 sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(UserStates.PYI_NO_MATCH.value, pageResponse.getPage());
+        assertEquals(UserStates.PYI_KBV_FAIL.value, pageResponse.getPage());
     }
 }

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -652,6 +652,38 @@ class JourneyEngineHandlerTest {
                 UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals(UserStates.PYI_TECHNICAL_ERROR_PAGE.value, pageResponse.getPage());
+        assertEquals(UserStates.PYI_NO_MATCH.value, pageResponse.getPage());
+    }
+
+    @Test
+    void shouldReturnPYINoMatchPageIfFraudVCValidationCriReturnsFail() throws IOException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put("journeyStep", "fail");
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(
+                UserStates.PYI_NO_MATCH.toString(),
+                sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.PYI_NO_MATCH.value, pageResponse.getPage());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
@@ -15,7 +15,8 @@ public enum UserStates {
     IPV_ERROR_PAGE("page-ipv-error"),
     PYI_TECHNICAL_ERROR_PAGE("pyi-technical"),
     PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE("pyi-technical-unrecoverable"),
-    PYI_NO_MATCH("pyi-no-match");
+    PYI_NO_MATCH("pyi-no-match"),
+    PYI_KBV_FAIL("pyi-kbv-fail");
 
     public final String value;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
@@ -14,7 +14,8 @@ public enum UserStates {
     CRI_ERROR("cri-error"),
     IPV_ERROR_PAGE("page-ipv-error"),
     PYI_TECHNICAL_ERROR_PAGE("pyi-technical"),
-    PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE("pyi-technical-unrecoverable");
+    PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE("pyi-technical-unrecoverable"),
+    PYI_NO_MATCH("pyi-no-match");
 
     public final String value;
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated JourneyEngine Lambda to check the JourneyStep returned in the path parameters. 

If 'next' it will return the CRI Address Journey Response and set the UserState.

If 'error' it will return the Journey End Response.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1272](https://govukverify.atlassian.net/browse/PYIC-1272)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed
