### PR TITLE
PYIC-1515: Enforce JAR encryption

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/HttpResponseExceptionWithErrorBody.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/HttpResponseExceptionWithErrorBody.java
@@ -6,7 +6,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import java.util.Map;
 
 @ExcludeFromGeneratedCoverageReport
-public class HttpResponseExceptionWithErrorBody extends Throwable {
+public class HttpResponseExceptionWithErrorBody extends Exception {
     private final int responseCode;
     private final ErrorResponse errorResponse;
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enforce JAR encryption

### Why did it change

We were allowing JAR request objects to be un-encrypted. This is bad and
we should stop doing it.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1515](https://govukverify.atlassian.net/browse/PYIC-1515)

