### PR TITLE
PYIC-1740: Update statemachine to use new renamed lambda endpoints

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -34,7 +34,7 @@ END_JOURNEY:
       targetState: END
       response:
         type: journey
-        journeyStepId: /journey/session/end
+        journeyStepId: /journey/build-client-oauth-response
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -58,7 +58,7 @@ IPV_IDENTITY_START_PAGE:
       targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/start/stubUkPassport
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -69,7 +69,7 @@ CRI_UK_PASSPORT:
       targetState: CRI_ADDRESS
       response:
         type: journey
-        journeyStepId: /journey/cri/start/stubAddress
+        journeyStepId: /journey/cri/build-oauth-request/stubAddress
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -80,7 +80,7 @@ CRI_ADDRESS:
       targetState: CRI_FRAUD
       response:
         type: journey
-        journeyStepId: /journey/cri/start/stubFraud
+        journeyStepId: /journey/cri/build-oauth-request/stubFraud
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
@@ -102,7 +102,7 @@ PRE_KBV_TRANSITION_PAGE:
       targetState: CRI_KBV
       response:
         type: journey
-        journeyStepId: /journey/cri/start/stubKbv
+        journeyStepId: /journey/cri/build-oauth-request/stubKbv
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -34,7 +34,7 @@ END_JOURNEY:
       targetState: END
       response:
         type: journey
-        journeyStepId: /journey/session/end
+        journeyStepId: /journey/build-client-oauth-response
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -58,7 +58,7 @@ IPV_IDENTITY_START_PAGE:
       targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/start/stubUkPassport
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -69,7 +69,7 @@ CRI_UK_PASSPORT:
       targetState: CRI_ADDRESS
       response:
         type: journey
-        journeyStepId: /journey/cri/start/stubAddress
+        journeyStepId: /journey/cri/build-oauth-request/stubAddress
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -80,7 +80,7 @@ CRI_ADDRESS:
       targetState: CRI_FRAUD
       response:
         type: journey
-        journeyStepId: /journey/cri/start/stubFraud
+        journeyStepId: /journey/cri/build-oauth-request/stubFraud
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
@@ -102,7 +102,7 @@ PRE_KBV_TRANSITION_PAGE:
       targetState: CRI_KBV
       response:
         type: journey
-        journeyStepId: /journey/cri/start/stubKbv
+        journeyStepId: /journey/cri/build-oauth-request/stubKbv
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -34,7 +34,7 @@ END_JOURNEY:
       targetState: END
       response:
         type: journey
-        journeyStepId: /journey/session/end
+        journeyStepId: /journey/build-client-oauth-response
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -57,8 +57,8 @@ IPV_IDENTITY_START_PAGE:
       name: next
       targetState: CRI_UK_PASSPORT
       response:
-        type: cri
-        criId: PASSPORT_CRI_ID
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -68,8 +68,8 @@ CRI_UK_PASSPORT:
       name: next
       targetState: CRI_ADDRESS
       response:
-        type: cri
-        criId: ADDRESS_CRI_ID
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/address
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -79,8 +79,8 @@ CRI_ADDRESS:
       name: next
       targetState: CRI_FRAUD
       response:
-        type: cri
-        criId: FRAUD_CRI_ID
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/fraud
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
@@ -101,8 +101,8 @@ PRE_KBV_TRANSITION_PAGE:
       name: next
       targetState: CRI_KBV
       response:
-        type: cri
-        criId: KBV_CRI_ID
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/kbv
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -34,7 +34,7 @@ END_JOURNEY:
       targetState: END
       response:
         type: journey
-        journeyStepId: /journey/session/end
+        journeyStepId: /journey/build-client-oauth-response
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -58,7 +58,7 @@ IPV_IDENTITY_START_PAGE:
       targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/start/ukPassport
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -69,7 +69,7 @@ CRI_UK_PASSPORT:
       targetState: CRI_ADDRESS
       response:
         type: journey
-        journeyStepId: /journey/cri/start/address
+        journeyStepId: /journey/cri/build-oauth-request/address
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -80,7 +80,7 @@ CRI_ADDRESS:
       targetState: CRI_FRAUD
       response:
         type: journey
-        journeyStepId: /journey/cri/start/fraud
+        journeyStepId: /journey/cri/build-oauth-request/fraud
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
@@ -102,7 +102,7 @@ PRE_KBV_TRANSITION_PAGE:
       targetState: CRI_KBV
       response:
         type: journey
-        journeyStepId: /journey/cri/start/kbv
+        journeyStepId: /journey/cri/build-oauth-request/kbv
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -34,7 +34,7 @@ END_JOURNEY:
       targetState: END
       response:
         type: journey
-        journeyStepId: /journey/session/end
+        journeyStepId: /journey/build-client-oauth-response
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -58,7 +58,7 @@ IPV_IDENTITY_START_PAGE:
       targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/start/ukPassport
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -69,7 +69,7 @@ CRI_UK_PASSPORT:
       targetState: CRI_ADDRESS
       response:
         type: journey
-        journeyStepId: /journey/cri/start/address
+        journeyStepId: /journey/cri/build-oauth-request/address
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -80,7 +80,7 @@ CRI_ADDRESS:
       targetState: CRI_FRAUD
       response:
         type: journey
-        journeyStepId: /journey/cri/start/fraud
+        journeyStepId: /journey/cri/build-oauth-request/fraud
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
@@ -102,7 +102,7 @@ PRE_KBV_TRANSITION_PAGE:
       targetState: CRI_KBV
       response:
         type: journey
-        journeyStepId: /journey/cri/start/kbv
+        journeyStepId: /journey/cri/build-oauth-request/kbv
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -282,7 +282,7 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_UK_PASSPORT_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/cri/start/ukPassport", criResponse.get("journey"));
+        assertEquals("/journey/cri/build-oauth-request/ukPassport", criResponse.get("journey"));
     }
 
     @Test
@@ -314,7 +314,7 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_ADDRESS_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/cri/start/address", criResponse.get("journey"));
+        assertEquals("/journey/cri/build-oauth-request/address", criResponse.get("journey"));
     }
 
     @Test
@@ -378,7 +378,7 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_FRAUD_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/cri/start/fraud", criResponse.get("journey"));
+        assertEquals("/journey/cri/build-oauth-request/fraud", criResponse.get("journey"));
     }
 
     @Test
@@ -475,7 +475,7 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_KBV_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/cri/start/kbv", criResponse.get("journey"));
+        assertEquals("/journey/cri/build-oauth-request/kbv", criResponse.get("journey"));
     }
 
     @Test
@@ -599,7 +599,7 @@ class ProcessJourneyStepHandlerTest {
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/session/end", journeyResponse.get("journey"));
+        assertEquals("/journey/build-client-oauth-response", journeyResponse.get("journey"));
     }
 
     @Test
@@ -717,7 +717,7 @@ class ProcessJourneyStepHandlerTest {
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/session/end", journeyResponse.get("journey"));
+        assertEquals("/journey/build-client-oauth-response", journeyResponse.get("journey"));
     }
 
     @Test
@@ -878,6 +878,6 @@ class ProcessJourneyStepHandlerTest {
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/session/end", journeyResponse.get("journey"));
+        assertEquals("/journey/build-client-oauth-response", journeyResponse.get("journey"));
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update statemachine to use the new renamed lambda api endpoints.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
With the lambda rename work, some of the api gateway endpoints were renamed as well. This PR moves the statemachine over to using those new renamed endpoints so that the old ones can be deleted.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1740](https://govukverify.atlassian.net/browse/PYIC-1740)

