### PR TITLE
PYIC-1491 Revoke access token if auth code used more than once

### DIFF
--- a/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
+++ b/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
@@ -108,11 +108,14 @@ public class UserIdentityHandler
             }
 
             ClientSessionDetailsDto clientSessionDetails =
-                    ipvSessionService.getIpvSession(accessTokenItem.getIpvSessionId()).getClientSessionDetails();
+                    ipvSessionService
+                            .getIpvSession(accessTokenItem.getIpvSessionId())
+                            .getClientSessionDetails();
             LogHelper.attachClientIdToLogs(clientSessionDetails.getClientId());
-            
+
             UserIdentity userIdentity =
-                    userIdentityService.generateUserIdentity(ipvSessionId, clientSessionDetails.getUserId());
+                    userIdentityService.generateUserIdentity(
+                            ipvSessionId, clientSessionDetails.getUserId());
 
             auditService.sendAuditEvent(AuditEventTypes.IPV_IDENTITY_ISSUED);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
@@ -9,6 +9,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 public class AccessTokenItem implements DynamodbItem {
     private String accessToken;
     private String ipvSessionId;
+    private String revokedAtDateTime;
     private long ttl;
 
     @DynamoDbPartitionKey
@@ -26,6 +27,14 @@ public class AccessTokenItem implements DynamodbItem {
 
     public void setIpvSessionId(String ipvSessionId) {
         this.ipvSessionId = ipvSessionId;
+    }
+
+    public String getRevokedAtDateTime() {
+        return revokedAtDateTime;
+    }
+
+    public void setRevokedAtDateTime(String revokedAtDateTime) {
+        this.revokedAtDateTime = revokedAtDateTime;
     }
 
     public long getTtl() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
@@ -11,6 +11,10 @@ public class AuthorizationCodeItem implements DynamodbItem {
     private String authCode;
     private String ipvSessionId;
     private String redirectUrl;
+
+    private String issuedAccessToken;
+
+    private String exchangeDateTime;
     private long ttl;
 
     @DynamoDbPartitionKey
@@ -44,5 +48,21 @@ public class AuthorizationCodeItem implements DynamodbItem {
 
     public void setTtl(long ttl) {
         this.ttl = ttl;
+    }
+
+    public String getIssuedAccessToken() {
+        return issuedAccessToken;
+    }
+
+    public void setIssuedAccessToken(String issuedAccessToken) {
+        this.issuedAccessToken = issuedAccessToken;
+    }
+
+    public String getExchangeDateTime() {
+        return exchangeDateTime;
+    }
+
+    public void setExchangeDateTime(String exchangeDateTime) {
+        this.exchangeDateTime = exchangeDateTime;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
@@ -6,6 +6,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 
+import java.time.Instant;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.AUTH_CODES_TABLE_NAME;
@@ -53,7 +54,11 @@ public class AuthorizationCodeService {
         dataStore.create(authorizationCodeItem);
     }
 
-    public void revokeAuthorizationCode(String authorizationCode) {
-        dataStore.delete(DigestUtils.sha256Hex(authorizationCode));
+    public void setIssuedAccessToken(String authorizationCode, String accessToken) {
+        AuthorizationCodeItem authorizationCodeItem = dataStore.getItem(authorizationCode);
+        authorizationCodeItem.setIssuedAccessToken(DigestUtils.sha256Hex(accessToken));
+        authorizationCodeItem.setExchangeDateTime(Instant.now().toString());
+
+        dataStore.update(authorizationCodeItem);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
@@ -196,13 +196,12 @@ class AccessTokenServiceTest {
 
         when(mockDataStore.getItem(accessToken)).thenReturn(null);
 
-        try {
-            accessTokenService.revokeAccessToken(accessToken);
-            fail("Should have thrown an exception");
-        } catch (IllegalArgumentException e) {
-            assertEquals(
-                    "Failed to revoke access token - access token could not be found in DynamoDB",
-                    e.getMessage());
-        }
+        IllegalArgumentException thrown =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> accessTokenService.revokeAccessToken(accessToken));
+        assertEquals(
+                "Failed to revoke access token - access token could not be found in DynamoDB",
+                thrown.getMessage());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
@@ -27,13 +28,10 @@ import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
 import java.net.URI;
+import java.time.Instant;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -130,20 +128,21 @@ class AccessTokenServiceTest {
     }
 
     @Test
-    void shouldGetSessionIdByAccessTokenWhenValidAccessTokenProvided() {
+    void shouldGetAccessTokenItemWhenValidAccessTokenProvided() {
         String testIpvSessionId = SecureTokenHelper.generate();
         String accessToken = new BearerAccessToken().getValue();
 
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setIpvSessionId(testIpvSessionId);
-        when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken))).thenReturn(accessTokenItem);
+        AccessTokenItem expectedAccessTokenItem = new AccessTokenItem();
+        expectedAccessTokenItem.setIpvSessionId(testIpvSessionId);
+        when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken)))
+                .thenReturn(expectedAccessTokenItem);
 
-        String resultIpvSessionId = accessTokenService.getIpvSessionIdByAccessToken(accessToken);
+        AccessTokenItem actualAccessTokenItem = accessTokenService.getAccessToken(accessToken);
 
         verify(mockDataStore).getItem(DigestUtils.sha256Hex(accessToken));
 
-        assertNotNull(resultIpvSessionId);
-        assertEquals(testIpvSessionId, resultIpvSessionId);
+        assertNotNull(actualAccessTokenItem);
+        assertEquals(expectedAccessTokenItem, actualAccessTokenItem);
     }
 
     @Test
@@ -152,9 +151,58 @@ class AccessTokenServiceTest {
 
         when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken))).thenReturn(null);
 
