### PR TITLE
PYIC-1377: Implement session timeout

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -282,8 +282,6 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jarKmsEncryptionKeyId
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/backendSessionTimeout
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -757,6 +757,8 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/backendSessionTimeout
       Events:
         IPVCorePrivateAPI:
           Type: Api

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,8 +21,8 @@ import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -145,7 +146,7 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -173,10 +174,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState("INVALID-STATE");
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -201,10 +203,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -233,11 +236,12 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.IPV_IDENTITY_START_PAGE.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -268,11 +272,12 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -302,10 +307,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -333,11 +339,12 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -367,10 +374,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -398,10 +406,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -430,11 +439,12 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.PRE_KBV_TRANSITION_PAGE.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -464,10 +474,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -495,11 +506,12 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -530,10 +542,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -561,11 +574,12 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.IPV_SUCCESS_PAGE.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -589,10 +603,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -614,10 +629,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -645,10 +661,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -677,10 +694,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ERROR.toString());
 
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -704,10 +722,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -736,10 +755,11 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
 
         APIGatewayProxyResponseEvent response =
                 journeyEngineHandler.handleRequest(event, mockContext);
@@ -768,11 +788,12 @@ class JourneyEngineHandlerTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(new Date().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
 
         when(mockConfigurationService.getIpvJourneyCriStartUri()).thenReturn("/journey/cri/start/");
         when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =
@@ -789,5 +810,70 @@ class JourneyEngineHandlerTest {
 
         assertEquals(200, response.getStatusCode());
         assertEquals(UserStates.PYI_KBV_FAIL.value, pageResponse.getPage());
+    }
+
+    @Test
+    void shouldReturnErrorPageIfSessionHasExpired() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put(JOURNEY_STEP, NEXT);
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().minusSeconds(100).toString());
+        ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
+
+        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("99");
+        when(mockIpvSessionService.getIpvSession("1234")).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        PageResponse pageResponse = objectMapper.readValue(response.getBody(), PageResponse.class);
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+
+        IpvSessionItem capturedIpvSessionItem = sessionArgumentCaptor.getValue();
+        assertEquals(
+                UserStates.CORE_SESSION_TIMEOUT.toString(), capturedIpvSessionItem.getUserState());
+        assertEquals(OAuth2Error.ACCESS_DENIED.getCode(), capturedIpvSessionItem.getErrorCode());
+        assertEquals(
+                OAuth2Error.ACCESS_DENIED.getDescription(),
+                capturedIpvSessionItem.getErrorDescription());
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(UserStates.PYI_TECHNICAL_ERROR_PAGE.value, pageResponse.getPage());
+    }
+
+    @Test
+    void shouldReturnSessionEndJourneyIfStateIsSessionTimeout() throws Exception {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put(JOURNEY_STEP, NEXT);
+        event.setPathParameters(pathParameters);
+
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().minusSeconds(100).toString());
+        ipvSessionItem.setUserState(UserStates.CORE_SESSION_TIMEOUT.toString());
+
+        when(mockConfigurationService.getIpvJourneySessionEnd()).thenReturn("/journey/session/end");
+        when(mockIpvSessionService.getIpvSession("1234")).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response =
+                journeyEngineHandler.handleRequest(event, mockContext);
+        JourneyResponse journeyResponse =
+                objectMapper.readValue(response.getBody(), JourneyResponse.class);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("/journey/session/end", journeyResponse.getJourney());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserStates.java
@@ -8,16 +8,15 @@ public enum UserStates {
     PRE_KBV_TRANSITION_PAGE("page-pre-kbv-transition"),
     IPV_SUCCESS_PAGE("page-ipv-success"),
     CRI_UK_PASSPORT("cri-ukPassport"),
-    CRI_ACTIVITY_HISTORY("cri-activityHistory"),
     CRI_ADDRESS("cri-Address"),
     CRI_FRAUD("cri-fraud"),
     CRI_KBV("cri-kbv"),
     CRI_ERROR("cri-error"),
-    IPV_ERROR_PAGE("page-ipv-error"),
     PYI_TECHNICAL_ERROR_PAGE("pyi-technical"),
     PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE("pyi-technical-unrecoverable"),
     PYI_NO_MATCH("pyi-no-match"),
-    PYI_KBV_FAIL("pyi-kbv-fail");
+    PYI_KBV_FAIL("pyi-kbv-fail"),
+    CORE_SESSION_TIMEOUT("core-session-timeout");
 
     public final String value;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -12,7 +12,6 @@ public class IpvSessionItem {
     private String ipvSessionId;
     private String userState;
     private String creationDateTime;
-    private String expirationDateTime;
     private ClientSessionDetailsDto clientSessionDetails;
     private CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails;
     private String errorCode;
@@ -41,14 +40,6 @@ public class IpvSessionItem {
 
     public void setCreationDateTime(String creationDateTime) {
         this.creationDateTime = creationDateTime;
-    }
-
-    public String getExpirationDateTime() {
-        return expirationDateTime;
-    }
-
-    public void setExpirationDateTime(String expirationDateTime) {
-        this.expirationDateTime = expirationDateTime;
     }
 
     public ClientSessionDetailsDto getClientSessionDetails() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -39,13 +39,9 @@ public class IpvSessionService {
     public String generateIpvSession(
             ClientSessionDetailsDto clientSessionDetailsDto, ErrorObject errorObject) {
 
-        Instant now = Instant.now();
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
-        ipvSessionItem.setCreationDateTime(now.toString());
-        ipvSessionItem.setExpirationDateTime(
-                now.plusSeconds(Long.parseLong(configurationService.getBackendSessionTimeout()))
-                        .toString());
+        ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         String userState =

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -12,7 +12,6 @@ import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 
-import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 
@@ -53,7 +52,6 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldCreateSessionItem() {
-        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         String ipvSessionID =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
@@ -68,25 +66,17 @@ class IpvSessionServiceTest {
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockDataStore).create(ipvSessionItemArgumentCaptor.capture());
-        IpvSessionItem capturedIpvSessionItem = ipvSessionItemArgumentCaptor.getValue();
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
 
-        assertNotNull(capturedIpvSessionItem.getIpvSessionId());
-        assertNotNull(capturedIpvSessionItem.getCreationDateTime());
-        assertNotNull(capturedIpvSessionItem.getExpirationDateTime());
+        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
         assertEquals(
-                7200,
-                Instant.parse(capturedIpvSessionItem.getExpirationDateTime()).getEpochSecond()
-                        - Instant.parse(capturedIpvSessionItem.getCreationDateTime())
-                                .getEpochSecond());
-
-        assertEquals(capturedIpvSessionItem.getIpvSessionId(), ipvSessionID);
-        assertEquals(
-                UserStates.INITIAL_IPV_JOURNEY.toString(), capturedIpvSessionItem.getUserState());
+                UserStates.INITIAL_IPV_JOURNEY.toString(),
+                ipvSessionItemArgumentCaptor.getValue().getUserState());
     }
 
     @Test
     void shouldCreateSessionItemForDebugJourney() {
-        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         String ipvSessionID =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
@@ -101,24 +91,17 @@ class IpvSessionServiceTest {
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockDataStore).create(ipvSessionItemArgumentCaptor.capture());
-        IpvSessionItem capturedIpvSessionItem = ipvSessionItemArgumentCaptor.getValue();
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
 
-        assertNotNull(capturedIpvSessionItem.getIpvSessionId());
-        assertNotNull(capturedIpvSessionItem.getCreationDateTime());
-        assertNotNull(capturedIpvSessionItem.getExpirationDateTime());
+        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
         assertEquals(
-                7200,
-                Instant.parse(capturedIpvSessionItem.getExpirationDateTime()).getEpochSecond()
-                        - Instant.parse(capturedIpvSessionItem.getCreationDateTime())
-                                .getEpochSecond());
-
-        assertEquals(capturedIpvSessionItem.getIpvSessionId(), ipvSessionID);
-        assertEquals(UserStates.DEBUG_PAGE.toString(), capturedIpvSessionItem.getUserState());
+                UserStates.DEBUG_PAGE.toString(),
+                ipvSessionItemArgumentCaptor.getValue().getUserState());
     }
 
     @Test
     void shouldCreateSessionItemWithErrorObject() {
-        when(mockConfigurationService.getBackendSessionTimeout()).thenReturn("7200");
         ErrorObject testErrorObject = new ErrorObject("server_error", "Test error");
         String ipvSessionID =
                 ipvSessionService.generateIpvSession(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Implement session timeout

~There is an outstanding question on what error page the user should see having timed out. At
the moment this PR will show them the technical error page. But that doesn't feel quite right.
I've asked @galund what he thinks. Opinions welcome.~

### Why did it change

[PYIC-1377: Don't explicitly set expiry time on session](https://github.com/alphagov/di-ipv-core-back/commit/946dc31062f8ba333acf3edeb0254b029475ea28) 

Rather than setting an expiry time on the session when it's created, it
will be better to check the creation time + timeout period at the point
we want to see if the session has expired. That way, any changes to the
timeout period will apply to all sessions, including those that already
exist.
  
[PYIC-1377: Handle session timeout in journey engine](https://github.com/alphagov/di-ipv-core-back/commit/9bd7a8687b3e338ba30c7fcd5b5368036da7b61b) 

This updates the journey engine to check if a users session has timed
out. If it has it updates their user state to a timeout state with
appropriate oauth error code and description, and returns a page
response for an error page. When the user clicks continue and comes back
into the journey engine, they're returned a joureny response to the
session end lambda.

When returning from a CRI a users VC is processed before they come back
into the journey engine. This means that if they time out while in a
CRI we will still capture the credential on their return, before
updating their state.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1377](https://govukverify.atlassian.net/browse/PYIC-1377)
