### PR TITLE
PYIC-1535: Return invalid_client from access token endpoint

### DIFF
--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -137,8 +137,8 @@ public class AccessTokenHandler
         } catch (ClientAuthenticationException e) {
             LOGGER.error("Client authentication failed: ", e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    OAuth2Error.INVALID_GRANT.getHTTPStatusCode(),
-                    OAuth2Error.INVALID_GRANT.toJSONObject());
+                    OAuth2Error.INVALID_CLIENT.getHTTPStatusCode(),
+                    OAuth2Error.INVALID_CLIENT.toJSONObject());
         }
     }
 

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
@@ -187,7 +187,7 @@ class AccessTokenHandlerTest {
     }
 
     @Test
-    void shouldReturn400WhenInvalidJwtProvided() throws Exception {
+    void shouldReturn401WhenInvalidJwtProvided() throws Exception {
         authorizationCodeItem.setRedirectUrl("https://different.example.com");
 
         when(mockAccessTokenService.validateAuthorizationGrant(any()))
@@ -209,13 +209,13 @@ class AccessTokenHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorResponse.getCode());
-        assertEquals(OAuth2Error.INVALID_GRANT.getDescription(), errorResponse.getDescription());
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+        assertEquals(OAuth2Error.INVALID_CLIENT.getCode(), errorResponse.getCode());
+        assertEquals(OAuth2Error.INVALID_CLIENT.getDescription(), errorResponse.getDescription());
     }
 
     @Test
-    void shouldReturn400WhenJwtMissingFromRequestProvided() throws Exception {
+    void shouldReturn401WhenJwtMissingFromRequestProvided() throws Exception {
         String tokenRequestBody =
                 "code=12345&redirect_uri=http://test.com&grant_type=authorization_code&client_id=test_client_id";
 
@@ -231,9 +231,9 @@ class AccessTokenHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
-        assertEquals(HTTPResponse.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorResponse.getCode());
-        assertEquals(OAuth2Error.INVALID_GRANT.getDescription(), errorResponse.getDescription());
+        assertEquals(HTTPResponse.SC_UNAUTHORIZED, response.getStatusCode());
+        assertEquals(OAuth2Error.INVALID_CLIENT.getCode(), errorResponse.getCode());
+        assertEquals(OAuth2Error.INVALID_CLIENT.getDescription(), errorResponse.getDescription());
     }
 
     @Test


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return invalid_client from access token endpoint

### Why did it change

If the client authentication fails at the access token endpoint, we
should be returning an invalid_client oauth error and a 401 status code.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1535](https://govukverify.atlassian.net/browse/PYIC-1535)
