### PR TITLE
PYIC-1665: Allow Single CI from Fraud CRI

### DIFF
--- a/lambdas/validatecricheck/src/main/java/uk/gov/di/ipv/core/validatecricheck/validation/FraudEvidenceValidator.java
+++ b/lambdas/validatecricheck/src/main/java/uk/gov/di/ipv/core/validatecricheck/validation/FraudEvidenceValidator.java
@@ -17,6 +17,8 @@ public class FraudEvidenceValidator implements CriEvidenceValidator {
         if (evidence.getIdentityFraudScore() < GPG_45_M1A_FRAUD_SCORE) {
             return false;
         }
-        return evidence.getCi() == null || evidence.getCi().isEmpty();
+
+        var ci = evidence.getCi();
+        return ci == null || ci.isEmpty() || (ci.size() == 1 && ci.get(0).equals("A01"));
     }
 }

--- a/lambdas/validatecricheck/src/test/java/uk/gov/di/ipv/core/validatecricheck/validators/FraudEvidenceValidatorTest.java
+++ b/lambdas/validatecricheck/src/test/java/uk/gov/di/ipv/core/validatecricheck/validators/FraudEvidenceValidatorTest.java
@@ -95,6 +95,30 @@ class FraudEvidenceValidatorTest {
         assertTrue(criCheckValidator.isSuccess(userIssuedCredentialsItem));
     }
 
+    @Test
+    void returnsTrueForSuccessfulFraudCheckWithSingleA01ContraIndicators()
+            throws Exception, HttpResponseExceptionWithErrorBody {
+        JSONObject evidenceJsonWithEmptyCiList =
+                new JSONObject(
+                        Map.of(
+                                EVIDENCE,
+                                List.of(
+                                        Map.of(
+                                                "type",
+                                                "IdentityCheck",
+                                                "txn",
+                                                "a-random-uuid",
+                                                "identityFraudScore",
+                                                "2",
+                                                "ci",
+                                                List.of("A01")))));
+
+        UserIssuedCredentialsItem userIssuedCredentialsItem =
+                getUserIssuedCredentialsItem(evidenceJsonWithEmptyCiList);
+
+        assertTrue(criCheckValidator.isSuccess(userIssuedCredentialsItem));
+    }
+
     private UserIssuedCredentialsItem getUserIssuedCredentialsItem(JSONObject evidence)
             throws Exception {
         JWTClaimsSet claimsSet = new JWTClaimsSet.Builder().claim(VC_CLAIM, evidence).build();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow a single A01 CI to pass validation

### Why did it change

As a tactical measure we want to allow a single A01 CI to pass validation. This CI has a score below the threshold so this single CI if present will not cause a failure.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1665](https://govukverify.atlassian.net/browse/PYIC-1665)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed
