### PR TITLE
PYIC-1485: Add identifiers to log lines

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -19,6 +19,7 @@ import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.exceptions.ClientAuthenticationException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
@@ -88,6 +89,8 @@ public class AccessTokenHandler
                                     authorizationGrant.getAuthorizationCode().getValue())
                             .orElseThrow();
 
+            LogHelper.attachSessionIdToLogs(authorizationCodeItem.getIpvSessionId());
+
             if (redirectUrlsDoNotMatch(authorizationCodeItem, authorizationGrant)) {
                 LOGGER.error(
                         "Redirect URL in token request does not match that received in auth code request. Session ID: {}",
@@ -124,6 +127,8 @@ public class AccessTokenHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     OAuth2Error.INVALID_GRANT.getHTTPStatusCode(),
                     OAuth2Error.INVALID_GRANT.toJSONObject());
+        } finally {
+            LogHelper.clear();
         }
     }
 

--- a/lambdas/accesstoken/src/main/resources/log4j2.yaml
+++ b/lambdas/accesstoken/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/credentialissuerconfig/src/main/resources/log4j2.yaml
+++ b/lambdas/credentialissuerconfig/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/credentialissuererror/src/main/resources/log4j2.yaml
+++ b/lambdas/credentialissuererror/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/credentialissuerreturn/src/main/resources/log4j2.yaml
+++ b/lambdas/credentialissuerreturn/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/credentialissuerstart/src/main/resources/log4j2.yaml
+++ b/lambdas/credentialissuerstart/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/issuedcredentials/src/main/resources/log4j2.yaml
+++ b/lambdas/issuedcredentials/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
+++ b/lambdas/issuedcredentials/src/test/java/uk/gov/di/ipv/core/issuedcredentials/IssuedCredentialsHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
@@ -29,7 +30,7 @@ public class IssuedCredentialsHandlerTest {
     void shouldReturn200OnSuccessfulRequest() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         String ipvSessionId = "a-session-id";
-        event.setHeaders(Map.of(IssuedCredentialsHandler.IPV_SESSION_ID_HEADER_KEY, ipvSessionId));
+        event.setHeaders(Map.of(RequestHelper.IPV_SESSION_ID_HEADER, ipvSessionId));
 
         Map<String, String> userIssuedCredentials =
                 Map.of(
@@ -64,7 +65,7 @@ public class IssuedCredentialsHandlerTest {
     @Test
     void shouldReturn400IfSessionIdIsEmptyString() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of(IssuedCredentialsHandler.IPV_SESSION_ID_HEADER_KEY, ""));
+        event.setHeaders(Map.of(RequestHelper.IPV_SESSION_ID_HEADER, ""));
         IssuedCredentialsHandler issuedCredentialsHandler =
                 new IssuedCredentialsHandler(mockUserIdentityService, mockConfigurationService);
 

--- a/lambdas/journeyengine/src/main/resources/log4j2.yaml
+++ b/lambdas/journeyengine/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -63,6 +63,7 @@ class JourneyEngineHandlerTest {
     void shouldReturn400OnMissingParams() throws IOException {
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
         event.setPathParameters(Collections.emptyMap());
 
         APIGatewayProxyResponseEvent response =
@@ -81,8 +82,8 @@ class JourneyEngineHandlerTest {
 
     @Test
     void shouldReturn400OnMissingJourneyStepParam() throws IOException {
-
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("ipv-session-id", "1234"));
         event.setPathParameters(Collections.emptyMap());
         event.setPathParameters(Map.of("InvalidStep", "any"));
 

--- a/lambdas/sessionend/src/main/resources/log4j2.yaml
+++ b/lambdas/sessionend/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
+++ b/lambdas/sessionstart/src/main/java/uk/gov/di/ipv/core/session/IpvSessionStartHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.core.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.core.library.exceptions.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -146,6 +147,8 @@ public class IpvSessionStartHandler
             LOGGER.error("Failed to parse request body into map because: {}", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_REQUEST);
+        } finally {
+            LogHelper.clear();
         }
     }
 
@@ -157,6 +160,8 @@ public class IpvSessionStartHandler
             LOGGER.warn("Missing client_id query parameter");
             isInvalid = true;
         }
+        LogHelper.attachClientIdToLogs(sessionParams.get(CLIENT_ID_PARAM_KEY));
+        LOGGER.info("Client ID received in session params - not yet validated");
 
         if (StringUtils.isBlank(sessionParams.get(REQUEST_PARAM_KEY))) {
             LOGGER.warn("Missing request query parameter");

--- a/lambdas/sessionstart/src/main/resources/log4j2.yaml
+++ b/lambdas/sessionstart/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
+++ b/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
@@ -17,9 +17,11 @@ import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -86,12 +88,14 @@ public class UserIdentityHandler
                                         " - The supplied access token was not found in the database")
                                 .toJSONObject());
             }
