### PR TITLE
PYIC-1695 Refactor storage: read auth code+access token from session

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -185,8 +185,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub access-token-${Environment}
-          AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AuthCodesTable.Arn]]
-          ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AccessTokensTable.Arn]]
           CLIENT_AUTH_JWT_IDS_TABLE_NAME: !Ref ClientAuthJwtIdsTable
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
       Policies:
@@ -194,10 +192,6 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref AccessTokensTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref AuthCodesTable
         - DynamoDBCrudPolicy:
             TableName: !Ref ClientAuthJwtIdsTable
         - SSMParameterReadPolicy:
@@ -255,14 +249,9 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub session-end-${Environment}
-          AUTH_CODES_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AuthCodesTable.Arn]]
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
-        - DynamoDBWritePolicy:
-            TableName: !Ref AuthCodesTable
-        - DynamoDBReadPolicy:
-            TableName: !Ref AuthCodesTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
@@ -656,7 +645,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub user-identity-${Environment}
-          ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AccessTokensTable.Arn]]
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsV2Table.Arn]]
           IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
@@ -665,8 +653,6 @@ Resources:
             TableName: !Ref UserIssuedCredentialsV2Table
         - DynamoDBWritePolicy:
             TableName: !Ref UserIssuedCredentialsV2Table
-        - DynamoDBCrudPolicy:
-            TableName: !Ref AccessTokensTable
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
@@ -1038,46 +1024,6 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
 
-  AuthCodesTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
-      TableName: !Sub "auth-codes-${Environment}"
-      BillingMode: "PAY_PER_REQUEST"
-      AttributeDefinitions:
-        - AttributeName: "authCode"
-          AttributeType: "S"
-      KeySchema:
-        - AttributeName: "authCode"
-          KeyType: "HASH"
-      TimeToLiveSpecification:
-        AttributeName: "ttl"
-        Enabled: true
-      SSESpecification:
-        # checkov:skip=CKV_AWS_119: Implement Customer Managed Keys in PYIC-1391
-        SSEEnabled: true
-        SSEType: KMS
-
-  AccessTokensTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
-      TableName: !Sub "access-tokens-${Environment}"
-      BillingMode: "PAY_PER_REQUEST"
-      AttributeDefinitions:
-        - AttributeName: "accessToken"
-          AttributeType: "S"
-      KeySchema:
-        - AttributeName: "accessToken"
-          KeyType: "HASH"
-      TimeToLiveSpecification:
-        AttributeName: "ttl"
-        Enabled: true
-      SSESpecification:
-        # checkov:skip=CKV_AWS_119: Implement Customer Managed Keys in PYIC-1391
-        SSEEnabled: true
-        SSEType: KMS
-
   SessionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -1090,6 +1036,19 @@ Resources:
       KeySchema:
         - AttributeName: "ipvSessionId"
           KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "authorizationCode-index"
+          KeySchema:
+            - AttributeName: "authorizationCode"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: "ALL"
+        - IndexName: "accessToken-index"
+          KeySchema:
+            - AttributeName: "accessToken"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: "ALL"
       TimeToLiveSpecification:
         AttributeName: "ttl"
         Enabled: true

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -17,10 +17,10 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.exceptions.ClientAuthenticationException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
 import uk.gov.di.ipv.core.library.service.AuthorizationCodeService;
@@ -90,16 +90,16 @@ public class AccessTokenHandler
                         validationResult.getError().toJSONObject());
             }
 
