### PR TITLE
BAY: Tidy up api gateway response generator

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ApiGatewayResponseGenerator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ApiGatewayResponseGenerator.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpHeaders;
+import org.apache.http.entity.ContentType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -12,22 +13,16 @@ import java.util.Map;
 
 public class ApiGatewayResponseGenerator {
 
-    private static final String JSON_CONTENT_TYPE_VALUE = "application/json";
-
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private ApiGatewayResponseGenerator() {}
 
-    public static APIGatewayProxyResponseEvent proxyJoseResponse(int statusCode, String payload) {
-        Map<String, String> responseHeaders = Map.of(HttpHeaders.CONTENT_TYPE, "application/jose");
-        return proxyResponse(statusCode, payload, responseHeaders);
-    }
-
     public static <T> APIGatewayProxyResponseEvent proxyJsonResponse(int statusCode, T body) {
+
         Map<String, String> responseHeaders =
-                Map.of(HttpHeaders.CONTENT_TYPE, JSON_CONTENT_TYPE_VALUE);
+                Map.of(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
 
         try {
             return proxyResponse(statusCode, generateResponseBody(body), responseHeaders);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Tidy up api gateway response generator

### Why did it change

This uses a constant defined by apache for application/json content type
and removes an unused method.

