### PR TITLE
PYIC-1739: Delete existing VCs when starting session

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -392,12 +392,15 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub initialise-ipv-session-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt SessionsTable.Arn]]
+          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref UserIssuedCredentialsV2Table
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/clients/*
         - SSMParameterReadPolicy:

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -38,6 +38,7 @@ import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.KmsRsaDecrypter;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.validation.JarValidator;
 
 import java.security.KeyFactory;
@@ -67,6 +68,7 @@ class InitialiseIpvSessionHandlerTest {
     @Mock private KmsRsaDecrypter mockKmsRsaDecrypter;
     @Mock private JarValidator mockJarValidator;
     @Mock private AuditService mockAuditService;
+    @Mock private UserIdentityService mockUserIdentityService;
     @InjectMocks private InitialiseIpvSessionHandler initialiseIpvSessionHandler;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -137,6 +139,8 @@ class InitialiseIpvSessionHandlerTest {
         ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
         verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
         assertEquals(AuditEventTypes.IPV_JOURNEY_START, auditEventCaptor.getValue().getEventName());
+
+        verify(mockUserIdentityService).deleteUserIssuedCredentials("test-user-id");
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -12,16 +12,17 @@ public class LogHelper {
 
     public enum LogField {
         CLIENT_ID_LOG_FIELD("clientId"),
+        COMPONENT_ID_LOG_FIELD("componentId"),
         CRI_ID_LOG_FIELD("criId"),
+        DYNAMODB_TABLE_NAME("dynamoDbTableName"),
+        DYNAMODB_KEY_VALUE("dynamoDbKeyValue"),
+        EVIDENCE_TYPE("evidenceType"),
         ERROR_CODE_LOG_FIELD("errorCode"),
         ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
         IPV_SESSION_ID_LOG_FIELD("ipvSessionId"),
-        COMPONENT_ID_LOG_FIELD("componentId"),
         JTI_LOG_FIELD("jti"),
         JTI_USED_AT_LOG_FIELD("jtiUsedAt"),
-        DYNAMODB_TABLE_NAME("dynamoDbTableName"),
-        DYNAMODB_KEY_VALUE("dynamoDbKeyValue"),
-        EVIDENCE_TYPE("evidenceType");
+        NUMBER_OF_VCS("numberOfVCs");
         private final String fieldName;
 
         LogField(String fieldName) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.domain.UserIssuedDebugCredential;
 import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 
@@ -86,6 +87,19 @@ public class UserIdentityService {
         return credentialIssuerItems.stream()
                 .map(UserIssuedCredentialsItem::getCredential)
                 .collect(Collectors.toList());
+    }
+
+    public void deleteUserIssuedCredentials(String userId) {
+        List<UserIssuedCredentialsItem> credentialIssuerItems = dataStore.getItems(userId);
+        if (!credentialIssuerItems.isEmpty()) {
+            LogHelper.logInfoMessageWithFieldAndValue(
+                    "Deleting existing issued VCs",
+                    LogHelper.LogField.NUMBER_OF_VCS,
+                    String.valueOf(credentialIssuerItems.size()));
+        }
+        for (UserIssuedCredentialsItem item : credentialIssuerItems) {
+            dataStore.delete(item.getUserId(), item.getCredentialIssuer());
+        }
     }
 
     public UserIssuedCredentialsItem getUserIssuedCredential(String userId, String criId) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.UserIdentity.ADDRESS_CLAIM_NAME;
@@ -574,6 +575,26 @@ class UserIdentityServiceTest {
 
         assertEquals(SIGNED_VC_1, vcList.get(0));
         assertEquals(SIGNED_VC_2, vcList.get(1));
+    }
+
+    @Test
+    void shouldDeleteAllExistingVCs() {
+        List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
+                List.of(
+                        createUserIssuedCredentialsItem(
+                                "a-users-id", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                        createUserIssuedCredentialsItem(
+                                "a-users-id", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                        createUserIssuedCredentialsItem(
+                                "a-users-id", "sausages", SIGNED_VC_3, LocalDateTime.now()));
+
+        when(mockDataStore.getItems("a-users-id")).thenReturn(userIssuedCredentialsItemList);
+
+        userIdentityService.deleteUserIssuedCredentials("a-users-id");
+
+        verify(mockDataStore).delete("a-users-id", "ukPassport");
+        verify(mockDataStore).delete("a-users-id", "fraud");
+        verify(mockDataStore).delete("a-users-id", "sausages");
     }
 
     private UserIssuedCredentialsItem createUserIssuedCredentialsItem(


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Delete existing VCs when starting session

### Why did it change

As we now store VCs against the users ID, rather than their session, we
end up sending old names and addresses as part of the shared claims. For
example, if a user has tried a journey and made a mistake, then come
back later for another crack, we'll include the incorrect data from the
first attempt.

We do want to store VCs, but we need a proper think about how to handle
them. For now, we'll just delete any existing ones from the table when a
user starts a new session. This puts us back to a similar position to
how we were running before switching to user IDs as the primary key.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1739](https://govukverify.atlassian.net/browse/PYIC-1739)
