### PR TITLE
PYIC-1758 Start sending govuk_signin_journey_id in JAR to CRIs

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
@@ -48,7 +48,8 @@ public class AuthorizationRequestHelper {
             CredentialIssuerConfig credentialIssuerConfig,
             ConfigurationService configurationService,
             String oauthState,
-            String userId)
+            String userId,
+            String govukSigninJourneyId)
             throws HttpResponseExceptionWithErrorBody {
         Instant now = Instant.now();
 
@@ -83,7 +84,8 @@ public class AuthorizationRequestHelper {
                                                                 JWT_TTL_SECONDS)),
                                                 ChronoUnit.SECONDS)))
                         .notBeforeTime(Date.from(now))
-                        .subject(userId);
+                        .subject(userId)
+                        .claim("govuk_signin_journey_id", govukSigninJourneyId);
 
         if (Objects.nonNull(sharedClaims)) {
             claimsSetBuilder.claim(SHARED_CLAIMS, sharedClaims);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelperTest.java
@@ -65,6 +65,7 @@ class AuthorizationRequestHelperTest {
     public static final String MOCK_CORE_FRONT_CALLBACK_URL = "callbackUri";
     public static final String CRI_ID = "cri_id";
     public static final String TEST_USER_ID = "test-user-id";
+    public static final String TEST_JOURNEY_ID = "test-journey-id";
     public static final String OAUTH_STATE = SecureTokenHelper.generate();
 
     private final SharedClaimsResponse sharedClaims =
@@ -105,10 +106,14 @@ class AuthorizationRequestHelperTest {
                         credentialIssuerConfig,
                         configurationService,
                         OAUTH_STATE,
-                        TEST_USER_ID);
+                        TEST_USER_ID,
+                        TEST_JOURNEY_ID);
 
         assertEquals(IPV_ISSUER, result.getJWTClaimsSet().getIssuer());
         assertEquals(TEST_USER_ID, result.getJWTClaimsSet().getSubject());
+        assertEquals(
+                TEST_JOURNEY_ID,
+                result.getJWTClaimsSet().getStringClaim("govuk_signin_journey_id"));
         assertEquals(AUDIENCE, result.getJWTClaimsSet().getAudience().get(0));
         assertEquals(sharedClaims, result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
         assertEquals(OAUTH_STATE.toString(), result.getJWTClaimsSet().getClaim("state"));
@@ -133,7 +138,8 @@ class AuthorizationRequestHelperTest {
                         credentialIssuerConfig,
                         configurationService,
                         OAUTH_STATE,
-                        TEST_USER_ID);
+                        TEST_USER_ID,
+                        TEST_JOURNEY_ID);
         assertNull(result.getJWTClaimsSet().getClaims().get(SHARED_CLAIMS));
     }
 
@@ -152,7 +158,8 @@ class AuthorizationRequestHelperTest {
                                         credentialIssuerConfig,
                                         configurationService,
                                         OAUTH_STATE,
-                                        TEST_USER_ID));
+                                        TEST_USER_ID,
+                                        TEST_JOURNEY_ID));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to sign Shared Attributes", exception.getErrorReason());
     }
@@ -172,7 +179,8 @@ class AuthorizationRequestHelperTest {
                                         credentialIssuerConfig,
                                         configurationService,
                                         OAUTH_STATE,
-                                        TEST_USER_ID));
+                                        TEST_USER_ID,
+                                        TEST_JOURNEY_ID));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to build Core Front Callback Url", exception.getErrorReason());
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Pass through `govuk_signin_journey_id` as a custom claim in the JAR to CRIs

### Why did it change

We need to be able to track a user journey across multiple sub systems, each of which has different session ids and scopes. To do this we will accept an id from auth/orc that represents a user journey from a particular RP and use it when writing application logs and audit messages. This change will allow the CRIs to pick up the journey id from the JAR and use it for application logs/audit messages to continue the tracking

### Issue tracking
- [PYIC-1758](https://govukverify.atlassian.net/browse/PYIC-1758)
