### PR TITLE
PYIC-1757 Store govuk_signin_journey_id in user's session and log in all application logs and audit messages

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -228,6 +228,7 @@ public class DataStoreIpvSessionIT {
                 "https//example.com",
                 "test-state",
                 "test-user-id",
+                "test-journey-id",
                 false);
     }
 

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -85,9 +85,18 @@ public class BuildClientOauthResponseHandler
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
             IpvSessionItem ipvSessionItem = sessionService.getIpvSession(ipvSessionId);
             String userId = sessionService.getUserId(ipvSessionId);
-            LogHelper.attachClientIdToLogs(ipvSessionItem.getClientSessionDetails().getClientId());
+            ClientSessionDetailsDto clientSessionDetailsDto =
+                    ipvSessionItem.getClientSessionDetails();
 
-            AuditEventUser auditEventUser = new AuditEventUser(userId, ipvSessionId);
+            LogHelper.attachClientIdToLogs(clientSessionDetailsDto.getClientId());
+            LogHelper.attachGovukSigninJourneyIdToLogs(
+                    clientSessionDetailsDto.getGovukSigninJourneyId());
+
+            AuditEventUser auditEventUser =
+                    new AuditEventUser(
+                            userId,
+                            ipvSessionId,
+                            clientSessionDetailsDto.getGovukSigninJourneyId());
 
             ClientResponse clientResponse;
 

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -276,6 +276,7 @@ class BuildClientOauthResponseHandlerTest {
                         "https://example.com",
                         "test-state",
                         "test-user-id",
+                        "test-journey-id",
                         false);
         item.setClientSessionDetails(clientSessionDetailsDto);
 
@@ -288,6 +289,7 @@ class BuildClientOauthResponseHandlerTest {
                 "test-client-id",
                 "https://example.com",
                 "test-state",
+                "test-journey-id",
                 "test-user-id",
                 false);
     }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -24,6 +24,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -93,6 +94,8 @@ class BuildCriOauthRequestHandlerTest {
 
     private BuildCriOauthRequestHandler underTest;
 
+    private ClientSessionDetailsDto clientSessionDetailsDto;
+
     @BeforeEach
     void setUp()
             throws URISyntaxException, InvalidKeySpecException, NoSuchAlgorithmException,
@@ -117,6 +120,10 @@ class BuildCriOauthRequestHandlerTest {
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
                         "http://www.example.com/audience");
+
+        clientSessionDetailsDto = new ClientSessionDetailsDto();
+        clientSessionDetailsDto.setUserId(TEST_USER_ID);
+        clientSessionDetailsDto.setGovukSigninJourneyId("test-journey-id");
     }
 
     @Test
