### PR TITLE
PYIC-1729 Refactor storage: read access token from session

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -185,7 +185,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub access-token-${Environment}
-          ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AccessTokensTable.Arn]]
           CLIENT_AUTH_JWT_IDS_TABLE_NAME: !Ref ClientAuthJwtIdsTable
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
       Policies:
@@ -193,8 +192,6 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref AccessTokensTable
         - DynamoDBCrudPolicy:
             TableName: !Ref ClientAuthJwtIdsTable
         - SSMParameterReadPolicy:
@@ -648,7 +645,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub user-identity-${Environment}
-          ACCESS_TOKENS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt AccessTokensTable.Arn]]
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsV2Table.Arn]]
           IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
@@ -657,9 +653,9 @@ Resources:
             TableName: !Ref UserIssuedCredentialsV2Table
         - DynamoDBWritePolicy:
             TableName: !Ref UserIssuedCredentialsV2Table
-        - DynamoDBCrudPolicy:
-            TableName: !Ref AccessTokensTable
         - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
+        - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
@@ -1030,26 +1026,6 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
 
-  AccessTokensTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
-      TableName: !Sub "access-tokens-${Environment}"
-      BillingMode: "PAY_PER_REQUEST"
-      AttributeDefinitions:
-        - AttributeName: "accessToken"
-          AttributeType: "S"
-      KeySchema:
-        - AttributeName: "accessToken"
-          KeyType: "HASH"
-      TimeToLiveSpecification:
-        AttributeName: "ttl"
-        Enabled: true
-      SSESpecification:
-        # checkov:skip=CKV_AWS_119: Implement Customer Managed Keys in PYIC-1391
-        SSEEnabled: true
-        SSEType: KMS
-
   SessionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -1061,6 +1037,8 @@ Resources:
           AttributeType: "S"
         - AttributeName: "authorizationCode"
           AttributeType: "S"
+        - AttributeName: "accessToken"
+          AttributeType: "S"
       KeySchema:
         - AttributeName: "ipvSessionId"
           KeyType: "HASH"
@@ -1068,6 +1046,12 @@ Resources:
         - IndexName: "authorizationCode"
           KeySchema:
             - AttributeName: "authorizationCode"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: "ALL"
+        - IndexName: "accessToken"
+          KeySchema:
+            - AttributeName: "accessToken"
               KeyType: "HASH"
           Projection:
             ProjectionType: "ALL"

