### PR TITLE
PYIC-1773: Create healthcheck endpoint for external API

### DIFF
--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -21,7 +21,6 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IssueClientAccessTokenFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
 
-
   /user-identity:
     get:
       description: "Returns a list of Verifiable Credentials representig the users identity"
@@ -40,3 +39,23 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildUserIdentityFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
+
+  /healthcheck:
+    get:
+      description: "returns a 200 for Route53 health checks to use"
+      responses:
+        200:
+          description: "A healthcheck response"
+          content:
+            application/json:
+              schema:
+                type: "object"
+      x-amazon-apigateway-integration:
+        type: "MOCK"
+        requestTemplates:
+          application/json: "{\"statusCode\":200}"
+        responses:
+          200:
+            statusCode: 200
+            responseTemplates:
+              application/json: "{\"healthcheck\": \"ok\"}"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Create healthcheck endpoint for external API

### Why did it change
We're implementing route53 healthchecks for our public hosted zones. We
can add a new endpoint to the external API for the healthchecks to hit.

This adds a MOCK type integration - rather than actually integrating
with an AWS service it will return a canned response.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1773](https://govukverify.atlassian.net/browse/PYIC-1773)
