### PR TITLE
PYIC-1819: Add new JWKS endpoint to external api

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -77,9 +77,9 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - "ssm:GetParameter"
+                  - "ssm:GetParametersByPath"
                 Resource:
-                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/core/outputs/jwks'
+                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Environment}/deploy/core/outputs/*'
 
   IPVCorePrivateAPI:
     Type: AWS::Serverless::Api
@@ -143,6 +143,8 @@ Resources:
 
   IPVCoreExternalAPI:
     Type: AWS::Serverless::Api
+    DependsOn:
+      - "JWKSParamRole"
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub IPV Core External API Gateway ${Environment}

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -60,6 +60,27 @@ Mappings:
       provisionedConcurrency: 1
 
 Resources:
+  JWKSParamRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+        Version: 2012-10-17
+      Policies:
+        - PolicyName: AccessJWKSjson
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ssm:GetParameter"
+                Resource:
+                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/core/outputs/jwks'
+
   IPVCorePrivateAPI:
     Type: AWS::Serverless::Api
     Properties:

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -61,7 +61,7 @@ paths:
           default:
             statusCode: "200"
             responseTemplates:
-              application/json: "#set($inputRoot = $input.path('$')){\"keys\":[#foreach($elem in $inputRoot.GetParametersByPathResponse.GetParametersByPathResult.Parameters)$util.parseJson($elem.Value)#if($foreach.hasNext),#end#end]}"
+              application/json: "#set($inputRoot = $input.path('$')){\"keys\":[#foreach($elem in $inputRoot.GetParametersByPathResponse.GetParametersByPathResult.Parameters)$elem.Value#if($foreach.hasNext),#end#end]}"
         passthroughBehavior: "when_no_match"
 
   /healthcheck:

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -40,6 +40,30 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildUserIdentityFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
 
+  /.well-known/jwks.json:
+    get:
+      description: "returns JWKS Json"
+      responses:
+        200:
+          description: "The list of public keys"
+          content:
+            application/json:
+              schema:
+                type: "object"
+      x-amazon-apigateway-integration:
+        type: "aws"
+        httpMethod: "GET"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:ssm:action/GetParameter&Name=/core/outputs/jwks
+        credentials:
+          Fn::GetAtt: ["JWKSParamRole", "Arn"]
+        responses:
+          default:
+            statusCode: "200"
+            responseTemplates:
+              application/json: "$util.parseJson($input.json('$.GetParameterResponse.GetParameterResult.Parameter.Value'))"
+        passthroughBehavior: "when_no_match"
+
   /healthcheck:
     get:
       description: "returns a 200 for Route53 health checks to use"

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -54,14 +54,14 @@ paths:
         type: "aws"
         httpMethod: "GET"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:ssm:action/GetParameter&Name=/core/outputs/jwks
+          Fn::Sub: 'arn:aws:apigateway:${AWS::Region}:ssm:action/GetParametersByPath&Path=/${Environment}/deploy/core/outputs/'
         credentials:
           Fn::GetAtt: ["JWKSParamRole", "Arn"]
         responses:
           default:
             statusCode: "200"
             responseTemplates:
-              application/json: "$util.parseJson($input.json('$.GetParameterResponse.GetParameterResult.Parameter.Value'))"
+              application/json: "#set($inputRoot = $input.path('$')){\"keys\":[#foreach($elem in $inputRoot.GetParametersByPathResponse.GetParametersByPathResult.Parameters)$util.parseJson($elem.Value)#if($foreach.hasNext),#end#end]}"
         passthroughBehavior: "when_no_match"
 
   /healthcheck:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add new JWKS api endpoint to serve our public keys from.

The api endpoint will pull the value from SSM. This is because we currently store the certs there. This is just temporary until we decide to implement a proper key rotation method.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
As part of the app system integration work they requested the keys be made available from a JWKS endpoint.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1819](https://govukverify.atlassian.net/browse/PYIC-1819)

