### PR TITLE
PYIC-1532: expire auth code shortly after issue

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -193,6 +193,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/backendSessionTtl
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/authCodeExpirySeconds
       Events:
         IPVCoreExternalAPI:
           Type: Api

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -163,7 +163,9 @@ Resources:
   IPVAccessTokenFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-access-token-${Environment}"
       Handler: uk.gov.di.ipv.core.accesstoken.AccessTokenHandler::handleRequest
       Runtime: java11
@@ -226,7 +228,9 @@ Resources:
   IPVSessionEndFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-session-end-${Environment}"
       Handler: uk.gov.di.ipv.core.sessionend.SessionEndHandler::handleRequest
       Runtime: java11
@@ -295,7 +299,9 @@ Resources:
   IPVSessionStartFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-session-start-${Environment}"
       Handler: uk.gov.di.ipv.core.session.IpvSessionStartHandler::handleRequest
       Runtime: java11
@@ -376,7 +382,9 @@ Resources:
   IPVCriReturnFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-credential-issuer-return-${Environment}"
       Handler: uk.gov.di.ipv.core.credentialissuerreturn.CredentialIssuerReturnHandler::handleRequest
       Runtime: java11
@@ -467,7 +475,9 @@ Resources:
   IPVCredentialIssuerStartFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-credential-issuer-start-${Environment}"
       Handler: uk.gov.di.ipv.core.credentialissuer.CredentialIssuerStartHandler::handleRequest
       Runtime: java11
@@ -554,7 +564,9 @@ Resources:
   IPVCredentialIssuerErrorFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-credential-issuer-error-${Environment}"
       Handler: uk.gov.di.ipv.core.credentialissuererror.CredentialIssuerErrorHandler::handleRequest
       Runtime: java11
@@ -618,7 +630,9 @@ Resources:
   IPVUserIdentityFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "ipv-user-identity-${Environment}"
       Handler: uk.gov.di.ipv.core.useridentity.UserIdentityHandler::handleRequest
       Runtime: java11
@@ -690,7 +704,9 @@ Resources:
   IPVCredentialIssuerConfig:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "credential-issuer-config-${Environment}"
       Handler: uk.gov.di.ipv.core.credentialissuerconfig.CredentialIssuerConfigHandler::handleRequest
       Runtime: java11
@@ -743,7 +759,9 @@ Resources:
   IPVIssuedCredentials:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "issued-credentials-${Environment}"
       Handler: uk.gov.di.ipv.core.issuedcredentials.IssuedCredentialsHandler::handleRequest
       Runtime: java11
@@ -796,7 +814,9 @@ Resources:
   IPVJourneyEngineFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "journey-engine-${Environment}"
       Handler: uk.gov.di.ipv.core.journeyengine.JourneyEngineHandler::handleRequest
       Runtime: java11
@@ -861,7 +881,9 @@ Resources:
   IPVValidateCriCheckFunction:
     Type: AWS::Serverless::Function
     Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "validate-cri-check-${Environment}"
       Handler: uk.gov.di.ipv.core.validatecricheck.ValidateCriCheckHandler::handleRequest
       Runtime: java11

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -99,6 +99,16 @@ public class AccessTokenHandler
                         error.getHTTPStatusCode(), error.toJSONObject());
             }
 
