### PR TITLE
BAU: Authenticate client first in access token endpoint

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -65,9 +65,11 @@ public class AccessTokenHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
-            var params = URLUtils.parseParameters(input.getBody());
+            tokenRequestValidator.authenticateClient(input.getBody());
+
             AuthorizationCodeGrant authorizationGrant =
-                    (AuthorizationCodeGrant) AuthorizationGrant.parse(params);
+                    (AuthorizationCodeGrant)
+                            AuthorizationGrant.parse(URLUtils.parseParameters(input.getBody()));
             ValidationResult<ErrorObject> validationResult =
                     accessTokenService.validateAuthorizationGrant(authorizationGrant);
             if (!validationResult.isValid()) {
@@ -78,8 +80,6 @@ public class AccessTokenHandler
                         getHttpStatusCodeForErrorResponse(validationResult.getError()),
                         validationResult.getError().toJSONObject());
             }
-
-            tokenRequestValidator.authenticateClient(input.getBody());
 
             AuthorizationCodeItem authorizationCodeItem =
                     authorizationCodeService


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Authenticate client first in access token endpoint

### Why did it change

We can authenticate the client before parsing the auth grant. We should
probably do that.

