### PR TITLE
BAU: Reinstate pre-kbv-transition page

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -102,34 +102,34 @@ SELECT_CRI:
   name: SELECT_CRI
   parent: null
   events:
-    ukPassport:
+    stubUkPassport:
       type: basic
       name: next
       targetState: CRI_UK_PASSPORT
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
-    address:
+    stubAddress:
       type: basic
       name: address
       targetState: CRI_ADDRESS
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubAddress
-    fraud:
+    stubFraud:
       type: basic
       name: fraud
       targetState: CRI_FRAUD
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubFraud
-    kbv:
+    stubKbv:
       type: basic
       name: kbv
-      targetState: CRI_KBV
+      targetState: PRE_KBV_TRANSITION_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubKbv
+        type: page
+        pageId: page-pre-kbv-transition
     fail:
       type: basic
       name: fail

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -126,10 +126,10 @@ SELECT_CRI:
     stubKbv:
       type: basic
       name: kbv
-      targetState: CRI_KBV
+      targetState: PRE_KBV_TRANSITION_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubKbv
+        type: page
+        pageId: page-pre-kbv-transition
     fail:
       type: basic
       name: fail

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -126,10 +126,10 @@ SELECT_CRI:
     kbv:
       type: basic
       name: kbv
-      targetState: CRI_KBV
+      targetState: PRE_KBV_TRANSITION_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/kbv
+        type: page
+        pageId: page-pre-kbv-transition
     fail:
       type: basic
       name: fail

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -126,10 +126,10 @@ SELECT_CRI:
     kbv:
       type: basic
       name: kbv
-      targetState: CRI_KBV
+      targetState: PRE_KBV_TRANSITION_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/kbv
+        type: page
+        pageId: page-pre-kbv-transition
     fail:
       type: basic
       name: fail

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -126,10 +126,10 @@ SELECT_CRI:
     kbv:
       type: basic
       name: kbv
-      targetState: CRI_KBV
+      targetState: PRE_KBV_TRANSITION_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/kbv
+        type: page
+        pageId: page-pre-kbv-transition
     fail:
       type: basic
       name: fail


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Reinstate pre-kbv-transition page

### Why did it change

In a recent refactor the pre-kbv transition page was skipped. This puts
it back in the flow.

It also updates the events for the build environment CRI_STATE state.
These should be stubs. The build env is currently broken.

~I have no idea how any of this made it to prod...~
We don't run a full journey in our smoke tests for build and staging, so this wasn't picked up in the pipeline.

