### PR TITLE
PYIC-1279: Return error journey response if Cri error is received

### DIFF
--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -124,8 +124,9 @@ public class CredentialIssuerReturnHandler
                     HttpStatus.SC_OK, errorJourneyResponse);
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
+            JourneyResponse errorJourneyResponse = new JourneyResponse(JOURNEY_ERROR_ENDPOINT);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+                    HttpStatus.SC_OK, errorJourneyResponse);
         }
     }
 

--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -35,6 +35,7 @@ public class CredentialIssuerReturnHandler
     private static final Logger LOGGER =
             LoggerFactory.getLogger(CredentialIssuerReturnHandler.class);
     private static final String CRI_VALIDATE_ENDPOINT = "/journey/cri/validate/";
+    private static final String JOURNEY_ERROR_ENDPOINT = "/journey/error";
 
     private final CredentialIssuerService credentialIssuerService;
     private final ConfigurationService configurationService;
@@ -116,10 +117,11 @@ public class CredentialIssuerReturnHandler
                     new JourneyResponse(
                             String.format(
                                     "%s%s", CRI_VALIDATE_ENDPOINT, credentialIssuerConfig.getId()));
-            return ApiGatewayResponseGenerator.proxyJsonResponse(200, journeyResponse);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, journeyResponse);
         } catch (CredentialIssuerException e) {
+            JourneyResponse errorJourneyResponse = new JourneyResponse(JOURNEY_ERROR_ENDPOINT);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getHttpStatusCode(), e.getErrorResponse());
+                    HttpStatus.SC_OK, errorJourneyResponse);
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
+++ b/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
@@ -322,7 +322,7 @@ class CredentialIssuerReturnHandlerTest {
     }
 
     @Test
-    void shouldReceive400ResponseCodeIfCredentialIssuerServiceThrowsException()
+    void shouldReceive200ErrorJourneyResponseIfCredentialIssuerServiceThrowsException()
             throws JsonProcessingException {
         APIGatewayProxyRequestEvent input =
                 createRequestEvent(
@@ -352,13 +352,13 @@ class CredentialIssuerReturnHandlerTest {
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
         Integer statusCode = response.getStatusCode();
         Map responseBody = getResponseBodyAsMap(response);
-        assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
-        assertEquals(ErrorResponse.INVALID_TOKEN_REQUEST.getCode(), responseBody.get("code"));
+        assertEquals(HTTPResponse.SC_OK, statusCode);
+        assertEquals("/journey/error", responseBody.get("journey"));
         verifyNoInteractions(context);
     }
 
     @Test
-    void shouldReturn500IfCredentialIssuerServiceGetCredentialThrows()
+    void shouldReturn200ErrorJourneyResponseIfCredentialIssuerServiceGetCredentialThrows()
             throws JsonProcessingException {
         when(credentialIssuerService.exchangeCodeForToken(any(), any(), anyString()))
                 .thenReturn(new BearerAccessToken());
@@ -388,14 +388,12 @@ class CredentialIssuerReturnHandlerTest {
                         Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
 
-        assertEquals(HTTPResponse.SC_SERVER_ERROR, response.getStatusCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER.getCode(),
-                getResponseBodyAsMap(response).get("code"));
+        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/error", getResponseBodyAsMap(response).get("journey"));
     }
 
     @Test
-    void shouldThrow500IfVCFailsValidation() throws Exception {
+    void shouldReturrn200ErrorJourneyIfVCFailsValidation() throws Exception {
         BearerAccessToken accessToken = mock(BearerAccessToken.class);
 
         when(credentialIssuerService.exchangeCodeForToken(
@@ -437,10 +435,8 @@ class CredentialIssuerReturnHandlerTest {
                         Map.of("ipv-session-id", sessionId));
         APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
 
-        assertEquals(HTTPResponse.SC_SERVER_ERROR, response.getStatusCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL.getCode(),
-                getResponseBodyAsMap(response).get("code"));
+        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/error", getResponseBodyAsMap(response).get("journey"));
     }
 
     private Map getResponseBodyAsMap(APIGatewayProxyResponseEvent response)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Return a /journey/error response when we receive an error from a CRI.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
If we receive an Oauth error from a CRI then we need to render the the recoverable error page which will be handled from within the journeyEngine lambda. Returning a /journey/error response ensures the journey engine renders the expected error page.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1279](https://govukverify.atlassian.net/browse/PYIC-1279)

