### PR TITLE
PYIC-1480: Hash codes and tokens before persisting

### DIFF
--- a/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
+++ b/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
@@ -8,6 +8,7 @@ import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -66,14 +67,14 @@ public class UserIdentityHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
-            String accessTokenString =
-                    RequestHelper.getHeaderByKey(input.getHeaders(), AUTHORIZATION_HEADER_KEY);
-
-            // Performs validation on header value and throws a ParseException if invalid
-            AccessToken.parse(accessTokenString);
+            AccessToken accessToken =
+                    AccessToken.parse(
+                            RequestHelper.getHeaderByKey(
+                                    input.getHeaders(), AUTHORIZATION_HEADER_KEY),
+                            AccessTokenType.BEARER);
 
             String ipvSessionId =
-                    accessTokenService.getIpvSessionIdByAccessToken(accessTokenString);
+                    accessTokenService.getIpvSessionIdByAccessToken(accessToken.getValue());
 
             if (StringUtils.isBlank(ipvSessionId)) {
                 LOGGER.error(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -9,6 +9,7 @@ import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
+import org.apache.commons.codec.digest.DigestUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
@@ -56,14 +57,14 @@ public class AccessTokenService {
     }
 
     public String getIpvSessionIdByAccessToken(String accessToken) {
-        AccessTokenItem accessTokenItem = dataStore.getItem(accessToken);
+        AccessTokenItem accessTokenItem = dataStore.getItem(DigestUtils.sha256Hex(accessToken));
         return Objects.isNull(accessTokenItem) ? null : accessTokenItem.getIpvSessionId();
     }
 
     public void persistAccessToken(AccessTokenResponse tokenResponse, String ipvSessionId) {
         AccessTokenItem accessTokenItem = new AccessTokenItem();
         accessTokenItem.setAccessToken(
-                tokenResponse.getTokens().getBearerAccessToken().toAuthorizationHeader());
+                DigestUtils.sha256Hex(tokenResponse.getTokens().getBearerAccessToken().getValue()));
         accessTokenItem.setIpvSessionId(ipvSessionId);
         dataStore.create(accessTokenItem);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import org.apache.commons.codec.digest.DigestUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
@@ -37,14 +38,15 @@ public class AuthorizationCodeService {
     }
 
     public Optional<AuthorizationCodeItem> getAuthorizationCodeItem(String authorizationCode) {
-        AuthorizationCodeItem authorizationCodeItem = dataStore.getItem(authorizationCode);
+        AuthorizationCodeItem authorizationCodeItem =
+                dataStore.getItem(DigestUtils.sha256Hex(authorizationCode));
         return Optional.ofNullable(authorizationCodeItem);
     }
 
     public void persistAuthorizationCode(
             String authorizationCode, String ipvSessionId, String redirectUrl) {
         AuthorizationCodeItem authorizationCodeItem = new AuthorizationCodeItem();
-        authorizationCodeItem.setAuthCode(authorizationCode);
+        authorizationCodeItem.setAuthCode(DigestUtils.sha256Hex(authorizationCode));
         authorizationCodeItem.setIpvSessionId(ipvSessionId);
         authorizationCodeItem.setRedirectUrl(redirectUrl);
 
@@ -52,6 +54,6 @@ public class AuthorizationCodeService {
     }
 
     public void revokeAuthorizationCode(String authorizationCode) {
-        dataStore.delete(authorizationCode);
+        dataStore.delete(DigestUtils.sha256Hex(authorizationCode));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
@@ -14,6 +14,7 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -123,22 +124,23 @@ class AccessTokenServiceTest {
         assertNotNull(capturedAccessTokenItem);
         assertEquals(testIpvSessionId, capturedAccessTokenItem.getIpvSessionId());
         assertEquals(
-                accessTokenResponse.getTokens().getBearerAccessToken().toAuthorizationHeader(),
+                DigestUtils.sha256Hex(
+                        accessTokenResponse.getTokens().getBearerAccessToken().getValue()),
                 capturedAccessTokenItem.getAccessToken());
     }
 
     @Test
     void shouldGetSessionIdByAccessTokenWhenValidAccessTokenProvided() {
         String testIpvSessionId = UUID.randomUUID().toString();
-        String accessToken = new BearerAccessToken().toAuthorizationHeader();
+        String accessToken = new BearerAccessToken().getValue();
 
         AccessTokenItem accessTokenItem = new AccessTokenItem();
         accessTokenItem.setIpvSessionId(testIpvSessionId);
-        when(mockDataStore.getItem(accessToken)).thenReturn(accessTokenItem);
+        when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken))).thenReturn(accessTokenItem);
 
         String resultIpvSessionId = accessTokenService.getIpvSessionIdByAccessToken(accessToken);
 
-        verify(mockDataStore).getItem(accessToken);
+        verify(mockDataStore).getItem(DigestUtils.sha256Hex(accessToken));
 
         assertNotNull(resultIpvSessionId);
         assertEquals(testIpvSessionId, resultIpvSessionId);
@@ -146,13 +148,13 @@ class AccessTokenServiceTest {
 
     @Test
     void shouldReturnNullWhenInvalidAccessTokenProvided() {
-        String accessToken = new BearerAccessToken().toAuthorizationHeader();
+        String accessToken = new BearerAccessToken().getValue();
 
-        when(mockDataStore.getItem(accessToken)).thenReturn(null);
+        when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken))).thenReturn(null);
 
         String resultIpvSessionId = accessTokenService.getIpvSessionIdByAccessToken(accessToken);
 
-        verify(mockDataStore).getItem(accessToken);
+        verify(mockDataStore).getItem(DigestUtils.sha256Hex(accessToken));
         assertNull(resultIpvSessionId);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,7 +54,8 @@ class AuthorizationCodeServiceTest {
         assertEquals(
                 ipvSessionId, authorizationCodeItemArgumentCaptor.getValue().getIpvSessionId());
         assertEquals(
-                testCode.getValue(), authorizationCodeItemArgumentCaptor.getValue().getAuthCode());
+                DigestUtils.sha256Hex(testCode.getValue()),
+                authorizationCodeItemArgumentCaptor.getValue().getAuthCode());
         assertEquals(redirectUrl, authorizationCodeItemArgumentCaptor.getValue().getRedirectUrl());
     }
 
