### PR TITLE
PYIC-1538: Revoke access tokens after being used in User Identity Handler.

### DIFF
--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
@@ -310,7 +310,7 @@ class AccessTokenHandlerTest {
         String errorMessage = "Failed to revoke access token";
         doThrow(new IllegalArgumentException(errorMessage))
                 .when(mockAccessTokenService)
-                .revokeAccessToken(any());
+                .revokeAccessToken(any(String.class));
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 

--- a/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
+++ b/lambdas/useridentity/src/main/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandler.java
@@ -110,6 +110,8 @@ public class UserIdentityHandler
 
             auditService.sendAuditEvent(AuditEventTypes.IPV_IDENTITY_ISSUED);
 
+            accessTokenService.revokeAccessToken(accessTokenItem);
+
             return ApiGatewayResponseGenerator.proxyJsonResponse(HTTPResponse.SC_OK, userIdentity);
         } catch (ParseException e) {
             LOGGER.error("Failed to parse access token");

--- a/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
+++ b/lambdas/useridentity/src/test/java/uk/gov/di/ipv/core/useridentity/UserIdentityHandlerTest.java
@@ -157,6 +157,7 @@ class UserIdentityHandlerTest {
         assertEquals(userIdentity.getAddressClaim(), responseBody.getAddressClaim());
 
         verify(mockAuditService).sendAuditEvent(AuditEventTypes.IPV_IDENTITY_ISSUED);
+        verify(mockAccessTokenService).revokeAccessToken(accessTokenItem);
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -73,14 +73,18 @@ public class AccessTokenService {
         dataStore.create(accessTokenItem);
     }
 
+    public void revokeAccessToken(AccessTokenItem accessTokenItem) throws IllegalArgumentException {
+        if (StringUtils.isBlank(accessTokenItem.getRevokedAtDateTime())) {
+            accessTokenItem.setRevokedAtDateTime(Instant.now().toString());
+            dataStore.update(accessTokenItem);
+        }
+    }
+
     public void revokeAccessToken(String accessToken) throws IllegalArgumentException {
         AccessTokenItem accessTokenItem = dataStore.getItem(accessToken);
 
         if (Objects.nonNull(accessTokenItem)) {
-            if (StringUtils.isBlank(accessTokenItem.getRevokedAtDateTime())) {
-                accessTokenItem.setRevokedAtDateTime(Instant.now().toString());
-                dataStore.update(accessTokenItem);
-            }
+            revokeAccessToken(accessTokenItem);
         } else {
             throw new IllegalArgumentException(
                     "Failed to revoke access token - access token could not be found in DynamoDB");


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Revoke access tokens after being used in User Identity Handler.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- We have the ability to revoke our access tokens. We only do this if an auth core is used multiple times. We should use the same mechanism to revoke the access token once it’s been used in the user identity endpoint.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1538](https://govukverify.atlassian.net/browse/PYIC-1538)
