### PR TITLE
PYIC-1279: Return Nimbus ErrorObject for cri errors that will be handled by the CriError lambda

### DIFF
--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -82,7 +82,9 @@ public class CredentialIssuerReturnHandler
 
             if (errorResponse.isPresent()) {
                 LOGGER.error("Validation failed: {}", errorResponse.get().getMessage());
-                return ApiGatewayResponseGenerator.proxyJsonResponse(400, errorResponse.get());
+
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        HttpStatus.SC_BAD_REQUEST, errorResponse.get());
             }
             CredentialIssuerConfig credentialIssuerConfig = getCredentialIssuerConfig(request);
 
@@ -111,8 +113,12 @@ public class CredentialIssuerReturnHandler
             JourneyResponse journeyResponse = new JourneyResponse(NEXT_JOURNEY_STEP_URI);
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, journeyResponse);
         } catch (CredentialIssuerException e) {
+            LOGGER.error(
+                    "Error retreiving credential from CRI beccause: {}",
+                    e.getErrorObject().getDescription());
+
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getHttpStatusCode(), e.getErrorResponse());
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getErrorObject().toJSONObject());
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CredentialIssuerException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CredentialIssuerException.java
@@ -1,18 +1,20 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
 public class CredentialIssuerException extends RuntimeException {
 
-    private final ErrorResponse errorResponse;
+    private final ErrorObject errorObject;
 
     private final int httpStatusCode;
 
-    public CredentialIssuerException(int httpStatusCode, ErrorResponse errorResponse) {
-        this.errorResponse = errorResponse;
+    public CredentialIssuerException(int httpStatusCode, ErrorObject errorObject) {
+        this.errorObject = errorObject;
         this.httpStatusCode = httpStatusCode;
     }
 
-    public ErrorResponse getErrorResponse() {
-        return errorResponse;
+    public ErrorObject getErrorObject() {
+        return errorObject;
     }
 
     public int getHttpStatusCode() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -6,6 +6,7 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import com.nimbusds.oauth2.sdk.TokenRequest;
@@ -113,15 +114,16 @@ public class CredentialIssuerService {
                         errorObject.getCode(),
                         errorObject.getDescription(),
                         errorObject.getHTTPStatusCode());
-                throw new CredentialIssuerException(
-                        HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST);
+                throw new CredentialIssuerException(HTTPResponse.SC_BAD_REQUEST, errorObject);
             }
             return tokenResponse.toSuccessResponse().getTokens().getBearerAccessToken();
         } catch (IOException | ParseException | JOSEException | URISyntaxException e) {
             LOGGER.error("Error exchanging token: {}", e.getMessage(), e);
             throw new CredentialIssuerException(
                     HTTPResponse.SC_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_EXCHANGE_AUTHORIZATION_CODE);
+                    new ErrorObject(
+                            OAuth2Error.SERVER_ERROR_CODE,
+                            ErrorResponse.FAILED_TO_EXCHANGE_AUTHORIZATION_CODE.getMessage()));
         }
     }
 
@@ -140,7 +142,9 @@ public class CredentialIssuerService {
                         response.getStatusMessage());
                 throw new CredentialIssuerException(
                         HTTPResponse.SC_SERVER_ERROR,
-                        ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
+                        new ErrorObject(
+                                OAuth2Error.SERVER_ERROR_CODE,
+                                ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getMessage()));
             }
 
             return (SignedJWT) response.getContentAsJWT();
@@ -149,7 +153,9 @@ public class CredentialIssuerService {
             LOGGER.error("Error retrieving credential: {}", e.getMessage());
             throw new CredentialIssuerException(
                     HTTPResponse.SC_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
+                    new ErrorObject(
+                            OAuth2Error.SERVER_ERROR_CODE,
+                            ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getMessage()));
         }
     }
 
@@ -168,7 +174,10 @@ public class CredentialIssuerService {
         } catch (UnsupportedOperationException e) {
             LOGGER.error("Error persisting user credential: {}", e.getMessage(), e);
             throw new CredentialIssuerException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_SAVE_CREDENTIAL);
+                    HTTPResponse.SC_SERVER_ERROR,
+                    new ErrorObject(
+                            OAuth2Error.SERVER_ERROR_CODE,
+                            ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getMessage()));
         }
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidator.java
@@ -10,6 +10,8 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +52,9 @@ public class VerifiableCredentialJwtValidator {
             LOGGER.error("Error transcoding signature: '{}'", e.getMessage());
             throw new CredentialIssuerException(
                     HTTPResponse.SC_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
+                    new ErrorObject(
+                            OAuth2Error.SERVER_ERROR_CODE,
+                            ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage()));
         }
 
         try {
@@ -60,17 +64,25 @@ public class VerifiableCredentialJwtValidator {
                 LOGGER.error("Verifiable credential signature not valid");
                 throw new CredentialIssuerException(
                         HTTPResponse.SC_SERVER_ERROR,
-                        ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
+                        new ErrorObject(
+                                OAuth2Error.SERVER_ERROR_CODE,
+                                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL
+                                        .getMessage()));
             }
         } catch (JOSEException e) {
             LOGGER.error("JOSE exception when verifying signature: '{}'", e.getMessage());
             throw new CredentialIssuerException(
                     HTTPResponse.SC_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
+                    new ErrorObject(
+                            OAuth2Error.SERVER_ERROR_CODE,
+                            ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage()));
         } catch (ParseException e) {
             LOGGER.error("Error parsing credential issuer public JWK: '{}'", e.getMessage());
             throw new CredentialIssuerException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_PARSE_JWK);