@@ -146,7 +153,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn("callbackUrl");
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockIpvSessionService.getUserId(SESSION_ID)).thenReturn(TEST_USER_ID);
+        when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -239,7 +246,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn("callbackUrl");
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockIpvSessionService.getUserId(SESSION_ID)).thenReturn(TEST_USER_ID);
+        when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -273,7 +280,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn("callbackUrl");
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockIpvSessionService.getUserId(SESSION_ID)).thenReturn(TEST_USER_ID);
+        when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(

--- a/lambdas/build-debug-credential-data/src/test/java/uk/gov/di/ipv/core/builddebugcredentialdata/BuildDebugCredentialDataHandlerTest.java
+++ b/lambdas/build-debug-credential-data/src/test/java/uk/gov/di/ipv/core/builddebugcredentialdata/BuildDebugCredentialDataHandlerTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
@@ -35,7 +37,11 @@ public class BuildDebugCredentialDataHandlerTest {
         String userId = "a-user-id";
         event.setHeaders(Map.of(RequestHelper.IPV_SESSION_ID_HEADER, ipvSessionId));
 
-        when(mockIpvSessionService.getUserId(ipvSessionId)).thenReturn(userId);
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ClientSessionDetailsDto clientSessionDetailsDto = new ClientSessionDetailsDto();
+        clientSessionDetailsDto.setUserId(userId);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
+        when(mockIpvSessionService.getIpvSession(ipvSessionId)).thenReturn(ipvSessionItem);
         Map<String, String> userIssuedCredentials =
                 Map.of(
                         "criOne", "credential issued by criOne",

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -108,9 +108,13 @@ public class BuildUserIdentityHandler
 
             ClientSessionDetailsDto clientSessionDetails = ipvSessionItem.getClientSessionDetails();
             LogHelper.attachClientIdToLogs(clientSessionDetails.getClientId());
+            LogHelper.attachGovukSigninJourneyIdToLogs(
+                    clientSessionDetails.getGovukSigninJourneyId());
 
             String userId = clientSessionDetails.getUserId();
-            AuditEventUser auditEventUser = new AuditEventUser(userId, ipvSessionId);
+            AuditEventUser auditEventUser =
+                    new AuditEventUser(
+                            userId, ipvSessionId, clientSessionDetails.getGovukSigninJourneyId());
 
             String sub = userId;
             UserIdentity userIdentity = userIdentityService.generateUserIdentity(userId, sub);

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -99,6 +99,7 @@ class BuildUserIdentityHandlerTest {
                         "http://example.com",
                         "test-state",
                         "test-user-id",
+                        "test-journey-id",
                         false));
         ipvSessionItem.setAccessToken(TEST_ACCESS_TOKEN);
         ipvSessionItem.setAccessTokenMetadata(new AccessTokenMetadata());

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.ipv.core.evaluategpg45scores.exception.UnknownEvidenceTypeExcep
 import uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45Profile;
 import uk.gov.di.ipv.core.evaluategpg45scores.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -60,7 +61,13 @@ public class EvaluateGpg45ScoresHandler
         LogHelper.attachComponentIdToLogs();
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(event);
-            String userId = ipvSessionService.getUserId(ipvSessionId);
+            ClientSessionDetailsDto clientSessionDetailsDto =
+                    ipvSessionService.getIpvSession(ipvSessionId).getClientSessionDetails();
+            String userId = clientSessionDetailsDto.getUserId();
+
+            LogHelper.attachGovukSigninJourneyIdToLogs(
+                    clientSessionDetailsDto.getGovukSigninJourneyId());
+
             List<String> credentials = userIdentityService.getUserIssuedCredentials(userId);
 
             JourneyResponse journeyResponse;

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -121,6 +121,9 @@ public class InitialiseIpvSessionHandler
                             sessionParams.get(CLIENT_ID_PARAM_KEY),
                             Boolean.parseBoolean(sessionParams.get(IS_DEBUG_JOURNEY_PARAM_KEY)));
 
+            LogHelper.attachGovukSigninJourneyIdToLogs(
+                    clientSessionDetailsDto.getGovukSigninJourneyId());
+
             userIdentityService.deleteUserIssuedCredentials(clientSessionDetailsDto.getUserId());
 
             IpvSessionItem ipvSessionItem =
@@ -129,7 +132,8 @@ public class InitialiseIpvSessionHandler
             AuditEventUser auditEventUser =
                     new AuditEventUser(
                             ipvSessionItem.getClientSessionDetails().getUserId(),
-                            ipvSessionItem.getIpvSessionId());
+                            ipvSessionItem.getIpvSessionId(),
+                            clientSessionDetailsDto.getGovukSigninJourneyId());
 
             auditService.sendAuditEvent(
                     new AuditEvent(AuditEventTypes.IPV_JOURNEY_START, componentId, auditEventUser));
