### PR TITLE
Fix missing env var and Dynamo permission on new version of initialis…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -475,12 +475,15 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub initialise-ipv-session-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref UserIssuedCredentialsV2Table
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/clients/*
         - SSMParameterReadPolicy:


### PR DESCRIPTION
…e session lambda

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add missing ENV var and DynamoDB permission to the new version of the initialise session lambda.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
These vars were added to the old "ToBeRemoved" version of the lambda but not the new one. Now that core-front is using the new lambda we are seeing a Dynamo permission denied error due to the missing var and policy.
<!-- Describe the reason these changes were made - the "why" -->

