### PR TITLE
PYIC-1530: Return correct error code if redirect URLs don't match

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -104,8 +104,8 @@ public class AccessTokenHandler
                         "Redirect URL in token request does not match that received in auth code request. Session ID: {}",
                         authorizationCodeItem.getIpvSessionId());
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        OAuth2Error.INVALID_REQUEST.getHTTPStatusCode(),
-                        OAuth2Error.INVALID_REQUEST.toJSONObject());
+                        OAuth2Error.INVALID_GRANT.getHTTPStatusCode(),
+                        OAuth2Error.INVALID_GRANT.toJSONObject());
             }
 
             AccessTokenResponse accessTokenResponse =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
@@ -116,10 +116,8 @@ public class TokenRequestValidator {
     private ClientAuthenticationVerifier<Object> getClientAuthVerifier(
             ConfigurationService configurationService) {
 
-        ConfigurationServicePublicKeySelector configurationServicePublicKeySelector =
-                new ConfigurationServicePublicKeySelector(configurationService);
         return new ClientAuthenticationVerifier<>(
-                configurationServicePublicKeySelector,
+                new ConfigurationServicePublicKeySelector(configurationService),
                 Set.of(new Audience(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS))));
     }
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return correct error code if redirect URLs don't match

### Why did it change

[PYIC-1530: Return correct error code if redirect URLs don't match](https://github.com/alphagov/di-ipv-core-back/pull/344/commits/d9455cb9f322511e8370231acb4667e910426243) 

We should be returning an invalid_grant error code if the redirect URL
received on the access token endpoint doesn't match that from the auth
endpoint, according the OAuth RFC.
  
[BAU: Inline ConfigurationServicePublicKeySelector](https://github.com/alphagov/di-ipv-core-back/pull/344/commits/54aeb53783db8d6dd2aa4c0ef6f17ccf8ffd658f) 

This moves the instantiation of the
ConfigurationServicePublicKeySelector into the call to the constructor
of the ClientAuthenticationVerifier. It's just a little tidier and
avoids unnecessarily assigning a var.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1530](https://govukverify.atlassian.net/browse/PYIC-1530)