--- a/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
+++ b/lambdas/accesstoken/src/main/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandler.java
@@ -95,7 +95,7 @@ public class AccessTokenHandler
             LogHelper.attachIpvSessionIdToLogs(ipvSessionItem.getIpvSessionId());
 
             if (ipvSessionItem.getAccessToken() != null) {
-                ErrorObject error = revokeAccessToken(ipvSessionItem.getAccessToken());
+                ErrorObject error = revokeAccessToken(ipvSessionItem);
                 LogHelper.logOauthError(
                         "Auth code has been used multiple times",
                         error.getCode(),
@@ -143,9 +143,6 @@ public class AccessTokenHandler
 
             AccessTokenResponse accessTokenResponse =
                     accessTokenService.generateAccessToken().toSuccessResponse();
-
-            String sessionId = ipvSessionItem.getIpvSessionId();
-            accessTokenService.persistAccessToken(accessTokenResponse, sessionId);
             sessionService.setAccessToken(
                     ipvSessionItem, accessTokenResponse.getTokens().getBearerAccessToken());
 
@@ -208,9 +205,9 @@ public class AccessTokenHandler
                 .equals(authorizationCodeMetadata.getRedirectUrl());
     }
 
-    private ErrorObject revokeAccessToken(String accessToken) {
+    private ErrorObject revokeAccessToken(IpvSessionItem ipvSessionItem) {
         try {
-            accessTokenService.revokeAccessToken(accessToken);
+            sessionService.revokeAccessToken(ipvSessionItem);
             return OAuth2Error.INVALID_GRANT.setDescription(
                     "Authorization code used too many times");
         } catch (IllegalArgumentException e) {

--- a/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
+++ b/lambdas/accesstoken/src/test/java/uk/gov/di/ipv/core/accesstoken/AccessTokenHandlerTest.java
@@ -283,7 +283,7 @@ class AccessTokenHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        verify(mockAccessTokenService).revokeAccessToken(TEST_ACCESS_TOKEN);
+        verify(mockSessionService).revokeAccessToken(mockSessionItem);
 
         ErrorObject errorResponse = createErrorObjectFromResponse(response.getBody());
         assertEquals(HTTPResponse.SC_BAD_REQUEST, response.getStatusCode());
@@ -308,8 +308,8 @@ class AccessTokenHandlerTest {
 
         String errorMessage = "Failed to revoke access token";
         doThrow(new IllegalArgumentException(errorMessage))
-                .when(mockAccessTokenService)
-                .revokeAccessToken(any(String.class));
+                .when(mockSessionService)
+                .revokeAccessToken(mockSessionItem);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.library.config;
 
 public enum EnvironmentVariable {
-    ACCESS_TOKENS_TABLE_NAME,
     BEARER_TOKEN_TTL,
     CLIENT_AUTH_JWT_IDS_TABLE_NAME,
     CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX,

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AccessTokenMetadata.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/AccessTokenMetadata.java
@@ -10,11 +10,14 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 public class AccessTokenMetadata {
     private String creationDateTime;
     private String expiryDateTime;
+    private String revokedAtDateTime;
 
     public AccessTokenMetadata() {}
 
-    public AccessTokenMetadata(String creationDateTime, String expiryDateTime) {
+    public AccessTokenMetadata(
+            String creationDateTime, String expiryDateTime, String revokedAtDateTime) {
         this.creationDateTime = creationDateTime;
         this.expiryDateTime = expiryDateTime;
+        this.revokedAtDateTime = revokedAtDateTime;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -84,6 +84,7 @@ public class IpvSessionItem implements DynamodbItem {
         this.authorizationCodeMetadata = authorizationCodeMetadata;
     }
 
+    @DynamoDbSecondaryPartitionKey(indexNames = "accessToken")
     public String getAccessToken() {
         return accessToken;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/AccessTokenService.java
@@ -10,39 +10,13 @@ import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
-import com.nimbusds.oauth2.sdk.util.StringUtils;
-import org.apache.commons.codec.digest.DigestUtils;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.persistence.DataStore;
-import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
-
-import java.time.Instant;
-import java.util.Objects;
-
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ACCESS_TOKENS_TABLE_NAME;
 
 public class AccessTokenService {
     protected static final Scope DEFAULT_SCOPE = new Scope("user-credentials");
-    private final DataStore<AccessTokenItem> dataStore;
     private final ConfigurationService configurationService;
 
-    @ExcludeFromGeneratedCoverageReport
     public AccessTokenService(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
-        boolean isRunningLocally = this.configurationService.isRunningLocally();
-        this.dataStore =
-                new DataStore<>(
-                        this.configurationService.getEnvironmentVariable(ACCESS_TOKENS_TABLE_NAME),
-                        AccessTokenItem.class,
-                        DataStore.getClient(isRunningLocally),
-                        isRunningLocally,
-                        configurationService);
-    }
-
-    public AccessTokenService(
-            DataStore<AccessTokenItem> dataStore, ConfigurationService configurationService) {
-        this.dataStore = dataStore;
         this.configurationService = configurationService;
     }
 
@@ -58,40 +32,5 @@ public class AccessTokenService {
             return new ValidationResult<>(false, OAuth2Error.UNSUPPORTED_GRANT_TYPE);
         }
         return ValidationResult.createValidResult();
-    }
-
-    public AccessTokenItem getAccessToken(String accessToken) {
-        return dataStore.getItem(DigestUtils.sha256Hex(accessToken));
-    }
-
-    public void persistAccessToken(AccessTokenResponse tokenResponse, String ipvSessionId) {
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        BearerAccessToken accessToken = tokenResponse.getTokens().getBearerAccessToken();
-        accessTokenItem.setAccessToken(DigestUtils.sha256Hex(accessToken.getValue()));
-        accessTokenItem.setIpvSessionId(ipvSessionId);
-        accessTokenItem.setExpiryDateTime(toExpiryDateTime(accessToken.getLifetime()));
-        dataStore.create(accessTokenItem);
-    }
-
-    public void revokeAccessToken(AccessTokenItem accessTokenItem) throws IllegalArgumentException {
-        if (StringUtils.isBlank(accessTokenItem.getRevokedAtDateTime())) {
-            accessTokenItem.setRevokedAtDateTime(Instant.now().toString());
-            dataStore.update(accessTokenItem);
-        }
-    }
-
-    public void revokeAccessToken(String accessToken) throws IllegalArgumentException {
-        AccessTokenItem accessTokenItem = dataStore.getItem(accessToken);
-
-        if (Objects.nonNull(accessTokenItem)) {
-            revokeAccessToken(accessTokenItem);
-        } else {
-            throw new IllegalArgumentException(
-                    "Failed to revoke access token - access token could not be found in DynamoDB");
-        }
-    }
-
-    private String toExpiryDateTime(long expirySeconds) {
-        return Instant.now().plusSeconds(expirySeconds).toString();
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
@@ -55,6 +56,12 @@ public class IpvSessionService {
         return Optional.ofNullable(ipvSessionItem);
     }
 
+    public Optional<IpvSessionItem> getIpvSessionByAccessToken(String accessToken) {
+        IpvSessionItem ipvSessionItem =
+                dataStore.getItemByIndex("accessToken", DigestUtils.sha256Hex(accessToken));
+        return Optional.ofNullable(ipvSessionItem);
+    }
+
     public String getUserId(String ipvSessionId) {
         return this.getIpvSession(ipvSessionId).getClientSessionDetails().getUserId();
     }
@@ -101,6 +108,15 @@ public class IpvSessionService {
         ipvSessionItem.setAccessToken(DigestUtils.sha256Hex(accessToken.getValue()));
         ipvSessionItem.setAccessTokenMetadata(accessTokenMetadata);
         updateIpvSession(ipvSessionItem);
+    }
+
+    public void revokeAccessToken(IpvSessionItem ipvSessionItem) throws IllegalArgumentException {
+        AccessTokenMetadata accessTokenMetadata = ipvSessionItem.getAccessTokenMetadata();
+        if (StringUtils.isBlank(accessTokenMetadata.getRevokedAtDateTime())) {
+            accessTokenMetadata.setRevokedAtDateTime(Instant.now().toString());
+            ipvSessionItem.setAccessTokenMetadata(accessTokenMetadata);
+            updateIpvSession(ipvSessionItem);
+        }
     }
 
     public void updateIpvSession(IpvSessionItem updatedIpvSessionItem) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AccessTokenServiceTest.java
@@ -7,43 +7,29 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
 import com.nimbusds.oauth2.sdk.TokenResponse;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
-import com.nimbusds.oauth2.sdk.token.Tokens;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
-import uk.gov.di.ipv.core.library.persistence.DataStore;
-import uk.gov.di.ipv.core.library.persistence.item.AccessTokenItem;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
 import java.net.URI;
-import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.service.AccessTokenService.DEFAULT_SCOPE;
 
 @ExtendWith(MockitoExtension.class)
 class AccessTokenServiceTest {
-
-    @Mock private DataStore<AccessTokenItem> mockDataStore;
     @Mock private ConfigurationService mockConfigurationService;
 
     private AccessTokenService accessTokenService;
 
     @BeforeEach
     void setUp() {
-        this.accessTokenService = new AccessTokenService(mockDataStore, mockConfigurationService);
+        this.accessTokenService = new AccessTokenService(mockConfigurationService);
     }
 
     @Test
@@ -84,104 +70,5 @@ class AccessTokenServiceTest {
         assertNotNull(validationResult);
         assertTrue(validationResult.isValid());
         assertNull(validationResult.getError());
-    }
-
-    @Test
-    void shouldPersistAccessToken() {
-        String testIpvSessionId = SecureTokenHelper.generate();
-        AccessToken accessToken = new BearerAccessToken();
-        AccessTokenResponse accessTokenResponse =
-                new AccessTokenResponse(new Tokens(accessToken, null));
-        ArgumentCaptor<AccessTokenItem> accessTokenItemArgCaptor =
-                ArgumentCaptor.forClass(AccessTokenItem.class);
-
-        accessTokenService.persistAccessToken(accessTokenResponse, testIpvSessionId);
-
-        verify(mockDataStore).create(accessTokenItemArgCaptor.capture());
-        AccessTokenItem capturedAccessTokenItem = accessTokenItemArgCaptor.getValue();
-        assertNotNull(capturedAccessTokenItem);
-        assertEquals(testIpvSessionId, capturedAccessTokenItem.getIpvSessionId());
-        assertEquals(
-                DigestUtils.sha256Hex(
-                        accessTokenResponse.getTokens().getBearerAccessToken().getValue()),
-                capturedAccessTokenItem.getAccessToken());
-    }
-
-    @Test
-    void shouldGetAccessTokenItemWhenValidAccessTokenProvided() {
-        String testIpvSessionId = SecureTokenHelper.generate();
-        String accessToken = new BearerAccessToken().getValue();
-
-        AccessTokenItem expectedAccessTokenItem = new AccessTokenItem();
-        expectedAccessTokenItem.setIpvSessionId(testIpvSessionId);
-        when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken)))
-                .thenReturn(expectedAccessTokenItem);
-
-        AccessTokenItem actualAccessTokenItem = accessTokenService.getAccessToken(accessToken);
-
-        verify(mockDataStore).getItem(DigestUtils.sha256Hex(accessToken));
-
-        assertNotNull(actualAccessTokenItem);
-        assertEquals(expectedAccessTokenItem, actualAccessTokenItem);
-    }
-
-    @Test
-    void shouldReturnNullWhenInvalidAccessTokenProvided() {
-        String accessToken = new BearerAccessToken().getValue();
-
-        when(mockDataStore.getItem(DigestUtils.sha256Hex(accessToken))).thenReturn(null);
-
-        AccessTokenItem actualAccessTokenItem = accessTokenService.getAccessToken(accessToken);
-
-        verify(mockDataStore).getItem(DigestUtils.sha256Hex(accessToken));
-        assertNull(actualAccessTokenItem);
-    }
-
-    @Test
-    void shouldRevokeAccessToken() {
-        String accessToken = "test-access-token";
-
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(accessToken);
-
-        when(mockDataStore.getItem(accessToken)).thenReturn(accessTokenItem);
-
-        accessTokenService.revokeAccessToken(accessToken);
-
-        ArgumentCaptor<AccessTokenItem> accessTokenItemArgCaptor =
-                ArgumentCaptor.forClass(AccessTokenItem.class);
-
-        verify(mockDataStore).update(accessTokenItemArgCaptor.capture());
-        assertNotNull(accessTokenItemArgCaptor.getValue().getRevokedAtDateTime());
-    }
-
-    @Test
-    void shouldNotAttemptUpdateIfAccessTokenIsAlreadyRevoked() {
-        String accessToken = "test-access-token";
-
-        AccessTokenItem accessTokenItem = new AccessTokenItem();
-        accessTokenItem.setAccessToken(accessToken);
-        accessTokenItem.setRevokedAtDateTime(Instant.now().toString());
-
-        when(mockDataStore.getItem(accessToken)).thenReturn(accessTokenItem);
-
-        accessTokenService.revokeAccessToken(accessToken);
-
-        verify(mockDataStore, Mockito.times(0)).update(any());
-    }
-
-    @Test
-    void shouldThrowExceptionIfAccessTokenCanNotBeFoundWhenRevoking() {
-        String accessToken = "test-access-token";
-
-        when(mockDataStore.getItem(accessToken)).thenReturn(null);
-
-        IllegalArgumentException thrown =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> accessTokenService.revokeAccessToken(accessToken));
-        assertEquals(
-                "Failed to revoke access token - access token could not be found in DynamoDB",
-                thrown.getMessage());
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Read access token and metadata from sessions table and delete AccessTokensTable

### Why did it change

We're streamlining the storage of the authorization codes and access tokens so they now sit in the sessions table rather than their own separate tables. The associated metadata for each is also stored in its own object in the session. This PR completes the migration, reading the access tokens and metadata from the session (via secondary index) and removing the old access tokens table.

### Issue tracking
- [PYIC-1729](https://govukverify.atlassian.net/browse/PYIC-1729)

