### PR TITLE
BAU: Parse auth grant instead of token request

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -4,14 +4,14 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.AuthorizationGrant;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.TokenRequest;
-import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,7 +28,6 @@ import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.validation.TokenRequestValidator;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
-import java.net.URI;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -36,6 +35,7 @@ public class AccessTokenHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOGGER = LogManager.getLogger();
+    public static final String SCOPE = "scope";
 
     private final AccessTokenService accessTokenService;
     private final AuthorizationCodeService authorizationCodeService;
@@ -68,23 +68,33 @@ public class AccessTokenHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
-            TokenRequest tokenRequest = createTokenRequest(input.getBody());
-
+            var params = URLUtils.parseParameters(input.getBody());
+            AuthorizationCodeGrant authorizationGrant =
+                    (AuthorizationCodeGrant) AuthorizationGrant.parse(params);
             ValidationResult<ErrorObject> validationResult =
-                    accessTokenService.validateTokenRequest(tokenRequest);
+                    accessTokenService.validateAuthorizationGrant(authorizationGrant);
             if (!validationResult.isValid()) {
-                LOGGER.error(
-                        "Invalid access token request, error description: {}",
-                        validationResult.getError().getDescription());
+                ErrorObject error = validationResult.getError();
+                LogHelper.logOauthError(
+                        "Invalid auth grant received", error.getCode(), error.getDescription());
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         getHttpStatusCodeForErrorResponse(validationResult.getError()),
                         validationResult.getError().toJSONObject());
             }
 
-            tokenRequestValidator.authenticateClient(input.getBody());
+            Scope scope = Scope.parse(params.get(SCOPE));
+            ValidationResult<ErrorObject> scopeValidationResult =
+                    accessTokenService.validateScope(scope);
+            if (!scopeValidationResult.isValid()) {
+                ErrorObject error = scopeValidationResult.getError();
+                LogHelper.logOauthError(
+                        "Invalid scope received", error.getCode(), error.getDescription());
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        getHttpStatusCodeForErrorResponse(scopeValidationResult.getError()),
+                        scopeValidationResult.getError().toJSONObject());
+            }
 
-            AuthorizationCodeGrant authorizationGrant =
-                    (AuthorizationCodeGrant) tokenRequest.getAuthorizationGrant();
+            tokenRequestValidator.authenticateClient(input.getBody());
 
             AuthorizationCodeItem authorizationCodeItem =
                     authorizationCodeService
@@ -114,7 +124,7 @@ public class AccessTokenHandler
             }
 
             AccessTokenResponse accessTokenResponse =
-                    accessTokenService.generateAccessToken(tokenRequest).toSuccessResponse();
+                    accessTokenService.generateAccessToken(scope).toSuccessResponse();
 
             accessTokenService.persistAccessToken(
                     accessTokenResponse, authorizationCodeItem.getIpvSessionId());
@@ -145,18 +155,6 @@ public class AccessTokenHandler
                     OAuth2Error.INVALID_GRANT.getHTTPStatusCode(),
                     OAuth2Error.INVALID_GRANT.toJSONObject());
         }
-    }
-
-    @Tracing
-    private TokenRequest createTokenRequest(String requestBody) throws ParseException {
-        // The URI is not needed/consumed in the resultant TokenRequest
-        // therefore any value can be passed here to ensure the parse method
-        // successfully materialises a TokenRequest
-        URI arbitraryUri = URI.create("https://gds");
-        HTTPRequest request = new HTTPRequest(HTTPRequest.Method.POST, arbitraryUri);
-        request.setQuery(requestBody);
-        request.setContentType(ContentType.APPLICATION_URLENCODED.getType());
-        return TokenRequest.parse(request);
     }
 
     @Tracing

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -5,7 +5,6 @@ import com.nimbusds.oauth2.sdk.AuthorizationGrant;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -45,22 +44,15 @@ public class AccessTokenService {
         this.configurationService = configurationService;
     }
 
