### PR TITLE
PYIC-1694 Refactor storage: write authorization code and access token to session

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -189,6 +189,8 @@ Resources:
           ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AccessTokensTable.Arn]]
           CLIENT_AUTH_JWT_IDS_TABLE_NAME: !Ref ClientAuthJwtIdsTable
       Policies:
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionsTable
         - DynamoDBCrudPolicy:
             TableName: !Ref AccessTokensTable
         - DynamoDBCrudPolicy:
@@ -258,6 +260,8 @@ Resources:
             TableName: !Ref AuthCodesTable
         - DynamoDBReadPolicy:
             TableName: !Ref AuthCodesTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -188,7 +188,10 @@ Resources:
           AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AuthCodesTable.Arn]]
           ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AccessTokensTable.Arn]]
           CLIENT_AUTH_JWT_IDS_TABLE_NAME: !Ref ClientAuthJwtIdsTable
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
       Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
         - DynamoDBCrudPolicy:

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
@@ -24,6 +24,7 @@ import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
+import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.validation.TokenRequestValidator;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
@@ -46,6 +47,7 @@ class AccessTokenHandlerTest {
     private Context context;
     private AccessTokenService mockAccessTokenService;
     private AuthorizationCodeService mockAuthorizationCodeService;
+    private IpvSessionService mockSessionService;
     private TokenRequestValidator mockTokenRequestValidator;
 
     private AccessTokenHandler handler;
@@ -62,6 +64,8 @@ class AccessTokenHandlerTest {
         mockAuthorizationCodeService = mock(AuthorizationCodeService.class);
         ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
 
+        mockSessionService = mock(IpvSessionService.class);
+
         mockTokenRequestValidator = mock(TokenRequestValidator.class);
 
         context = mock(Context.class);
@@ -70,6 +74,7 @@ class AccessTokenHandlerTest {
                 new AccessTokenHandler(
                         mockAccessTokenService,
                         mockAuthorizationCodeService,
+                        mockSessionService,
                         mockConfigurationService,
                         mockTokenRequestValidator);
 

--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
@@ -121,6 +121,10 @@ public class SessionEndHandler
                         authorizationCode.getValue(),
                         ipvSessionId,
                         authorizationRequest.getRedirectionURI().toString());
+                sessionService.setAuthorizationCode(
+                        ipvSessionItem,
+                        authorizationCode.getValue(),
+                        authorizationRequest.getRedirectionURI().toString());
 
                 clientResponse =
                         generateClientSuccessResponse(ipvSessionItem, authorizationCode.getValue());

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AccessTokenMetadata.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AccessTokenMetadata.java
@@ -10,14 +10,11 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 public class AccessTokenMetadata {
     private String creationDateTime;
     private String expiryDateTime;
-    private String revokedAtDateTime;
 
     public AccessTokenMetadata() {}
 
-    public AccessTokenMetadata(
-            String creationDateTime, String expiryDateTime, String revokedAtDateTime) {
+    public AccessTokenMetadata(String creationDateTime, String expiryDateTime) {
         this.creationDateTime = creationDateTime;
         this.expiryDateTime = expiryDateTime;
-        this.revokedAtDateTime = revokedAtDateTime;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AccessTokenMetadata.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AccessTokenMetadata.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import lombok.Data;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@DynamoDbBean
+@Data
+public class AccessTokenMetadata {
+    private String creationDateTime;
+    private String expiryDateTime;
+    private String revokedAtDateTime;
+
+    public AccessTokenMetadata() {}
+
+    public AccessTokenMetadata(
+            String creationDateTime, String expiryDateTime, String revokedAtDateTime) {
+        this.creationDateTime = creationDateTime;
+        this.expiryDateTime = expiryDateTime;
+        this.revokedAtDateTime = revokedAtDateTime;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AuthorizationCodeMetadata.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AuthorizationCodeMetadata.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import lombok.Data;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@DynamoDbBean
+@Data
+public class AuthorizationCodeMetadata {
+    private String redirectUrl;
+    private String creationDateTime;
+    private String exchangeDateTime;
+
+    public AuthorizationCodeMetadata() {}
+
+    public AuthorizationCodeMetadata(
+            String redirectUrl, String creationDateTime, String exchangeDateTime) {
+        this.redirectUrl = redirectUrl;
+        this.creationDateTime = creationDateTime;
+        this.exchangeDateTime = exchangeDateTime;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AuthorizationCodeMetadata.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AuthorizationCodeMetadata.java
@@ -10,14 +10,11 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 public class AuthorizationCodeMetadata {
     private String redirectUrl;
     private String creationDateTime;
-    private String exchangeDateTime;
 
     public AuthorizationCodeMetadata() {}
 
-    public AuthorizationCodeMetadata(
-            String redirectUrl, String creationDateTime, String exchangeDateTime) {
+    public AuthorizationCodeMetadata(String redirectUrl, String creationDateTime) {
         this.redirectUrl = redirectUrl;
         this.creationDateTime = creationDateTime;
-        this.exchangeDateTime = exchangeDateTime;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.core.library.persistence.item;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
+import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 
@@ -14,6 +16,10 @@ public class IpvSessionItem implements DynamodbItem {
     private String creationDateTime;
     private ClientSessionDetailsDto clientSessionDetails;
     private CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails;
+    private String authorizationCode;
+    private AuthorizationCodeMetadata authorizationCodeMetadata;
+    private String accessToken;
+    private AccessTokenMetadata accessTokenMetadata;
     private String errorCode;
     private String errorDescription;
     private long ttl;
@@ -58,6 +64,38 @@ public class IpvSessionItem implements DynamodbItem {
 
     public CredentialIssuerSessionDetailsDto getCredentialIssuerSessionDetails() {
         return credentialIssuerSessionDetails;
+    }
+
+    public String getAuthorizationCode() {
+        return authorizationCode;
+    }
+
+    public void setAuthorizationCode(String authorizationCode) {
+        this.authorizationCode = authorizationCode;
+    }
+
+    public AuthorizationCodeMetadata getAuthorizationCodeMetadata() {
+        return authorizationCodeMetadata;
+    }
+
+    public void setAuthorizationCodeMetadata(AuthorizationCodeMetadata authorizationCodeMetadata) {
+        this.authorizationCodeMetadata = authorizationCodeMetadata;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public AccessTokenMetadata getAccessTokenMetadata() {
+        return accessTokenMetadata;
+    }
+
+    public void setAccessTokenMetadata(AccessTokenMetadata accessTokenMetadata) {
+        this.accessTokenMetadata = accessTokenMetadata;
     }
 
     public String getErrorCode() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -75,19 +75,18 @@ public class IpvSessionService {
 
     public void setAuthorizationCode(
             IpvSessionItem ipvSessionItem, String authorizationCode, String redirectUrl) {
-        AuthorizationCodeMetadata authorizationCodeMetadata =
-                new AuthorizationCodeMetadata(redirectUrl, Instant.now().toString(), null);
+        AuthorizationCodeMetadata authorizationCodeMetadata = new AuthorizationCodeMetadata();
+        authorizationCodeMetadata.setCreationDateTime(Instant.now().toString());
+        authorizationCodeMetadata.setRedirectUrl(redirectUrl);
         ipvSessionItem.setAuthorizationCode(DigestUtils.sha256Hex(authorizationCode));
         ipvSessionItem.setAuthorizationCodeMetadata(authorizationCodeMetadata);
         updateIpvSession(ipvSessionItem);
     }
 
     public void setAccessToken(IpvSessionItem ipvSessionItem, BearerAccessToken accessToken) {
-        AccessTokenMetadata accessTokenMetadata =
-                new AccessTokenMetadata(
-                        Instant.now().toString(),
-                        toExpiryDateTime(accessToken.getLifetime()),
-                        null);
+        AccessTokenMetadata accessTokenMetadata = new AccessTokenMetadata();
+        accessTokenMetadata.setCreationDateTime(Instant.now().toString());
+        accessTokenMetadata.setExpiryDateTime(toExpiryDateTime(accessToken.getLifetime()));
         ipvSessionItem.setAccessToken(DigestUtils.sha256Hex(accessToken.getValue()));
         ipvSessionItem.setAccessTokenMetadata(accessTokenMetadata);
         updateIpvSession(ipvSessionItem);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.ipv.core.library.service;
 
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -146,5 +148,40 @@ class IpvSessionServiceTest {
         ipvSessionService.updateIpvSession(ipvSessionItem);
 
         verify(mockDataStore).update(ipvSessionItem);
+    }
+
+    @Test
+    void shouldSetAuthorizationCodeAndMetadataOnSessionItem() {
+        AuthorizationCode testCode = new AuthorizationCode();
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setUserState(UserStates.IPV_SUCCESS_PAGE.toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+
+        ipvSessionService.setAuthorizationCode(
+                ipvSessionItem, testCode.getValue(), "http://example.com");
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockDataStore).update(ipvSessionItemArgumentCaptor.capture());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getAuthorizationCode());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getAuthorizationCodeMetadata());
+    }
+
+    @Test
+    void shouldSetAccessTokenAndMetadataOnSessionItem() {
+        BearerAccessToken accessToken = new BearerAccessToken("test-access-token");
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setUserState(UserStates.IPV_SUCCESS_PAGE.toString());
+        ipvSessionItem.setCreationDateTime(new Date().toString());
+
+        ipvSessionService.setAccessToken(ipvSessionItem, accessToken);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockDataStore).update(ipvSessionItemArgumentCaptor.capture());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getAccessToken());
+        assertNotNull(ipvSessionItemArgumentCaptor.getValue().getAccessTokenMetadata());
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Write the authorization code, access token and a metadata object for each to the session table.

### Why did it change

We want to streamline the auth code/access token storage by folding them into the session table. To stage out the changes into production, this PR just starts by writing the auth code, access token and associated metadata to the session table alongside the existing tables.

### Issue tracking
- [PYIC-1694](https://govukverify.atlassian.net/browse/PYIC-1694)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed