### PR TITLE
PYIC-1827: Construct a full redirectUrl containing all required query params

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/domain/CriDetails.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/domain/CriDetails.java
@@ -14,15 +14,19 @@ public class CriDetails {
 
     @JsonProperty private final String request;
 
+    @JsonProperty private final String redirectUrl;
+
     @JsonCreator
     public CriDetails(
             @JsonProperty(value = "id", required = true) String id,
             @JsonProperty(value = "ipvClientId", required = true) String ipvClientId,
             @JsonProperty(value = "authorizeUrl", required = true) String authorizeUrl,
-            @JsonProperty(value = "request", required = true) String request) {
+            @JsonProperty(value = "request", required = true) String request,
+            @JsonProperty(value = "redirectUrl", required = true) String redirectUrl) {
         this.id = id;
         this.ipvClientId = ipvClientId;
         this.authorizeUrl = authorizeUrl;
         this.request = request;
+        this.redirectUrl = redirectUrl;
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add a new param to the CRI json response being returned to core-front. This new param will be a full constructed URL with all query params needed to redirect onto a CRI.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Currently the lambda returns all the individual bits of data required for the redirect uri and the front-end stitches them together. Now core-back will be responsible for constructing the full url. This will also including conditionally adding the "response_type" query param only for the app system.

A separate front-end PR will 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1827](https://govukverify.atlassian.net/browse/PYIC-1827)

Core-front PR - https://github.com/alphagov/di-ipv-core-front/pull/373