@@ -65,12 +67,13 @@ class AuthorizationCodeServiceTest {
         AuthorizationCodeItem testItem = new AuthorizationCodeItem();
         testItem.setIpvSessionId(ipvSessionId);
 
-        when(mockDataStore.getItem(testCode.getValue())).thenReturn(testItem);
+        when(mockDataStore.getItem(DigestUtils.sha256Hex(testCode.getValue())))
+                .thenReturn(testItem);
 
         AuthorizationCodeItem authorizationCodeItem =
                 authorizationCodeService.getAuthorizationCodeItem(testCode.getValue()).get();
 
-        verify(mockDataStore).getItem(testCode.getValue());
+        verify(mockDataStore).getItem(DigestUtils.sha256Hex(testCode.getValue()));
         assertEquals(ipvSessionId, authorizationCodeItem.getIpvSessionId());
     }
 
@@ -78,12 +81,12 @@ class AuthorizationCodeServiceTest {
     void shouldReturnEmptyOptionalWhenInvalidAuthCodeProvided() {
         AuthorizationCode testCode = new AuthorizationCode();
 
-        when(mockDataStore.getItem(testCode.getValue())).thenReturn(null);
+        when(mockDataStore.getItem(DigestUtils.sha256Hex(testCode.getValue()))).thenReturn(null);
 
         Optional<AuthorizationCodeItem> authorizationCodeItem =
                 authorizationCodeService.getAuthorizationCodeItem(testCode.getValue());
 
-        verify(mockDataStore).getItem(testCode.getValue());
+        verify(mockDataStore).getItem(DigestUtils.sha256Hex(testCode.getValue()));
         assertTrue(authorizationCodeItem.isEmpty());
     }
 
@@ -93,6 +96,6 @@ class AuthorizationCodeServiceTest {
 
         authorizationCodeService.revokeAuthorizationCode(testCode.getValue());
 
-        verify(mockDataStore).delete(testCode.getValue());
+        verify(mockDataStore).delete(DigestUtils.sha256Hex(testCode.getValue()));
     }
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Hash codes and tokens before persisting

### Why did it change

RFC6819 suggests we should be hashing auth codes and access tokens
before storing them in the DB. This would prevent an attacker with
access to the DB from using them without brute forcing the acutal
values.

As these tokens have short life spans and high entropy, a salt isn't
required.

https://www.rfc-editor.org/rfc/rfc6819.html#section-5.1.4.1.3


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1480](https://govukverify.atlassian.net/browse/PYIC-1480)

