### PR TITLE
BAU: Replace UUIDs with a secure string

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.di.ipv.core.library.domain.UserStates;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
@@ -24,7 +25,6 @@ import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -41,7 +41,7 @@ public class DataStoreIpvSessionIT {
             "credentialIssuerSessionDetails";
     private static final List<String> createdItemIds = new ArrayList<>();
     private static final String CRI_ID = "criId";
-    private static final String OAUTH_STATE = UUID.randomUUID().toString();
+    private static final String OAUTH_STATE = SecureTokenHelper.generate();
 
     private static DataStore<IpvSessionItem> ipvSessionItemDataStore;
     private static Table tableTestHarness;
@@ -88,7 +88,7 @@ public class DataStoreIpvSessionIT {
     @Test
     void shouldPutIpvSessionIntoTable() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setClientSessionDetails(generateClientSessionDetails());
@@ -135,7 +135,7 @@ public class DataStoreIpvSessionIT {
     @Test
     void shouldReadIpvSessionFromTable() throws JsonProcessingException {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setClientSessionDetails(generateClientSessionDetails());
@@ -172,7 +172,7 @@ public class DataStoreIpvSessionIT {
     @Test
     void shouldUpdateIpvSessionInTable() throws JsonProcessingException {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setClientSessionDetails(generateClientSessionDetails());

--- a/lambdas/credentialissuererror/src/test/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandlerTest.java
+++ b/lambdas/credentialissuererror/src/test/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandlerTest.java
@@ -14,12 +14,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditExtensionParams;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,7 +51,7 @@ class CredentialIssuerErrorHandlerTest {
                                 "error", errorCode,
                                 "error_description", errorDescription,
                                 "credential_issuer_id", "ukPassport"),
-                        Map.of("ipv-session-id", UUID.randomUUID().toString()));
+                        Map.of("ipv-session-id", SecureTokenHelper.generate()));
 
         APIGatewayProxyResponseEvent response =
                 credentialIssuerErrorHandler.handleRequest(event, mockContext);

--- a/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
+++ b/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerRequestDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
@@ -35,7 +36,6 @@ import uk.gov.di.ipv.core.library.validation.VerifiableCredentialJwtValidator;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,7 +83,7 @@ class CredentialIssuerReturnHandlerTest {
     private static ClientSessionDetailsDto clientSessionDetailsDto;
     private static CredentialIssuerSessionDetailsDto credentialIssuerSessionDetailsDto;
     private final String authorization_code = "bar";
-    private final String sessionId = UUID.randomUUID().toString();
+    private final String sessionId = SecureTokenHelper.generate();
     private final String passportIssuerId = CREDENTIAL_ISSUER_ID;
     private final String testApiKey = "test-api-key";
 

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.core.journeyengine.domain.PageResponse;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.UserStates;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -25,7 +26,6 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -152,7 +152,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
 
@@ -180,7 +180,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState("INVALID-STATE");
 
@@ -209,7 +209,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
 
@@ -242,7 +242,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.IPV_IDENTITY_START_PAGE.toString());
 
@@ -278,7 +278,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
 
@@ -313,7 +313,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
 
@@ -345,7 +345,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.toString());
 
@@ -380,7 +380,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ADDRESS.toString());
 
@@ -412,7 +412,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
 
@@ -445,7 +445,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.PRE_KBV_TRANSITION_PAGE.toString());
 
@@ -480,7 +480,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
 
@@ -512,7 +512,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
 
@@ -547,7 +547,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
 
@@ -579,7 +579,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.IPV_SUCCESS_PAGE.toString());
 
@@ -607,7 +607,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.toString());
 
@@ -633,7 +633,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.toString());
 
@@ -665,7 +665,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.DEBUG_PAGE.toString());
 
@@ -698,7 +698,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_ERROR.toString());
 
@@ -726,7 +726,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
 
@@ -759,7 +759,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_FRAUD.toString());
 
@@ -792,7 +792,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(UserStates.CRI_KBV.toString());
 
@@ -827,7 +827,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().minusSeconds(100).toString());
         ipvSessionItem.setUserState(UserStates.CRI_UK_PASSPORT.toString());
 
