### PR TITLE
PYIC-1371: Load the CRI id's via env variables

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -758,6 +758,10 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           IPV_JOURNEY_CRI_START_URI: "/journey/cri/start/"
           IPV_JOURNEY_SESSION_END_URI: "/journey/session/end"
+          PASSPORT_CRI_ID: !Sub "${PASSPORT_CRI_ID}"
+          ADDRESS_CRI_ID: !Sub "${ADDRESS_CRI_ID}"
+          FRAUD_CRI_ID: !Sub "${FRAUD_CRI_ID}"
+          KBV_CRI_ID: !Sub "${KBV_CRI_ID}"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable

--- a/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
+++ b/lambdas/journeyengine/src/main/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandler.java
@@ -54,10 +54,6 @@ public class JourneyEngineHandler
 
     private static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
     private static final String JOURNEY_STEP_PARAM = "journeyStep";
-    private static final String UK_PASSPORT_CRI_ID = "ukPassport";
-    private static final String ADDRESS_CRI_ID = "address";
-    private static final String KBV_CRI_ID = "kbv";
-    private static final String FRAUD_CRI_ID = "fraud";
 
     private final IpvSessionService ipvSessionService;
     private final ConfigurationService configurationService;
@@ -150,13 +146,15 @@ public class JourneyEngineHandler
                 case IPV_IDENTITY_START_PAGE:
                     updateUserState(CRI_UK_PASSPORT, ipvSessionItem);
                     builder.setJourneyResponse(
-                            new JourneyResponse(criStartUri + UK_PASSPORT_CRI_ID));
+                            new JourneyResponse(
+                                    criStartUri + configurationService.getPassportCriId()));
                     break;
                 case CRI_UK_PASSPORT:
                     if (journeyStep.equals(NEXT)) {
                         updateUserState(CRI_ADDRESS, ipvSessionItem);
                         builder.setJourneyResponse(
-                                new JourneyResponse(criStartUri + ADDRESS_CRI_ID));
+                                new JourneyResponse(
+                                        criStartUri + configurationService.getAddressCriId()));
                     } else if (journeyStep.equals(ERROR)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
@@ -170,7 +168,9 @@ public class JourneyEngineHandler
                 case CRI_ADDRESS:
                     if (journeyStep.equals(NEXT)) {
                         updateUserState(CRI_FRAUD, ipvSessionItem);
-                        builder.setJourneyResponse(new JourneyResponse(criStartUri + FRAUD_CRI_ID));
+                        builder.setJourneyResponse(
+                                new JourneyResponse(
+                                        criStartUri + configurationService.getFraudCriId()));
                     } else if (journeyStep.equals(ERROR)) {
                         updateUserState(CRI_ERROR, ipvSessionItem);
                         builder.setPageResponse(new PageResponse(PYI_TECHNICAL_ERROR_PAGE.value));
@@ -194,7 +194,8 @@ public class JourneyEngineHandler
                     break;
                 case PRE_KBV_TRANSITION_PAGE:
                     updateUserState(CRI_KBV, ipvSessionItem);
-                    builder.setJourneyResponse(new JourneyResponse(criStartUri + KBV_CRI_ID));
+                    builder.setJourneyResponse(
+                            new JourneyResponse(criStartUri + configurationService.getKbvCriId()));
                     break;
                 case CRI_KBV:
                     if (journeyStep.equals(NEXT)) {

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -242,6 +242,7 @@ class JourneyEngineHandlerTest {
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
+        when(mockConfigurationService.getPassportCriId()).thenReturn("ukPassport");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -278,6 +279,7 @@ class JourneyEngineHandlerTest {
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
+        when(mockConfigurationService.getAddressCriId()).thenReturn("address");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -345,6 +347,7 @@ class JourneyEngineHandlerTest {
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
+        when(mockConfigurationService.getFraudCriId()).thenReturn("fraud");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -445,6 +448,7 @@ class JourneyEngineHandlerTest {
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
         when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
+        when(mockConfigurationService.getKbvCriId()).thenReturn("kbv");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -118,6 +118,22 @@ public class ConfigurationService {
         return System.getenv("SQS_AUDIT_EVENT_QUEUE_URL");
     }
 
+    public String getPassportCriId() {
+        return System.getenv("PASSPORT_CRI_ID");
+    }
+
+    public String getAddressCriId() {
+        return System.getenv("ADDRESS_CRI_ID");
+    }
+
+    public String getFraudCriId() {
+        return System.getenv("FRAUD_CRI_ID");
+    }
+
+    public String getKbvCriId() {
+        return System.getenv("KBV_CRI_ID");
+    }
+
     public long getBearerAccessTokenTtl() {
         return Optional.ofNullable(System.getenv("BEARER_TOKEN_TTL"))
                 .map(Long::valueOf)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -37,10 +37,6 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 
 public class UserIdentityService {
     private static final Logger LOGGER = LoggerFactory.getLogger(UserIdentityService.class);
-    private static final String ADDRESS_CRI_TYPE = "address";
-    private static final String PASSPORT_CRI_TYPE = "ukPassport";
-    private static final String FRAUD_CRI_TYPE = "fraud";
-    private static final String KBV_CRI_TYPE = "kbv";
     private static final String NAME_PROPERTY_NAME = "name";
     private static final String BIRTH_DATE_PROPERTY_NAME = "birthDate";
     private static final String ADDRESS_PROPERTY_NAME = "address";
@@ -51,6 +47,11 @@ public class UserIdentityService {
     private static final int GPG_45_M1A_VALIDITY_SCORE = 2;
     private static final int GPG_45_M1A_FRAUD_SCORE = 1;
     private static final int GPG_45_M1A_VERIFICATION_SCORE = 2;
+    private static final List<String> ADDRESS_CRI_TYPES =
+            List.of(ADDRESS_PROPERTY_NAME, "stubAddress");
+    private static final List<String> PASSPORT_CRI_TYPES = List.of("ukPassport", "stubUkPassport");
+    private static final List<String> FRAUD_CRI_TYPES = List.of("fraud", "stubFraud");
+    private static final List<String> KBV_CRI_TYPES = List.of("kbv", "stubKbv");
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final ConfigurationService configurationService;
@@ -161,7 +162,7 @@ public class UserIdentityService {
                 JSONObject vcClaim = (JSONObject) jwtClaimsSet.getClaim(VC_CLAIM);
                 JSONArray evidenceArray = ((JSONArray) vcClaim.get(VC_EVIDENCE));
 
-                if (item.getCredentialIssuer().equals(PASSPORT_CRI_TYPE)) {
+                if (PASSPORT_CRI_TYPES.contains(item.getCredentialIssuer())) {
                     validPassport =
                             isValidScore(
                                     evidenceArray,
@@ -169,7 +170,7 @@ public class UserIdentityService {
                                     GPG_45_M1A_VALIDITY_SCORE);
                 }
 
-                if (item.getCredentialIssuer().equals(FRAUD_CRI_TYPE)) {
+                if (FRAUD_CRI_TYPES.contains(item.getCredentialIssuer())) {
                     validFraud =
                             isValidScore(
                                     evidenceArray,
@@ -177,7 +178,7 @@ public class UserIdentityService {
                                     GPG_45_M1A_FRAUD_SCORE);
                 }
 
-                if (item.getCredentialIssuer().equals(KBV_CRI_TYPE)) {
+                if (KBV_CRI_TYPES.contains(item.getCredentialIssuer())) {
                     validKbv =
                             isValidScore(
                                     evidenceArray,
@@ -196,7 +197,7 @@ public class UserIdentityService {
             List<UserIssuedCredentialsItem> credentialIssuerItems)
             throws HttpResponseExceptionWithErrorBody {
         for (UserIssuedCredentialsItem item : credentialIssuerItems) {
-            if (item.getCredentialIssuer().equals(PASSPORT_CRI_TYPE)) {
+            if (PASSPORT_CRI_TYPES.contains(item.getCredentialIssuer())) {
                 try {
                     JsonNode nameNode =
                             objectMapper
@@ -261,7 +262,8 @@ public class UserIdentityService {
                 credentialIssuerItems.stream()
                         .filter(
                                 credential ->
-                                        ADDRESS_CRI_TYPE.equals(credential.getCredentialIssuer()))
+                                        ADDRESS_CRI_TYPES.contains(
+                                                credential.getCredentialIssuer()))
                         .findFirst()
                         .orElseThrow(
                                 () -> {
@@ -303,7 +305,8 @@ public class UserIdentityService {
                 credentialIssuerItems.stream()
                         .filter(
                                 credential ->
-                                        PASSPORT_CRI_TYPE.equals(credential.getCredentialIssuer()))
+                                        PASSPORT_CRI_TYPES.contains(
+                                                credential.getCredentialIssuer()))
                         .findFirst()
                         .orElseThrow(
                                 () -> {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -298,6 +298,30 @@ class ConfigurationServiceTest {
     }
 
     @Test
+    void shouldReturnPassportCriId() {
+        environmentVariables.set("PASSPORT_CRI_ID", "ukPassport");
+        assertEquals("ukPassport", configurationService.getPassportCriId());
+    }
+
+    @Test
+    void shouldReturnAddressCriId() {
+        environmentVariables.set("ADDRESS_CRI_ID", "address");
+        assertEquals("address", configurationService.getAddressCriId());
+    }
+
+    @Test
+    void shouldReturnFraudCriId() {
+        environmentVariables.set("FRAUD_CRI_ID", "fraud");
+        assertEquals("fraud", configurationService.getFraudCriId());
+    }
+
+    @Test
+    void shouldReturnKbvCriId() {
+        environmentVariables.set("KBV_CRI_ID", "kbv");
+        assertEquals("kbv", configurationService.getKbvCriId());
+    }
+
+    @Test
     void shouldGetSecretValueFromSecretsManager() {
         Map<String, String> apiKeySecret = Map.of("apiKey", "api-key-value");
         GetSecretValueResponse response =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
For the journey engine lambda, load the CRI ID values via environment variables. This way we can use the env var to control wether the journey engine should be using the real or stub version of each CRI per env.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Make it easier to swap between using the stu/real version of CRI's per environment
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1371](https://govukverify.atlassian.net/browse/PYIC-1371)

