### PR TITLE
PYIC-1337: Update to start returning journey errors

### DIFF
--- a/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
+++ b/lambdas/credentialissuerstart/src/main/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandler.java
@@ -61,7 +61,7 @@ public class CredentialIssuerStartHandler
     public static final int BAD_REQUEST = 400;
     public static final int OK = 200;
     public static final String SHARED_CLAIMS = "shared_claims";
-    public static final String ERROR_JOURNEY_STEP_URI = "/journey/error";
+    public static final JourneyResponse ERROR_JOURNEY = new JourneyResponse("/journey/error");
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -128,19 +128,13 @@ public class CredentialIssuerStartHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(OK, criResponse);
         } catch (HttpResponseExceptionWithErrorBody exception) {
             LOGGER.error("Failed to create cri JAR because: {}", exception.getMessage());
-            JourneyResponse errorJourneyResponse = new JourneyResponse(ERROR_JOURNEY_STEP_URI);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_OK, errorJourneyResponse);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, ERROR_JOURNEY);
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
-            JourneyResponse errorJourneyResponse = new JourneyResponse(ERROR_JOURNEY_STEP_URI);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_OK, errorJourneyResponse);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, ERROR_JOURNEY);
         } catch (ParseException | JOSEException e) {
             LOGGER.error("Failed to parse encryption public JWK: {}", e.getMessage());
-            JourneyResponse errorJourneyResponse = new JourneyResponse(ERROR_JOURNEY_STEP_URI);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_OK, errorJourneyResponse);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, ERROR_JOURNEY);
         }
     }
 

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -185,17 +185,16 @@ class CredentialIssuerStartHandlerTest {
     }
 
     @Test
-    void shouldReturnBadRequestIfSessionIdIsNotInTheHeader() throws JsonProcessingException {
+    void shouldReturnErrorJourneyIfSessionIdIsNotInTheHeader() throws JsonProcessingException {
         when(configurationService.getCredentialIssuer(CRI_ID)).thenReturn(credentialIssuerConfig);
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
         input.setPathParameters(Map.of("criId", CRI_ID));
         input.setHeaders(Map.of("not-ipv-session-header", "dummy-value"));
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
-        assertEquals(400, response.getStatusCode());
+        assertEquals(200, response.getStatusCode());
         Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
-        assertEquals(1010, responseBody.get("code"));
-        assertEquals("Missing ipv session id header", responseBody.get("message"));
+        assertEquals("/journey/error", responseBody.get("journey"));
     }
 
     private void assertSharedClaimsJWTIsValid(String request)

--- a/lambdas/validatecricheck/src/main/java/uk/gov/di/ipv/core/validatecricheck/ValidateCriCheckHandler.java
+++ b/lambdas/validatecricheck/src/main/java/uk/gov/di/ipv/core/validatecricheck/ValidateCriCheckHandler.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.utils.StringUtils;
@@ -28,6 +29,7 @@ public class ValidateCriCheckHandler
     public static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
     public static final String JOURNEY_NEXT = "/journey/next";
     public static final String JOURNEY_FAIL = "/journey/fail";
+    public static final String JOURNEY_ERROR = "/journey/error";
     public static final int OK = 200;
     public static final int BAD_REQUEST = 400;
 
@@ -63,8 +65,9 @@ public class ValidateCriCheckHandler
                             : new JourneyResponse(JOURNEY_FAIL);
             return ApiGatewayResponseGenerator.proxyJsonResponse(OK, journeyResponse);
         } catch (HttpResponseExceptionWithErrorBody e) {
+            JourneyResponse errorJourneyResponse = new JourneyResponse(JOURNEY_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getResponseCode(), e.getErrorBody());
+                    HttpStatus.SC_OK, errorJourneyResponse);
         }
     }
 

