### PR TITLE
PYIC-1533: Normalise error responses

### DIFF
--- a/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
+++ b/lambdas/credentialissuerreturn/src/test/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandlerTest.java
@@ -574,7 +574,7 @@ class CredentialIssuerReturnHandlerTest {
         Integer statusCode = response.getStatusCode();
         Map responseBody = getResponseBodyAsMap(response);
         assertEquals(HTTPResponse.SC_BAD_REQUEST, statusCode);
-        assertEquals(errorResponse.getCode(), responseBody.get("code"));
+        assertEquals(errorResponse.getCode(), responseBody.get("error"));
         verifyNoInteractions(credentialIssuerService);
     }
 }

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -193,7 +193,7 @@ class CredentialIssuerStartHandlerTest {
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
         assertEquals(400, response.getStatusCode());
         Map<String, Object> responseBody = objectMapper.readValue(response.getBody(), Map.class);
-        assertEquals("Missing ipv session id header", responseBody.get("message"));
+        assertEquals("Missing ipv session id header", responseBody.get("error_description"));
     }
 
     private void assertSharedClaimsJWTIsValid(String request)

--- a/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
+++ b/lambdas/journeyengine/src/test/java/uk/gov/di/ipv/core/journeyengine/JourneyEngineHandlerTest.java
@@ -115,9 +115,10 @@ class JourneyEngineHandlerTest {
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), responseBody.get("error"));
         assertEquals(
-                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), responseBody.get("message"));
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                responseBody.get("error_description"));
     }
 
     @Test

--- a/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
+++ b/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
@@ -10,7 +10,6 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.Logging;
@@ -119,7 +118,8 @@ public class UserIdentityHandler
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+                    OAuth2Error.SERVER_ERROR.getHTTPStatusCode(),
+                    OAuth2Error.SERVER_ERROR.toJSONObject());
         } catch (HttpResponseExceptionWithErrorBody e) {
             LOGGER.error(
                     "Failed to generate the user identity output because: {}", e.getErrorReason());

--- a/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
+++ b/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
@@ -182,10 +182,10 @@ class UserIdentityHandlerTest {
         assertEquals(500, response.getStatusCode());
         assertEquals(
                 String.valueOf(ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM.getCode()),
-                responseBody.get("code"));
+                responseBody.get("error"));
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM.getMessage(),
-                responseBody.get("message"));
+                responseBody.get("error_description"));
     }
 
     @Test

--- a/lambdas/validatecricheck/src/test/java/uk/gov/di/ipv/core/validatecricheck/ValidateCriCheckHandlerTest.java
+++ b/lambdas/validatecricheck/src/test/java/uk/gov/di/ipv/core/validatecricheck/ValidateCriCheckHandlerTest.java
@@ -79,7 +79,9 @@ class ValidateCriCheckHandlerTest {
         var error = gson.fromJson(response.getBody(), Map.class);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID.getMessage(), error.get("message"));
+        assertEquals(
+                ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID.getMessage(),
+                error.get("error_description"));
     }
 
     @Test
@@ -92,7 +94,9 @@ class ValidateCriCheckHandlerTest {
         var error = gson.fromJson(response.getBody(), Map.class);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID.getMessage(), error.get("message"));
+        assertEquals(
+                ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID.getMessage(),
+                error.get("error_description"));
     }
 
     @Test
@@ -104,7 +108,8 @@ class ValidateCriCheckHandlerTest {
         var error = gson.fromJson(response.getBody(), Map.class);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), error.get("message"));
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), error.get("error_description"));
     }
 
     @Test
@@ -117,6 +122,7 @@ class ValidateCriCheckHandlerTest {
         var error = gson.fromJson(response.getBody(), Map.class);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), error.get("message"));
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), error.get("error_description"));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/HttpResponseExceptionWithErrorBody.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/HttpResponseExceptionWithErrorBody.java
@@ -24,7 +24,8 @@ public class HttpResponseExceptionWithErrorBody extends Throwable {
     }
 
     public Map<String, Object> getErrorBody() {
-        return Map.of("code", errorResponse.getCode(), "message", errorResponse.getMessage());
+        return Map.of(
+                "error", errorResponse.getCode(), "error_description", errorResponse.getMessage());
     }
 
     public ErrorResponse getErrorResponse() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -49,6 +49,10 @@ public class LogHelper {
         attachFieldToLogs(LogField.IPV_SESSION_ID_LOG_FIELD, sessionId);
     }
 
