### PR TITLE
PYIC-1689: Implement evaluate-gpg45-scores lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -983,6 +983,13 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub evaluate-gpg45-scores-${Environment}
+          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsTable
+          USER_ISSUED_CREDENTIALS_V2_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref UserIssuedCredentialsTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref UserIssuedCredentialsV2Table
       Events:
         IPVCorePrivateAPI:
           Type: Api

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -13,10 +13,15 @@ dependencies {
 
 	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			project(":lib")
 
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
 			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
+
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-junit-jupiter:4.2.0"

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -4,12 +4,74 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.logging.Logging;
+import software.amazon.lambda.powertools.tracing.Tracing;
+import uk.gov.di.ipv.core.evaluategpg45scores.exception.UnknownEvidenceTypeException;
+import uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45ProfileEvaluator;
+import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
+
+import java.text.ParseException;
+import java.util.List;
 
 public class EvaluateGpg45ScoresHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    public static final String JOURNEY_SESSION_END = "/journey/session/end";
+    public static final String JOURNEY_NEXT = "/journey/next";
+    public static final String JOURNEY_ERROR = "/journey/error";
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final UserIdentityService userIdentityService;
+    private final Gpg45ProfileEvaluator gpg45ProfileEvaluator;
+
+    public EvaluateGpg45ScoresHandler(
+            UserIdentityService userIdentityService, Gpg45ProfileEvaluator gpg45ProfileEvaluator) {
+        this.userIdentityService = userIdentityService;
+        this.gpg45ProfileEvaluator = gpg45ProfileEvaluator;
+    }
+
+    public EvaluateGpg45ScoresHandler() {
+        this.userIdentityService = new UserIdentityService(new ConfigurationService());
+        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator();
+    }
+
     @Override
+    @Tracing
+    @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return null;
+            APIGatewayProxyRequestEvent event, Context context) {
+        LogHelper.attachComponentIdToLogs();
+        try {
+            String ipvSessionId = RequestHelper.getIpvSessionId(event);
+            List<String> credentials = userIdentityService.getUserIssuedCredentials(ipvSessionId);
+
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_OK,
+                    gpg45ProfileEvaluator.credentialsSatisfyProfile(credentials, Gpg45Profile.M1A)
+                            ? new JourneyResponse(JOURNEY_SESSION_END)
+                            : new JourneyResponse(JOURNEY_NEXT));
+
+        } catch (HttpResponseExceptionWithErrorBody e) {
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    e.getResponseCode(), e.getErrorBody());
+        } catch (ParseException e) {
+            LOGGER.error("Unable to parse GPG45 scores from existing credentials", e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_OK, new JourneyResponse(JOURNEY_ERROR));
+        } catch (UnknownEvidenceTypeException e) {
+            LOGGER.error("Unable to determine type of credential", e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_OK, new JourneyResponse(JOURNEY_ERROR));
+        }
     }
 }

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/domain/CredentialEvidenceItem.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/domain/CredentialEvidenceItem.java
@@ -1,0 +1,111 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.domain;
+
+import lombok.Getter;
+import uk.gov.di.ipv.core.evaluategpg45scores.exception.UnknownEvidenceTypeException;
+import uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
+
+@Getter
+public class CredentialEvidenceItem {
+    private Integer activityScore;
+    private Integer identityFraudScore;
+    private Integer strengthScore;
+    private Integer validityScore;
+    private Integer verificationScore;
+    private List<String> ci;
+
+    public EvidenceType getType() throws UnknownEvidenceTypeException {
+        if (isActivity()) {
+            return EvidenceType.ACTIVITY;
+        } else if (isIdentityFraud()) {
+            return EvidenceType.IDENTITY_FRAUD;
+        } else if (isEvidence()) {
+            return EvidenceType.EVIDENCE;
+        } else if (isVerification()) {
+            return EvidenceType.VERIFICATION;
+        } else {
+            throw new UnknownEvidenceTypeException();
+        }
+    }
+
+    public Gpg45Scores.Evidence getEvidenceScore() {
+        return new Gpg45Scores.Evidence(getStrengthScore(), getValidityScore());
+    }
+
+    public boolean hasContraIndicators() {
+        return ci != null && !ci.isEmpty();
+    }
+
+    private int numberOfContraIndicators() {
+        return ci.size();
+    }
+
+    private boolean isActivity() {
+        return activityScore != null
+                && identityFraudScore == null
+                && strengthScore == null
+                && validityScore == null
+                && verificationScore == null;
+    }
+
+    private boolean isIdentityFraud() {
+        return identityFraudScore != null
+                && activityScore == null
+                && strengthScore == null
+                && validityScore == null
+                && verificationScore == null;
+    }
+
+    private boolean isEvidence() {
+        return strengthScore != null
+                && validityScore != null
+                && activityScore == null
+                && identityFraudScore == null
+                && verificationScore == null;
+    }
+
+    private boolean isVerification() {
+        return verificationScore != null
+                && activityScore == null
+                && identityFraudScore == null
+                && strengthScore == null
+                && validityScore == null;
+    }
+
+    @Getter
+    public enum EvidenceType {
+        ACTIVITY(
+                generateComparator(CredentialEvidenceItem::getActivityScore),
+                CredentialEvidenceItem::getActivityScore),
+        IDENTITY_FRAUD(
+                generateComparator(CredentialEvidenceItem::getIdentityFraudScore),
+                CredentialEvidenceItem::getIdentityFraudScore),
+        EVIDENCE(null, null),
+        VERIFICATION(
+                generateComparator(CredentialEvidenceItem::getVerificationScore),
+                CredentialEvidenceItem::getVerificationScore);
+
+        public final Comparator<CredentialEvidenceItem> comparator;
+        public final Function<CredentialEvidenceItem, Integer> scoreGetter;
+
+        EvidenceType(
+                Comparator<CredentialEvidenceItem> comparator,
+                Function<CredentialEvidenceItem, Integer> scoreGetter) {
+            this.comparator = comparator;
+            this.scoreGetter = scoreGetter;
+        }
+
+        private static Comparator<CredentialEvidenceItem> generateComparator(
+                ToIntFunction<CredentialEvidenceItem> keyExtractor) {
+            return Comparator.comparingInt(keyExtractor)
+                    .thenComparing(
+                            Comparator.comparingInt(
+                                            CredentialEvidenceItem::numberOfContraIndicators)
+                                    .reversed());
+        }
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/exception/UnknownEvidenceTypeException.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/exception/UnknownEvidenceTypeException.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.exception;
+
+public class UnknownEvidenceTypeException extends Exception {}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45Profile.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45Profile.java
@@ -75,7 +75,7 @@ public enum Gpg45Profile {
      * @return {@code true} if the elements in the provided {@code Gpg45Scores} are all equal or
      *     greater than the profile's `{@code Gpg45Scores}.
      */
-    public boolean satisfiedBy(Gpg45Scores target) {
+    public boolean isSatisfiedBy(Gpg45Scores target) {
         return satisfactoryEvidence(target)
                 && (scores.activity() <= target.activity())
                 && (scores.fraud() <= target.fraud())

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45Profile.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45Profile.java
@@ -1,0 +1,102 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.gpg45;
+
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_11;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_22;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_32;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_33;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_42;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_43;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_44;
+
+/** Enumeration of all GPG 45 profiles along with their reference Gpg45Scores value. */
+public enum Gpg45Profile {
+    L1A("L1A", new Gpg45Scores(EV_22, 0, 1, 1)),
+    L1B("L1B", new Gpg45Scores(EV_32, 0, 0, 1)),
+    L1C("L1C", new Gpg45Scores(EV_11, 3, 2, 2)),
+    L2A("L2A", new Gpg45Scores(EV_11, EV_11, 2, 1, 2)),
+    L2B("L2B", new Gpg45Scores(EV_11, EV_11, 2, 2, 1)),
+    L3A("L3A", new Gpg45Scores(EV_11, EV_11, EV_11, 2, 1, 1)),
+    M1A("M1A", new Gpg45Scores(EV_42, 0, 1, 2)),
+    M1B("M1B", new Gpg45Scores(EV_32, 1, 2, 2)),
+    M1C("M1C", new Gpg45Scores(EV_33, 0, 0, 3)),
+    M1D("M1D", new Gpg45Scores(EV_22, 2, 1, 3)),
+    M2A("M2A", new Gpg45Scores(EV_22, EV_22, 3, 2, 2)),
+    M2B("M2B", new Gpg45Scores(EV_32, EV_22, 1, 1, 2)),
+    M2C("M2C", new Gpg45Scores(EV_32, EV_22, 0, 1, 3)),
+    M3A("M3A", new Gpg45Scores(EV_22, EV_22, EV_22, 2, 2, 2)),
+    H1A("H1A", new Gpg45Scores(EV_43, 0, 1, 3)),
+    H1B("H1B", new Gpg45Scores(EV_33, 2, 1, 3)),
+    H1C("H1C", new Gpg45Scores(EV_43, 0, 0, 4)),
+    H2A("H2A", new Gpg45Scores(EV_22, EV_22, 3, 2, 3)),
+    H2B("H2B", new Gpg45Scores(EV_42, EV_32, 0, 2, 3)),
+    H2C("H2C", new Gpg45Scores(EV_33, EV_22, 1, 1, 3)),
+    H2D("H2D", new Gpg45Scores(EV_33, EV_22, 0, 1, 3)),
+    H2E("H2E", new Gpg45Scores(EV_43, EV_33, 0, 0, 3)),
+    H3A("H3A", new Gpg45Scores(EV_22, EV_22, EV_22, 2, 2, 3)),
+    V1A("V1A", new Gpg45Scores(EV_43, 0, 3, 3)),
+    V1B("V1B", new Gpg45Scores(EV_44, 0, 1, 3)),
+    V1C("V1C", new Gpg45Scores(EV_43, 1, 1, 4)),
+    V1D("V1D", new Gpg45Scores(EV_44, 0, 0, 4)),
+    V2A("V2A", new Gpg45Scores(EV_33, EV_33, 3, 2, 3)),
+    V2B("V2B", new Gpg45Scores(EV_43, EV_33, 0, 2, 3)),
+    V2C("V2C", new Gpg45Scores(EV_43, EV_22, 2, 2, 3)),
+    V2D("V2D", new Gpg45Scores(EV_44, EV_44, 0, 0, 3)),
+    V3A("V3A", new Gpg45Scores(EV_33, EV_22, EV_22, 3, 3, 3));
+
+    public final String label;
+    public final Gpg45Scores scores;
+
+    Gpg45Profile(String label, Gpg45Scores scores) {
+        this.label = label;
+        this.scores = scores;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public Gpg45Scores getScores() {
+        return scores;
+    }
+
+    public String code() {
+        return String.format("%1$s%2$s", label, scores.toString());
+    }
+
+    public Gpg45Scores difference(Gpg45Scores target) {
+        return scores.difference(target);
+    }
+
+    /**
+     * Checks if that the provided {@code Gpg45Scores} satisfy the {@code Gpg45Scores} for this
+     * profile.
+     *
+     * @param target The {@code Gpg45Scores} to compare.
+     * @return {@code true} if the elements in the provided {@code Gpg45Scores} are all equal or
+     *     greater than the profile's `{@code Gpg45Scores}.
+     */
+    public boolean satisfiedBy(Gpg45Scores target) {
+        return satisfactoryEvidence(target)
+                && (scores.activity() <= target.activity())
+                && (scores.fraud() <= target.fraud())
+                && (scores.verification() <= target.verification());
+    }
+
+    private boolean satisfactoryEvidence(Gpg45Scores target) {
+        if (scores.evidences().size() > target.evidences().size()) {
+            return false;
+        }
+
+        for (int i = 0; i < scores.evidences().size(); i++) {
+            var sourceEvidence = scores.getEvidence(i);
+            var targetEvidence = target.getEvidence(i);
+
+            if ((targetEvidence.strength() < sourceEvidence.strength())
+                    || (targetEvidence.validity() < sourceEvidence.validity())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluator.java
@@ -46,7 +46,7 @@ public class Gpg45ProfileEvaluator {
     public boolean credentialsSatisfyProfile(List<String> credentials, Gpg45Profile profile)
             throws ParseException, UnknownEvidenceTypeException {
         var evidenceMap = parseGpg45ScoresFromCredentials(credentials);
-        return profile.satisfiedBy(buildScore(evidenceMap))
+        return profile.isSatisfiedBy(buildScore(evidenceMap))
                 && !contraIndicatorsPresent(evidenceMap);
     }
 

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluator.java
@@ -1,0 +1,112 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.gpg45;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.nimbusds.jose.shaded.json.JSONArray;
+import com.nimbusds.jose.shaded.json.JSONObject;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem;
+import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem.EvidenceType;
+import uk.gov.di.ipv.core.evaluategpg45scores.exception.UnknownEvidenceTypeException;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
+
+public class Gpg45ProfileEvaluator {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Gson gson = new Gson();
+    private static final int NO_SCORE = 0;
+
+    public boolean credentialsSatisfyProfile(List<String> credentials, Gpg45Profile profile)
+            throws ParseException, UnknownEvidenceTypeException {
+        var evidenceMap = parseGpg45ScoresFromCredentials(credentials);
+        return profile.satisfiedBy(buildScore(evidenceMap))
+                && !contraIndicatorsPresent(evidenceMap);
+    }
+
+    private Map<EvidenceType, List<CredentialEvidenceItem>> parseGpg45ScoresFromCredentials(
+            List<String> credentials) throws ParseException, UnknownEvidenceTypeException {
+        Map<EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
+                Map.of(
+                        EvidenceType.ACTIVITY, new ArrayList<>(),
+                        EvidenceType.EVIDENCE, new ArrayList<>(),
+                        EvidenceType.IDENTITY_FRAUD, new ArrayList<>(),
+                        EvidenceType.VERIFICATION, new ArrayList<>());
+
+        for (String credential : credentials) {
+            JSONObject vcClaim =
+                    (JSONObject) SignedJWT.parse(credential).getJWTClaimsSet().getClaim(VC_CLAIM);
+            JSONArray evidenceArray = (JSONArray) vcClaim.get(VC_EVIDENCE);
+            if (evidenceArray == null) {
+                continue;
+            }
+
+            List<CredentialEvidenceItem> credentialEvidenceList =
+                    gson.fromJson(
+                            evidenceArray.toJSONString(),
+                            new TypeToken<List<CredentialEvidenceItem>>() {}.getType());
+            for (CredentialEvidenceItem evidenceItem : credentialEvidenceList) {
+                evidenceMap.get(evidenceItem.getType()).add(evidenceItem);
+            }
+        }
+
+        return evidenceMap;
+    }
+
+    private Gpg45Scores buildScore(Map<EvidenceType, List<CredentialEvidenceItem>> evidenceMap) {
+        return Gpg45Scores.builder()
+                .withActivity(extractMaxScoreFromEvidenceMap(evidenceMap, EvidenceType.ACTIVITY))
+                .withFraud(extractMaxScoreFromEvidenceMap(evidenceMap, EvidenceType.IDENTITY_FRAUD))
+                .withVerification(
+                        extractMaxScoreFromEvidenceMap(evidenceMap, EvidenceType.VERIFICATION))
+                .withEvidences(
+                        evidenceMap.get(EvidenceType.EVIDENCE).stream()
+                                .map(CredentialEvidenceItem::getEvidenceScore)
+                                .collect(Collectors.toList()))
+                .build();
+    }
+
+    private Integer extractMaxScoreFromEvidenceMap(
+            Map<EvidenceType, List<CredentialEvidenceItem>> evidenceMap,
+            EvidenceType evidenceType) {
+        return evidenceMap.get(evidenceType).stream()
+                .max(evidenceType.getComparator())
+                .map(evidenceType.getScoreGetter())
+                .orElse(NO_SCORE);
+    }
+
+    private boolean contraIndicatorsPresent(
+            Map<EvidenceType, List<CredentialEvidenceItem>> evidenceMap) {
+        boolean contraIndicatorFound;
+        for (EvidenceType evidenceType : EvidenceType.values()) {
+            if (evidenceType == EvidenceType.EVIDENCE) {
+                contraIndicatorFound =
+                        evidenceMap.get(evidenceType).stream()
+                                .anyMatch(CredentialEvidenceItem::hasContraIndicators);
+            } else {
+                contraIndicatorFound =
+                        evidenceMap.get(evidenceType).stream()
+                                .max(evidenceType.getComparator())
+                                .map(CredentialEvidenceItem::hasContraIndicators)
+                                .orElse(false);
+            }
+            if (contraIndicatorFound) {
+                LogHelper.logInfoMessageWithFieldAndValue(
+                        "Contra Indicators found in credentials",
+                        LogHelper.LogField.EVIDENCE_TYPE,
+                        evidenceType.name());
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluator.java
@@ -5,8 +5,6 @@ import com.google.gson.reflect.TypeToken;
 import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nimbusds.jwt.SignedJWT;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem;
 import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem.EvidenceType;
 import uk.gov.di.ipv.core.evaluategpg45scores.exception.UnknownEvidenceTypeException;
@@ -26,7 +24,6 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 
 public class Gpg45ProfileEvaluator {
 
-    private static final Logger LOGGER = LogManager.getLogger();
     private static final Gson gson = new Gson();
     private static final int NO_SCORE = 0;
 
@@ -131,7 +128,8 @@ public class Gpg45ProfileEvaluator {
     }
 
     private boolean anyCredentialsDoNotMeetM1A(
-            EvidenceType evidenceType, List<CredentialEvidenceItem> credentialEvidenceItems) {
+            EvidenceType evidenceType, List<CredentialEvidenceItem> credentialEvidenceItems)
+            throws UnknownEvidenceTypeException {
         switch (evidenceType) {
             case EVIDENCE:
                 return !credentialEvidenceItems.stream()
@@ -143,7 +141,7 @@ public class Gpg45ProfileEvaluator {
             case ACTIVITY:
                 return false;
             default:
-                throw new RuntimeException("What");
+                throw new UnknownEvidenceTypeException();
         }
     }
 }

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45Scores.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45Scores.java
@@ -148,10 +148,12 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
 
     /**
      * Compares the score to another. A negative value indicates that there is some negative value
-     * in the {@code difference} between this score and the other.
+     * in the {@code difference} between this score and the other. A positive value indicates that
+     * there is some positive value in the {@code difference}. A value of zero indicates that there
+     * is no difference.
      *
      * @param other
-     * @return
+     * @return integer
      */
     @Override
     public int compareTo(Gpg45Scores other) {

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45Scores.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45Scores.java
@@ -1,0 +1,273 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.gpg45;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Gpg45Scores is a collection of values that represent the scores gathered when assessing identity
+ * proofing using GPG 45.
+ *
+ * <p>Objects if this class are immutable.
+ */
+public class Gpg45Scores implements Comparable<Gpg45Scores> {
+
+    public static final Evidence EV_11 = new Gpg45Scores.Evidence(1, 1);
+    public static final Evidence EV_22 = new Gpg45Scores.Evidence(2, 2);
+    public static final Evidence EV_32 = new Gpg45Scores.Evidence(3, 2);
+    public static final Evidence EV_33 = new Gpg45Scores.Evidence(3, 3);
+    public static final Evidence EV_42 = new Gpg45Scores.Evidence(4, 2);
+    public static final Evidence EV_43 = new Gpg45Scores.Evidence(4, 3);
+    public static final Evidence EV_44 = new Gpg45Scores.Evidence(4, 4);
+
+    private final List<Evidence> evidences;
+    private final int activity;
+    private final int fraud;
+    private final int verification;
+
+    public Gpg45Scores(int strength, int validity, int activity, int fraud, int verification) {
+        this.activity = activity;
+        this.fraud = fraud;
+        this.verification = verification;
+        this.evidences = List.of(new Evidence(strength, validity));
+    }
+
+    public Gpg45Scores(Evidence evidence, int activity, int fraud, int verification) {
+        this.activity = activity;
+        this.fraud = fraud;
+        this.verification = verification;
+        this.evidences = List.of(evidence);
+    }
+
+    public Gpg45Scores(
+            Evidence evidence1, Evidence evidence2, int activity, int fraud, int verification) {
+        this(Arrays.asList(evidence1, evidence2), activity, fraud, verification);
+    }
+
+    public Gpg45Scores(
+            Evidence evidence1,
+            Evidence evidence2,
+            Evidence evidence3,
+            int activity,
+            int fraud,
+            int verification) {
+        this(Arrays.asList(evidence1, evidence2, evidence3), activity, fraud, verification);
+    }
+
+    public Gpg45Scores(List<Evidence> evidence, int activity, int fraud, int verification) {
+        this.activity = activity;
+        this.fraud = fraud;
+        this.verification = verification;
+        this.evidences =
+                evidence.stream()
+                        .sorted(
+                                Comparator.comparing(Evidence::strength)
+                                        .thenComparing(Evidence::validity)
+                                        .reversed())
+                        .collect(Collectors.toList());
+    }
+
+    public int activity() {
+        return activity;
+    }
+
+    public int fraud() {
+        return fraud;
+    }
+
+    public int verification() {
+        return verification;
+    }
+
+    public List<Evidence> evidences() {
+        return evidences;
+    }
+
+    public Evidence getEvidence(int index) {
+        if (evidences.size() < index) {
+            return new Gpg45Scores.Evidence(0, 0);
+        }
+
+        return evidences.get(index);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "[" + evidences + ", " + activity + ", " + fraud + ", " + verification + "]";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        Gpg45Scores that = (Gpg45Scores) other;
+        return activity == that.activity
+                && fraud == that.fraud
+                && verification == that.verification
+                && evidences.equals(that.evidences);
+    }
+
+    public Gpg45Scores difference(Gpg45Scores other) {
+
+        return new Gpg45Scores(
+                diffEvidence(other),
+                other.activity() - activity,
+                other.fraud() - fraud,
+                other.verification() - verification);
+    }
+
+    private List<Gpg45Scores.Evidence> diffEvidence(Gpg45Scores target) {
+
+        var evidenceDiff = new ArrayList<Evidence>();
+        var maxEvidence = Math.max(evidences.size(), target.evidences().size());
+
+        for (int i = 0; i < maxEvidence; i++) {
+            var sourceEvidence = getEvidence(i);
+            var targetEvidence = target.getEvidence(i);
+
+            evidenceDiff.add(
+                    new Gpg45Scores.Evidence(
+                            targetEvidence.strength() - sourceEvidence.strength(),
+                            targetEvidence.validity() - sourceEvidence.validity()));
+        }
+        return evidenceDiff;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(evidences, activity, fraud, verification);
+    }
+
+    /**
+     * Compares the score to another. A negative value indicates that there is some negative value
+     * in the {@code difference} between this score and the other.
+     *
+     * @param other
+     * @return
+     */
+    @Override
+    public int compareTo(Gpg45Scores other) {
+        var diff = difference(other);
+        int negativeCount = 0;
+        int positiveCount = 0;
+        for (Evidence e : diff.evidences()) {
+            if (e.strength() < 0) {
+                negativeCount += e.strength();
+            } else {
+                positiveCount += e.strength();
+            }
+            if (e.validity() < 0) {
+                negativeCount += e.validity();
+            } else {
+                positiveCount += e.validity();
+            }
+        }
+
+        if (diff.activity() < 0) {
+            negativeCount += diff.activity();
+        } else {
+            positiveCount += diff.activity();
+        }
+
+        if (diff.fraud() < 0) {
+            negativeCount += diff.fraud();
+        } else {
+            positiveCount += diff.fraud();
+        }
+
+        if (diff.verification() < 0) {
+            negativeCount += diff.verification();
+        } else {
+            positiveCount += diff.verification();
+        }
+
+        if (negativeCount < 0) {
+            return negativeCount;
+        }
+
+        return positiveCount;
+    }
+
+    static class Builder {
+
+        private List<Evidence> evidences = new ArrayList<>();
+        private int activity;
+        private int fraud;
+        private int verification;
+
+        public Builder withEvidence(Evidence evidence) {
+            this.evidences.add(evidence);
+            return this;
+        }
+
+        public Builder withEvidences(List<Evidence> evidencesList) {
+            this.evidences =
+                    Stream.concat(this.evidences.stream(), evidencesList.stream())
+                            .collect(Collectors.toList());
+            return this;
+        }
+
+        public Builder withActivity(int activity) {
+            this.activity = activity;
+            return this;
+        }
+
+        public Builder withFraud(int fraud) {
+            this.fraud = fraud;
+            return this;
+        }
+
+        public Builder withVerification(int verification) {
+            this.verification = verification;
+            return this;
+        }
+
+        public Gpg45Scores build() {
+            return new Gpg45Scores(evidences, activity, fraud, verification);
+        }
+    }
+
+    public static class Evidence {
+        private final int strength;
+        private final int validity;
+
+        public Evidence(int strength, int validity) {
+            this.strength = strength;
+            this.validity = validity;
+        }
+
+        public int validity() {
+            return validity;
+        }
+
+        public int strength() {
+            return strength;
+        }
+
+        @Override
+        public String toString() {
+            return "" + strength + validity;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Evidence evidence = (Evidence) o;
+            return strength == evidence.strength && validity == evidence.validity;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(strength, validity);
+        }
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/FraudEvidenceValidator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/FraudEvidenceValidator.java
@@ -5,6 +5,10 @@ import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem;
 public class FraudEvidenceValidator {
     public static final int GPG_45_M1A_FRAUD_SCORE = 1;
 
+    private FraudEvidenceValidator() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static boolean validate(CredentialEvidenceItem item) {
         if (item.getIdentityFraudScore() < GPG_45_M1A_FRAUD_SCORE) {
             return false;

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/FraudEvidenceValidator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/FraudEvidenceValidator.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.validation;
+
+import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem;
+
+public class FraudEvidenceValidator {
+    public static final int GPG_45_M1A_FRAUD_SCORE = 1;
+
+    public static boolean validate(CredentialEvidenceItem item) {
+        if (item.getIdentityFraudScore() < GPG_45_M1A_FRAUD_SCORE) {
+            return false;
+        }
+        return item.getCi() == null || item.getCi().isEmpty();
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/KbvEvidenceValidator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/KbvEvidenceValidator.java
@@ -5,6 +5,10 @@ import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem;
 public class KbvEvidenceValidator {
     public static final int GPG_45_M1A_VERIFICATION_SCORE = 2;
 
+    private KbvEvidenceValidator() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static boolean validate(CredentialEvidenceItem item) {
         return item.getVerificationScore() >= GPG_45_M1A_VERIFICATION_SCORE;
     }

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/KbvEvidenceValidator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/KbvEvidenceValidator.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.validation;
+
+import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem;
+
+public class KbvEvidenceValidator {
+    public static final int GPG_45_M1A_VERIFICATION_SCORE = 2;
+
+    public static boolean validate(CredentialEvidenceItem item) {
+        return item.getVerificationScore() >= GPG_45_M1A_VERIFICATION_SCORE;
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/PassportEvidenceValidator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/PassportEvidenceValidator.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.validation;
+
+import uk.gov.di.ipv.core.evaluategpg45scores.domain.CredentialEvidenceItem;
+
+public class PassportEvidenceValidator {
+    public static final int GPG_45_M1A_STRENGTH_SCORE = 4;
+    public static final int GPG_45_M1A_VALIDITY_SCORE = 2;
+
+    public static boolean validate(CredentialEvidenceItem item) {
+
+        if (item.getStrengthScore() < GPG_45_M1A_STRENGTH_SCORE) {
+            return false;
+        }
+        if (item.getValidityScore() < GPG_45_M1A_VALIDITY_SCORE) {
+            return false;
+        }
+        return item.getCi() == null || item.getCi().isEmpty();
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/PassportEvidenceValidator.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/validation/PassportEvidenceValidator.java
@@ -6,6 +6,10 @@ public class PassportEvidenceValidator {
     public static final int GPG_45_M1A_STRENGTH_SCORE = 4;
     public static final int GPG_45_M1A_VALIDITY_SCORE = 2;
 
+    private PassportEvidenceValidator() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static boolean validate(CredentialEvidenceItem item) {
 
         if (item.getStrengthScore() < GPG_45_M1A_STRENGTH_SCORE) {

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -31,7 +31,7 @@ import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
 
 @ExtendWith(MockitoExtension.class)
-public class EvaluateGpg45ScoreHandlerTest {
+class EvaluateGpg45ScoreHandlerTest {
 
     private static final String TEST_SESSION_ID = "test-session-id";
     private static final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -1,0 +1,118 @@
+package uk.gov.di.ipv.core.evaluategpg45scores;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.google.gson.Gson;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.evaluategpg45scores.exception.UnknownEvidenceTypeException;
+import uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45ProfileEvaluator;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_ERROR;
+import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_NEXT;
+import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_SESSION_END;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
+
+@ExtendWith(MockitoExtension.class)
+public class EvaluateGpg45ScoreHandlerTest {
+
+    private static final String TEST_SESSION_ID = "test-session-id";
+    private static final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+    public static final List<String> CREDENTIALS = List.of("Some", "gathered", "credentials");
+
+    @Mock private Context context;
+    @Mock private UserIdentityService userIdentityService;
+    @Mock private Gpg45ProfileEvaluator gpg45ProfileEvaluator;
+    @InjectMocks private EvaluateGpg45ScoresHandler evaluateGpg45ScoresHandler;
+
+    private final Gson gson = new Gson();
+
+    @BeforeAll
+    static void setUp() {
+        event.setHeaders(Map.of(IPV_SESSION_ID_HEADER, TEST_SESSION_ID));
+    }
+
+    @Test
+    void shouldReturnJourneySessionEndIfScoresSatisfyM1AGpg45Profile() throws Exception {
+        when(userIdentityService.getUserIssuedCredentials(TEST_SESSION_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1A))
+                .thenReturn(true);
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_SESSION_END, journeyResponse.getJourney());
+        verify(userIdentityService).getUserIssuedCredentials(TEST_SESSION_ID);
+    }
+
+    @Test
+    void shouldReturnJourneyNextIfScoresDoNotSatisfyM1AGpg45Profile() throws Exception {
+        when(userIdentityService.getUserIssuedCredentials(TEST_SESSION_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1A))
+                .thenReturn(false);
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_NEXT, journeyResponse.getJourney());
+        verify(userIdentityService).getUserIssuedCredentials(TEST_SESSION_ID);
+    }
+
+    @Test
+    void shouldReturn400IfSessionIdNotInHeader() {
+        APIGatewayProxyRequestEvent eventWithoutHeaders = new APIGatewayProxyRequestEvent();
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(eventWithoutHeaders, context);
+        var error = gson.fromJson(response.getBody(), Map.class);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), error.get("error_description"));
+    }
+
+    @Test
+    void shouldReturnJourneyErrorIfFailedToParseCredentials() throws Exception {
+        when(userIdentityService.getUserIssuedCredentials(TEST_SESSION_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1A))
+                .thenThrow(new ParseException("Whoops", 0));
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_ERROR, journeyResponse.getJourney());
+        verify(userIdentityService).getUserIssuedCredentials(TEST_SESSION_ID);
+    }
+
+    @Test
+    void shouldReturnJourneyErrorIfCredentialOfUnknownType() throws Exception {
+        when(userIdentityService.getUserIssuedCredentials(TEST_SESSION_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1A))
+                .thenThrow(new UnknownEvidenceTypeException());
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_ERROR, journeyResponse.getJourney());
+        verify(userIdentityService).getUserIssuedCredentials(TEST_SESSION_ID);
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_ERROR;
+import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_FAIL;
 import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_NEXT;
 import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_SESSION_END;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
@@ -59,6 +60,20 @@ public class EvaluateGpg45ScoreHandlerTest {
 
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         assertEquals(JOURNEY_SESSION_END, journeyResponse.getJourney());
+        verify(userIdentityService).getUserIssuedCredentials(TEST_SESSION_ID);
+    }
+
+    @Test
+    void shouldReturnJourneyFailIfAnyCredentialsAreNotEnoughForM1A() throws Exception {
+        when(userIdentityService.getUserIssuedCredentials(TEST_SESSION_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.anyCredentialsGatheredDoNotMeetM1A(CREDENTIALS))
+                .thenReturn(true);
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_FAIL, journeyResponse.getJourney());
         verify(userIdentityService).getUserIssuedCredentials(TEST_SESSION_ID);
     }
 

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -1,0 +1,122 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.gpg45;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.evaluategpg45scores.exception.UnknownEvidenceTypeException;
+
+import java.text.ParseException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Gpg45ProfileEvaluatorTest {
+
+    private final Gpg45ProfileEvaluator evaluator = new Gpg45ProfileEvaluator();
+    private final String M1A_PASSPORT_VC =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJhdWQiOiJodHRwczpcL1wvaWRlbnRpdHkuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJuYmYiOjE2NTg4Mjk2NDcsImlzcyI6Imh0dHBzOlwvXC9yZXZpZXctcC5pbnRlZ3JhdGlvbi5hY2NvdW50Lmdvdi51ayIsImV4cCI6MTY1ODgzNjg0NywidmMiOnsiZXZpZGVuY2UiOlt7InZhbGlkaXR5U2NvcmUiOjIsInN0cmVuZ3RoU2NvcmUiOjQsImNpIjpudWxsLCJ0eG4iOiIxMjNhYjkzZC0zYTQzLTQ2ZWYtYTJjMS0zYzY0NDQyMDY0MDgiLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayJ9XSwiY3JlZGVudGlhbFN1YmplY3QiOnsicGFzc3BvcnQiOlt7ImV4cGlyeURhdGUiOiIyMDMwLTAxLTAxIiwiZG9jdW1lbnROdW1iZXIiOiIzMjE2NTQ5ODcifV0sIm5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl19fQ.MEYCIQC-2fwJVvFLM8SnCKk_5EHX_ZPdTN2-kaOxNjXky86LUgIhAIMZUuTztxyyqa3ZkyaqnkMl1vPl1HQ2FbQ9LxPQChn";
+    private final String M1A_ADDRESS_VC =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWEuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3MjAsImV4cCI6MTY1ODgzNjkyMCwidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIkFkZHJlc3NDcmVkZW50aWFsIl0sIkBjb250ZXh0IjpbImh0dHBzOlwvXC93d3cudzMub3JnXC8yMDE4XC9jcmVkZW50aWFsc1wvdjEiLCJodHRwczpcL1wvdm9jYWIubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsXC9jb250ZXh0c1wvaWRlbnRpdHktdjEuanNvbmxkIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImFkZHJlc3MiOlt7InVwcm4iOjEwMDEyMDAxMjA3NywiYnVpbGRpbmdOdW1iZXIiOiI4IiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInBvc3RhbENvZGUiOiJCQTIgNUFBIiwiYWRkcmVzc0NvdW50cnkiOiJHQiIsInZhbGlkRnJvbSI6IjIwMDAtMDEtMDEifV19fX0.MEQCIDGSdiAuPOEQGRlU_SGRWkVYt28oCVAVIuVWkAseN_RCAiBsdf5qS5BIsAoaebo8L60yaUuZjxU9mYloBa24IFWYsw";
+    private final String M1A_FRAUD_VC =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwiaWRlbnRpdHlGcmF1ZFNjb3JlIjoxLCJjaSI6W119XX19.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
+    private final String M1A_KBV_VC =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWsuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk5MTcsImV4cCI6MTY1ODgzNzExNywidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eG4iOiI3TEFLUlRBN0ZTIiwidmVyaWZpY2F0aW9uU2NvcmUiOjIsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIn0seyJhZGRyZXNzQ291bnRyeSI6IkdCIiwidXBybiI6MTAwMTIwMDEyMDc3LCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJ2YWxpZEZyb20iOiIyMDAwLTAxLTAxIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX19fQ.MEUCIAD3CkUQctCBxPIonRsYylmAsWsodyzpLlRzSTKvJBxHAiEAsewH-Ke7x8R3879-KQCwGAcYPt_14Wq7a6bvsb5tH_8";
+
+    private final String PASSPORT_VC_FAILED =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDpmZDgwMTVmMy1mYjA5LTRiZjctYWU3ZS02MDMzNTAzOGRjYTgiLCJhdWQiOiJodHRwczpcL1wvaWRlbnRpdHkuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJuYmYiOjE2NTg4Mzk3NzIsImlzcyI6Imh0dHBzOlwvXC9yZXZpZXctcC5pbnRlZ3JhdGlvbi5hY2NvdW50Lmdvdi51ayIsImV4cCI6MTY1ODg0Njk3MiwidmMiOnsiZXZpZGVuY2UiOlt7InZhbGlkaXR5U2NvcmUiOjAsInN0cmVuZ3RoU2NvcmUiOjQsImNpIjpbIkQwMiJdLCJ0eG4iOiJlNmMwOTA3NC1hMjczLTRiOGMtOTVmOC0zYWE1YjI2NDgzMmUiLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayJ9XSwiY3JlZGVudGlhbFN1YmplY3QiOnsicGFzc3BvcnQiOlt7ImV4cGlyeURhdGUiOiIyMDI0LTA5LTI5IiwiZG9jdW1lbnROdW1iZXIiOiIxMjM0NTY3ODkifV0sIm5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoia3NkamhmcyJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6InFza2RqaGYifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODQtMDktMjgifV19LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXX19.MEUCIQDD0Y0ftHUJmhQ_oDX6wo23loLQ-_EZqoivq2eMoKPYiAIgcmaaGjV7KX8FYNJhPM_v7kWxl1WS9HBx6iiXsv0gODI";
+    private final String FRAUD_VC_FAILED =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDo0MDI1Yjg5Mi1mZmU5LTRjZGUtYWJmMy0xOTgxYTZiYTQ5MmIiLCJuYmYiOjE2NTg4NDAwMTIsImV4cCI6MTY1ODg0NzIxMiwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJET1dOSU5HIFNUUkVFVCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiU1cxQSAyQUEiLCJidWlsZGluZ051bWJlciI6IjEwIiwiaWQiOm51bGwsImFkZHJlc3NMb2NhbGl0eSI6IkxPTkRPTiIsInN1YkJ1aWxkaW5nTmFtZSI6bnVsbH1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdLCJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJ0eG4iOiJSQjAwMDEwMzQ5NzQ0MyIsImlkZW50aXR5RnJhdWRTY29yZSI6MSwiY2kiOlsiQTAyIl19XX19.MEYCIQCRMVowC7JDu1e1jAmNB-isSb4qmlU4lbNJx5bL5n_fjwIhAPf5Yqx-iHzWPeuaevM0D0x3HYVJ-2KFGDyJEo6PwI4g";
+    private final String KBV_VC_FAILED =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWsuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDpiOGI0NTZmNy05OGRlLTRkYjktOGJiMy02OWM5ODUxMGY0YWQiLCJuYmYiOjE2NTg5MDkyOTAsImV4cCI6MTY1ODkxNjQ5MCwidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eG4iOiI3TEJINlpETExEIiwidmVyaWZpY2F0aW9uU2NvcmUiOjAsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIn0seyJhZGRyZXNzQ291bnRyeSI6IkdCIiwidXBybiI6MTAwMTIwMDEyMDc3LCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJ2YWxpZEZyb20iOiIyMDAwLTAxLTAxIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX19fQ.MEYCIQCS7vwI_4ILb9opo6ObpuKnLXzSGSGOQhlPOgM1PTI2KwIhAPzpJK4vDC2ztnKK00EPqI8wvbeSMM7TVyku_pm7yRQZ";
+    private final String VC_WITH_BAD_EVIDENCE_BLOB =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwidGhpc0RvZXNOb3RNYWtlU2Vuc2VTY29yZSI6MSwiY2kiOltdfV19fQo.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
+
+    @Test
+    void shouldReturnTrueIfCredentialsSatisfyProfile() throws Exception {
+        assertTrue(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC, M1A_KBV_VC),
+                        Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldReturnFalseIfNoCredentialsFound() throws Exception {
+        assertFalse(evaluator.credentialsSatisfyProfile(List.of(), Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldReturnFalseIfOnlyPassportCredential() throws Exception {
+        assertFalse(
+                evaluator.credentialsSatisfyProfile(List.of(M1A_PASSPORT_VC), Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldReturnFalseIfOnlyOnlyPassportAndAddressCredential() throws Exception {
+        assertFalse(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC), Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldReturnFalseIfOnlyOnlyPassportAndAddressAndFraudCredential() throws Exception {
+        assertFalse(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC), Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldReturnFalseIfFailedPassportCredential() throws Exception {
+        assertFalse(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(PASSPORT_VC_FAILED, M1A_ADDRESS_VC, M1A_FRAUD_VC, M1A_KBV_VC),
+                        Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldReturnFalseIfFailedFraudCredential() throws Exception {
+        assertFalse(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, FRAUD_VC_FAILED, M1A_KBV_VC),
+                        Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldReturnFalseIfFailedKbvCredential() throws Exception {
+        assertFalse(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC, KBV_VC_FAILED),
+                        Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldUseHighestScoringValuesForCredentials() throws Exception {
+        assertTrue(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(
+                                M1A_PASSPORT_VC,
+                                M1A_ADDRESS_VC,
+                                FRAUD_VC_FAILED,
+                                M1A_FRAUD_VC,
+                                KBV_VC_FAILED,
+                                M1A_KBV_VC),
+                        Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldThrowIfCredentialsCanNotBeParse() {
+        assertThrows(
+                ParseException.class,
+                () ->
+                        evaluator.credentialsSatisfyProfile(
+                                List.of("This is nonsense 🫤"), Gpg45Profile.M1A));
+    }
+
+    @Test
+    void shouldThrowIfUnrecognisedEvidenceType() {
+        assertThrows(
+                UnknownEvidenceTypeException.class,
+                () ->
+                        evaluator.credentialsSatisfyProfile(
+                                List.of(VC_WITH_BAD_EVIDENCE_BLOB), Gpg45Profile.M1A));
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.evaluategpg45scores.exception.UnknownEvidenceTypeException;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -32,7 +33,7 @@ public class Gpg45ProfileEvaluatorTest {
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwidGhpc0RvZXNOb3RNYWtlU2Vuc2VTY29yZSI6MSwiY2kiOltdfV19fQo.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
 
     @Test
-    void shouldReturnTrueIfCredentialsSatisfyProfile() throws Exception {
+    void credentialsSatisfyProfileShouldReturnTrueIfCredentialsSatisfyProfile() throws Exception {
         assertTrue(
                 evaluator.credentialsSatisfyProfile(
                         List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC, M1A_KBV_VC),
@@ -40,32 +41,34 @@ public class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
-    void shouldReturnFalseIfNoCredentialsFound() throws Exception {
+    void credentialsSatisfyProfileShouldReturnFalseIfNoCredentialsFound() throws Exception {
         assertFalse(evaluator.credentialsSatisfyProfile(List.of(), Gpg45Profile.M1A));
     }
 
     @Test
-    void shouldReturnFalseIfOnlyPassportCredential() throws Exception {
+    void credentialsSatisfyProfileShouldReturnFalseIfOnlyPassportCredential() throws Exception {
         assertFalse(
                 evaluator.credentialsSatisfyProfile(List.of(M1A_PASSPORT_VC), Gpg45Profile.M1A));
     }
 
     @Test
-    void shouldReturnFalseIfOnlyOnlyPassportAndAddressCredential() throws Exception {
+    void credentialsSatisfyProfileShouldReturnFalseIfOnlyOnlyPassportAndAddressCredential()
+            throws Exception {
         assertFalse(
                 evaluator.credentialsSatisfyProfile(
                         List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC), Gpg45Profile.M1A));
     }
 
     @Test
-    void shouldReturnFalseIfOnlyOnlyPassportAndAddressAndFraudCredential() throws Exception {
+    void credentialsSatisfyProfileShouldReturnFalseIfOnlyOnlyPassportAndAddressAndFraudCredential()
+            throws Exception {
         assertFalse(
                 evaluator.credentialsSatisfyProfile(
                         List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC), Gpg45Profile.M1A));
     }
 
     @Test
-    void shouldReturnFalseIfFailedPassportCredential() throws Exception {
+    void credentialsSatisfyProfileShouldReturnFalseIfFailedPassportCredential() throws Exception {
         assertFalse(
                 evaluator.credentialsSatisfyProfile(
                         List.of(PASSPORT_VC_FAILED, M1A_ADDRESS_VC, M1A_FRAUD_VC, M1A_KBV_VC),
@@ -73,7 +76,7 @@ public class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
-    void shouldReturnFalseIfFailedFraudCredential() throws Exception {
+    void credentialsSatisfyProfileShouldReturnFalseIfFailedFraudCredential() throws Exception {
         assertFalse(
                 evaluator.credentialsSatisfyProfile(
                         List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, FRAUD_VC_FAILED, M1A_KBV_VC),
@@ -81,7 +84,7 @@ public class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
-    void shouldReturnFalseIfFailedKbvCredential() throws Exception {
+    void credentialsSatisfyProfileShouldReturnFalseIfFailedKbvCredential() throws Exception {
         assertFalse(
                 evaluator.credentialsSatisfyProfile(
                         List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC, KBV_VC_FAILED),
@@ -89,7 +92,7 @@ public class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
-    void shouldUseHighestScoringValuesForCredentials() throws Exception {
+    void credentialsSatisfyProfileShouldUseHighestScoringValuesForCredentials() throws Exception {
         assertTrue(
                 evaluator.credentialsSatisfyProfile(
                         List.of(
@@ -103,7 +106,7 @@ public class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
-    void shouldThrowIfCredentialsCanNotBeParse() {
+    void credentialsSatisfyProfileShouldThrowIfCredentialsCanNotBeParse() {
         assertThrows(
                 ParseException.class,
                 () ->
@@ -112,11 +115,40 @@ public class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
-    void shouldThrowIfUnrecognisedEvidenceType() {
+    void credentialsSatisfyProfileShouldThrowIfUnrecognisedEvidenceType() {
         assertThrows(
                 UnknownEvidenceTypeException.class,
                 () ->
                         evaluator.credentialsSatisfyProfile(
                                 List.of(VC_WITH_BAD_EVIDENCE_BLOB), Gpg45Profile.M1A));
+    }
+
+    @Test
+    void anyCredentialsGatheredDoNotMeetM1AShouldReturnFalseForGoodCredentials() throws Exception {
+        List<String> goodCredentials =
+                List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC, M1A_KBV_VC);
+        List<String> gatheredCredentials = new ArrayList<>();
+        assertFalse(evaluator.anyCredentialsGatheredDoNotMeetM1A(gatheredCredentials));
+        for (String credential : goodCredentials) {
+            gatheredCredentials.add(credential);
+            assertFalse(evaluator.anyCredentialsGatheredDoNotMeetM1A(gatheredCredentials));
+        }
+    }
+
+    @Test
+    void anyCredentialsGatheredDoNotMeetM1AShouldReturnTrueForBadPassportCredential()
+            throws Exception {
+        assertTrue(evaluator.anyCredentialsGatheredDoNotMeetM1A(List.of(PASSPORT_VC_FAILED)));
+    }
+
+    @Test
+    void anyCredentialsGatheredDoNotMeetM1AShouldReturnTrueForBadFraudCredential()
+            throws Exception {
+        assertTrue(evaluator.anyCredentialsGatheredDoNotMeetM1A(List.of(FRAUD_VC_FAILED)));
+    }
+
+    @Test
+    void anyCredentialsGatheredDoNotMeetM1AShouldReturnTrueForBadKbvCredential() throws Exception {
+        assertTrue(evaluator.anyCredentialsGatheredDoNotMeetM1A(List.of(KBV_VC_FAILED)));
     }
 }

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class Gpg45ProfileEvaluatorTest {
+class Gpg45ProfileEvaluatorTest {
 
     private final Gpg45ProfileEvaluator evaluator = new Gpg45ProfileEvaluator();
     private final String M1A_PASSPORT_VC =

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileTest.java
@@ -24,40 +24,40 @@ class Gpg45ProfileTest {
     @Test
     void shouldMatchExact() {
         for (Gpg45Profile profile : Gpg45Profile.values()) {
-            assertTrue(profile.satisfiedBy(profile.getScores()));
+            assertTrue(profile.isSatisfiedBy(profile.getScores()));
         }
     }
 
     @Test
     void shouldMatchHigher() {
-        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, 0, 1, 2)));
-        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_32, 1, 1, 1)));
-        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_33, 0, 1, 1)));
-        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, 1, 1, 1)));
-        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, 1, 2, 1)));
-        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_44, 4, 4, 4)));
-        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, EV_11, 0, 1, 2)));
+        assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_22, 0, 1, 2)));
+        assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_32, 1, 1, 1)));
+        assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_33, 0, 1, 1)));
+        assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_22, 1, 1, 1)));
+        assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_22, 1, 2, 1)));
+        assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_44, 4, 4, 4)));
+        assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_22, EV_11, 0, 1, 2)));
     }
 
     @Test
     void shouldMatchExtraEvidence() {
         Gpg45Scores target = new Gpg45Scores(EV_22, EV_11, 0, 1, 1);
-        assertTrue(Gpg45Profile.L1A.satisfiedBy(target));
+        assertTrue(Gpg45Profile.L1A.isSatisfiedBy(target));
     }
 
     @Test
     void shouldNotMatchLower() {
-        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 1, 1, 3)));
-        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 1, 0, 4)));
-        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 0, 1, 4)));
-        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_42, 1, 1, 4)));
-        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_33, 1, 1, 4)));
-        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_32, 0, 0, 3)));
+        assertFalse(Gpg45Profile.V1C.isSatisfiedBy(new Gpg45Scores(EV_43, 1, 1, 3)));
+        assertFalse(Gpg45Profile.V1C.isSatisfiedBy(new Gpg45Scores(EV_43, 1, 0, 4)));
+        assertFalse(Gpg45Profile.V1C.isSatisfiedBy(new Gpg45Scores(EV_43, 0, 1, 4)));
+        assertFalse(Gpg45Profile.V1C.isSatisfiedBy(new Gpg45Scores(EV_42, 1, 1, 4)));
+        assertFalse(Gpg45Profile.V1C.isSatisfiedBy(new Gpg45Scores(EV_33, 1, 1, 4)));
+        assertFalse(Gpg45Profile.V1C.isSatisfiedBy(new Gpg45Scores(EV_32, 0, 0, 3)));
     }
 
     @Test
     void shouldNotMatchMissingEvidence() {
-        assertFalse(Gpg45Profile.V2A.satisfiedBy(new Gpg45Scores(EV_33, 3, 2, 3)));
+        assertFalse(Gpg45Profile.V2A.isSatisfiedBy(new Gpg45Scores(EV_33, 3, 2, 3)));
     }
 
     @Test
@@ -110,7 +110,7 @@ class Gpg45ProfileTest {
                                             System.out.println(scores);
                                             var matches = new ArrayList<Gpg45Profile>();
                                             for (Gpg45Profile profile : Gpg45Profile.values()) {
-                                                if (profile.satisfiedBy(scores)) {
+                                                if (profile.isSatisfiedBy(scores)) {
                                                     matches.add(profile);
                                                     System.out.println(profile.code());
                                                 }

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileTest.java
@@ -1,0 +1,130 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.gpg45;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_11;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_22;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_32;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_33;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_42;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_43;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_44;
+
+public class Gpg45ProfileTest {
+
+    @Test
+    public void shouldMatchExact() {
+        for (Gpg45Profile profile : Gpg45Profile.values()) {
+            assertTrue(profile.satisfiedBy(profile.getScores()));
+        }
+    }
+
+    @Test
+    public void shouldMatchHigher() {
+        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, 0, 1, 2)));
+        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_32, 1, 1, 1)));
+        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_33, 0, 1, 1)));
+        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, 1, 1, 1)));
+        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, 1, 2, 1)));
+        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_44, 4, 4, 4)));
+        assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, EV_11, 0, 1, 2)));
+    }
+
+    @Test
+    public void shouldMatchExtraEvidence() {
+        Gpg45Scores target = new Gpg45Scores(EV_22, EV_11, 0, 1, 1);
+        assertTrue(Gpg45Profile.L1A.satisfiedBy(target));
+    }
+
+    @Test
+    public void shouldNotMatchLower() {
+        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 1, 1, 3)));
+        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 1, 0, 4)));
+        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 0, 1, 4)));
+        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_42, 1, 1, 4)));
+        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_33, 1, 1, 4)));
+        assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_32, 0, 0, 3)));
+    }
+
+    @Test
+    public void shouldNotMatchMissingEvidence() {
+        assertFalse(Gpg45Profile.V2A.satisfiedBy(new Gpg45Scores(EV_33, 3, 2, 3)));
+    }
+
+    @Test
+    public void shouldFindDifference() {
+        assertEquals(
+                new Gpg45Scores(-2, -2, -2, -1, -3),
+                Gpg45Profile.H1B.difference(new Gpg45Scores(EV_11, 0, 0, 0)));
+        assertEquals(
+                new Gpg45Scores(0, 0, 0, 0, 0),
+                Gpg45Profile.H1B.difference(new Gpg45Scores(EV_33, 2, 1, 3)));
+        assertEquals(
+                new Gpg45Scores(1, 1, 1, 1, 1),
+                Gpg45Profile.H1B.difference(new Gpg45Scores(EV_44, 3, 2, 4)));
+    }
+
+    @Test
+    public void testAllPossibleCombinations() {
+        int verificationMax = 4;
+        int fraudMax = 3;
+        int activityMax = 4;
+        int validityMax = 4;
+        int strengthMax = 4;
+
+        // IntStream.range(0, verificationMax+1).forEach(i ->System.out.println(i));
+
+        Map<String, List<Gpg45Profile>> profileMap = new HashMap<>();
+
+        System.out.println("Map build");
+        var t0 = System.currentTimeMillis();
+
+        for (int verification = 0; verification <= verificationMax; verification++) {
+            for (int fraud = 0; fraud <= fraudMax; fraud++) {
+                for (int activity = 0; activity <= activityMax; activity++) {
+                    List<Gpg45Scores.Evidence> evidences = new ArrayList<>();
+                    for (int doc = 0; doc < 3; doc++) {
+                        evidences.add(new Gpg45Scores.Evidence(0, 0));
+                        for (int validity = 0; validity <= validityMax; validity++) {
+                            for (int strength = 0; strength <= strengthMax; strength++) {
+                                var evidence = new Gpg45Scores.Evidence(strength, validity);
+                                evidences.set(doc, evidence);
+                                var scores =
+                                        new Gpg45Scores(evidences, activity, fraud, verification);
+                                System.out.println(scores);
+                                var matches = new ArrayList<Gpg45Profile>();
+                                for (Gpg45Profile profile : Gpg45Profile.values()) {
+                                    if (profile.satisfiedBy(scores)) {
+                                        matches.add(profile);
+                                        System.out.println(profile.code());
+                                    }
+                                }
+                                if (matches.size() == 0) {
+                                    System.out.println("NONE");
+                                }
+                                profileMap.put(scores.toString(), matches);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        var t1 = System.currentTimeMillis();
+        System.out.println("T:" + (t1 - t0));
+        System.out.println("Map lookup");
+        var profiles = profileMap.get("[[22], 3, 1, 3]");
+        for (Gpg45Profile profile : profiles) {
+            System.out.println(profile.label);
+        }
+        var t2 = System.currentTimeMillis();
+        System.out.println("T:" + (t2 - t1));
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,17 +19,17 @@ import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_42;
 import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_43;
 import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_44;
 
-public class Gpg45ProfileTest {
+class Gpg45ProfileTest {
 
     @Test
-    public void shouldMatchExact() {
+    void shouldMatchExact() {
         for (Gpg45Profile profile : Gpg45Profile.values()) {
             assertTrue(profile.satisfiedBy(profile.getScores()));
         }
     }
 
     @Test
-    public void shouldMatchHigher() {
+    void shouldMatchHigher() {
         assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_22, 0, 1, 2)));
         assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_32, 1, 1, 1)));
         assertTrue(Gpg45Profile.L1A.satisfiedBy(new Gpg45Scores(EV_33, 0, 1, 1)));
@@ -39,13 +40,13 @@ public class Gpg45ProfileTest {
     }
 
     @Test
-    public void shouldMatchExtraEvidence() {
+    void shouldMatchExtraEvidence() {
         Gpg45Scores target = new Gpg45Scores(EV_22, EV_11, 0, 1, 1);
         assertTrue(Gpg45Profile.L1A.satisfiedBy(target));
     }
 
     @Test
-    public void shouldNotMatchLower() {
+    void shouldNotMatchLower() {
         assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 1, 1, 3)));
         assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 1, 0, 4)));
         assertFalse(Gpg45Profile.V1C.satisfiedBy(new Gpg45Scores(EV_43, 0, 1, 4)));
@@ -55,12 +56,12 @@ public class Gpg45ProfileTest {
     }
 
     @Test
-    public void shouldNotMatchMissingEvidence() {
+    void shouldNotMatchMissingEvidence() {
         assertFalse(Gpg45Profile.V2A.satisfiedBy(new Gpg45Scores(EV_33, 3, 2, 3)));
     }
 
     @Test
-    public void shouldFindDifference() {
+    void shouldFindDifference() {
         assertEquals(
                 new Gpg45Scores(-2, -2, -2, -1, -3),
                 Gpg45Profile.H1B.difference(new Gpg45Scores(EV_11, 0, 0, 0)));
@@ -73,58 +74,66 @@ public class Gpg45ProfileTest {
     }
 
     @Test
-    public void testAllPossibleCombinations() {
-        int verificationMax = 4;
-        int fraudMax = 3;
-        int activityMax = 4;
-        int validityMax = 4;
-        int strengthMax = 4;
+    void testAllPossibleCombinations() {
+        assertDoesNotThrow(
+                () -> {
+                    int verificationMax = 4;
+                    int fraudMax = 3;
+                    int activityMax = 4;
+                    int validityMax = 4;
+                    int strengthMax = 4;
 
-        // IntStream.range(0, verificationMax+1).forEach(i ->System.out.println(i));
+                    Map<String, List<Gpg45Profile>> profileMap = new HashMap<>();
 
-        Map<String, List<Gpg45Profile>> profileMap = new HashMap<>();
+                    System.out.println("Map build");
+                    var t0 = System.currentTimeMillis();
 
-        System.out.println("Map build");
-        var t0 = System.currentTimeMillis();
-
-        for (int verification = 0; verification <= verificationMax; verification++) {
-            for (int fraud = 0; fraud <= fraudMax; fraud++) {
-                for (int activity = 0; activity <= activityMax; activity++) {
-                    List<Gpg45Scores.Evidence> evidences = new ArrayList<>();
-                    for (int doc = 0; doc < 3; doc++) {
-                        evidences.add(new Gpg45Scores.Evidence(0, 0));
-                        for (int validity = 0; validity <= validityMax; validity++) {
-                            for (int strength = 0; strength <= strengthMax; strength++) {
-                                var evidence = new Gpg45Scores.Evidence(strength, validity);
-                                evidences.set(doc, evidence);
-                                var scores =
-                                        new Gpg45Scores(evidences, activity, fraud, verification);
-                                System.out.println(scores);
-                                var matches = new ArrayList<Gpg45Profile>();
-                                for (Gpg45Profile profile : Gpg45Profile.values()) {
-                                    if (profile.satisfiedBy(scores)) {
-                                        matches.add(profile);
-                                        System.out.println(profile.code());
+                    for (int verification = 0; verification <= verificationMax; verification++) {
+                        for (int fraud = 0; fraud <= fraudMax; fraud++) {
+                            for (int activity = 0; activity <= activityMax; activity++) {
+                                List<Gpg45Scores.Evidence> evidences = new ArrayList<>();
+                                for (int doc = 0; doc < 3; doc++) {
+                                    evidences.add(new Gpg45Scores.Evidence(0, 0));
+                                    for (int validity = 0; validity <= validityMax; validity++) {
+                                        for (int strength = 0;
+                                                strength <= strengthMax;
+                                                strength++) {
+                                            var evidence =
+                                                    new Gpg45Scores.Evidence(strength, validity);
+                                            evidences.set(doc, evidence);
+                                            var scores =
+                                                    new Gpg45Scores(
+                                                            evidences,
+                                                            activity,
+                                                            fraud,
+                                                            verification);
+                                            System.out.println(scores);
+                                            var matches = new ArrayList<Gpg45Profile>();
+                                            for (Gpg45Profile profile : Gpg45Profile.values()) {
+                                                if (profile.satisfiedBy(scores)) {
+                                                    matches.add(profile);
+                                                    System.out.println(profile.code());
+                                                }
+                                            }
+                                            if (matches.size() == 0) {
+                                                System.out.println("NONE");
+                                            }
+                                            profileMap.put(scores.toString(), matches);
+                                        }
                                     }
                                 }
-                                if (matches.size() == 0) {
-                                    System.out.println("NONE");
-                                }
-                                profileMap.put(scores.toString(), matches);
                             }
                         }
                     }
-                }
-            }
-        }
-        var t1 = System.currentTimeMillis();
-        System.out.println("T:" + (t1 - t0));
-        System.out.println("Map lookup");
-        var profiles = profileMap.get("[[22], 3, 1, 3]");
-        for (Gpg45Profile profile : profiles) {
-            System.out.println(profile.label);
-        }
-        var t2 = System.currentTimeMillis();
-        System.out.println("T:" + (t2 - t1));
+                    var t1 = System.currentTimeMillis();
+                    System.out.println("T:" + (t1 - t0));
+                    System.out.println("Map lookup");
+                    var profiles = profileMap.get("[[22], 3, 1, 3]");
+                    for (Gpg45Profile profile : profiles) {
+                        System.out.println(profile.label);
+                    }
+                    var t2 = System.currentTimeMillis();
+                    System.out.println("T:" + (t2 - t1));
+                });
     }
 }

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ScoresTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ScoresTest.java
@@ -1,0 +1,47 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.gpg45;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Profile.H2D;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_32;
+import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_33;
+
+public class Gpg45ScoresTest {
+
+    @Test
+    void shouldOrderEvidenceOnScoreAndValidity() {
+        Gpg45Scores score1 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
+        Gpg45Scores score2 = new Gpg45Scores(EV_32, EV_33, 0, 1, 3);
+
+        assertTrue(H2D.satisfiedBy(score1));
+        assertTrue(H2D.satisfiedBy(score2));
+    }
+
+    @Test
+    public void shouldBuild() {
+        var scores =
+                new Gpg45Scores.Builder()
+                        .withEvidence(new Gpg45Scores.Evidence(2, 2))
+                        .withActivity(1)
+                        .withFraud(1)
+                        .withVerification(1)
+                        .build();
+        assertEquals(new Gpg45Scores(2, 2, 1, 1, 1), scores);
+    }
+
+    @Test
+    public void shouldProduceReadableToString() {
+        var scores =
+                new Gpg45Scores.Builder()
+                        .withEvidence(new Gpg45Scores.Evidence(2, 2))
+                        .withEvidence(new Gpg45Scores.Evidence(3, 2))
+                        .withActivity(1)
+                        .withFraud(2)
+                        .withVerification(3)
+                        .build();
+
+        assertEquals("[[32, 22], 1, 2, 3]", scores.toString());
+    }
+}

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ScoresTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ScoresTest.java
@@ -17,8 +17,8 @@ class Gpg45ScoresTest {
         Gpg45Scores score1 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
         Gpg45Scores score2 = new Gpg45Scores(EV_32, EV_33, 0, 1, 3);
 
-        assertTrue(H2D.satisfiedBy(score1));
-        assertTrue(H2D.satisfiedBy(score2));
+        assertTrue(H2D.isSatisfiedBy(score1));
+        assertTrue(H2D.isSatisfiedBy(score2));
     }
 
     @Test

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ScoresTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ScoresTest.java
@@ -2,13 +2,15 @@ package uk.gov.di.ipv.core.evaluategpg45scores.gpg45;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Profile.H2D;
 import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_32;
 import static uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Scores.EV_33;
 
-public class Gpg45ScoresTest {
+class Gpg45ScoresTest {
 
     @Test
     void shouldOrderEvidenceOnScoreAndValidity() {
@@ -20,7 +22,7 @@ public class Gpg45ScoresTest {
     }
 
     @Test
-    public void shouldBuild() {
+    void shouldBuild() {
         var scores =
                 new Gpg45Scores.Builder()
                         .withEvidence(new Gpg45Scores.Evidence(2, 2))
@@ -32,7 +34,7 @@ public class Gpg45ScoresTest {
     }
 
     @Test
-    public void shouldProduceReadableToString() {
+    void shouldProduceReadableToString() {
         var scores =
                 new Gpg45Scores.Builder()
                         .withEvidence(new Gpg45Scores.Evidence(2, 2))
@@ -43,5 +45,35 @@ public class Gpg45ScoresTest {
                         .build();
 
         assertEquals("[[32, 22], 1, 2, 3]", scores.toString());
+    }
+
+    @Test
+    void getEvidenceShouldReturnEvidenceWithZeroScoresWhenNoEvidences() {
+        Gpg45Scores gpg45Scores = new Gpg45Scores(List.of(), 0, 1, 3);
+        assertEquals(new Gpg45Scores.Evidence(0, 0), gpg45Scores.getEvidence(1));
+    }
+
+    @Test
+    void compareToShouldReturnNegativeIfOtherHasALowerScore() {
+        Gpg45Scores score1 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
+        Gpg45Scores score2 = new Gpg45Scores(EV_33, EV_32, 0, 1, 1);
+
+        assertTrue(score1.compareTo(score2) < 0);
+    }
+
+    @Test
+    void compareToShouldReturnPositiveIfOtherHasAHigherScore() {
+        Gpg45Scores score1 = new Gpg45Scores(EV_33, EV_32, 0, 1, 1);
+        Gpg45Scores score2 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
+
+        assertTrue(score1.compareTo(score2) > 0);
+    }
+
+    @Test
+    void compareToShouldReturnZeroIfOtherHasSameScore() {
+        Gpg45Scores score1 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
+        Gpg45Scores score2 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
+
+        assertEquals(0, score1.compareTo(score2));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -17,10 +17,11 @@ public class LogHelper {
         ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
         IPV_SESSION_ID_LOG_FIELD("ipvSessionId"),
         COMPONENT_ID_LOG_FIELD("componentId"),
-        JTI_LOG_FIELD("JTI_LOG_FIELD"),
-        USED_AT_DATE_TIME_LOG_FIELD("USED_AT_DATE_TIME_LOG_FIELD"),
+        JTI_LOG_FIELD("jti"),
+        JTI_USED_AT_LOG_FIELD("jtiUsedAt"),
         DYNAMODB_TABLE_NAME("dynamoDbTableName"),
-        DYNAMODB_KEY_VALUE("dynamoDbKeyValue");
+        DYNAMODB_KEY_VALUE("dynamoDbKeyValue"),
+        EVIDENCE_TYPE("evidenceType");
         private final String fieldName;
 
         LogField(String fieldName) {
@@ -64,6 +65,13 @@ public class LogHelper {
         LoggingUtils.removeKeys(
                 LogField.ERROR_CODE_LOG_FIELD.getFieldName(),
                 LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName());
+    }
+
+    public static void logInfoMessageWithFieldAndValue(
+            String message, LogField logField, String logFieldValue) {
+        LoggingUtils.appendKey(logField.getFieldName(), logFieldValue);
+        LOGGER.info(message);
+        LoggingUtils.removeKey(logField.getFieldName());
     }
 
     private static void attachFieldToLogs(LogField field, String value) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/TokenRequestValidator.java
@@ -97,11 +97,11 @@ public class TokenRequestValidator {
         LoggingUtils.appendKey(
                 LogHelper.LogField.JTI_LOG_FIELD.getFieldName(), clientAuthJwtIdItem.getJwtId());
         LoggingUtils.appendKey(
-                LogHelper.LogField.USED_AT_DATE_TIME_LOG_FIELD.getFieldName(),
+                LogHelper.LogField.JTI_USED_AT_LOG_FIELD.getFieldName(),
                 clientAuthJwtIdItem.getUsedAtDateTime());
         LOGGER.warn("The client auth JWT id (jti) has already been used");
         LoggingUtils.removeKeys(
                 LogHelper.LogField.JTI_LOG_FIELD.getFieldName(),
-                LogHelper.LogField.USED_AT_DATE_TIME_LOG_FIELD.getFieldName());
+                LogHelper.LogField.JTI_USED_AT_LOG_FIELD.getFieldName());
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Implement evaluate-gpg45-scores lambda

### Why did it change

[PYIC-1689: Determine if credentials meet M1A](https://github.com/alphagov/di-ipv-core-back/commit/c337aef3ba641a200a6e06fe3da77b3fb3a882d2) 

This adds logic to the evaluate-gpg45-scores lambda to see if the
credentials gathered already are sufficient to meet the M1A profile. It
uses code already written, pulled in from here, for defining the
profiles and scores: https://github.com/alphagov/di-ipv-core-back/tree/wip/gpg45-lib/src/main/java/uk/gov/di/ipv/gpg45

When building the scores from the gathered credentials, for gpg45 scores
that only have one value (unlike evidence which can have multiple), this
will pick the score that has the highest value with the lowest number of
contra indicators. This will be useful in the future, but currently we
only ever expect to have score for each type of score so there is
actually nothing to sort.

If the credentials are determined to have met the M1A profile we end the
users session. If not, we continue them on the journey.
  
[PYIC-1689: Fail journey in gpg45 evaluator if failing credential](https://github.com/alphagov/di-ipv-core-back/commit/02c26516bd1b72967c1580cb87634e816e41a0fd) 

We need to fail a journey if we receive a VC from a CRI that won't allow
us to meet M1A. Currently this is done by the validatecricheck lambda.

This steals some of the logic from there to do an upfront check on all
the credentials gathered so far in the evaluate-gpg45-scores lambda. It
will fail the journey if any VCs don't meet M1A.

This logic will be moved to the CRI selector lambda in future - this
lambda should just be responsible for deciding if we've met a profile or
if we need more evidence. The CRI selector should be responsible for
failing a journey if it decides there are no more paths for a user to
take.

Adding this in makes some of the logic added in the previous commit
redundant - specifically the handling of CIs. This logic will be needed
when the fail check is moved to the CRI selector lambda so it should
stay.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1689](https://govukverify.atlassian.net/browse/PYIC-1689)