+            LogHelper.attachSessionIdToLogs(ipvSessionId);
 
-            String userId =
-                    ipvSessionService
-                            .getIpvSession(ipvSessionId)
-                            .getClientSessionDetails()
-                            .getUserId();
+            ClientSessionDetailsDto clientSessionDetails =
+                    ipvSessionService.getIpvSession(ipvSessionId).getClientSessionDetails();
+
+            LogHelper.attachClientIdToLogs(clientSessionDetails.getClientId());
+
+            String userId = clientSessionDetails.getUserId();
 
             UserIdentity userIdentity =
                     userIdentityService.generateUserIdentity(ipvSessionId, userId);

--- a/lambdas/useridentity/src/main/resources/log4j2.yaml
+++ b/lambdas/useridentity/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lambdas/validatecricheck/src/main/resources/log4j2.yaml
+++ b/lambdas/validatecricheck/src/main/resources/log4j2.yaml
@@ -6,11 +6,15 @@ Configuration:
       JsonTemplateLayout:
         eventTemplateUri: "classpath:JsonLayout.json"
         eventTemplateAdditionalField:
-          - key: session-id
-            value: "$${ctx:sessionId:-unknown}"
-          - key: request-id
+          - key: aws-request-id
             format: JSON
             value: '{"$resolver": "pattern", "pattern": "%X{AWSRequestId}"}'
