### PR TITLE
PYIC-1427: Account for null VC evidence

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionsVcEvidence.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionsVcEvidence.java
@@ -21,6 +21,6 @@ public class AuditExtensionsVcEvidence implements AuditExtensions {
             @JsonProperty(value = "evidence", required = false) String evidence)
             throws JsonProcessingException {
         this.iss = iss;
-        this.evidence = new ObjectMapper().readTree(evidence);
+        this.evidence = evidence == null ? null : new ObjectMapper().readTree(evidence);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionsVcEvidenceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionsVcEvidenceTest.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.core.library.auditing;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AuditExtensionsVcEvidenceTest {
+
+    @Test
+    public void shouldInitWithNullEvidence() throws JsonProcessingException {
+        var auditExtensions = new AuditExtensionsVcEvidence("http://issuer.example.com", null);
+        assertNull(auditExtensions.getEvidence());
+    }
+}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow `AuditExtensionsVcEvidence` to be initialised with a null evidence parameter.

### Why did it change

VCs from the Address CRI do not contain an `evidence` section. In this case we should simply not include the evidence section in the audit event extension.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1427](https://govukverify.atlassian.net/browse/PYIC-1427)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
