### PR TITLE
PYIC-1369: Set backend session expiry time

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -282,6 +282,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jarKmsEncryptionKeyId
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/backendSessionTimeout
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -12,6 +12,7 @@ public class IpvSessionItem {
     private String ipvSessionId;
     private String userState;
     private String creationDateTime;
+    private String expirationDateTime;
     private ClientSessionDetailsDto clientSessionDetails;
     private CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails;
 
@@ -38,6 +39,14 @@ public class IpvSessionItem {
 
     public void setCreationDateTime(String creationDateTime) {
         this.creationDateTime = creationDateTime;
+    }
+
+    public String getExpirationDateTime() {
+        return expirationDateTime;
+    }
+
+    public void setExpirationDateTime(String expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
     }
 
     public ClientSessionDetailsDto getClientSessionDetails() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -282,6 +282,11 @@ public class ConfigurationService {
         }
     }
 
+    public String getBackendSessionTimeout() {
+        return ssmProvider.get(
+                String.format("/%s/core/self/backendSessionTimeout", System.getenv(ENVIRONMENT)));
+    }
+
     private String getSecretsManagerValue(GetSecretValueRequest valueRequest) {
         try {
             GetSecretValueResponse valueResponse =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -38,9 +38,13 @@ public class IpvSessionService {
 
     public String generateIpvSession(ClientSessionDetailsDto clientSessionDetailsDto) {
 
+        Instant now = Instant.now();
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(Instant.now().toString());
+        ipvSessionItem.setCreationDateTime(now.toString());
+        ipvSessionItem.setExpirationDateTime(
+                now.plusSeconds(Long.parseLong(configurationService.getBackendSessionTimeout()))
+                        .toString());
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         String userState =

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -373,4 +373,12 @@ class ConfigurationServiceTest {
 
         assertNull(apiKey);
     }
+
+    @Test
+    void shouldReturnBackendSessionTimeout() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        String ttl = "7200";
+        when(ssmProvider.get("/test/core/self/backendSessionTimeout")).thenReturn(ttl);
+        assertEquals(ttl, configurationService.getBackendSessionTimeout());
+    }
 }


### PR DESCRIPTION
**See this config PR for adding the timeout parameter: https://github.com/alphagov/di-ipv-config/pull/628**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set backend session expiry time

### Why did it change

We're going to start checking if a users session has expired. To do this
we need to create an expiry time when their session is created. This timeout
should be pulled from config.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1369](https://govukverify.atlassian.net/browse/PYIC-1369)