-    public TokenResponse generateAccessToken(Scope scope) {
+    public TokenResponse generateAccessToken() {
         AccessToken accessToken =
-                new BearerAccessToken(configurationService.getBearerAccessTokenTtl(), scope);
+                new BearerAccessToken(configurationService.getBearerAccessTokenTtl(), null);
         return new AccessTokenResponse(new Tokens(accessToken, null));
     }
 
     public ValidationResult<ErrorObject> validateAuthorizationGrant(AuthorizationGrant authGrant) {
         if (!authGrant.getType().equals(GrantType.AUTHORIZATION_CODE)) {
             return new ValidationResult<>(false, OAuth2Error.UNSUPPORTED_GRANT_TYPE);
-        }
-        return ValidationResult.createValidResult();
-    }
-
-    public ValidationResult<ErrorObject> validateScope(Scope scope) {
-        if (StringUtils.isBlank(scope.toString())) {
-            return new ValidationResult<>(false, OAuth2Error.INVALID_SCOPE);
         }
         return ValidationResult.createValidResult();
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -1,10 +1,11 @@
 package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationGrant;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
-import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -44,16 +45,22 @@ public class AccessTokenService {
         this.configurationService = configurationService;
     }
 
-    public TokenResponse generateAccessToken(TokenRequest tokenRequest) {
+    public TokenResponse generateAccessToken(Scope scope) {
         AccessToken accessToken =
-                new BearerAccessToken(
-                        configurationService.getBearerAccessTokenTtl(), tokenRequest.getScope());
+                new BearerAccessToken(configurationService.getBearerAccessTokenTtl(), scope);
         return new AccessTokenResponse(new Tokens(accessToken, null));
     }
 
-    public ValidationResult<ErrorObject> validateTokenRequest(TokenRequest tokenRequest) {
-        if (!tokenRequest.getAuthorizationGrant().getType().equals(GrantType.AUTHORIZATION_CODE)) {
+    public ValidationResult<ErrorObject> validateAuthorizationGrant(AuthorizationGrant authGrant) {
+        if (!authGrant.getType().equals(GrantType.AUTHORIZATION_CODE)) {
             return new ValidationResult<>(false, OAuth2Error.UNSUPPORTED_GRANT_TYPE);
+        }
+        return ValidationResult.createValidResult();
+    }
+
+    public ValidationResult<ErrorObject> validateScope(Scope scope) {
+        if (StringUtils.isBlank(scope.toString())) {
+            return new ValidationResult<>(false, OAuth2Error.INVALID_SCOPE);
         }
         return ValidationResult.createValidResult();
     }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
@@ -6,7 +6,6 @@ import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -49,19 +48,15 @@ class AccessTokenServiceTest {
     @Test
     void shouldReturnSuccessfulTokenResponseOnSuccessfulExchange() {
         long testTokenTtl = 2400L;
-        Scope testScope = new Scope("test-scope");
         when(mockConfigurationService.getBearerAccessTokenTtl()).thenReturn(testTokenTtl);
 
-        TokenResponse response = accessTokenService.generateAccessToken(testScope);
+        TokenResponse response = accessTokenService.generateAccessToken();
 
         assertInstanceOf(AccessTokenResponse.class, response);
         assertNotNull(response.toSuccessResponse().getTokens().getAccessToken().getValue());
         assertEquals(
                 testTokenTtl,
                 response.toSuccessResponse().getTokens().getBearerAccessToken().getLifetime());
-        assertEquals(
-                testScope,
-                response.toSuccessResponse().getTokens().getBearerAccessToken().getScope());
     }
 
     @Test
@@ -85,24 +80,6 @@ class AccessTokenServiceTest {
         assertNotNull(validationResult);
         assertTrue(validationResult.isValid());
         assertNull(validationResult.getError());
-    }
-
-    @Test
-    void validateScopeShouldReturnValidationErrorForMissingScope() {
-        ValidationResult<ErrorObject> scopeValidationResult =
-                accessTokenService.validateScope(new Scope());
-
-        assertFalse(scopeValidationResult.isValid());
-        assertEquals(OAuth2Error.INVALID_SCOPE, scopeValidationResult.getError());
-    }
-
-    @Test
-    void validateScopeShouldValidResponseForWhenScopePresent() {
-        ValidationResult<ErrorObject> scopeValidationResult =
-                accessTokenService.validateScope(new Scope("some-scope"));
-
-        assertTrue(scopeValidationResult.isValid());
-        assertNull(scopeValidationResult.getError());
     }
 
     @Test


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Parse auth grant instead of token request

### Why did it change

When receiving an request to the access token endpoint we have been
manually recreating a TokenRequest object from an HTTPRequest and an
arbitrary URL. Rather than jumping through these hoops we can just parse
the auth grant and scope from the params directly.

This does raise the question of what are we doing with the requested
scope value. We have been playing back to the client whatever scope they
requested. We don't really use scopes in any meaningful way so this has
been fine, but we should probably be returning a default value, or no
value at all. ~This will get dealt with in another PR after talking to
the auth team about what they're sending us.~

[BAU: Remove scope from access token response](https://github.com/alphagov/di-ipv-core-back/pull/340/commits/586747f328ae3c9eceb77b4083cce34b93d88b1e) 

The auth team have confirmed they they aren't sending a scope in
requests to the access token endpoint. As such we can just return null.
We can revisit this at some point to decided to return a default value
if required.
