### PR TITLE
BAU: Temporary logging to diagnose OAuth state issue

### DIFF
--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -14,6 +14,7 @@ import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.Logging;
+import software.amazon.lambda.powertools.logging.LoggingUtils;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -190,7 +191,11 @@ public class CredentialIssuerReturnHandler
             return Optional.of(ErrorResponse.MISSING_OAUTH_STATE);
         }
 
-        if (!request.getState().equals(getPersistedOauthState(request))) {
+        String persistedOauthState = getPersistedOauthState(request);
+        if (!request.getState().equals(persistedOauthState)) {
+            LoggingUtils.appendKey("expected_state", persistedOauthState);
+            LoggingUtils.appendKey("request_state", request.getState());
+            LOGGER.error("state value in request does not match expected state");
             return Optional.of(ErrorResponse.INVALID_OAUTH_STATE);
         }
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Temporary logging to diagnose OAuth state issue

### Why did it change

We saw a lot of issues with OAuth states not matching during the first
go live period. To help diagnose what's happening we can log them.

The state values are already in the logs, so this shouldn't be an issue.