@@ -145,7 +149,10 @@ public class InitialiseIpvSessionHandler
 
             ClientSessionDetailsDto clientSessionDetailsDto =
                     generateErrorClientSessionDetails(
-                            e.getRedirectUri(), e.getClientId(), e.getState());
+                            e.getRedirectUri(),
+                            e.getClientId(),
+                            e.getState(),
+                            e.getGovukSigninJourneyId());
 
             IpvSessionItem ipvSessionItem =
                     ipvSessionService.generateIpvSession(
@@ -204,12 +211,14 @@ public class InitialiseIpvSessionHandler
                 claimsSet.getStringClaim("redirect_uri"),
                 claimsSet.getStringClaim("state"),
                 claimsSet.getSubject(),
+                claimsSet.getStringClaim("govuk_signin_journey_id"),
                 isDebugJourney);
     }
 
     @Tracing
     private ClientSessionDetailsDto generateErrorClientSessionDetails(
-            String redirectUri, String clientId, String state) {
-        return new ClientSessionDetailsDto(null, clientId, redirectUri, state, null, false);
+            String redirectUri, String clientId, String state, String govukSigninJourneyId) {
+        return new ClientSessionDetailsDto(
+                null, clientId, redirectUri, state, null, govukSigninJourneyId, false);
     }
 }

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -107,6 +107,7 @@ class InitialiseIpvSessionHandlerTest {
                         "http://example.com",
                         "test-state",
                         "test-user-id",
+                        "test-journey-id",
                         false);
 
         ipvSessionItem = new IpvSessionItem();
@@ -245,7 +246,8 @@ class InitialiseIpvSessionHandlerTest {
                                 new ErrorObject("server_error", "test error"),
                                 "http://example.com",
                                 "test-client",
-                                "test-state"));
+                                "test-state",
+                                "test-journey-id"));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams =

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -93,6 +93,8 @@ public class IssueClientAccessTokenHandler
                             .orElseThrow();
 
             LogHelper.attachIpvSessionIdToLogs(ipvSessionItem.getIpvSessionId());
+            LogHelper.attachGovukSigninJourneyIdToLogs(
+                    ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId());
 
             if (ipvSessionItem.getAccessToken() != null) {
                 ErrorObject error = revokeAccessToken(ipvSessionItem);

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java
@@ -20,6 +20,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.ClientAuthenticationException;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AccessTokenService;
@@ -88,6 +89,8 @@ class IssueClientAccessTokenHandlerTest {
         mockSessionItem.setIpvSessionId(TEST_SESSION_ID);
         mockSessionItem.setAuthorizationCode(TEST_AUTHORIZATION_CODE);
         mockSessionItem.setAuthorizationCodeMetadata(mockAuthorizationCodeMetadata);
+        ClientSessionDetailsDto clientSessionDetailsDto = new ClientSessionDetailsDto();
+        mockSessionItem.setClientSessionDetails(clientSessionDetailsDto);
     }
 
     @Test

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -92,6 +92,9 @@ public class ProcessJourneyStepHandler
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_ID);
             }
 
