### PR TITLE
PYIC-1513: Enrich Audit events

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -190,13 +190,7 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/clients/*
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/audienceForClients
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/backendSessionTtl
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/authCodeExpirySeconds
+            ParameterName: !Sub ${Environment}/core/self/*
       Events:
         IPVCoreExternalAPI:
           Type: Api
@@ -326,13 +320,7 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/clients/*
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/audienceForClients
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/maxAllowedAuthClientTtl
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/jarKmsEncryptionKeyId
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/backendSessionTtl
+            ParameterName: !Sub ${Environment}/core/self/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -416,15 +404,7 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/coreFrontCallbackUrl
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/signingKeyId
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/audienceForClients
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/backendSessionTtl
+            ParameterName: !Sub ${Environment}/core/self/*
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/*/api-key-*
         - SQSSendMessagePolicy:
@@ -505,13 +485,7 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/signingKeyId
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/jwtTtlSeconds
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/audienceForClients
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/coreFrontCallbackUrl
+            ParameterName: !Sub ${Environment}/core/self/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
@@ -588,6 +562,8 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -660,6 +636,8 @@ Resources:
             TableName: !Ref AccessTokensTable
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -670,8 +648,6 @@ Resources:
                 - 'kms:GenerateDataKey'
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/coreVtmClaim
       Events:
         IPVCoreExternalAPI:
           Type: Api
@@ -782,6 +758,8 @@ Resources:
             TableName: !Ref UserIssuedCredentialsTable
         - DynamoDBWritePolicy:
             TableName: !Ref UserIssuedCredentialsTable
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/*
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -840,15 +818,7 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/backendSessionTimeout
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/journey/passportCriId
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/journey/addressCriId
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/journey/fraudCriId
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub ${Environment}/core/self/journey/kbvCriId
+            ParameterName: !Sub ${Environment}/core/self/*
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -902,6 +872,8 @@ Resources:
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsTable
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/*
       Events:
         IPVCorePrivateAPI:
           Type: Api

--- a/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
+++ b/lambdas/credentialissuerreturn/src/main/java/uk/gov/di/ipv/core/credentialissuerreturn/CredentialIssuerReturnHandler.java
@@ -100,13 +100,11 @@ public class CredentialIssuerReturnHandler
                     configurationService.getSsmParameter(
                             ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
 
-            var ae =
+            auditService.sendAuditEvent(
                     new AuditEvent(
                             AuditEventTypes.IPV_CRI_AUTH_RESPONSE_RECEIVED,
                             componentId,
-                            auditEventUser);
-
-            auditService.sendAuditEvent(ae);
+                            auditEventUser));
 
             CredentialIssuerRequestDto request =
                     RequestHelper.convertRequest(input, CredentialIssuerRequestDto.class);

--- a/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
+++ b/lambdas/credentialissuerstart/src/test/java/uk/gov/di/ipv/core/credentialissuer/CredentialIssuerStartHandlerTest.java
@@ -17,8 +17,10 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -181,7 +183,10 @@ class CredentialIssuerStartHandlerTest {
         jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
         assertSharedClaimsJWTIsValid(jweObject.getPayload().toString());
 
-        verify(mockAuditService).sendAuditEvent(AuditEventTypes.IPV_REDIRECT_TO_CRI);
+        ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        assertEquals(
+                AuditEventTypes.IPV_REDIRECT_TO_CRI, auditEventCaptor.getValue().getEventName());
     }
 
     @Test

--- a/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
+++ b/lambdas/sessionend/src/test/java/uk/gov/di/ipv/core/sessionend/SessionEndHandlerTest.java
@@ -13,8 +13,10 @@ import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
@@ -99,7 +101,9 @@ class SessionEndHandlerTest {
                 .persistAuthorizationCode(
                         authorizationCode.getValue(), "12345", "https://example.com");
 
-        verify(mockAuditService).sendAuditEvent(AuditEventTypes.IPV_JOURNEY_END);
+        ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        assertEquals(AuditEventTypes.IPV_JOURNEY_END, auditEventCaptor.getValue().getEventName());
 
         String expectedRedirectUrl =
                 new URIBuilder("https://example.com")

--- a/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
+++ b/lambdas/sessionstart/src/test/java/uk/gov/di/ipv/core/session/IpvSessionStartHandlerTest.java
@@ -19,9 +19,11 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.JarValidationException;
@@ -116,7 +118,9 @@ class IpvSessionStartHandlerTest {
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         assertEquals(ipvSessionId, responseBody.get("ipvSessionId"));
 
-        verify(mockAuditService).sendAuditEvent(AuditEventTypes.IPV_JOURNEY_START);
+        ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        assertEquals(AuditEventTypes.IPV_JOURNEY_START, auditEventCaptor.getValue().getEventName());
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEvent.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEvent.java
@@ -25,13 +25,17 @@ public class AuditEvent {
     @JsonCreator
     public AuditEvent(
             @JsonProperty(value = "event_name", required = true) AuditEventTypes eventName,
-            @JsonProperty(value = "extensions", required = false) AuditExtensions extensions,
             @JsonProperty(value = "component_id", required = false) String componentId,
-            @JsonProperty(value = "user", required = false) AuditEventUser user) {
+            @JsonProperty(value = "user", required = false) AuditEventUser user,
+            @JsonProperty(value = "extensions", required = false) AuditExtensions extensions) {
         this.timestamp = Instant.now().getEpochSecond();
         this.eventName = eventName;
-        this.extensions = extensions;
         this.componentId = componentId;
         this.user = user;
+        this.extensions = extensions;
+    }
+
+    public AuditEvent(AuditEventTypes eventName, String componentId, AuditEventUser user) {
+        this(eventName, componentId, user, null);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -33,7 +33,7 @@ public class AuditService {
 
     public void sendAuditEvent(AuditEventTypes eventType, AuditExtensions extensions)
             throws SqsException {
-        AuditEvent auditEvent = new AuditEvent(eventType, extensions, null, null);
+        AuditEvent auditEvent = new AuditEvent(eventType, null, null, extensions);
         sendAuditEvent(auditEvent);
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -40,6 +40,10 @@ public class IpvSessionService {
         return dataStore.getItem(ipvSessionId);
     }
 
+    public String getUserId(String ipvSessionId) {
+        return this.getIpvSession(ipvSessionId).getClientSessionDetails().getUserId();
+    }
+
     public String generateIpvSession(
             ClientSessionDetailsDto clientSessionDetailsDto, ErrorObject errorObject) {
 


### PR DESCRIPTION
## Proposed changes

### What changed

Update the audit events and processing to add userId, sessionId and componentId.

### Why did it change

All audit events should have userId, sessionId and componentId as standard.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1513](https://govukverify.atlassian.net/browse/PYIC-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
