### PR TITLE
BAU: Parse token response as OAuth response

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -15,7 +15,6 @@ import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
-import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,7 +107,7 @@ public class CredentialIssuerService {
             }
 
             HTTPResponse httpResponse = httpRequest.send();
-            TokenResponse tokenResponse = parseTokenResponse(httpResponse);
+            TokenResponse tokenResponse = TokenResponse.parse(httpResponse);
 
             if (tokenResponse instanceof TokenErrorResponse) {
                 TokenErrorResponse errorResponse = tokenResponse.toErrorResponse();
@@ -169,10 +168,6 @@ public class CredentialIssuerService {
                     HTTPResponse.SC_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
         }
-    }
-
-    private TokenResponse parseTokenResponse(HTTPResponse httpResponse) throws ParseException {
-        return OIDCTokenResponseParser.parse(httpResponse);
     }
 
     public void persistUserCredentials(String credential, CredentialIssuerRequestDto request) {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Parse token response as OAuth response

### Why did it change

We were using an OIDC token response parser, rather than an OAuth token
response parser. While this still works, it also attempts to parse an
id_token as well as access_token and refresh_token. Using an OIDC thing
in a non OIDC flow was confusing, so we should switch to the correct
parser.