+            LogHelper.attachGovukSigninJourneyIdToLogs(
+                    ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId());
+
             String journeyStep = input.getPathParameters().get(JOURNEY_STEP_PARAM);
 
             Map<String, String> journeyStepResponse =

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
@@ -69,12 +70,15 @@ class ProcessJourneyStepHandlerTest {
     private ProcessJourneyStepHandler processJourneyStepHandler;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    private ClientSessionDetailsDto clientSessionDetailsDto;
+
     @BeforeEach
     void setUp() throws Exception {
         StateMachine stateMachine = new StateMachine(new StateMachineInitializer("production"));
         processJourneyStepHandler =
                 new ProcessJourneyStepHandler(
                         stateMachine, mockIpvSessionService, mockConfigurationService);
+        clientSessionDetailsDto = new ClientSessionDetailsDto();
     }
 
     @Test
@@ -175,6 +179,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(INITIAL_IPV_JOURNEY_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -204,6 +209,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState("INVALID-STATE");
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -233,6 +239,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(INITIAL_IPV_JOURNEY_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -267,6 +274,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(IPV_IDENTITY_START_PAGE_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -299,6 +307,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_UK_PASSPORT_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -331,6 +340,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_UK_PASSPORT_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -363,6 +373,11 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_ADDRESS_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
+
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -395,6 +410,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_ADDRESS_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -427,6 +443,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_FRAUD_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -460,7 +477,11 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(PRE_KBV_TRANSITION_PAGE_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -492,6 +513,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_FRAUD_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -524,7 +546,11 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_KBV_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -557,6 +583,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_KBV_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -589,7 +616,11 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(IPV_SUCCESS_PAGE_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -616,6 +647,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(DEBUG_PAGE_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -643,6 +675,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(DEBUG_PAGE_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -675,6 +708,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(DEBUG_PAGE_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -707,6 +741,11 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_ERROR_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
+
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -734,6 +773,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_UK_PASSPORT_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -766,6 +806,7 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_FRAUD_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
@@ -798,7 +839,11 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(CRI_KBV_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
@@ -831,7 +876,10 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().minusSeconds(100).toString());
         ipvSessionItem.setUserState(CRI_UK_PASSPORT_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("99");
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("99");
         when(mockIpvSessionService.getIpvSession("1234")).thenReturn(ipvSessionItem);
 
@@ -869,7 +917,9 @@ class ProcessJourneyStepHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().minusSeconds(100).toString());
         ipvSessionItem.setUserState(CORE_SESSION_TIMEOUT_STATE);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockIpvSessionService.getIpvSession("1234")).thenReturn(ipvSessionItem);
 
         APIGatewayProxyResponseEvent response =

--- a/lambdas/validate-cri-credential/src/main/java/uk/gov/di/ipv/core/validatecricredential/ValidateCriCredentialHandler.java
+++ b/lambdas/validate-cri-credential/src/main/java/uk/gov/di/ipv/core/validatecricredential/ValidateCriCredentialHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
@@ -63,8 +64,12 @@ public class ValidateCriCredentialHandler
         LogHelper.attachComponentIdToLogs();
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
-            String userId = ipvSessionService.getUserId(ipvSessionId);
+            IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
+            String userId = ipvSessionItem.getClientSessionDetails().getUserId();
             String criId = getCriId(input.getPathParameters());
+
+            LogHelper.attachGovukSigninJourneyIdToLogs(
+                    ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId());
             LogHelper.attachCriIdToLogs(criId);
 
             JourneyResponse journeyResponse =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
@@ -1,8 +1,11 @@
 package uk.gov.di.ipv.core.library.auditing;
 
+import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE;
 
 @ExcludeFromGeneratedCoverageReport
 @Getter
@@ -14,10 +17,20 @@ public class AuditEventUser {
     @JsonProperty(value = "session_id")
     private final String sessionId;
 
+    @JsonProperty(value = "govuk_signin_journey_id")
+    private final String govukSigninJourneyId;
+
     public AuditEventUser(
             @JsonProperty(value = "user_id", required = false) String userId,
-            @JsonProperty(value = "session_id", required = false) String sessionId) {
+            @JsonProperty(value = "session_id", required = false) String sessionId,
+            @JsonProperty(value = "govuk_signin_journey_id", required = false)
+                    String govukSigninJourneyId) {
         this.userId = userId;
         this.sessionId = sessionId;
+        if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
+            this.govukSigninJourneyId = GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE;
+        } else {
+            this.govukSigninJourneyId = govukSigninJourneyId;
+        }
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ClientSessionDetailsDto.java
@@ -13,6 +13,7 @@ public class ClientSessionDetailsDto {
     private String redirectUri;
     private String state;
     private String userId;
+    private String govukSigninJourneyId;
     private boolean debugJourney;
 
     public ClientSessionDetailsDto() {}
@@ -23,12 +24,14 @@ public class ClientSessionDetailsDto {
             String redirectUri,
             String state,
             String userId,
+            String govukSigninJourneyId,
             boolean debugJourney) {
         this.responseType = responseType;
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.state = state;
         this.userId = userId;
+        this.govukSigninJourneyId = govukSigninJourneyId;
         this.debugJourney = debugJourney;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/RecoverableJarValidationException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/RecoverableJarValidationException.java
@@ -8,13 +8,19 @@ public class RecoverableJarValidationException extends JarValidationException {
     private final String redirectUri;
     private final String clientId;
     private final String state;
+    private final String govukSigninJourneyId;
 
     public RecoverableJarValidationException(
-            ErrorObject errorObject, String redirectUri, String clientId, String state) {
+            ErrorObject errorObject,
+            String redirectUri,
+            String clientId,
+            String state,
+            String govukSigninJourneyId) {
         super(errorObject);
         this.redirectUri = redirectUri;
         this.clientId = clientId;
         this.state = state;
+        this.govukSigninJourneyId = govukSigninJourneyId;
     }
 
     public String getRedirectUri() {
@@ -27,5 +33,9 @@ public class RecoverableJarValidationException extends JarValidationException {
 
     public String getState() {
         return state;
+    }
+
+    public String getGovukSigninJourneyId() {
+        return govukSigninJourneyId;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
@@ -48,7 +48,8 @@ public class AuthorizationRequestHelper {
             CredentialIssuerConfig credentialIssuerConfig,
             ConfigurationService configurationService,
             String oauthState,
-            String userId)
+            String userId,
+            String govukSigninJourneyId)
             throws HttpResponseExceptionWithErrorBody {
         Instant now = Instant.now();
 
@@ -83,7 +84,8 @@ public class AuthorizationRequestHelper {
                                                                 JWT_TTL_SECONDS)),
                                                 ChronoUnit.SECONDS)))
                         .notBeforeTime(Date.from(now))
-                        .subject(userId);
+                        .subject(userId)
+                        .claim("govuk_signin_journey_id", govukSigninJourneyId);
 
         if (Objects.nonNull(sharedClaims)) {
             claimsSetBuilder.claim(SHARED_CLAIMS, sharedClaims);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.helpers;
 
+import com.amazonaws.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
@@ -10,6 +11,8 @@ public class LogHelper {
     private static final Logger LOGGER = LogManager.getLogger();
     public static final String CORE_COMPONENT_ID = "core";
 
+    public static final String GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE = "unknown";
+
     public enum LogField {
         CLIENT_ID_LOG_FIELD("clientId"),
         COMPONENT_ID_LOG_FIELD("componentId"),
@@ -19,6 +22,7 @@ public class LogHelper {
         EVIDENCE_TYPE("evidenceType"),
         ERROR_CODE_LOG_FIELD("errorCode"),
         ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
+        GOVUK_SIGNIN_JOURNEY_ID_FIELD("govuk_signin_journey_id"),
         IPV_SESSION_ID_LOG_FIELD("ipvSessionId"),
         JTI_LOG_FIELD("jti"),
         JTI_USED_AT_LOG_FIELD("jtiUsedAt"),
@@ -52,6 +56,15 @@ public class LogHelper {
 
     public static void attachIpvSessionIdToLogs(String sessionId) {
         attachFieldToLogs(LogField.IPV_SESSION_ID_LOG_FIELD, sessionId);
+    }
+
+    public static void attachGovukSigninJourneyIdToLogs(String govukSigninJourneyId) {
+        if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
+            attachFieldToLogs(
+                    LogField.GOVUK_SIGNIN_JOURNEY_ID_FIELD, GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE);
+        } else {
+            attachFieldToLogs(LogField.GOVUK_SIGNIN_JOURNEY_ID_FIELD, govukSigninJourneyId);
+        }
     }
 
     public static void logOauthError(String message, int errorCode, String errorDescription) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/validation/JarValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/validation/JarValidator.java
@@ -75,7 +75,8 @@ public class JarValidator {
                     e.getErrorObject(),
                     redirectUri.toString(),
                     clientId,
-                    jwtClaimsSet.getStringClaim("state"));
+                    jwtClaimsSet.getStringClaim("state"),
+                    jwtClaimsSet.getStringClaim("govuk_signin_journey_id"));
         }
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
@@ -65,6 +65,7 @@ class AuthorizationRequestHelperTest {
     public static final String MOCK_CORE_FRONT_CALLBACK_URL = "callbackUri";
     public static final String CRI_ID = "cri_id";
     public static final String TEST_USER_ID = "test-user-id";
+    public static final String TEST_JOURNEY_ID = "test-journey-id";
     public static final String OAUTH_STATE = SecureTokenHelper.generate();
 
     private final SharedClaimsResponse sharedClaims =
@@ -105,10 +106,14 @@ class AuthorizationRequestHelperTest {
                         credentialIssuerConfig,
                         configurationService,
                         OAUTH_STATE,
-                        TEST_USER_ID);
+                        TEST_USER_ID,
+                        TEST_JOURNEY_ID);
 
         assertEquals(IPV_ISSUER, result.getJWTClaimsSet().getIssuer());
         assertEquals(TEST_USER_ID, result.getJWTClaimsSet().getSubject());
+        assertEquals(
+                TEST_JOURNEY_ID,
+                result.getJWTClaimsSet().getStringClaim("govuk_signin_journey_id"));
         assertEquals(AUDIENCE, result.getJWTClaimsSet().getAudience().get(0));
         assertEquals(sharedClaims, result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
         assertEquals(OAUTH_STATE.toString(), result.getJWTClaimsSet().getClaim("state"));
@@ -133,7 +138,8 @@ class AuthorizationRequestHelperTest {
                         credentialIssuerConfig,
                         configurationService,
                         OAUTH_STATE,
-                        TEST_USER_ID);
+                        TEST_USER_ID,
+                        TEST_JOURNEY_ID);
         assertNull(result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
     }
 
@@ -152,7 +158,8 @@ class AuthorizationRequestHelperTest {
                                         credentialIssuerConfig,
                                         configurationService,
                                         OAUTH_STATE,
-                                        TEST_USER_ID));
+                                        TEST_USER_ID,
+                                        TEST_JOURNEY_ID));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to sign Shared Attributes", exception.getErrorReason());
     }
@@ -172,7 +179,8 @@ class AuthorizationRequestHelperTest {
                                         credentialIssuerConfig,
                                         configurationService,
                                         OAUTH_STATE,
-                                        TEST_USER_ID));
+                                        TEST_USER_ID,
+                                        TEST_JOURNEY_ID));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to build Core Front Callback Url", exception.getErrorReason());
     }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -102,6 +102,7 @@ class IpvSessionServiceTest {
                                 "http://example.come",
                                 "test-state",
                                 "test-user-id",
+                                "test-journey-id",
                                 false),
                         null);
 
@@ -128,6 +129,7 @@ class IpvSessionServiceTest {
                                 "http://example.come",
                                 "test-state",
                                 "test-user-id",
+                                "test-journey-id",
                                 true),
                         null);
 
@@ -154,6 +156,7 @@ class IpvSessionServiceTest {
                                 "http://example.come",
                                 "test-state",
                                 "test-user-id",
+                                "test-journey-id",
                                 false),
                         testErrorObject);
 


### PR DESCRIPTION
## Proposed changes

### What changed

Store value of `govuk_signin_journey_id` received in the JAR in the user's session and log in all application logs and audit messages

### Why did it change

We need to be able to track a user journey across multiple sub systems, each of which has different session ids and scopes. To do this we will accept an id from auth/orc that represents a user journey from a particular RP and use it when writing application logs and audit messages.

### Issue tracking
- [PYIC-1757](https://govukverify.atlassian.net/browse/PYIC-1757)
