### PR TITLE
PYIC-1531: Add default scope value for the access tokens

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationGrant;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -22,6 +23,7 @@ import java.util.Objects;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ACCESS_TOKENS_TABLE_NAME;
 
 public class AccessTokenService {
+    protected static final Scope DEFAULT_SCOPE = new Scope("user-credentials");
     private final DataStore<AccessTokenItem> dataStore;
     private final ConfigurationService configurationService;
 
@@ -46,7 +48,8 @@ public class AccessTokenService {
 
     public TokenResponse generateAccessToken() {
         AccessToken accessToken =
-                new BearerAccessToken(configurationService.getBearerAccessTokenTtl(), null);
+                new BearerAccessToken(
+                        configurationService.getBearerAccessTokenTtl(), DEFAULT_SCOPE);
         return new AccessTokenResponse(new Tokens(accessToken, null));
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.service.AccessTokenService.DEFAULT_SCOPE;
 
 @ExtendWith(MockitoExtension.class)
 class AccessTokenServiceTest {
@@ -57,6 +58,9 @@ class AccessTokenServiceTest {
         assertEquals(
                 testTokenTtl,
                 response.toSuccessResponse().getTokens().getBearerAccessToken().getLifetime());
+        assertEquals(
+                DEFAULT_SCOPE,
+                response.toSuccessResponse().getTokens().getAccessToken().getScope());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add default value for the scope of our returned access tokens. This is a recommended feature of the Oauth RFC's.

The auth team have already confirmed that they don't send us a scope value and will not use the value we return so the actual default value does not matter that much.
<!-- Describe the changes in detail - the "what"-->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1531](https://govukverify.atlassian.net/browse/PYIC-1531)

