### PR TITLE
BAU: Fix structured logging of message

### DIFF
--- a/lambdas/journeyengine/src/main/resources/IpvLambdaJsonLayout.json
+++ b/lambdas/journeyengine/src/main/resources/IpvLambdaJsonLayout.json
@@ -1,0 +1,88 @@
+{
+  "timestamp": {
+    "$resolver": "timestamp"
+  },
+  "instant": {
+    "epochSecond": {
+      "$resolver": "timestamp",
+      "epoch": {
+        "unit": "secs",
+        "rounded": true
+      }
+    },
+    "nanoOfSecond": {
+      "$resolver": "timestamp",
+      "epoch": {
+        "unit": "secs.nanos"
+      }
+    }
+  },
+  "thread": {
+    "$resolver": "thread",
+    "field": "name"
+  },
+  "level": {
+    "$resolver": "level",
+    "field": "name"
+  },
+  "loggerName": {
+    "$resolver": "logger",
+    "field": "name"
+  },
+  "message": {
+    "$resolver": "message"
+  },
+  "thrown": {
+    "message": {
+      "$resolver": "exception",
+      "field": "message"
+    },
+    "name": {
+      "$resolver": "exception",
+      "field": "className"
+    },
+    "extendedStackTrace": {
+      "$resolver": "exception",
+      "field": "stackTrace"
+    }
+  },
+  "contextStack": {
+    "$resolver": "ndc"
+  },
+  "endOfBatch": {
+    "$resolver": "endOfBatch"
+  },
+  "loggerFqcn": {
+    "$resolver": "logger",
+    "field": "fqcn"
+  },
+  "threadId": {
+    "$resolver": "thread",
+    "field": "id"
+  },
+  "threadPriority": {
+    "$resolver": "thread",
+    "field": "priority"
+  },
+  "source": {
+    "class": {
+      "$resolver": "source",
+      "field": "className"
+    },
+    "method": {
+      "$resolver": "source",
+      "field": "methodName"
+    },
+    "file": {
+      "$resolver": "source",
+      "field": "fileName"
+    },
+    "line": {
+      "$resolver": "source",
+      "field": "lineNumber"
+    }
+  },
+  "": {
+    "$resolver": "powertools"
+  }
+}

--- a/lambdas/journeyengine/src/main/resources/log4j2.yaml
+++ b/lambdas/journeyengine/src/main/resources/log4j2.yaml
@@ -5,7 +5,7 @@ Configuration:
       name: JsonAppender
       target: SYSTEM_OUT
       JsonTemplateLayout:
-        eventTemplateUri: "classpath:LambdaJsonLayout.json"
+        eventTemplateUri: "classpath:IpvLambdaJsonLayout.json"
   Loggers:
     logger:
       - name: JsonLogger


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We have extracted the Log4j2 `LambdaJsonLayout.json` from the Powertools logging library and updated it to allow MapMessages to be structured correctly. We then link to the modified version.

Original:
```
  "message": {
    "$resolver": "message",
    "stringified": true
  },
```

Replacement:
```
  "message": {
    "$resolver": "message"
  },
```

### Why did it change

We want our logs to be structured to enable programatic analysis of them. Our previous attempt at this left the message field as a formatted string, rather than a correctly nested json object. 