-            AuthorizationCodeItem authorizationCodeItem =
-                    authorizationCodeService
-                            .getAuthorizationCodeItem(
+            IpvSessionItem ipvSessionItem =
+                    sessionService
+                            .getIpvSessionByAuthorizationCode(
                                     authorizationGrant.getAuthorizationCode().getValue())
                             .orElseThrow();
 
-            LogHelper.attachIpvSessionIdToLogs(authorizationCodeItem.getIpvSessionId());
+            LogHelper.attachIpvSessionIdToLogs(ipvSessionItem.getIpvSessionId());
 
-            if (authorizationCodeItem.getIssuedAccessToken() != null) {
-                ErrorObject error = revokeAccessToken(authorizationCodeItem.getIssuedAccessToken());
+            if (ipvSessionItem.getAccessToken() != null) {
+                ErrorObject error = revokeAccessToken(ipvSessionItem);
                 LogHelper.logOauthError(
                         "Auth code has been used multiple times",
                         error.getCode(),
@@ -108,20 +108,23 @@ public class AccessTokenHandler
                         error.getHTTPStatusCode(), error.toJSONObject());
             }
 
-            if (authorizationCodeService.isExpired(authorizationCodeItem)) {
+            if (authorizationCodeService.isExpired(ipvSessionItem.getAuthorizationCodeMetadata())) {
                 ErrorObject error =
                         OAuth2Error.INVALID_GRANT.setDescription("Authorization code expired");
                 LogHelper.logOauthError(
                         String.format(
                                 "Access Token could not be issued. The supplied authorization code has expired. Created at: %s",
-                                authorizationCodeItem.getCreationDateTime()),
+                                ipvSessionItem
+                                        .getAuthorizationCodeMetadata()
+                                        .getCreationDateTime()),
                         error.getCode(),
                         error.getDescription());
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         error.getHTTPStatusCode(), error.toJSONObject());
             }
 
-            if (redirectUrlsDoNotMatch(authorizationCodeItem, authorizationGrant)) {
+            if (redirectUrlsDoNotMatch(
+                    ipvSessionItem.getAuthorizationCodeMetadata(), authorizationGrant)) {
                 ErrorObject error =
                         OAuth2Error.INVALID_GRANT.setDescription(
                                 "Redirect URL in token request does not match redirect URL received in auth code request");
@@ -129,7 +132,7 @@ public class AccessTokenHandler
                 LogHelper.logOauthError(
                         String.format(
                                 "Invalid redirect URL value received. Session ID: %s",
-                                authorizationCodeItem.getIpvSessionId()),
+                                ipvSessionItem.getIpvSessionId()),
                         error.getCode(),
                         error.getDescription());
 
@@ -140,15 +143,8 @@ public class AccessTokenHandler
             AccessTokenResponse accessTokenResponse =
                     accessTokenService.generateAccessToken().toSuccessResponse();
 
-            String sessionId = authorizationCodeItem.getIpvSessionId();
-            accessTokenService.persistAccessToken(accessTokenResponse, sessionId);
-            IpvSessionItem ipvSessionItem = sessionService.getIpvSession(sessionId);
             sessionService.setAccessToken(
                     ipvSessionItem, accessTokenResponse.getTokens().getBearerAccessToken());
-
-            authorizationCodeService.setIssuedAccessToken(
-                    authorizationCodeItem.getAuthCode(),
-                    accessTokenResponse.getTokens().getBearerAccessToken().getValue());
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_OK, accessTokenResponse.toJSONObject());
@@ -190,15 +186,15 @@ public class AccessTokenHandler
 
     @Tracing
     private boolean redirectUrlsDoNotMatch(
-            AuthorizationCodeItem authorizationCodeItem,
+            AuthorizationCodeMetadata authorizationCodeMetadata,
             AuthorizationCodeGrant authorizationGrant) {
 
-        if (Objects.isNull(authorizationCodeItem.getRedirectUrl())
+        if (Objects.isNull(authorizationCodeMetadata.getRedirectUrl())
                 && Objects.isNull(authorizationGrant.getRedirectionURI())) {
             return false;
         }
 
-        if (Objects.isNull(authorizationCodeItem.getRedirectUrl())
+        if (Objects.isNull(authorizationCodeMetadata.getRedirectUrl())
                 || Objects.isNull(authorizationGrant.getRedirectionURI())) {
             return true;
         }
@@ -206,12 +202,12 @@ public class AccessTokenHandler
         return !authorizationGrant
                 .getRedirectionURI()
                 .toString()
-                .equals(authorizationCodeItem.getRedirectUrl());
+                .equals(authorizationCodeMetadata.getRedirectUrl());
     }
 
-    private ErrorObject revokeAccessToken(String accessToken) {
+    private ErrorObject revokeAccessToken(IpvSessionItem ipvSessionItem) {
         try {
-            accessTokenService.revokeAccessToken(accessToken);
+            sessionService.revokeAccessToken(ipvSessionItem);
             return OAuth2Error.INVALID_GRANT.setDescription(
                     "Authorization code used too many times");
         } catch (IllegalArgumentException e) {

--- a/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
+++ b/lambdas/sessionend/src/main/java/uk/gov/di/ipv/core/sessionend/SessionEndHandler.java
@@ -117,10 +117,6 @@ public class SessionEndHandler
                 AuthorizationCode authorizationCode =
                         authorizationCodeService.generateAuthorizationCode();
 
-                authorizationCodeService.persistAuthorizationCode(
-                        authorizationCode.getValue(),
-                        ipvSessionId,
-                        authorizationRequest.getRedirectionURI().toString());
                 sessionService.setAuthorizationCode(
                         ipvSessionItem,
                         authorizationCode.getValue(),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
@@ -1,8 +1,6 @@
 package uk.gov.di.ipv.core.library.config;
 
 public enum EnvironmentVariable {
-    ACCESS_TOKENS_TABLE_NAME,
-    AUTH_CODES_TABLE_NAME,
     BEARER_TOKEN_TTL,
     CLIENT_AUTH_JWT_IDS_TABLE_NAME,
     CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX,

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AccessTokenMetadata.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AccessTokenMetadata.java
@@ -10,11 +10,14 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 public class AccessTokenMetadata {
     private String creationDateTime;
     private String expiryDateTime;
+    private String revokedAtDateTime;
 
     public AccessTokenMetadata() {}
 
-    public AccessTokenMetadata(String creationDateTime, String expiryDateTime) {
+    public AccessTokenMetadata(
+            String creationDateTime, String expiryDateTime, String revokedAtDateTime) {
         this.creationDateTime = creationDateTime;
         this.expiryDateTime = expiryDateTime;
+        this.revokedAtDateTime = revokedAtDateTime;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.persistence.item;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
@@ -66,6 +67,7 @@ public class IpvSessionItem implements DynamodbItem {
         return credentialIssuerSessionDetails;
     }
 
+    @DynamoDbSecondaryPartitionKey(indexNames = "authorizationCode-index")
     public String getAuthorizationCode() {
         return authorizationCode;
     }
@@ -82,6 +84,7 @@ public class IpvSessionItem implements DynamodbItem {
         this.authorizationCodeMetadata = authorizationCodeMetadata;
     }
 
+    @DynamoDbSecondaryPartitionKey(indexNames = "accessToken-index")
     public String getAccessToken() {
         return accessToken;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -10,39 +10,13 @@ import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
-import com.nimbusds.oauth2.sdk.util.StringUtils;
-import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.persistence.DataStore;
-import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
-
-import java.time.Instant;
-import java.util.Objects;
-
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ACCESS_TOKENS_TABLE_NAME;
 
 public class AccessTokenService {
     protected static final Scope DEFAULT_SCOPE = new Scope("user-credentials");
-    private final DataStore<AccessTokenItem> dataStore;
     private final ConfigurationService configurationService;
 
-    @ExcludeFromGeneratedCoverageReport
     public AccessTokenService(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
-        boolean isRunningLocally = this.configurationService.isRunningLocally();
-        this.dataStore =
-                new DataStore<>(
-                        this.configurationService.getEnvironmentVariable(ACCESS_TOKENS_TABLE_NAME),
-                        AccessTokenItem.class,
-                        DataStore.getClient(isRunningLocally),
-                        isRunningLocally,
-                        configurationService);
-    }
-
-    public AccessTokenService(
-            DataStore<AccessTokenItem> dataStore, ConfigurationService configurationService) {
-        this.dataStore = dataStore;
         this.configurationService = configurationService;
     }
 
@@ -58,40 +32,5 @@ public class AccessTokenService {
             return new ValidationResult<>(false, OAuth2Error.UNSUPPORTED_GRANT_TYPE);
         }
         return ValidationResult.createValidResult();
-    }
-
-    public AccessTokenItem getAccessToken(String accessToken) {
-        return dataStore.getItem(DigestUtils.sha256Hex(accessToken));
-    }
-
-    public void persistAccessToken(AccessTokenResponse tokenResponse, String ipvSessionId) {
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        BearerAccessToken accessToken = tokenResponse.getTokens().getBearerAccessToken();
-        accessTokenItem.setAccessToken(DigestUtils.sha256Hex(accessToken.getValue()));
-        accessTokenItem.setIpvSessionId(ipvSessionId);
-        accessTokenItem.setExpiryDateTime(toExpiryDateTime(accessToken.getLifetime()));
-        dataStore.create(accessTokenItem);
-    }
-
-    public void revokeAccessToken(AccessTokenItem accessTokenItem) throws IllegalArgumentException {
-        if (StringUtils.isBlank(accessTokenItem.getRevokedAtDateTime())) {
-            accessTokenItem.setRevokedAtDateTime(Instant.now().toString());
-            dataStore.update(accessTokenItem);
-        }
-    }
-
-    public void revokeAccessToken(String accessToken) throws IllegalArgumentException {
-        AccessTokenItem accessTokenItem = dataStore.getItem(accessToken);
-
-        if (Objects.nonNull(accessTokenItem)) {
-            revokeAccessToken(accessTokenItem);
-        } else {
-            throw new IllegalArgumentException(
-                    "Failed to revoke access token - access token could not be found in DynamoDB");
-        }
-    }
-
-    private String toExpiryDateTime(long expirySeconds) {
-        return Instant.now().plusSeconds(expirySeconds).toString();
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeService.java
@@ -1,72 +1,24 @@
 package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
-import uk.gov.di.ipv.core.library.persistence.DataStore;
-import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
+import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 
 import java.time.Instant;
-import java.util.Optional;
-
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.AUTH_CODES_TABLE_NAME;
 
 public class AuthorizationCodeService {
-    private final DataStore<AuthorizationCodeItem> dataStore;
     private final ConfigurationService configurationService;
 
-    @ExcludeFromGeneratedCoverageReport
     public AuthorizationCodeService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        boolean isRunningLocally = this.configurationService.isRunningLocally();
-        this.dataStore =
-                new DataStore<>(
-                        this.configurationService.getEnvironmentVariable(AUTH_CODES_TABLE_NAME),
-                        AuthorizationCodeItem.class,
-                        DataStore.getClient(isRunningLocally),
-                        isRunningLocally,
-                        configurationService);
-    }
-
-    public AuthorizationCodeService(
-            DataStore<AuthorizationCodeItem> dataStore, ConfigurationService configurationService) {
-        this.configurationService = configurationService;
-        this.dataStore = dataStore;
     }
 
     public AuthorizationCode generateAuthorizationCode() {
         return new AuthorizationCode();
     }
 
-    public Optional<AuthorizationCodeItem> getAuthorizationCodeItem(String authorizationCode) {
-        AuthorizationCodeItem authorizationCodeItem =
-                dataStore.getItem(DigestUtils.sha256Hex(authorizationCode));
-        return Optional.ofNullable(authorizationCodeItem);
-    }
-
-    public void persistAuthorizationCode(
-            String authorizationCode, String ipvSessionId, String redirectUrl) {
-        AuthorizationCodeItem authorizationCodeItem =
-                new AuthorizationCodeItem(
-                        DigestUtils.sha256Hex(authorizationCode),
-                        ipvSessionId,
-                        redirectUrl,
-                        Instant.now().toString());
-
-        dataStore.create(authorizationCodeItem);
-    }
-
-    public void setIssuedAccessToken(String authorizationCode, String accessToken) {
-        AuthorizationCodeItem authorizationCodeItem = dataStore.getItem(authorizationCode);
-        authorizationCodeItem.setIssuedAccessToken(DigestUtils.sha256Hex(accessToken));
-        authorizationCodeItem.setExchangeDateTime(Instant.now().toString());
-
-        dataStore.update(authorizationCodeItem);
-    }
-
-    public boolean isExpired(AuthorizationCodeItem authCodeItem) {
-        return Instant.parse(authCodeItem.getCreationDateTime())
+    public boolean isExpired(AuthorizationCodeMetadata authorizationCodeMetadata) {
+        return Instant.parse(authorizationCodeMetadata.getCreationDateTime())
                 .isBefore(
                         Instant.now()
                                 .minusSeconds(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
@@ -7,43 +7,29 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
 import com.nimbusds.oauth2.sdk.TokenResponse;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
-import com.nimbusds.oauth2.sdk.token.Tokens;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
-import uk.gov.di.ipv.core.library.persistence.DataStore;
-import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
 import java.net.URI;
-import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.service.AccessTokenService.DEFAULT_SCOPE;
 
 @ExtendWith(MockitoExtension.class)
 class AccessTokenServiceTest {
-
-    @Mock private DataStore<AccessTokenItem> mockDataStore;
     @Mock private ConfigurationService mockConfigurationService;
 
     private AccessTokenService accessTokenService;
 
     @BeforeEach
     void setUp() {
-        this.accessTokenService = new AccessTokenService(mockDataStore, mockConfigurationService);
+        this.accessTokenService = new AccessTokenService(mockConfigurationService);
     }
 
     @Test
@@ -84,104 +70,5 @@ class AccessTokenServiceTest {
         assertNotNull(validationResult);
         assertTrue(validationResult.isValid());
         assertNull(validationResult.getError());
-    }
-
-    @Test
-    void shouldPersistAccessToken() {
-        String testIpvSessionId = SecureTokenHelper.generate();
-        AccessToken accessToken = new BearerAccessToken();
-        AccessTokenResponse accessTokenResponse =
-                new AccessTokenResponse(new Tokens(accessToken, null));
-        ArgumentCaptor<AccessTokenItem> accessTokenItemArgCaptor =
-                ArgumentCaptor.forClass(AccessTokenItem.class);
-
-        accessTokenService.persistAccessToken(accessTokenResponse, testIpvSessionId);
-
-        verify(mockDataStore).create(accessTokenItemArgCaptor.capture());
-        AccessTokenItem capturedAccessTokenItem = accessTokenItemArgCaptor.getValue();
-        assertNotNull(capturedAccessTokenItem);
-        assertEquals(testIpvSessionId, capturedAccessTokenItem.getIpvSessionId());
-        assertEquals(
-                DigestUtils.sha256Hex(
-                        accessTokenResponse.getTokens().getBearerAccessToken().getValue()),
-                capturedAccessTokenItem.getAccessToken());
-    }
-
-    @Test
-    void shouldGetAccessTokenItemWhenValidAccessTokenProvided() {
-        String testIpvSessionId = SecureTokenHelper.generate();
-        String accessToken = new BearerAccessToken().getValue();
-
-        AccessTokenItem expectedAccessTokenItem = new AccessTokenItem();
-        expectedAccessTokenItem.setIpvSessionId(testIpvSessionId);
-        when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken)))
-                .thenReturn(expectedAccessTokenItem);
-
-        AccessTokenItem actualAccessTokenItem = accessTokenService.getAccessToken(accessToken);
-
-        verify(mockDataStore).getItem(DigestUtils.sha256Hex(accessToken));
-
-        assertNotNull(actualAccessTokenItem);
-        assertEquals(expectedAccessTokenItem, actualAccessTokenItem);
-    }
-
-    @Test
-    void shouldReturnNullWhenInvalidAccessTokenProvided() {
-        String accessToken = new BearerAccessToken().getValue();
-
-        when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken))).thenReturn(null);
-
-        AccessTokenItem actualAccessTokenItem = accessTokenService.getAccessToken(accessToken);
-
-        verify(mockDataStore).getItem(DigestUtils.sha256Hex(accessToken));
-        assertNull(actualAccessTokenItem);
-    }
-
-    @Test
-    void shouldRevokeAccessToken() {
-        String accessToken = "test-access-token";
-
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(accessToken);
-
-        when(mockDataStore.getItem(accessToken)).thenReturn(accessTokenItem);
-
-        accessTokenService.revokeAccessToken(accessToken);
-
-        ArgumentCaptor<AccessTokenItem> accessTokenItemArgCaptor =
-                ArgumentCaptor.forClass(AccessTokenItem.class);
-
-        verify(mockDataStore).update(accessTokenItemArgCaptor.capture());
-        assertNotNull(accessTokenItemArgCaptor.getValue().getRevokedAtDateTime());
-    }
-
-    @Test
-    void shouldNotAttemptUpdateIfAccessTokenIsAlreadyRevoked() {
-        String accessToken = "test-access-token";
-
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(accessToken);
-        accessTokenItem.setRevokedAtDateTime(Instant.now().toString());
-
-        when(mockDataStore.getItem(accessToken)).thenReturn(accessTokenItem);
-
-        accessTokenService.revokeAccessToken(accessToken);
-
-        verify(mockDataStore, Mockito.times(0)).update(any());
-    }
-
-    @Test
-    void shouldThrowExceptionIfAccessTokenCanNotBeFoundWhenRevoking() {
-        String accessToken = "test-access-token";
-
-        when(mockDataStore.getItem(accessToken)).thenReturn(null);
-
-        IllegalArgumentException thrown =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> accessTokenService.revokeAccessToken(accessToken));
-        assertEquals(
-                "Failed to revoke access token - access token could not be found in DynamoDB",
-                thrown.getMessage());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuthorizationCodeServiceTest.java
@@ -1,39 +1,30 @@
 package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.persistence.DataStore;
-import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
+import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 
 import java.time.Instant;
-import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthorizationCodeServiceTest {
-
-    @Mock private DataStore<AuthorizationCodeItem> mockDataStore;
     @Mock private ConfigurationService mockConfigurationService;
 
     private AuthorizationCodeService authorizationCodeService;
 
     @BeforeEach
     void setUp() {
-        authorizationCodeService =
-                new AuthorizationCodeService(mockDataStore, mockConfigurationService);
+        authorizationCodeService = new AuthorizationCodeService(mockConfigurationService);
     }
 
     @Test
@@ -44,97 +35,22 @@ class AuthorizationCodeServiceTest {
     }
 
     @Test
-    void shouldCreateAuthorizationCodeInDataStore() {
-        AuthorizationCode testCode = new AuthorizationCode();
-        String ipvSessionId = "session-12345";
-        String redirectUrl = "https://example.com/callback";
-        authorizationCodeService.persistAuthorizationCode(
-                testCode.getValue(), ipvSessionId, redirectUrl);
-
-        ArgumentCaptor<AuthorizationCodeItem> authorizationCodeItemArgumentCaptor =
-                ArgumentCaptor.forClass(AuthorizationCodeItem.class);
-        verify(mockDataStore).create(authorizationCodeItemArgumentCaptor.capture());
-        assertEquals(
-                ipvSessionId, authorizationCodeItemArgumentCaptor.getValue().getIpvSessionId());
-        assertEquals(
-                DigestUtils.sha256Hex(testCode.getValue()),
-                authorizationCodeItemArgumentCaptor.getValue().getAuthCode());
-        assertEquals(redirectUrl, authorizationCodeItemArgumentCaptor.getValue().getRedirectUrl());
-    }
-
-    @Test
-    void shouldGetSessionIdByAuthCodeWhenValidAuthCodeProvided() {
-        AuthorizationCode testCode = new AuthorizationCode();
-        String ipvSessionId = "session-12345";
-
-        AuthorizationCodeItem testItem = new AuthorizationCodeItem();
-        testItem.setIpvSessionId(ipvSessionId);
-
-        when(mockDataStore.getItem(DigestUtils.sha256Hex(testCode.getValue())))
-                .thenReturn(testItem);
-
-        AuthorizationCodeItem authorizationCodeItem =
-                authorizationCodeService.getAuthorizationCodeItem(testCode.getValue()).get();
-
-        verify(mockDataStore).getItem(DigestUtils.sha256Hex(testCode.getValue()));
-        assertEquals(ipvSessionId, authorizationCodeItem.getIpvSessionId());
-    }
-
-    @Test
-    void shouldReturnEmptyOptionalWhenInvalidAuthCodeProvided() {
-        AuthorizationCode testCode = new AuthorizationCode();
-
-        when(mockDataStore.getItem(DigestUtils.sha256Hex(testCode.getValue()))).thenReturn(null);
-
-        Optional<AuthorizationCodeItem> authorizationCodeItem =
-                authorizationCodeService.getAuthorizationCodeItem(testCode.getValue());
-
-        verify(mockDataStore).getItem(DigestUtils.sha256Hex(testCode.getValue()));
-        assertTrue(authorizationCodeItem.isEmpty());
-    }
-
-    @Test
-    void shouldCallUpdateWithIssuedAccessTokenValue() {
-        AuthorizationCode testCode = new AuthorizationCode();
-        AuthorizationCodeItem authorizationCodeItem = new AuthorizationCodeItem();
-        authorizationCodeItem.setAuthCode(testCode.getValue());
-        authorizationCodeItem.setIpvSessionId("test-session-id");
-        authorizationCodeItem.setRedirectUrl("http://example.com");
-        authorizationCodeItem.setExchangeDateTime(Instant.now().toString());
-
-        when(mockDataStore.getItem(testCode.getValue())).thenReturn(authorizationCodeItem);
-        authorizationCodeService.setIssuedAccessToken(testCode.getValue(), "test-access-token");
-
-        ArgumentCaptor<AuthorizationCodeItem> authorizationCodeItemArgumentCaptor =
-                ArgumentCaptor.forClass(AuthorizationCodeItem.class);
-        verify(mockDataStore).update(authorizationCodeItemArgumentCaptor.capture());
-
-        assertNotNull(authorizationCodeItemArgumentCaptor.getValue().getExchangeDateTime());
-    }
-
-    @Test
     void isExpiredReturnsTrueIfAuthCodeItemHasExpired() {
         when(mockConfigurationService.getSsmParameter(any())).thenReturn("600");
-        AuthorizationCodeItem expiredAuthCodeItem =
-                new AuthorizationCodeItem(
-                        "auth-code",
-                        "ipv-session-id",
-                        "redirect-url",
-                        Instant.now().minusSeconds(601).toString());
+        AuthorizationCodeMetadata expiredAuthCodeMetadata =
+                new AuthorizationCodeMetadata(
+                        "redirect-url", Instant.now().minusSeconds(601).toString());
 
-        assertTrue(authorizationCodeService.isExpired(expiredAuthCodeItem));
+        assertTrue(authorizationCodeService.isExpired(expiredAuthCodeMetadata));
     }
 
     @Test
     void isExpiredReturnsFalseIfAuthCodeItemHasNotExpired() {
         when(mockConfigurationService.getSsmParameter(any())).thenReturn("600");
-        AuthorizationCodeItem expiredAuthCodeItem =
-                new AuthorizationCodeItem(
-                        "auth-code",
-                        "resource-id",
-                        "redirect-url",
-                        Instant.now().minusSeconds(599).toString());
+        AuthorizationCodeMetadata expiredAuthCodeMetadata =
+                new AuthorizationCodeMetadata(
+                        "redirect-url", Instant.now().minusSeconds(599).toString());
 
-        assertFalse(authorizationCodeService.isExpired(expiredAuthCodeItem));
+        assertFalse(authorizationCodeService.isExpired(expiredAuthCodeMetadata));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
@@ -18,6 +19,8 @@ import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,6 +56,40 @@ class IpvSessionServiceTest {
         assertEquals(ipvSessionItem.getIpvSessionId(), result.getIpvSessionId());
         assertEquals(ipvSessionItem.getUserState(), result.getUserState());
         assertEquals(ipvSessionItem.getCreationDateTime(), result.getCreationDateTime());
+    }
+
+    @Test
+    void shouldReturnSessionItemByAuthorizationCode() {
+        String ipvSessionID = SecureTokenHelper.generate();
+        String authorizationCode = "12345";
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(ipvSessionID);
+
+        when(mockDataStore.getItemByIndex(eq("authorizationCode-index"), anyString()))
+                .thenReturn(ipvSessionItem);
+
+        IpvSessionItem result =
+                ipvSessionService.getIpvSessionByAuthorizationCode(authorizationCode).orElseThrow();
+
+        assertEquals(result, ipvSessionItem);
+    }
+
+    @Test
+    void shouldReturnSessionItemByAccessToken() {
+        String ipvSessionID = SecureTokenHelper.generate();
+        String accessToken = "98765";
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(ipvSessionID);
+
+        when(mockDataStore.getItemByIndex(eq("accessToken-index"), anyString()))
+                .thenReturn(ipvSessionItem);
+
+        IpvSessionItem result =
+                ipvSessionService.getIpvSessionByAccessToken(accessToken).orElseThrow();
+
+        assertEquals(result, ipvSessionItem);
     }
 
     @Test
@@ -182,5 +219,25 @@ class IpvSessionServiceTest {
         verify(mockDataStore).update(ipvSessionItemArgumentCaptor.capture());
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getAccessToken());
         assertNotNull(ipvSessionItemArgumentCaptor.getValue().getAccessTokenMetadata());
+    }
+
+    @Test
+    void shouldRevokeAccessTokenOnSessionItem() {
+        BearerAccessToken accessToken = new BearerAccessToken("test-access-token");
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setAccessToken(accessToken.getValue());
+        ipvSessionItem.setAccessTokenMetadata(new AccessTokenMetadata());
+
+        ipvSessionService.revokeAccessToken(ipvSessionItem);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockDataStore).update(ipvSessionItemArgumentCaptor.capture());
+        assertNotNull(
+                ipvSessionItemArgumentCaptor
+                        .getValue()
+                        .getAccessTokenMetadata()
+                        .getRevokedAtDateTime());
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Read authorization code, access token and metadata from from sessions table and remove old tables

### Why did it change

We've streamlined the storage of the authorization codes and access tokens so they now sit in the sessions table rather than their own separate tables. The associated metadata for each is also stored in its own object in the session. This PR completes the migration to read the auth codes, access tokens and metadata from the session (via secondary index) and remove the old tables.

### Issue tracking
- [PYIC-1695](https://govukverify.atlassian.net/browse/PYIC-1695)