+                    HTTPResponse.SC_SERVER_ERROR,
+                    new ErrorObject(
+                            OAuth2Error.SERVER_ERROR_CODE,
+                            ErrorResponse.FAILED_TO_PARSE_JWK.getMessage()));
         }
     }
 
@@ -112,7 +124,9 @@ public class VerifiableCredentialJwtValidator {
             LOGGER.error("Verifiable credential claims set not valid: '{}'", e.getMessage());
             throw new CredentialIssuerException(
                     HTTPResponse.SC_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
+                    new ErrorObject(
+                            OAuth2Error.SERVER_ERROR_CODE,
+                            ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage()));
         }
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -102,7 +102,7 @@ class CredentialIssuerServiceTest {
     }
 
     @Test
-    void tokenErrorResponse(WireMockRuntimeInfo wmRuntimeInfo) {
+    void tokenErrorResponseMissingRedirectUri(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getIpvTokenTtl()).thenReturn("900");
         when(mockConfigurationService.getCoreFrontCallbackUrl())
                 .thenReturn("http://www.example.com/redirect");
@@ -134,7 +134,9 @@ class CredentialIssuerServiceTest {
                                         credentialIssuerRequestDto, credentialIssuerConfig));
 
         assertEquals(HTTPResponse.SC_BAD_REQUEST, exception.getHttpStatusCode());
-        assertEquals(ErrorResponse.INVALID_TOKEN_REQUEST, exception.getErrorResponse());
+        assertEquals(
+                "Request was missing the 'redirect_uri' parameter.",
+                exception.getErrorObject().getDescription());
     }
 
     @Test
@@ -168,7 +170,8 @@ class CredentialIssuerServiceTest {
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_EXCHANGE_AUTHORIZATION_CODE, exception.getErrorResponse());
+                ErrorResponse.FAILED_TO_EXCHANGE_AUTHORIZATION_CODE.getMessage(),
+                exception.getErrorObject().getDescription());
     }
 
     @Test
@@ -219,7 +222,9 @@ class CredentialIssuerServiceTest {
 
         assertNotNull(thrown);
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_SAVE_CREDENTIAL, thrown.getErrorResponse());
+        assertEquals(
+                ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getMessage(),
+                thrown.getErrorObject().getDescription());
     }
 
     @Test
@@ -271,7 +276,9 @@ class CredentialIssuerServiceTest {
                                         accessToken, credentialIssuerConfig));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER, thrown.getErrorResponse());
+        assertEquals(
+                ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getMessage(),
+                thrown.getErrorObject().getDescription());
     }
 
     @Test
@@ -296,7 +303,9 @@ class CredentialIssuerServiceTest {
                                         accessToken, credentialIssuerConfig));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER, thrown.getErrorResponse());
+        assertEquals(
+                ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getMessage(),
+                thrown.getErrorObject().getDescription());
     }
 
     private CredentialIssuerConfig getStubCredentialIssuerConfig(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/validation/VerifiableCredentialJwtValidatorTest.java
@@ -95,8 +95,8 @@ class VerifiableCredentialJwtValidatorTest {
                         () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
-                exception.getErrorResponse());
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage(),
+                exception.getErrorObject().getDescription());
     }
 
     @Test
@@ -113,7 +113,9 @@ class VerifiableCredentialJwtValidatorTest {
                         CredentialIssuerException.class,
                         () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_PARSE_JWK, exception.getErrorResponse());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_JWK.getMessage(),
+                exception.getErrorObject().getDescription());
     }
 
     @Test
@@ -132,8 +134,8 @@ class VerifiableCredentialJwtValidatorTest {
                         () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
-                exception.getErrorResponse());
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage(),
+                exception.getErrorObject().getDescription());
     }
 
     @Test
@@ -156,8 +158,8 @@ class VerifiableCredentialJwtValidatorTest {
                                         "THIS IS THE WRONG SUBJECT"));
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
-                exception.getErrorResponse());
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage(),
+                exception.getErrorObject().getDescription());
     }
 
     @Test
@@ -189,8 +191,8 @@ class VerifiableCredentialJwtValidatorTest {
                         () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
-                exception.getErrorResponse());
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage(),
+                exception.getErrorObject().getDescription());
     }
 
     @Test
@@ -222,8 +224,8 @@ class VerifiableCredentialJwtValidatorTest {
                         () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
-                exception.getErrorResponse());
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage(),
+                exception.getErrorObject().getDescription());
     }
 
     @Test
@@ -254,8 +256,8 @@ class VerifiableCredentialJwtValidatorTest {
                         () -> validator.validate(signedJWT, credentialIssuerConfig, SUBJECT));
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
-                exception.getErrorResponse());
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getMessage(),
+                exception.getErrorObject().getDescription());
     }
 
     private ECDSASigner getSigner() throws Exception {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Return a nimbus ErrorObject if the calls to the CRI /token or /credential endpoints fail.

Updated the CredentialIssuerException class to now use the ErrorObject instead. This ErrorObject will be returned back to core-front where it will be sent to the criError lambda to be logged as normal.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
We are now using the Nimbus ErrorObject class when dealing with Oauth errors. This update ensure's we are now handling any Oauth errors occur from the /token and /credential requests and pass them along to the CriError lambda as we do elsewhere.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1279](https://govukverify.atlassian.net/browse/PYIC-1279)

