### PR TITLE
PYIC-1302: Validate address CRI

### DIFF
--- a/lambdas/validatecricheck/src/main/java/uk/gov/di/ipv/core/validatecricheck/validation/CriCheckValidator.java
+++ b/lambdas/validatecricheck/src/main/java/uk/gov/di/ipv/core/validatecricheck/validation/CriCheckValidator.java
@@ -17,6 +17,7 @@ public class CriCheckValidator {
     public static final String CRI_ID_UK_PASSPORT = "ukPassport";
     public static final String CRI_ID_KBV = "kbv";
     public static final String CRI_ID_FRAUD = "fraud";
+    public static final String CRI_ID_ADDRESS = "address";
     public static final String EVIDENCE = "evidence";
     public static final int SERVER_ERROR = 500;
 
@@ -43,6 +44,9 @@ public class CriCheckValidator {
                 return new EvidenceValidator(new KbvEvidenceValidator()).validate(vcClaimJson);
             case CRI_ID_FRAUD:
                 return new EvidenceValidator(new FraudEvidenceValidator()).validate(vcClaimJson);
+            case CRI_ID_ADDRESS:
+                // The address CRI has no evidence to validate
+                return true;
             default:
                 LOGGER.error("Credential issuer ID not recognised: '{}'", credentialIssuerId);
                 throw new HttpResponseExceptionWithErrorBody(

--- a/lambdas/validatecricheck/src/test/java/uk/gov/di/ipv/core/validatecricheck/validators/CriCheckValidatorTest.java
+++ b/lambdas/validatecricheck/src/test/java/uk/gov/di/ipv/core/validatecricheck/validators/CriCheckValidatorTest.java
@@ -17,11 +17,13 @@ import java.util.Map;
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_VC_5;
+import static uk.gov.di.ipv.core.validatecricheck.validation.CriCheckValidator.CRI_ID_ADDRESS;
 import static uk.gov.di.ipv.core.validatecricheck.validation.CriCheckValidator.CRI_ID_UK_PASSPORT;
 import static uk.gov.di.ipv.core.validatecricheck.validation.CriCheckValidator.EVIDENCE;
 import static uk.gov.di.ipv.core.validatecricheck.validation.CriCheckValidator.SERVER_ERROR;
@@ -75,6 +77,15 @@ class CriCheckValidatorTest {
 
         assertEquals(SERVER_ERROR, error.getResponseCode());
         assertEquals(INVALID_CREDENTIAL_ISSUER_ID.getMessage(), error.getErrorReason());
+    }
+
+    @Test
+    void isSuccessReturnsTrueForAddressCri() throws HttpResponseExceptionWithErrorBody {
+        UserIssuedCredentialsItem userIssuedCredentialsItem = new UserIssuedCredentialsItem();
+        userIssuedCredentialsItem.setCredential(SIGNED_VC_5);
+        userIssuedCredentialsItem.setCredentialIssuer(CRI_ID_ADDRESS);
+
+        assertTrue(criCheckValidator.isSuccess(userIssuedCredentialsItem));
     }
 
     private UserIssuedCredentialsItem getUserIssuedCredentialsItem(JSONObject evidence)


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Validate address CRI

### Why did it change

The address CRI VCs do not contain an evidence block. As the
validate lambda is being called on the return from all VCs it needs to
know how to handle this. It should just return true.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1302](https://govukverify.atlassian.net/browse/PYIC-1302)