@@ -865,7 +865,7 @@ class JourneyEngineHandlerTest {
         event.setHeaders(Map.of("ipv-session-id", "1234"));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().minusSeconds(100).toString());
         ipvSessionItem.setUserState(UserStates.CORE_SESSION_TIMEOUT.toString());
 

--- a/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
+++ b/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
@@ -33,7 +34,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -258,7 +258,7 @@ class SessionEndHandlerTest {
 
     private IpvSessionItem generateIpvSessionItem() {
         IpvSessionItem item = new IpvSessionItem();
-        item.setIpvSessionId(UUID.randomUUID().toString());
+        item.setIpvSessionId(SecureTokenHelper.generate());
         item.setUserState("test-state");
         item.setCreationDateTime(new Date().toString());
 

--- a/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
+++ b/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
@@ -24,6 +24,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.JarValidationException;
 import uk.gov.di.ipv.core.library.exceptions.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -40,7 +41,6 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -95,7 +95,7 @@ class IpvSessionStartHandlerTest {
     @Test
     void shouldReturnIpvSessionIdWhenProvidedValidRequest()
             throws JsonProcessingException, JarValidationException, ParseException, SqsException {
-        String ipvSessionId = UUID.randomUUID().toString();
+        String ipvSessionId = SecureTokenHelper.generate();
         when(mockIpvSessionService.generateIpvSession(any(), any())).thenReturn(ipvSessionId);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
@@ -192,7 +192,7 @@ class IpvSessionStartHandlerTest {
     @Test
     void shouldReturnIpvSessionIdWhenRecoverableErrorFound()
             throws JsonProcessingException, JarValidationException, ParseException, SqsException {
-        String ipvSessionId = UUID.randomUUID().toString();
+        String ipvSessionId = SecureTokenHelper.generate();
         when(mockIpvSessionService.generateIpvSession(any(), any())).thenReturn(ipvSessionId);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenThrow(

--- a/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
+++ b/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -37,7 +38,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -50,7 +50,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.PASSPORT_JSON_1;
 @ExtendWith(MockitoExtension.class)
 class UserIdentityHandlerTest {
 
-    private static final String TEST_IPV_SESSION_ID = UUID.randomUUID().toString();
+    private static final String TEST_IPV_SESSION_ID = SecureTokenHelper.generate();
     public static final String VTM = "http://www.example.com/vtm";
 
     @Mock private Context mockContext;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
@@ -30,7 +30,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Objects;
-import java.util.UUID;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_FRONT_CALLBACK_URL;
@@ -48,7 +47,7 @@ public class AuthorizationRequestHelper {
             JWSSigner signer,
             CredentialIssuerConfig credentialIssuerConfig,
             ConfigurationService configurationService,
-            UUID oauthState,
+            String oauthState,
             String userId)
             throws HttpResponseExceptionWithErrorBody {
         Instant now = Instant.now();
@@ -67,7 +66,7 @@ public class AuthorizationRequestHelper {
                                 ResponseType.CODE,
                                 new ClientID(credentialIssuerConfig.getIpvClientId()))
                         .redirectionURI(redirectionURI)
-                        .state(new State(oauthState.toString()))
+                        .state(new State(oauthState))
                         .build()
                         .toJWTClaimsSet();
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/SecureTokenHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/SecureTokenHelper.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class SecureTokenHelper {
+
+    private SecureTokenHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static final int BYTES_OF_ENTROPY = 32;
+    private static final SecureRandom random = new SecureRandom();
+    private static final Base64.Encoder b64Encoder = Base64.getUrlEncoder().withoutPadding();
+
+    public static String generate() {
+        // Returns a B64 encoded random string with 256 bits of entropy
+        // For example: ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY
+        byte[] buffer = new byte[BYTES_OF_ENTROPY];
+        random.nextBytes(buffer);
+
+        return b64Encoder.encodeToString(buffer);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -25,6 +25,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerRequestDto;
 import uk.gov.di.ipv.core.library.helpers.JwtHelper;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 
@@ -34,7 +35,6 @@ import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
-import java.util.UUID;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_FRONT_CALLBACK_URL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
@@ -89,7 +89,7 @@ public class CredentialIssuerService {
                                                     configurationService.getSsmParameter(
                                                             JWT_TTL_SECONDS)))
                                     .toEpochSecond(),
-                            UUID.randomUUID().toString());
+                            SecureTokenHelper.generate());
             SignedJWT signedClientJwt =
                     JwtHelper.createSignedJwtFromObject(clientAuthClaims, signer);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -4,11 +4,11 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.UserStates;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 
 import java.time.Instant;
-import java.util.UUID;
 
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.IPV_SESSIONS_TABLE_NAME;
 
@@ -43,7 +43,7 @@ public class IpvSessionService {
             ClientSessionDetailsDto clientSessionDetailsDto, ErrorObject errorObject) {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
@@ -37,7 +37,6 @@ import java.text.ParseException;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -66,7 +65,7 @@ class AuthorizationRequestHelperTest {
     public static final String MOCK_CORE_FRONT_CALLBACK_URL = "callbackUri";
     public static final String CRI_ID = "cri_id";
     public static final String TEST_USER_ID = "test-user-id";
-    public static final UUID OAUTH_STATE = UUID.randomUUID();
+    public static final String OAUTH_STATE = SecureTokenHelper.generate();
 
     private final SharedClaimsResponse sharedClaims =
             new SharedClaimsResponse(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/SecureTokenHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/SecureTokenHelperTest.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.ipv.core.library.helpers.SecureTokenHelper.BYTES_OF_ENTROPY;
+
+class SecureTokenHelperTest {
+    @Test
+    void generateShouldGiveAB64StringOfKnownLength() {
+        String token = SecureTokenHelper.generate();
+
+        byte[] bytes = assertDoesNotThrow(() -> Base64.getUrlDecoder().decode(token));
+        assertEquals(BYTES_OF_ENTROPY, bytes.length);
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
@@ -21,12 +21,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
 import java.net.URI;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -110,7 +110,7 @@ class AccessTokenServiceTest {
 
     @Test
     void shouldPersistAccessToken() {
-        String testIpvSessionId = UUID.randomUUID().toString();
+        String testIpvSessionId = SecureTokenHelper.generate();
         AccessToken accessToken = new BearerAccessToken();
         AccessTokenResponse accessTokenResponse =
                 new AccessTokenResponse(new Tokens(accessToken, null));
@@ -131,7 +131,7 @@ class AccessTokenServiceTest {
 
     @Test
     void shouldGetSessionIdByAccessTokenWhenValidAccessTokenProvided() {
-        String testIpvSessionId = UUID.randomUUID().toString();
+        String testIpvSessionId = SecureTokenHelper.generate();
         String accessToken = new BearerAccessToken().getValue();
 
         AccessTokenItem accessTokenItem = new AccessTokenItem();

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.core.library.domain.CredentialIssuerException;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerRequestDto;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 
@@ -28,7 +29,6 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
-import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -55,7 +55,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_VC_1;
 @ExtendWith(MockitoExtension.class)
 class CredentialIssuerServiceTest {
 
-    private static final String TEST_IPV_SESSION_ID = UUID.randomUUID().toString();
+    private static final String TEST_IPV_SESSION_ID = SecureTokenHelper.generate();
     public static final String OAUTH_STATE = "oauth-state";
 
     @Mock private DataStore<UserIssuedCredentialsItem> mockDataStore;

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -9,11 +9,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.UserStates;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 
 import java.util.Date;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,7 +31,7 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldReturnSessionItem() {
-        String ipvSessionID = UUID.randomUUID().toString();
+        String ipvSessionID = SecureTokenHelper.generate();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
@@ -133,7 +133,7 @@ class IpvSessionServiceTest {
     @Test
     void shouldUpdateSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(UUID.randomUUID().toString());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setUserState(UserStates.INITIAL_IPV_JOURNEY.toString());
         ipvSessionItem.setCreationDateTime(new Date().toString());
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Replace UUIDs with a secure string

### Why did it change

I read this article and got overly paranoid about our use or UUIDs for
tokens. https://neilmadden.blog/2018/08/30/moving-away-from-uuids/

This updates our tokens to use a secure random string with 256 bits of
entropy rather than the 122 offered by UUIDs. This means we meet the
OAuth spec of at least 128 bits and preferably 160 bits.
