### PR TITLE
PYIC-1661: Fix null pointer bug for IpvSessionHandler

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -18,8 +18,9 @@ public class LogHelper {
         IPV_SESSION_ID_LOG_FIELD("ipvSessionId"),
         COMPONENT_ID_LOG_FIELD("componentId"),
         JTI_LOG_FIELD("JTI_LOG_FIELD"),
-        USED_AT_DATE_TIME_LOG_FIELD("USED_AT_DATE_TIME_LOG_FIELD");
-
+        USED_AT_DATE_TIME_LOG_FIELD("USED_AT_DATE_TIME_LOG_FIELD"),
+        DYNAMODB_TABLE_NAME("dynamoDbTableName"),
+        DYNAMODB_KEY_VALUE("dynamoDbKeyValue");
         private final String fieldName;
 
         LogField(String fieldName) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -44,7 +44,7 @@ public class IpvSessionService {
         return this.getIpvSession(ipvSessionId).getClientSessionDetails().getUserId();
     }
 
-    public String generateIpvSession(
+    public IpvSessionItem generateIpvSession(
             ClientSessionDetailsDto clientSessionDetailsDto, ErrorObject errorObject) {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -66,7 +66,7 @@ public class IpvSessionService {
 
         dataStore.create(ipvSessionItem);
 
-        return ipvSessionItem.getIpvSessionId();
+        return ipvSessionItem;
     }
 
     public void updateIpvSession(IpvSessionItem updatedIpvSessionItem) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
@@ -12,8 +12,11 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.DescribeTableEnhancedResponse;
 import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
@@ -90,6 +93,16 @@ class DataStoreTest {
 
     @Test
     void shouldGetItemFromDynamoDbTableViaPartitionKeyAndSortKey() {
+        TableDescription tableDescription =
+                TableDescription.builder().tableName("test-table").build();
+        DescribeTableResponse describeTableResponse =
+                DescribeTableResponse.builder().table(tableDescription).build();
+        when(mockDynamoDbTable.describeTable())
+                .thenReturn(
+                        new DescribeTableEnhancedResponse.Builder()
+                                .response(describeTableResponse)
+                                .build());
+
         dataStore.getItem("partition-key-12345", "sort-key-12345");
 
         ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
@@ -105,6 +118,16 @@ class DataStoreTest {
 
     @Test
     void shouldGetItemFromDynamoDbTableViaPartitionKey() {
+        TableDescription tableDescription =
+                TableDescription.builder().tableName("test-table").build();
+        DescribeTableResponse describeTableResponse =
+                DescribeTableResponse.builder().table(tableDescription).build();
+        when(mockDynamoDbTable.describeTable())
+                .thenReturn(
+                        new DescribeTableEnhancedResponse.Builder()
+                                .response(describeTableResponse)
+                                .build());
+
         dataStore.getItem("partition-key-12345");
 
         ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -52,7 +52,7 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldCreateSessionItem() {
-        String ipvSessionID =
+        IpvSessionItem ipvSessionItem =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
                                 "jwt",
@@ -69,7 +69,9 @@ class IpvSessionServiceTest {
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId());
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
 
-        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
+        assertEquals(
+                ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(),
+                ipvSessionItem.getIpvSessionId());
         assertEquals(
                 UserStates.INITIAL_IPV_JOURNEY.toString(),
                 ipvSessionItemArgumentCaptor.getValue().getUserState());
@@ -77,7 +79,7 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldCreateSessionItemForDebugJourney() {
-        String ipvSessionID =
+        IpvSessionItem ipvSessionItem =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
                                 "jwt",
@@ -94,7 +96,9 @@ class IpvSessionServiceTest {
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId());
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
 
-        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
+        assertEquals(
+                ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(),
+                ipvSessionItem.getIpvSessionId());
         assertEquals(
                 UserStates.DEBUG_PAGE.toString(),
                 ipvSessionItemArgumentCaptor.getValue().getUserState());
@@ -103,7 +107,7 @@ class IpvSessionServiceTest {
     @Test
     void shouldCreateSessionItemWithErrorObject() {
         ErrorObject testErrorObject = new ErrorObject("server_error", "Test error");
-        String ipvSessionID =
+        IpvSessionItem ipvSessionItem =
                 ipvSessionService.generateIpvSession(
                         new ClientSessionDetailsDto(
                                 "jwt",
@@ -119,7 +123,9 @@ class IpvSessionServiceTest {
         verify(mockDataStore).create(ipvSessionItemArgumentCaptor.capture());
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId());
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getCreationDateTime());
-        assertEquals(ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(), ipvSessionID);
+        assertEquals(
+                ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(),
+                ipvSessionItem.getIpvSessionId());
         assertEquals(
                 UserStates.FAILED_CLIENT_JAR.toString(),
                 ipvSessionItemArgumentCaptor.getValue().getUserState());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Refactor the IpvSessionService generateIpvSession() method to return the full IpvSessionItem object so that we don't need to perform a DynamoDB read request straight after the write request during the handler method.

Also added a WARN log in our DataStore getItemByKey method whenever we return null out of DynamoDB.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We were previously writing a new IpvSessionItem into DynamoDB and the performing a read request for that item straight after. We have seen a null pointer exception occur due to delays when writing that item in to the DB. This refactor removes the need for the read request and will avoid the possibility of that null pointer exception.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1661](https://govukverify.atlassian.net/browse/PYIC-1661)