--- a/lambdas/validatecricheck/src/test/java/uk/gov/di/ipv/core/validatecricheck/ValidateCriCheckHandlerTest.java
+++ b/lambdas/validatecricheck/src/test/java/uk/gov/di/ipv/core/validatecricheck/ValidateCriCheckHandlerTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.validatecricheck.ValidateCriCheckHandler.BAD_REQUEST;
 import static uk.gov.di.ipv.core.validatecricheck.ValidateCriCheckHandler.CRI_ID;
 import static uk.gov.di.ipv.core.validatecricheck.ValidateCriCheckHandler.IPV_SESSION_ID_HEADER_KEY;
 import static uk.gov.di.ipv.core.validatecricheck.ValidateCriCheckHandler.JOURNEY_FAIL;
@@ -71,19 +70,19 @@ class ValidateCriCheckHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorIfCriIdPathParameterIsNull() {
+    void shouldReturnJourneyErrorIfCriIdPathParameterIsNull() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(IPV_SESSION_ID_HEADER_KEY, sessionId));
 
         var response = validateCriCheckHandler.handleRequest(event, context);
         var error = gson.fromJson(response.getBody(), Map.class);
 
-        assertEquals(BAD_REQUEST, response.getStatusCode());
-        assertEquals("Missing credential issuer id", error.get("message"));
+        assertEquals(OK, response.getStatusCode());
+        assertEquals("/journey/error", error.get("journey"));
     }
 
     @Test
-    void shouldReturnErrorIfCriIdPathParameterIsEmpty() {
+    void shouldReturnJourneyErrorIfCriIdPathParameterIsEmpty() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setPathParameters(Map.of(CRI_ID, ""));
         event.setHeaders(Map.of(IPV_SESSION_ID_HEADER_KEY, sessionId));
@@ -91,24 +90,24 @@ class ValidateCriCheckHandlerTest {
         var response = validateCriCheckHandler.handleRequest(event, context);
         var error = gson.fromJson(response.getBody(), Map.class);
 
-        assertEquals(BAD_REQUEST, response.getStatusCode());
-        assertEquals("Missing credential issuer id", error.get("message"));
+        assertEquals(OK, response.getStatusCode());
+        assertEquals("/journey/error", error.get("journey"));
     }
 
     @Test
-    void shouldReturnErrorIfIpvSessionIdHeaderIsNull() {
+    void shouldReturnJourneyErrorIfIpvSessionIdHeaderIsNull() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setPathParameters(Map.of(CRI_ID, criId));
 
         var response = validateCriCheckHandler.handleRequest(event, context);
         var error = gson.fromJson(response.getBody(), Map.class);
 
-        assertEquals(BAD_REQUEST, response.getStatusCode());
-        assertEquals("Missing ipv session id header", error.get("message"));
+        assertEquals(OK, response.getStatusCode());
+        assertEquals("/journey/error", error.get("journey"));
     }
 
     @Test
-    void shouldReturnErrorIfIpvSessionIdHeaderIsMissing() {
+    void shouldReturnJourneyErrorIfIpvSessionIdHeaderIsMissing() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setPathParameters(Map.of(CRI_ID, criId));
         event.setHeaders(Map.of(IPV_SESSION_ID_HEADER_KEY, ""));
@@ -116,7 +115,7 @@ class ValidateCriCheckHandlerTest {
         var response = validateCriCheckHandler.handleRequest(event, context);
         var error = gson.fromJson(response.getBody(), Map.class);
 
-        assertEquals(BAD_REQUEST, response.getStatusCode());
-        assertEquals("Missing ipv session id header", error.get("message"));
+        assertEquals(OK, response.getStatusCode());
+        assertEquals("/journey/error", error.get("journey"));
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update CriStart and ValidateCri lambda's to start returning journey errors instead of 500 error responses.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
These are recoverable error scenario's, so returning an error journey will mean we still attempt to display the recoverable error page and return the user back to orc.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1337](https://govukverify.atlassian.net/browse/PYIC-1337)