+    public static void logOauthError(String message, int errorCode, String errorDescription) {
+        logOauthError(message, Integer.toString(errorCode), errorDescription);
+    }
+
     public static void logOauthError(String message, String errorCode, String errorDescription) {
         LoggingUtils.appendKey(LogField.ERROR_CODE_LOG_FIELD.getFieldName(), errorCode);
         LoggingUtils.appendKey(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -299,10 +299,10 @@ class UserIdentityServiceTest {
         assertEquals(500, thrownError.getResponseCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM.getCode(),
-                thrownError.getErrorBody().get("code"));
+                thrownError.getErrorBody().get("error"));
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM.getMessage(),
-                thrownError.getErrorBody().get("message"));
+                thrownError.getErrorBody().get("error_description"));
     }
 
     @Test
@@ -331,10 +331,10 @@ class UserIdentityServiceTest {
         assertEquals(500, thrownError.getResponseCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM.getCode(),
-                thrownError.getErrorBody().get("code"));
+                thrownError.getErrorBody().get("error"));
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM.getMessage(),
-                thrownError.getErrorBody().get("message"));
+                thrownError.getErrorBody().get("error_description"));
     }
 
     @Test
@@ -406,10 +406,10 @@ class UserIdentityServiceTest {
         assertEquals(500, thrownError.getResponseCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_PASSPORT_CLAIM.getCode(),
-                thrownError.getErrorBody().get("code"));
+                thrownError.getErrorBody().get("error"));
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_PASSPORT_CLAIM.getMessage(),
-                thrownError.getErrorBody().get("message"));
+                thrownError.getErrorBody().get("error_description"));
     }
 
     @Test
@@ -516,10 +516,10 @@ class UserIdentityServiceTest {
         assertEquals(500, thrownException.getResponseCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_ADDRESS_CLAIM.getCode(),
-                thrownException.getErrorBody().get("code"));
+                thrownException.getErrorBody().get("error"));
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_ADDRESS_CLAIM.getMessage(),
-                thrownException.getErrorBody().get("message"));
+                thrownException.getErrorBody().get("error_description"));
     }
 
     @Test
@@ -547,10 +547,10 @@ class UserIdentityServiceTest {
         assertEquals(500, thrownException.getResponseCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_ADDRESS_CLAIM.getCode(),
-                thrownException.getErrorBody().get("code"));
+                thrownException.getErrorBody().get("error"));
         assertEquals(
                 ErrorResponse.FAILED_TO_GENERATE_ADDRESS_CLAIM.getMessage(),
-                thrownException.getErrorBody().get("message"));
+                thrownException.getErrorBody().get("error_description"));
     }
 
     @Test


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Normalise error responses

### Why did it change

This started as normalising the error responses from the user identity
endpoint to match the OAuth error response pattern of a json object with
`error` and `error_description` fields.

In a few places we throw an `HttpResponseExceptionWithErrorBody` error,
which includes one of our own `ErrorResponse` enums to describe what
happens. We were serializing them with `code` and `message` fields. This
meant that the client would receive different style error responses
depending on the error. This updates the `getErrorBody` method on the
`HttpResponseExceptionWithErrorBody` to serialize them in the same way
as OAuth errors. This has had knock on effects into other lambdas.

This may be a TERRIBLE idea.

But I'm hoping it will start a discussion about our use of our
`ErrorResponse` enum and why we do it that way, as I think it's
confusing.

This also refactors the validation in the CRI return lambda from using
optionals and to just throwing, which I think is a bit cleaner.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1533](https://govukverify.atlassian.net/browse/PYIC-1533)
