### PR TITLE
BAU: Refactor credential issue error logging and LogHelper

### DIFF
--- a/lambdas/credentialissuererror/src/main/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandler.java
+++ b/lambdas/credentialissuererror/src/main/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandler.java
@@ -67,15 +67,13 @@ public class CredentialIssuerErrorHandler
                     RequestHelper.convertRequest(input, CredentialIssuerErrorDto.class);
             LogHelper.attachCriIdToLogs(credentialIssuerErrorDto.getCredentialIssuerId());
 
-            LOGGER.error(
-                    "An error occurred with the {} cri",
-                    credentialIssuerErrorDto.getCredentialIssuerId());
-
             if (!ALLOWED_OAUTH_ERROR_CODES.contains(credentialIssuerErrorDto.getError())) {
                 LOGGER.error("Unknown Oauth error code received");
             }
-            LOGGER.error("Error code: {}", credentialIssuerErrorDto.getError());
-            LOGGER.error(credentialIssuerErrorDto.getErrorDescription());
+            LogHelper.logOauthError(
+                    "OAuth error received from CRI",
+                    credentialIssuerErrorDto.getError(),
+                    credentialIssuerErrorDto.getErrorDescription());
 
             sendAuditEvent(credentialIssuerErrorDto);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -8,16 +8,17 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @ExcludeFromGeneratedCoverageReport
 public class LogHelper {
     private static final Logger LOGGER = LogManager.getLogger();
+    public static final String CLIENT_ID_LOG_FIELD = "clientId";
+    public static final String CRI_ID_LOG_FIELD = "criId";
+    public static final String ERROR_CODE_LOG_FIELD = "errorCode";
+    public static final String ERROR_DESCRIPTION_LOG_FIELD = "errorDescription";
+    public static final String IPV_SESSION_ID_LOG_FIELD = "ipvSessionId";
+    public static final String COMPONENT_ID_LOG_FIELD = "componentId";
+    public static final String COMPONENT_ID = "core";
 
     private LogHelper() {
         throw new IllegalStateException("Utility class");
     }
-
-    public static final String CLIENT_ID_LOG_FIELD = "clientId";
-    public static final String CRI_ID_LOG_FIELD = "criId";
-    public static final String IPV_SESSION_ID_LOG_FIELD = "ipvSessionId";
-    public static final String COMPONENT_ID_LOG_FIELD = "componentId";
-    public static final String COMPONENT_ID = "core";
 
     public static void attachComponentIdToLogs() {
         attachFieldToLogs(COMPONENT_ID_LOG_FIELD, COMPONENT_ID);
@@ -33,6 +34,13 @@ public class LogHelper {
 
     public static void attachIpvSessionIdToLogs(String sessionId) {
         attachFieldToLogs(IPV_SESSION_ID_LOG_FIELD, sessionId);
+    }
+
+    public static void logOauthError(String message, String errorCode, String errorDescription) {
+        LoggingUtils.appendKey(ERROR_CODE_LOG_FIELD, errorCode);
+        LoggingUtils.appendKey(ERROR_DESCRIPTION_LOG_FIELD, errorDescription);
+        LOGGER.error(message);
+        LoggingUtils.removeKeys(ERROR_CODE_LOG_FIELD, ERROR_DESCRIPTION_LOG_FIELD);
     }
 
     private static void attachFieldToLogs(String field, String value) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -8,43 +8,59 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @ExcludeFromGeneratedCoverageReport
 public class LogHelper {
     private static final Logger LOGGER = LogManager.getLogger();
-    public static final String CLIENT_ID_LOG_FIELD = "clientId";
-    public static final String CRI_ID_LOG_FIELD = "criId";
-    public static final String ERROR_CODE_LOG_FIELD = "errorCode";
-    public static final String ERROR_DESCRIPTION_LOG_FIELD = "errorDescription";
-    public static final String IPV_SESSION_ID_LOG_FIELD = "ipvSessionId";
-    public static final String COMPONENT_ID_LOG_FIELD = "componentId";
-    public static final String COMPONENT_ID = "core";
+    public static final String CORE_COMPONENT_ID = "core";
+
+    public enum LogField {
+        CLIENT_ID_LOG_FIELD("clientId"),
+        CRI_ID_LOG_FIELD("criId"),
+        ERROR_CODE_LOG_FIELD("errorCode"),
+        ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
+        IPV_SESSION_ID_LOG_FIELD("ipvSessionId"),
+        COMPONENT_ID_LOG_FIELD("componentId");
+
+        private final String fieldName;
+
+        LogField(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        String getFieldName() {
+            return fieldName;
+        }
+    }
 
     private LogHelper() {
         throw new IllegalStateException("Utility class");
     }
 
     public static void attachComponentIdToLogs() {
-        attachFieldToLogs(COMPONENT_ID_LOG_FIELD, COMPONENT_ID);
+        attachFieldToLogs(LogField.COMPONENT_ID_LOG_FIELD, CORE_COMPONENT_ID);
     }
 
     public static void attachClientIdToLogs(String clientId) {
-        attachFieldToLogs(CLIENT_ID_LOG_FIELD, clientId);
+        attachFieldToLogs(LogField.CLIENT_ID_LOG_FIELD, clientId);
     }
 
     public static void attachCriIdToLogs(String criId) {
-        attachFieldToLogs(CRI_ID_LOG_FIELD, criId);
+        attachFieldToLogs(LogField.CRI_ID_LOG_FIELD, criId);
     }
 
     public static void attachIpvSessionIdToLogs(String sessionId) {
-        attachFieldToLogs(IPV_SESSION_ID_LOG_FIELD, sessionId);
+        attachFieldToLogs(LogField.IPV_SESSION_ID_LOG_FIELD, sessionId);
     }
 
     public static void logOauthError(String message, String errorCode, String errorDescription) {
-        LoggingUtils.appendKey(ERROR_CODE_LOG_FIELD, errorCode);
-        LoggingUtils.appendKey(ERROR_DESCRIPTION_LOG_FIELD, errorDescription);
+        LoggingUtils.appendKey(LogField.ERROR_CODE_LOG_FIELD.getFieldName(), errorCode);
+        LoggingUtils.appendKey(
+                LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName(), errorDescription);
         LOGGER.error(message);
-        LoggingUtils.removeKeys(ERROR_CODE_LOG_FIELD, ERROR_DESCRIPTION_LOG_FIELD);
+        LoggingUtils.removeKeys(
+                LogField.ERROR_CODE_LOG_FIELD.getFieldName(),
+                LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName());
     }
 
-    private static void attachFieldToLogs(String field, String value) {
-        LoggingUtils.appendKey(field, value);
-        LOGGER.info("{} attached to logs", field);
+    private static void attachFieldToLogs(LogField field, String value) {
+        LoggingUtils.appendKey(field.getFieldName(), value);
+        LOGGER.info("{} attached to logs", field.getFieldName());
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

[BAU: Refactor CRI error logging](https://github.com/alphagov/di-ipv-core-back/commit/1ba4aff635b652f79c402f2f4ab4ef7ee6b58de6) 

We were logging the received OAuth error on separate lines. This moves
them to fields by using a new helper.
  
[BAU: Make LogHelper log fields enums](https://github.com/alphagov/di-ipv-core-back/commit/a8f11eca738995a8df6252bb35a64dc9076b4286) 

This should make it more obvious that we're logging a structured set of
fields that can be tied together and searched.
