### PR TITLE
PYIC-1495 Set Provisioned Concurrency Within Template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -29,16 +29,11 @@ Parameters:
     Type: String
     Description: The address cri id which relates to the cri config in parameter store to be used by the journey engine
     Default: address
-  ProvisionedConcurrentExecutions:
-    Type: Number
-    Description: >-
-      The number of lambda execution environments to keep permanently ready to reduce cold starts.
-    Default: 0
 
 Conditions:
   AddProvisionedConcurrency: !Not
     - !Equals
-      - !Ref ProvisionedConcurrentExecutions
+      - !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
       -  0
   IsDevelopmentEnvironment: !Not
     - !Or
@@ -47,8 +42,23 @@ Conditions:
       - !Equals [ !Ref Environment, "integration"]
       - !Equals [ !Ref Environment, "production"]
 
-Resources:
+# The AWS Account Id is used in the following mapping section because we have
+# multiple developer environments and it is undesirable to have to keep this
+# mapping up to date with each developer environment.
+Mappings:
+  EnvironmentConfiguration:
+    "130355686670": # Development
+      provisionedConcurrency: 0
+    "457601271792": # Build
+      provisionedConcurrency: 0
+    "335257547869": # Staging
+      provisionedConcurrency: 1
+    "991138514218": # Integration
+      provisionedConcurrency: 1
+    "075701497069": # Production
+      provisionedConcurrency: 1
 
+Resources:
   IPVCorePrivateAPI:
     Type: AWS::Serverless::Api
     Properties:
@@ -194,7 +204,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVAccessTokenFunctionLogGroup:
@@ -263,7 +273,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVSessionEndFunctionLogGroup:
@@ -344,7 +354,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVSessionStartFunctionLogGroup:
@@ -435,7 +445,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVCriReturnFunctionLogGroup:
@@ -522,7 +532,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVCredentialIssuerStartFunctionLogGroup:
@@ -586,7 +596,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVCredentialIssuerErrorFunctionLogGroup:
@@ -658,7 +668,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVUserIdentityFunctionLogGroup:
@@ -711,7 +721,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVCredentialIssuerFunctionLogGroup:
@@ -764,7 +774,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVIssuedCredentialsFunctionLogGroup:
@@ -829,7 +839,7 @@ Resources:
       ProvisionedConcurrencyConfig:
         !If
           - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
           - !Ref AWS::NoValue
 
   IPVJourneyEngineFunctionLogGroup:
@@ -879,9 +889,9 @@ Resources:
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrentExecutions
-        - !Ref AWS::NoValue
+          - AddProvisionedConcurrency
+          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
+          - !Ref AWS::NoValue
 
   IPVValidateCriCheckFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
This sets the provisioned concurrency of each lambda based using a look
up in the Mappings section. This makes it simpler to find the setting
and to deploy changes.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
As above
### What changed
As above
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The initial implementation relied upon setting the parameter via the cli or CI configuration. Having the setting within the CI configuration makes it harder to find and also creates "interesting" scenarios where updates to the CI configuration do not necessarily trigger a deployment of the app that propagates through environments. Moving the setting into the template's Mappings section makes it simpler to find and will always trigger a deployment when it changes.

This has been successfully deployed into my dev environment. Integration and Production are currently set to provisioned concurrency of 1 and this brings staging inline with production as best practice.

Concourse pipeline configuration is not currently passing the parameter when deploying the stack so it is safe to remove in this commit.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1495](https://govukverify.atlassian.net/browse/PYIC-1495)

