### PR TITLE
PYIC-1517: Validate Access Token has not expired.

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AccessTokenItem.java
@@ -11,6 +11,7 @@ public class AccessTokenItem implements DynamodbItem {
     private String ipvSessionId;
     private String revokedAtDateTime;
     private long ttl;
+    private String expiryDateTime;
 
     @DynamoDbPartitionKey
     public String getAccessToken() {
@@ -43,5 +44,13 @@ public class AccessTokenItem implements DynamodbItem {
 
     public void setTtl(long ttl) {
         this.ttl = ttl;
+    }
+
+    public void setExpiryDateTime(String expiryDateTime) {
+        this.expiryDateTime = expiryDateTime;
+    }
+
+    public String getExpiryDateTime() {
+        return expiryDateTime;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -64,9 +64,10 @@ public class AccessTokenService {
 
     public void persistAccessToken(AccessTokenResponse tokenResponse, String ipvSessionId) {
         AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(
-                DigestUtils.sha256Hex(tokenResponse.getTokens().getBearerAccessToken().getValue()));
+        BearerAccessToken accessToken = tokenResponse.getTokens().getBearerAccessToken();
+        accessTokenItem.setAccessToken(DigestUtils.sha256Hex(accessToken.getValue()));
         accessTokenItem.setIpvSessionId(ipvSessionId);
+        accessTokenItem.setExpiryDateTime(toExpiryDateTime(accessToken.getLifetime()));
         dataStore.create(accessTokenItem);
     }
 
@@ -82,5 +83,9 @@ public class AccessTokenService {
             throw new IllegalArgumentException(
                     "Failed to revoke access token - access token could not be found in DynamoDB");
         }
+    }
+
+    private String toExpiryDateTime(long expirySeconds) {
+        return Instant.now().plusSeconds(expirySeconds).toString();
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Validate that the Access Token has not expired.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
"We set the lifetime of access tokens returned to the client to one hour. We don’t however validate this in the protected resource endpoint. We should reject access tokens that have expired."

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1517](https://govukverify.atlassian.net/browse/PYIC-1517)