+            if (authorizationCodeService.isExpired(authorizationCodeItem)) {
+                LOGGER.error(
+                        "Access Token could not be issued. The supplied authorization code has expired. Created at: {}",
+                        authorizationCodeItem.getCreationDateTime());
+                ErrorObject error =
+                        OAuth2Error.INVALID_GRANT.setDescription("Authorization code expired");
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        error.getHTTPStatusCode(), error.toJSONObject());
+            }
+
             if (redirectUrlsDoNotMatch(authorizationCodeItem, authorizationGrant)) {
                 LOGGER.error(
                         "Redirect URL in token request does not match that received in auth code request. Session ID: {}",

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
@@ -185,7 +185,9 @@ class AccessTokenHandlerTest {
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorResponse.getCode());
-        assertEquals(OAuth2Error.INVALID_GRANT.getDescription(), errorResponse.getDescription());
+        assertEquals(
+                "The supplied authorization code was not found in the database",
+                errorResponse.getDescription());
     }
 
     @Test
@@ -236,7 +238,7 @@ class AccessTokenHandlerTest {
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
         assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
         assertEquals(OAuth2Error.INVALID_CLIENT.getCode(), errorResponse.getCode());
-        assertEquals(OAuth2Error.INVALID_CLIENT.getDescription(), errorResponse.getDescription());
+        assertEquals("error", errorResponse.getDescription());
     }
 
     @Test
@@ -258,7 +260,7 @@ class AccessTokenHandlerTest {
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
         assertEquals(HTTPResponse.SC_UNAUTHORIZED, response.getStatusCode());
         assertEquals(OAuth2Error.INVALID_CLIENT.getCode(), errorResponse.getCode());
-        assertEquals(OAuth2Error.INVALID_CLIENT.getDescription(), errorResponse.getDescription());
+        assertEquals("error", errorResponse.getDescription());
     }
 
     @Test
@@ -341,7 +343,9 @@ class AccessTokenHandlerTest {
 
         assertEquals(HTTPResponse.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorResponse.getCode());
-        assertEquals(OAuth2Error.INVALID_GRANT.getDescription(), errorResponse.getDescription());
+        assertEquals(
+                "Redirect URL in token request does not match redirect URL received in auth code request",
+                errorResponse.getDescription());
     }
 
     private ErrorObject createErrorObjectFromResponse(String responseBody) throws ParseException {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -14,6 +14,7 @@ public enum ConfigurationVariable {
     JWT_TTL_SECONDS("/%s/core/self/jwtTtlSeconds"),
     MAX_ALLOWED_AUTH_CLIENT_TTL("/%s/core/self/maxAllowedAuthClientTtl"),
     PASSPORT_CRI_ID("/%s/core/self/journey/passportCriId"),
+    AUTH_CODE_EXPIRY_SECONDS("/%s/core/self/authCodeExpirySeconds"),
     PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("/%s/core/clients/%s/publicKeyMaterialForCoreToVerify");
 
     private final String value;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/AuthorizationCodeItem.java
@@ -11,11 +11,20 @@ public class AuthorizationCodeItem implements DynamodbItem {
     private String authCode;
     private String ipvSessionId;
     private String redirectUrl;
-
     private String issuedAccessToken;
-
     private String exchangeDateTime;
+    private String creationDateTime;
     private long ttl;
+
+    public AuthorizationCodeItem() {}
+
+    public AuthorizationCodeItem(
+            String authCode, String ipvSessionId, String redirectUrl, String creationDateTime) {
+        this.authCode = authCode;
+        this.ipvSessionId = ipvSessionId;
+        this.redirectUrl = redirectUrl;
+        this.creationDateTime = creationDateTime;
+    }
 
     @DynamoDbPartitionKey
     public String getAuthCode() {
@@ -64,5 +73,13 @@ public class AuthorizationCodeItem implements DynamodbItem {
 
     public void setExchangeDateTime(String exchangeDateTime) {
         this.exchangeDateTime = exchangeDateTime;
+    }
+
+    public String getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(String creationDateTime) {
+        this.creationDateTime = creationDateTime;
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeServiceTest.java
@@ -15,8 +15,10 @@ import java.time.Instant;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -108,5 +110,31 @@ class AuthorizationCodeServiceTest {
         verify(mockDataStore).update(authorizationCodeItemArgumentCaptor.capture());
 
         assertNotNull(authorizationCodeItemArgumentCaptor.getValue().getExchangeDateTime());
+    }
+
+    @Test
+    void isExpiredReturnsTrueIfAuthCodeItemHasExpired() {
+        when(mockConfigurationService.getSsmParameter(any())).thenReturn("600");
+        AuthorizationCodeItem expiredAuthCodeItem =
+                new AuthorizationCodeItem(
+                        "auth-code",
+                        "ipv-session-id",
+                        "redirect-url",
+                        Instant.now().minusSeconds(601).toString());
+
+        assertTrue(authorizationCodeService.isExpired(expiredAuthCodeItem));
+    }
+
+    @Test
+    void isExpiredReturnsFalseIfAuthCodeItemHasNotExpired() {
+        when(mockConfigurationService.getSsmParameter(any())).thenReturn("600");
+        AuthorizationCodeItem expiredAuthCodeItem =
+                new AuthorizationCodeItem(
+                        "auth-code",
+                        "resource-id",
+                        "redirect-url",
+                        Instant.now().minusSeconds(599).toString());
+
+        assertFalse(authorizationCodeService.isExpired(expiredAuthCodeItem));
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Expire the auth codes shortly after issuing them.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We want to expire auth codes after a configured period of time. RFC 6749
states that they should have a short life span. 10 minutes is
recommended.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1532](https://govukverify.atlassian.net/browse/PYIC-1532)

