### PR TITLE
BAU: Route access-denied events correctly

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -17,6 +17,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -17,6 +17,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -17,6 +17,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -17,6 +17,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -17,6 +17,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: null


### PR DESCRIPTION

## Proposed changes

### What changed

Update statemachine config to accept `access-denied` events and route them to the PYI_NO_MATCH state.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We want to treat access-denied events like a no-match, rather than an error.
