### PR TITLE
PYIC-1380: Add the ttl value to our dynamoDB items

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Integration tests
         env:
           IPV_SESSIONS_TABLE_NAME: sessions-build
+          ENVIRONMENT: build
         run: ./gradlew intTest
 
       - name: SAM validate

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Integration tests
         env:
           IPV_SESSIONS_TABLE_NAME: sessions-build
+          ENVIRONMENT: build
         run: ./gradlew intTest
 
       - name: Perform Static Analysis

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -158,6 +158,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/audienceForClients
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/backendSessionTtl
       Events:
         IPVCoreExternalAPI:
           Type: Api
@@ -282,6 +284,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/jarKmsEncryptionKeyId
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/backendSessionTtl
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -367,6 +371,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/audienceForClients
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/backendSessionTtl
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/ukPassport/api-key-*
         - AWSSecretsManagerGetSecretValuePolicy:
@@ -850,6 +856,9 @@ Resources:
           KeyType: "HASH"
         - AttributeName: "credentialIssuer"
           KeyType: "RANGE"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: "TRUE"
 
   AuthCodesTable:
     Type: AWS::DynamoDB::Table
@@ -862,6 +871,9 @@ Resources:
       KeySchema:
         - AttributeName: "authCode"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: "TRUE"
 
   AccessTokensTable:
     Type: AWS::DynamoDB::Table
@@ -874,6 +886,9 @@ Resources:
       KeySchema:
         - AttributeName: "accessToken"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: "TRUE"
 
   SessionsTable:
     Type: AWS::DynamoDB::Table
@@ -886,6 +901,9 @@ Resources:
       KeySchema:
         - AttributeName: "ipvSessionId"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: "TRUE"
 
 Outputs:
   IPVCorePrivateAPIGatewayID:

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -44,6 +45,7 @@ public class DataStoreIpvSessionIT {
 
     private static DataStore<IpvSessionItem> ipvSessionItemDataStore;
     private static Table tableTestHarness;
+    private static ConfigurationService configurationService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -55,12 +57,15 @@ public class DataStoreIpvSessionIT {
                     "The environment variable 'IPV_SESSIONS_TABLE_NAME' must be provided to run this test");
         }
 
