### PR TITLE
PYIC-1247: Load api key from secret manager and include on header for the requests to the passport api

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -367,6 +367,14 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/audienceForClients
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/ukPassport/api-key-*
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/address/api-key-*
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/fraud/api-key-*
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/kbv/api-key-*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:

--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -74,8 +74,8 @@ public class CredentialIssuerReturnHandler
             APIGatewayProxyRequestEvent input, Context context) {
         CredentialIssuerRequestDto request =
                 RequestHelper.convertRequest(input, CredentialIssuerRequestDto.class);
-        try {
 
+        try {
             auditService.sendAuditEvent(AuditEventTypes.IPV_CRI_AUTH_RESPONSE_RECEIVED);
 
             var errorResponse = validate(request);
@@ -86,11 +86,15 @@ public class CredentialIssuerReturnHandler
             }
             CredentialIssuerConfig credentialIssuerConfig = getCredentialIssuerConfig(request);
 
+            String apiKey =
+                    configurationService.getCriPrivateApiKey(credentialIssuerConfig.getId());
+
             BearerAccessToken accessToken =
-                    credentialIssuerService.exchangeCodeForToken(request, credentialIssuerConfig);
+                    credentialIssuerService.exchangeCodeForToken(
+                            request, credentialIssuerConfig, apiKey);
             SignedJWT verifiableCredential =
                     credentialIssuerService.getVerifiableCredential(
-                            accessToken, credentialIssuerConfig);
+                            accessToken, credentialIssuerConfig, apiKey);
 
             verifiableCredentialJwtValidator.validate(
                     verifiableCredential,

--- a/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
+++ b/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
@@ -85,6 +85,7 @@ class CredentialIssuerReturnHandlerTest {
     private final String authorization_code = "bar";
     private final String sessionId = UUID.randomUUID().toString();
     private final String passportIssuerId = CREDENTIAL_ISSUER_ID;
+    private final String testApiKey = "test-api-key";
 
     @BeforeAll
     static void setUp() throws URISyntaxException {
@@ -131,13 +132,17 @@ class CredentialIssuerReturnHandlerTest {
         JSONObject testCredential = new JSONObject();
         testCredential.appendField("foo", "bar");
 
-        when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
+        when(credentialIssuerService.exchangeCodeForToken(
+                        requestDto.capture(), eq(passportIssuer), eq(testApiKey)))
                 .thenReturn(new BearerAccessToken());
 
-        when(credentialIssuerService.getVerifiableCredential(any(), any())).thenReturn(signedJWT);
+        when(credentialIssuerService.getVerifiableCredential(any(), any(), anyString()))
+                .thenReturn(signedJWT);
 
         when(configurationService.getCredentialIssuer(CREDENTIAL_ISSUER_ID))
                 .thenReturn(passportIssuer);
+
+        when(configurationService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
 
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -269,14 +274,18 @@ class CredentialIssuerReturnHandlerTest {
     void shouldReceive200ResponseCodeIfAllRequestParametersValid() throws Exception {
         BearerAccessToken accessToken = mock(BearerAccessToken.class);
 
-        when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
+        when(credentialIssuerService.exchangeCodeForToken(
+                        requestDto.capture(), eq(passportIssuer), eq(testApiKey)))
                 .thenReturn(accessToken);
 
-        when(credentialIssuerService.getVerifiableCredential(accessToken, passportIssuer))
+        when(credentialIssuerService.getVerifiableCredential(
+                        accessToken, passportIssuer, testApiKey))
                 .thenReturn(SignedJWT.parse(SIGNED_VC_1));
 
         when(configurationService.getCredentialIssuer(CREDENTIAL_ISSUER_ID))
                 .thenReturn(passportIssuer);
+
+        when(configurationService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
 
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -326,13 +335,15 @@ class CredentialIssuerReturnHandlerTest {
                                 OAUTH_STATE),
                         Map.of("ipv-session-id", sessionId));
 
-        when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
+        when(credentialIssuerService.exchangeCodeForToken(
+                        requestDto.capture(), eq(passportIssuer), eq(testApiKey)))
                 .thenThrow(
                         new CredentialIssuerException(
                                 HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
 
         when(configurationService.getCredentialIssuer(CREDENTIAL_ISSUER_ID))
                 .thenReturn(passportIssuer);
+        when(configurationService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
 
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(ipvSessionItem.getCredentialIssuerSessionDetails())
@@ -349,9 +360,9 @@ class CredentialIssuerReturnHandlerTest {
     @Test
     void shouldReturn500IfCredentialIssuerServiceGetCredentialThrows()
             throws JsonProcessingException {
-        when(credentialIssuerService.exchangeCodeForToken(any(), any()))
+        when(credentialIssuerService.exchangeCodeForToken(any(), any(), anyString()))
                 .thenReturn(new BearerAccessToken());
-        when(credentialIssuerService.getVerifiableCredential(any(), any()))
+        when(credentialIssuerService.getVerifiableCredential(any(), any(), anyString()))
                 .thenThrow(
                         new CredentialIssuerException(
                                 HTTPResponse.SC_SERVER_ERROR,
@@ -359,6 +370,7 @@ class CredentialIssuerReturnHandlerTest {
 
         when(configurationService.getCredentialIssuer(CREDENTIAL_ISSUER_ID))
                 .thenReturn(passportIssuer);
+        when(configurationService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
 
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(ipvSessionItem.getCredentialIssuerSessionDetails())
@@ -386,14 +398,18 @@ class CredentialIssuerReturnHandlerTest {
     void shouldThrow500IfVCFailsValidation() throws Exception {
         BearerAccessToken accessToken = mock(BearerAccessToken.class);
 
-        when(credentialIssuerService.exchangeCodeForToken(requestDto.capture(), eq(passportIssuer)))
+        when(credentialIssuerService.exchangeCodeForToken(
+                        requestDto.capture(), eq(passportIssuer), eq(testApiKey)))
                 .thenReturn(accessToken);
 
-        when(credentialIssuerService.getVerifiableCredential(accessToken, passportIssuer))
+        when(credentialIssuerService.getVerifiableCredential(
+                        accessToken, passportIssuer, testApiKey))
                 .thenReturn(SignedJWT.parse(SIGNED_VC_1));
 
         when(configurationService.getCredentialIssuer(CREDENTIAL_ISSUER_ID))
                 .thenReturn(passportIssuer);
+
+        when(configurationService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
 
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Load a CRI's private api key from AWS secrets manager if it exists. If it doesn't exist the exception will be caught and null is returned.

The private api key is then sent in the "x-api-key" header to the CRI's /token and /credential requests if it exists.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The CRI's /token and /credential endpoints are now being secured with private api keys.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1247](https://govukverify.atlassian.net/browse/PYIC-1247)