+          - key: client-id
+            value: "$${ctx:client-id:-unknown}"
+          - key: cri-id
+            value: "$${ctx:cri-id:-unknown}"
+          - key: session-id
+            value: "$${ctx:session-id:-unknown}"
   Loggers:
     Root:
       level: info

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/HttpResponseExceptionWithErrorBody.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/HttpResponseExceptionWithErrorBody.java
@@ -26,4 +26,8 @@ public class HttpResponseExceptionWithErrorBody extends Throwable {
     public Map<String, Object> getErrorBody() {
         return Map.of("code", errorResponse.getCode(), "message", errorResponse.getMessage());
     }
+
+    public ErrorResponse getErrorResponse() {
+        return errorResponse;
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -1,0 +1,32 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import org.slf4j.MDC;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class LogHelper {
+
+    private LogHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static final String CLIENT_ID_LOG_FIELD = "client-id";
+    public static final String CRI_ID_LOG_FIELD = "cri-id";
+    public static final String SESSION_ID_LOG_FIELD = "session-id";
+
+    public static void attachClientIdToLogs(String clientId) {
+        MDC.put(CLIENT_ID_LOG_FIELD, clientId);
+    }
+
+    public static void attachCriIdToLogs(String criId) {
+        MDC.put(CRI_ID_LOG_FIELD, criId);
+    }
+
+    public static void attachSessionIdToLogs(String sessionId) {
+        MDC.put(SESSION_ID_LOG_FIELD, sessionId);
+    }
+
+    public static void clear() {
+        MDC.clear();
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -1,10 +1,13 @@
 package uk.gov.di.ipv.core.library.helpers;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @ExcludeFromGeneratedCoverageReport
 public class LogHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogHelper.class);
 
     private LogHelper() {
         throw new IllegalStateException("Utility class");
@@ -27,6 +30,7 @@ public class LogHelper {
     }
 
     public static void clear() {
+        LOGGER.info("Clearing MDC");
         MDC.clear();
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -3,8 +3,13 @@ package uk.gov.di.ipv.core.library.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -17,6 +22,7 @@ public class RequestHelper {
 
     public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequestHelper.class);
 
     private RequestHelper() {}
 
@@ -71,5 +77,18 @@ public class RequestHelper {
             }
         }
         return null;
+    }
+
+    public static String getIpvSessionId(APIGatewayProxyRequestEvent event)
+            throws HttpResponseExceptionWithErrorBody {
+        String ipvSessionId =
+                RequestHelper.getHeaderByKey(event.getHeaders(), IPV_SESSION_ID_HEADER);
+        if (ipvSessionId == null) {
+            LOGGER.error("{} not present in header", IPV_SESSION_ID_HEADER);
+            throw new HttpResponseExceptionWithErrorBody(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
+        }
+        LogHelper.attachSessionIdToLogs(ipvSessionId);
+        return ipvSessionId;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.UserStates;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -44,6 +45,9 @@ public class IpvSessionService {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+
+        LogHelper.attachSessionIdToLogs(ipvSessionItem.getIpvSessionId());
+
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/JarValidator.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.core.library.exceptions.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.library.helpers.JwtHelper;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.KmsRsaDecrypter;
 
@@ -82,6 +83,7 @@ public class JarValidator {
     private void validateClientId(String clientId) throws JarValidationException {
         try {
             configurationService.getSsmParameter(CLIENT_AUTHENTICATION_METHOD, clientId);
+            LogHelper.attachClientIdToLogs(clientId);
         } catch (ParameterNotFoundException e) {
             LOGGER.error("Unknown client id provided {}", clientId);
             throw new JarValidationException(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.core.library.domain.ConfigurationServicePublicKeySelector;
 import uk.gov.di.ipv.core.library.exceptions.ClientAuthenticationException;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
@@ -57,6 +58,8 @@ public class TokenRequestValidator {
             clientJwt = PrivateKeyJWT.parse(requestBody);
 
             clientId = clientJwt.getClientID().getValue();
+
+            LogHelper.attachClientIdToLogs(clientId);
 
             String clientAuthenticationMethod =
                     configurationService.getSsmParameter(CLIENT_AUTHENTICATION_METHOD, clientId);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -1,8 +1,12 @@
 package uk.gov.di.ipv.core.library.helpers;
 
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import java.util.HashMap;
 import java.util.List;
@@ -11,7 +15,9 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
 
 class RequestHelperTest {
 
@@ -53,5 +59,49 @@ class RequestHelperTest {
     @Test
     void getHeaderByKeyShouldReturnNullIfHeaderNotFound() {
         assertNull(RequestHelper.getHeaderByKey(Map.of("tome", "toyou"), "ohdearohdear"));
+    }
+
+    @Test
+    void getIpvSessionIdShouldReturnSessionId() throws HttpResponseExceptionWithErrorBody {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of(IPV_SESSION_ID_HEADER, "a-session-id"));
+
+        assertEquals("a-session-id", RequestHelper.getIpvSessionId(event));
+    }
+
+    @Test
+    void getIpvSessionIdShouldThrowIfSessionIdIsNull() {
+        var event = new APIGatewayProxyRequestEvent();
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(IPV_SESSION_ID_HEADER, null);
+
+        event.setHeaders(headers);
+
+        var exception =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> RequestHelper.getIpvSessionId(event));
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                exception.getErrorResponse().getMessage());
+    }
+
+    @Test
+    void getIpvSessionIdShouldThrowIfSessionIdIsEmptyString() {
+        var event = new APIGatewayProxyRequestEvent();
+
+        event.setHeaders(Map.of(IPV_SESSION_ID_HEADER, ""));
+
+        var exception =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> RequestHelper.getIpvSessionId(event));
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                exception.getErrorResponse().getMessage());
     }
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add identifiers to log lines

### Why did it change
This updates each lambda to add the ipv session ID, the credential
issuer ID or the client ID when any are available to the logs produced.
These values will help us run queries over our logging to tie things together.
We might decide to add more in the future.

It uses a new helper to abstract some of this away. The helper adds the
values to the MDC (ThreadContext in log4j2): https://logging.apache.org/log4j/2.x/manual/thread-context.html

The MDC is thread specific but I've had a test and it looks like it gets
reused between Lambda invocations. Because of this we need to make sure
we're clearing the MDC at the end of every lambda. This has resulted in
each lambda getting wrapped in a try block with a `finally` to make sure
it's never missed.

This change has also altered the responses of some of the lambdas in
some situations. Rather than returning a journey error response, I've
changed it to just returning a 400. This happens where we the
ipv-session-id has not been sent in the header. If this ever happens
something is seriously wrong and trying to continue the journey is
probably a bad idea and we should just throw. Opinions encouraged.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1485](https://govukverify.atlassian.net/browse/PYIC-1485)
