### PR TITLE
PYIC-1485: Log in JSON format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,12 @@ ext {
 		awsJavaSdkSqs:'1.12.197',
 		awsLambdaJavaCore:'1.2.1',
 		awsLambdaJavaEvents:'3.11.0',
+		awsLambdaJavaLog4j2:'1.5.1',
 		dynamodbEnhanced:'2.17.89',
 		gson:'2.8.9',
 		jackson:'2.13.2',
 		kms:'2.17.100',
+		log4j:'2.17.1',
 		lombok:'1.18.22',
 		nimbusdsOauth2OidcSdk:'9.27',
 		powertoolsParameters:'1.11.0',
@@ -51,5 +53,20 @@ ext {
 }
 
 subprojects {
+	configurations {
+		loggingImplementation
+		loggingRunTimeOnly
+	}
+
+	dependencies {
+		loggingImplementation "org.slf4j:slf4j-api:$rootProject.ext.dependencyVersions.slf4j"
+
+		loggingRunTimeOnly "org.apache.logging.log4j:log4j-api:$dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-core:$dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-layout-template-json:$dependencyVersions.log4j",
+				"org.apache.logging.log4j:log4j-slf4j18-impl:$dependencyVersions.log4j",
+				"com.amazonaws:aws-lambda-java-log4j2:$dependencyVersions.awsLambdaJavaLog4j2"
+	}
+
 	task allDeps(type: DependencyReportTask) {}
 }

--- a/lambdas/accesstoken/build.gradle
+++ b/lambdas/accesstoken/build.gradle
@@ -20,10 +20,12 @@ dependencies {
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/accesstoken/src/main/resources/log4j2.yaml
+++ b/lambdas/accesstoken/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/credentialissuerconfig/build.gradle
+++ b/lambdas/credentialissuerconfig/build.gradle
@@ -13,8 +13,10 @@ dependencies {
 
 	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/credentialissuerconfig/src/main/resources/log4j2.yaml
+++ b/lambdas/credentialissuerconfig/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/credentialissuererror/build.gradle
+++ b/lambdas/credentialissuererror/build.gradle
@@ -16,7 +16,10 @@ dependencies {
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/credentialissuererror/src/main/resources/log4j2.yaml
+++ b/lambdas/credentialissuererror/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/credentialissuerreturn/build.gradle
+++ b/lambdas/credentialissuerreturn/build.gradle
@@ -21,10 +21,12 @@ dependencies {
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/credentialissuerreturn/src/main/resources/log4j2.yaml
+++ b/lambdas/credentialissuerreturn/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/credentialissuerstart/build.gradle
+++ b/lambdas/credentialissuerstart/build.gradle
@@ -21,9 +21,11 @@ dependencies {
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/credentialissuerstart/src/main/resources/log4j2.yaml
+++ b/lambdas/credentialissuerstart/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/issuedcredentials/build.gradle
+++ b/lambdas/issuedcredentials/build.gradle
@@ -13,7 +13,10 @@ dependencies {
 
 	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/issuedcredentials/src/main/resources/log4j2.yaml
+++ b/lambdas/issuedcredentials/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/journeyengine/build.gradle
+++ b/lambdas/journeyengine/build.gradle
@@ -13,7 +13,10 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/journeyengine/src/main/resources/log4j2.yaml
+++ b/lambdas/journeyengine/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/sessionend/build.gradle
+++ b/lambdas/sessionend/build.gradle
@@ -21,10 +21,12 @@ dependencies {
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/sessionend/src/main/resources/log4j2.yaml
+++ b/lambdas/sessionend/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/sessionstart/build.gradle
+++ b/lambdas/sessionstart/build.gradle
@@ -21,10 +21,12 @@ dependencies {
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/sessionstart/src/main/resources/log4j2.yaml
+++ b/lambdas/sessionstart/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/useridentity/build.gradle
+++ b/lambdas/useridentity/build.gradle
@@ -21,10 +21,12 @@ dependencies {
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/useridentity/src/main/resources/log4j2.yaml
+++ b/lambdas/useridentity/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lambdas/validatecricheck/build.gradle
+++ b/lambdas/validatecricheck/build.gradle
@@ -15,7 +15,10 @@ dependencies {
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			configurations.loggingImplementation,
 			project(":lib")
+
+	runtimeOnly configurations.loggingRunTimeOnly
 
 	aspect "software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 

--- a/lambdas/validatecricheck/src/main/resources/log4j2.yaml
+++ b/lambdas/validatecricheck/src/main/resources/log4j2.yaml
@@ -1,0 +1,20 @@
+Configuration:
+  status: warn
+  appenders:
+    Lambda:
+      name: Lambda
+      JsonTemplateLayout:
+        eventTemplateUri: "classpath:JsonLayout.json"
+        eventTemplateAdditionalField:
+          - key: session-id
+            value: "$${ctx:sessionId:-unknown}"
+          - key: request-id
+            format: JSON
+            value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Lambda
+
+

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			"org.apache.commons:commons-lang3:3.5",
 			"org.apache.httpcomponents:httpclient:$rootProject.ext.dependencyVersions.apacheHttpclient",
-			"org.slf4j:slf4j-simple:$rootProject.ext.dependencyVersions.slf4j",
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.awssdk:kms:$rootProject.ext.dependencyVersions.kms",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Log in JSON format
Another ticket is to actually make good use of the new capabilities introduced here

### Why did it change

This leverages the AWS docs found here:
https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html#java-logging-log4j2
as well as RFC0030:
https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0030-cross-programme-logging-format.md
and the auth teams previous good work:
https://github.com/alphagov/di-authentication-api/blob/main/ipv-api/src/main/resources/log4j2.xml

This uses the `aws-lambda-java-log4j2` library to allow is to include
the AWS request ID in each log line.

It defines a couple of new gradle configurations in the root project
which are then pulled in by the sub projects to reduce repetition.

It adds a YAML configuration file to each sub project to configure the
logging. Currently we're only adding a couple of custom fields,
session-id and aws-request-id. We can add more as we identify what they
are. The log4j2 docs are good for understanding what's happening:
https://logging.apache.org/log4j/2.x/manual/configuration.html#YAML
https://logging.apache.org/log4j/2.x/manual/json-template-layout.html

As we're already using slf4j to create our loggers we don't need to
update our code o get hold of a logger which is nice.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1485](https://govukverify.atlassian.net/browse/PYIC-1485)

![Screenshot 2022-06-22 at 16 10 24](https://user-images.githubusercontent.com/13836290/175065785-916ee301-c3ab-425e-bd9e-4dbc683e276b.png)

