### PR TITLE
PYIC-1516: Enforce private key jwt auth method

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -5,7 +5,6 @@ public enum ConfigurationVariable {
     AUDIENCE_FOR_CLIENTS("/%s/core/self/audienceForClients"),
     BACKEND_SESSION_TIMEOUT("/%s/core/self/backendSessionTimeout"),
     BACKEND_SESSION_TTL("/%s/core/self/backendSessionTtl"),
-    CLIENT_AUTHENTICATION_METHOD("/%s/core/clients/%s/authenticationMethod"),
     CLIENT_ISSUER("/%s/core/clients/%s/issuer"),
     CORE_FRONT_CALLBACK_URL("/%s/core/self/coreFrontCallbackUrl"),
     CORE_VTM_CLAIM("/%s/core/self/coreVtmClaim"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/JarValidator.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Set;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_AUTHENTICATION_METHOD;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_ISSUER;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY;
@@ -82,7 +81,7 @@ public class JarValidator {
 
     private void validateClientId(String clientId) throws JarValidationException {
         try {
-            configurationService.getSsmParameter(CLIENT_AUTHENTICATION_METHOD, clientId);
+            configurationService.getSsmParameter(CLIENT_ISSUER, clientId);
             LogHelper.attachClientIdToLogs(clientId);
         } catch (ParameterNotFoundException e) {
             LOGGER.error("Unknown client id provided {}", clientId);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
@@ -12,30 +12,20 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.domain.ConfigurationServicePublicKeySelector;
 import uk.gov.di.ipv.core.library.exceptions.ClientAuthenticationException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
 import java.time.OffsetDateTime;
 import java.util.Date;
-import java.util.Map;
 import java.util.Set;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_AUTHENTICATION_METHOD;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
 
 public class TokenRequestValidator {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final String CLIENT_ASSERTION_PARAM = "client_assertion";
-    private static final String CLIENT_ID_PARAM = "client_id";
-    private static final String NONE = "none";
-    private static final String JWT = "jwt";
-
     private final ConfigurationService configurationService;
     private final ClientAuthenticationVerifier<Object> verifier;
-
-    private String clientId;
 
     public TokenRequestValidator(ConfigurationService configurationService) {
         this.configurationService = configurationService;
@@ -43,59 +33,15 @@ public class TokenRequestValidator {
     }
 
     public void authenticateClient(String requestBody) throws ClientAuthenticationException {
-        Map<String, String> queryParams = RequestHelper.parseRequestBody(requestBody);
-        if (queryParams.containsKey(CLIENT_ASSERTION_PARAM)) {
-            authenticateClientWithJwt(requestBody);
-        } else {
-            authenticateClientWithoutJwt(queryParams);
-        }
-    }
-
-    private void authenticateClientWithJwt(String requestBody)
-            throws ClientAuthenticationException {
         PrivateKeyJWT clientJwt;
         try {
             clientJwt = PrivateKeyJWT.parse(requestBody);
-
-            clientId = clientJwt.getClientID().getValue();
-
-            LogHelper.attachClientIdToLogs(clientId);
-
-            String clientAuthenticationMethod =
-                    configurationService.getSsmParameter(CLIENT_AUTHENTICATION_METHOD, clientId);
-
-            if (clientAuthenticationMethod.equals(NONE)) {
-                return;
-            }
-
+            LogHelper.attachClientIdToLogs(clientJwt.getClientID().getValue());
             verifier.verify(clientJwt, null, null);
             validateMaxAllowedAuthClientTtl(clientJwt.getJWTAuthenticationClaimsSet());
         } catch (ParseException | InvalidClientException | JOSEException e) {
             LOGGER.error("Validation of client_assertion jwt failed");
             throw new ClientAuthenticationException(e);
-        }
-    }
-
-    private void authenticateClientWithoutJwt(Map<String, String> queryParams)
-            throws ClientAuthenticationException {
-        if (queryParams.containsKey(CLIENT_ID_PARAM)) {
-            clientId = queryParams.get(CLIENT_ID_PARAM);
-
-            String clientAuthenticationMethod =
-                    configurationService.getSsmParameter(CLIENT_AUTHENTICATION_METHOD, clientId);
-
-            if (clientAuthenticationMethod.equals(JWT)) {
-                LOGGER.error("Missing client_assertion jwt for configured client {}", clientId);
-                throw new ClientAuthenticationException(
-                        String.format(
-                                "Missing client_assertion jwt for configured client '%s'",
-                                clientId));
-            }
-        } else {
-            LOGGER.error(
-                    "Missing either client_assertion or client_id values in request. Failed to establish client_id value.");
-            throw new ClientAuthenticationException(
-                    "Unknown client, no client_id value or client_assertion jwt found in request");
         }
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/validation/JarValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/validation/JarValidatorTest.java
@@ -45,7 +45,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_AUTHENTICATION_METHOD;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_ISSUER;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY;
@@ -68,7 +67,6 @@ class JarValidatorTest {
     private final String issuerClaim = "test-issuer";
     private final String subjectClaim = "test-subject";
 
-    private final String clientAuthMethod = "client-auth-method";
     private final String responseTypeClaim = "code";
     private final String clientIdClaim = "test-client-id";
     private final String redirectUriClaim = "https://example.com";
@@ -118,8 +116,6 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
         when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
                 .thenReturn(issuerClaim);
@@ -135,7 +131,7 @@ class JarValidatorTest {
     @Test
     void shouldFailValidationChecksOnInvalidClientId()
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
+        when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
                 .thenThrow(ParameterNotFoundException.builder().build());
 
         SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
@@ -183,8 +179,8 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK_2);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
+        when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
+                .thenReturn(issuerClaim);
 
         SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
 
@@ -206,8 +202,8 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn("invalid-jwk");
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
+        when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
+                .thenReturn(issuerClaim);
         SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
 
         JarValidationException thrown =
@@ -230,8 +226,8 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
+        when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
+                .thenReturn(issuerClaim);
         when(configurationService.getClientRedirectUrls(anyString()))
                 .thenReturn(Collections.singletonList(redirectUriClaim));
 
@@ -265,8 +261,6 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
         when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
                 .thenReturn(issuerClaim);
@@ -315,8 +309,6 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
         when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
                 .thenReturn(issuerClaim);
@@ -367,8 +359,6 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
         when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
                 .thenReturn(issuerClaim);
@@ -419,8 +409,6 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
         when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
                 .thenReturn(issuerClaim);
@@ -469,8 +457,6 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
         when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
                 .thenReturn(issuerClaim);
@@ -519,8 +505,6 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
         when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
                 .thenReturn(issuerClaim);
@@ -572,8 +556,8 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
+        when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
+                .thenReturn(issuerClaim);
         when(configurationService.getClientRedirectUrls(anyString()))
                 .thenReturn(Collections.singletonList("test-redirect-uri"));
 
@@ -598,8 +582,8 @@ class JarValidatorTest {
         when(configurationService.getSsmParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configurationService.getSsmParameter(eq(CLIENT_AUTHENTICATION_METHOD), anyString()))
-                .thenReturn(clientAuthMethod);
+        when(configurationService.getSsmParameter(eq(CLIENT_ISSUER), anyString()))
+                .thenReturn(issuerClaim);
 
         Map<String, Object> claims =
                 Map.of(


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enforce private key jwt auth method

### Why did it change

Our RFCs state that we should be enforcing private_key_jwt for our token
endpoint. We made the client auth method configurable, including none,
to help us build the system.
We don't use anything other than `jwt` anywhere, so we should close this
potential issue.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1516](https://govukverify.atlassian.net/browse/PYIC-1516)