-        String resultIpvSessionId = accessTokenService.getIpvSessionIdByAccessToken(accessToken);
+        AccessTokenItem actualAccessTokenItem = accessTokenService.getAccessToken(accessToken);
 
         verify(mockDataStore).getItem(DigestUtils.sha256Hex(accessToken));
-        assertNull(resultIpvSessionId);
+        assertNull(actualAccessTokenItem);
+    }
+
+    @Test
+    void shouldRevokeAccessToken() {
+        String accessToken = "test-access-token";
+
+        AccessTokenItem accessTokenItem = new AccessTokenItem();
+        accessTokenItem.setAccessToken(accessToken);
+
+        when(mockDataStore.getItem(accessToken)).thenReturn(accessTokenItem);
+
+        accessTokenService.revokeAccessToken(accessToken);
+
+        ArgumentCaptor<AccessTokenItem> accessTokenItemArgCaptor =
+                ArgumentCaptor.forClass(AccessTokenItem.class);
+
+        verify(mockDataStore).update(accessTokenItemArgCaptor.capture());
+        assertNotNull(accessTokenItemArgCaptor.getValue().getRevokedAtDateTime());
+    }
+
+    @Test
+    void shouldNotAttemptUpdateIfAccessTokenIsAlreadyRevoked() {
+        String accessToken = "test-access-token";
+
+        AccessTokenItem accessTokenItem = new AccessTokenItem();
+        accessTokenItem.setAccessToken(accessToken);
+        accessTokenItem.setRevokedAtDateTime(Instant.now().toString());
+
+        when(mockDataStore.getItem(accessToken)).thenReturn(accessTokenItem);
+
+        accessTokenService.revokeAccessToken(accessToken);
+
+        verify(mockDataStore, Mockito.times(0)).update(any());
+    }
+
+    @Test
+    void shouldThrowExceptionIfAccessTokenCanNotBeFoundWhenRevoking() {
+        String accessToken = "test-access-token";
+
+        when(mockDataStore.getItem(accessToken)).thenReturn(null);
+
+        try {
+            accessTokenService.revokeAccessToken(accessToken);
+            fail("Should have thrown an exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals(
+                    "Failed to revoke access token - access token could not be found in DynamoDB",
+                    e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Revoke issued access token if an auth code is re-used.

To do this we associate an access token with the original auth code record when it is issued. Then when an auth code is used we can check an access token for it has not already been issued.

Also we now revoke an access token by setting a field with the datetime it is revoked (rather than simply deleting it), making it easier to track/investigate issues.

### Why did it change

To meet the requirements of [RFC6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2) which states that "If an authorization code is used more than once, the authorization server MUST deny the request and SHOULD revoke (when possible) all tokens previously issued based on that authorization code." This is also echoed in [RFC6819](https://www.rfc-editor.org/rfc/rfc6819.html#section-5.1.5.4).

### Issue tracking
- [PYIC-1491](https://govukverify.atlassian.net/browse/PYIC-1491)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
