### PR TITLE
FIX: PYI_NO_MATCH and PYI_KBV_FAIL now end the journey.

### DIFF
--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -152,7 +152,7 @@ public class JourneyEngineHandler
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
                     } else if (journeyStep.equals(FAIL)) {
-                        updateUserState(CRI_ERROR, ipvSessionItem);
+                        updateUserState(PYI_NO_MATCH, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_NO_MATCH.value));
                     } else {
                         handleInvalidJourneyStep(journeyStep, CRI_UK_PASSPORT.value);
@@ -203,6 +203,8 @@ public class JourneyEngineHandler
                     }
                     break;
                 case IPV_SUCCESS_PAGE:
+                case PYI_NO_MATCH:
+                case PYI_KBV_FAIL:
                 case CRI_ERROR:
                     builder.setJourneyResponse(new JourneyResponse(journeyEndUri));
                     break;

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -654,7 +654,8 @@ class JourneyEngineHandlerTest {
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(
-                UserStates.CRI_ERROR.toString(), sessionArgumentCaptor.getValue().getUserState());
+                UserStates.PYI_NO_MATCH.toString(),
+                sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
         assertEquals(UserStates.PYI_NO_MATCH.value, pageResponse.getPage());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
PYI_NO_MATCH and PYI_KBV_FAIL states are now handled by the joruney engine and return a JourneyResponse that takes the user to the end of the journey.