+        ConfigurationService configurationService = new ConfigurationService();
+
         ipvSessionItemDataStore =
                 new DataStore<>(
                         ipvSessionsTableName,
                         IpvSessionItem.class,
                         DataStore.getClient(false),
-                        false);
+                        false,
+                        configurationService);
 
         AmazonDynamoDB independentClient =
                 AmazonDynamoDBClient.builder().withRegion("eu-west-2").build();

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -45,7 +45,6 @@ public class DataStoreIpvSessionIT {
 
     private static DataStore<IpvSessionItem> ipvSessionItemDataStore;
     private static Table tableTestHarness;
-    private static ConfigurationService configurationService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 public class AccessTokenItem {
     private String accessToken;
     private String ipvSessionId;
+    private long ttl;
 
     @DynamoDbPartitionKey
     public String getAccessToken() {
@@ -23,5 +24,13 @@ public class AccessTokenItem {
 
     public void setIpvSessionId(String ipvSessionId) {
         this.ipvSessionId = ipvSessionId;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
@@ -2,8 +2,10 @@ package uk.gov.di.ipv.core.library.persistence.item;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @DynamoDbBean
+@ExcludeFromGeneratedCoverageReport
 public class AccessTokenItem implements DynamodbItem {
     private String accessToken;
     private String ipvSessionId;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
@@ -4,7 +4,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
 @DynamoDbBean
-public class AccessTokenItem {
+public class AccessTokenItem implements DynamodbItem {
     private String accessToken;
     private String ipvSessionId;
     private long ttl;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
@@ -2,8 +2,10 @@ package uk.gov.di.ipv.core.library.persistence.item;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @DynamoDbBean
+@ExcludeFromGeneratedCoverageReport
 public class AuthorizationCodeItem implements DynamodbItem {
 
     private String authCode;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
@@ -4,7 +4,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
 @DynamoDbBean
-public class AuthorizationCodeItem {
+public class AuthorizationCodeItem implements DynamodbItem {
 
     private String authCode;
     private String ipvSessionId;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
@@ -9,6 +9,7 @@ public class AuthorizationCodeItem {
     private String authCode;
     private String ipvSessionId;
     private String redirectUrl;
+    private long ttl;
 
     @DynamoDbPartitionKey
     public String getAuthCode() {
@@ -33,5 +34,13 @@ public class AuthorizationCodeItem {
 
     public void setRedirectUrl(String redirectUrl) {
         this.redirectUrl = redirectUrl;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/DynamodbItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/DynamodbItem.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.core.library.persistence.item;
+
+public interface DynamodbItem {
+    void setTtl(long ttl);
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -8,7 +8,7 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
-public class IpvSessionItem {
+public class IpvSessionItem implements DynamodbItem {
     private String ipvSessionId;
     private String userState;
     private String creationDateTime;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -16,6 +16,7 @@ public class IpvSessionItem {
     private CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails;
     private String errorCode;
     private String errorDescription;
+    private long ttl;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {
@@ -73,5 +74,13 @@ public class IpvSessionItem {
 
     public void setErrorDescription(String errorDescription) {
         this.errorDescription = errorDescription;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/UserIssuedCredentialsItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/UserIssuedCredentialsItem.java
@@ -7,7 +7,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortK
 import java.time.LocalDateTime;
 
 @DynamoDbBean
-public class UserIssuedCredentialsItem {
+public class UserIssuedCredentialsItem implements DynamodbItem {
 
     private String ipvSessionId;
     private String credentialIssuer;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/UserIssuedCredentialsItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/UserIssuedCredentialsItem.java
@@ -3,10 +3,12 @@ package uk.gov.di.ipv.core.library.persistence.item;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.time.LocalDateTime;
 
 @DynamoDbBean
+@ExcludeFromGeneratedCoverageReport
 public class UserIssuedCredentialsItem implements DynamodbItem {
 
     private String ipvSessionId;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/UserIssuedCredentialsItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/UserIssuedCredentialsItem.java
@@ -13,6 +13,7 @@ public class UserIssuedCredentialsItem {
     private String credentialIssuer;
     private String credential;
     private LocalDateTime dateCreated;
+    private long ttl;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {
@@ -46,5 +47,13 @@ public class UserIssuedCredentialsItem {
 
     public void setCredential(String credential) {
         this.credential = credential;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
+import java.time.Instant;
 import java.util.Objects;
 
 public class AccessTokenService {
@@ -62,6 +63,8 @@ public class AccessTokenService {
         accessTokenItem.setAccessToken(
                 tokenResponse.getTokens().getBearerAccessToken().toAuthorizationHeader());
         accessTokenItem.setIpvSessionId(ipvSessionId);
+        accessTokenItem.setTtl(
+                Instant.now().plusSeconds(configurationService.getSessionTtl()).getEpochSecond());
         dataStore.create(accessTokenItem);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -14,7 +14,6 @@ import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
-import java.time.Instant;
 import java.util.Objects;
 
 public class AccessTokenService {
@@ -30,7 +29,8 @@ public class AccessTokenService {
                         this.configurationService.getAccessTokensTableName(),
                         AccessTokenItem.class,
                         DataStore.getClient(isRunningLocally),
-                        isRunningLocally);
+                        isRunningLocally,
+                        configurationService);
     }
 
     public AccessTokenService(
@@ -63,8 +63,6 @@ public class AccessTokenService {
         accessTokenItem.setAccessToken(
                 tokenResponse.getTokens().getBearerAccessToken().toAuthorizationHeader());
         accessTokenItem.setIpvSessionId(ipvSessionId);
-        accessTokenItem.setTtl(
-                Instant.now().plusSeconds(configurationService.getSessionTtl()).getEpochSecond());
         dataStore.create(accessTokenItem);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
@@ -5,6 +5,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 
+import java.time.Instant;
 import java.util.Optional;
 
 public class AuthorizationCodeService {
@@ -44,6 +45,8 @@ public class AuthorizationCodeService {
         authorizationCodeItem.setAuthCode(authorizationCode);
         authorizationCodeItem.setIpvSessionId(ipvSessionId);
         authorizationCodeItem.setRedirectUrl(redirectUrl);
+        authorizationCodeItem.setTtl(
+                Instant.now().plusSeconds(configurationService.getSessionTtl()).getEpochSecond());
 
         dataStore.create(authorizationCodeItem);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
@@ -5,7 +5,6 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 
-import java.time.Instant;
 import java.util.Optional;
 
 public class AuthorizationCodeService {
@@ -21,7 +20,8 @@ public class AuthorizationCodeService {
                         this.configurationService.getAuthCodesTableName(),
                         AuthorizationCodeItem.class,
                         DataStore.getClient(isRunningLocally),
-                        isRunningLocally);
+                        isRunningLocally,
+                        configurationService);
     }
 
     public AuthorizationCodeService(
@@ -45,8 +45,6 @@ public class AuthorizationCodeService {
         authorizationCodeItem.setAuthCode(authorizationCode);
         authorizationCodeItem.setIpvSessionId(ipvSessionId);
         authorizationCodeItem.setRedirectUrl(redirectUrl);
-        authorizationCodeItem.setTtl(
-                Instant.now().plusSeconds(configurationService.getSessionTtl()).getEpochSecond());
 
         dataStore.create(authorizationCodeItem);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -287,6 +287,13 @@ public class ConfigurationService {
                 String.format("/%s/core/self/backendSessionTimeout", System.getenv(ENVIRONMENT)));
     }
 
+    public long getSessionTtl() {
+        return Long.parseLong(
+                ssmProvider.get(
+                        String.format(
+                                "/%s/core/self/backendSessionTtl", System.getenv(ENVIRONMENT))));
+    }
+
     private String getSecretsManagerValue(GetSecretValueRequest valueRequest) {
         try {
             GetSecretValueResponse valueResponse =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -287,7 +287,7 @@ public class ConfigurationService {
                 String.format("/%s/core/self/backendSessionTimeout", System.getenv(ENVIRONMENT)));
     }
 
-    public long getSessionTtl() {
+    public long getBackendSessionTtl() {
         return Long.parseLong(
                 ssmProvider.get(
                         String.format(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -32,7 +32,6 @@ import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -57,7 +56,8 @@ public class CredentialIssuerService {
                         this.configurationService.getUserIssuedCredentialTableName(),
                         UserIssuedCredentialsItem.class,
                         DataStore.getClient(isRunningLocally),
-                        isRunningLocally);
+                        isRunningLocally,
+                        configurationService);
     }
 
     public CredentialIssuerService(
@@ -181,8 +181,6 @@ public class CredentialIssuerService {
         userIssuedCredentials.setCredentialIssuer(request.getCredentialIssuerId());
         userIssuedCredentials.setCredential(credential);
         userIssuedCredentials.setDateCreated(LocalDateTime.now());
-        userIssuedCredentials.setTtl(
-                Instant.now().plusSeconds(configurationService.getSessionTtl()).getEpochSecond());
         try {
             dataStore.create(userIssuedCredentials);
         } catch (UnsupportedOperationException e) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -32,6 +32,7 @@ import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -180,6 +181,8 @@ public class CredentialIssuerService {
         userIssuedCredentials.setCredentialIssuer(request.getCredentialIssuerId());
         userIssuedCredentials.setCredential(credential);
         userIssuedCredentials.setDateCreated(LocalDateTime.now());
+        userIssuedCredentials.setTtl(
+                Instant.now().plusSeconds(configurationService.getSessionTtl()).getEpochSecond());
         try {
             dataStore.create(userIssuedCredentials);
         } catch (UnsupportedOperationException e) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -23,7 +23,8 @@ public class IpvSessionService {
                         this.configurationService.getIpvSessionTableName(),
                         IpvSessionItem.class,
                         DataStore.getClient(isRunningLocally),
-                        isRunningLocally);
+                        isRunningLocally,
+                        configurationService);
     }
 
     public IpvSessionService(
@@ -52,9 +53,6 @@ public class IpvSessionService {
             ipvSessionItem.setErrorCode(errorObject.getCode());
             ipvSessionItem.setErrorDescription(errorObject.getDescription());
         }
-
-        ipvSessionItem.setTtl(
-                Instant.now().plusSeconds(configurationService.getSessionTtl()).getEpochSecond());
 
         dataStore.create(ipvSessionItem);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -53,6 +53,9 @@ public class IpvSessionService {
             ipvSessionItem.setErrorDescription(errorObject.getDescription());
         }
 
+        ipvSessionItem.setTtl(
+                Instant.now().plusSeconds(configurationService.getSessionTtl()).getEpochSecond());
+
         dataStore.create(ipvSessionItem);
 
         return ipvSessionItem.getIpvSessionId();

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -61,7 +61,8 @@ public class UserIdentityService {
                         this.configurationService.getUserIssuedCredentialTableName(),
                         UserIssuedCredentialsItem.class,
                         DataStore.getClient(isRunningLocally),
-                        isRunningLocally);
+                        isRunningLocally,
+                        configurationService);
     }
 
     public UserIdentityService(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -381,4 +381,12 @@ class ConfigurationServiceTest {
         when(ssmProvider.get("/test/core/self/backendSessionTimeout")).thenReturn(ttl);
         assertEquals(ttl, configurationService.getBackendSessionTimeout());
     }
+
+    @Test
+    void shouldReturnBackendSessionTtl() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        long ttl = 7200;
+        when(ssmProvider.get("/test/core/self/backendSessionTtl")).thenReturn(String.valueOf(ttl));
+        assertEquals(ttl, configurationService.getBackendSessionTtl());
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Enable the TTL setting on our DynamoDB tables with the "ttl" attribute name.

Add the "ttl" property to all our DynamoDB items that retrieves the SSM backendSessionTtl param and sets an epoch seconds value on the ttl property. This value should be set to 24 hours
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This property will be used to automatically delete our dynamoDB items based of the ttl property on each item.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1380](https://govukverify.atlassian.net/browse/PYIC-1380)

