### PR TITLE
PYIC-1829: Remove unused properties from the criResponse

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -187,12 +187,7 @@ public class BuildCriOauthRequestHandler
         }
 
         return new CriResponse(
-                new CriDetails(
-                        credentialIssuerConfig.getId(),
-                        credentialIssuerConfig.getIpvClientId(),
-                        credentialIssuerConfig.getAuthorizeUrl().toString(),
-                        jweObject.serialize(),
-                        redirectUri.build().toString()));
+                new CriDetails(credentialIssuerConfig.getId(), redirectUri.build().toString()));
     }
 
     private JWEObject signEncryptJar(

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/domain/CriDetails.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/domain/CriDetails.java
@@ -8,25 +8,13 @@ import lombok.Getter;
 public class CriDetails {
     @JsonProperty private final String id;
 
-    @JsonProperty private final String ipvClientId;
-
-    @JsonProperty private final String authorizeUrl;
-
-    @JsonProperty private final String request;
-
     @JsonProperty private final String redirectUrl;
 
     @JsonCreator
     public CriDetails(
             @JsonProperty(value = "id", required = true) String id,
-            @JsonProperty(value = "ipvClientId", required = true) String ipvClientId,
-            @JsonProperty(value = "authorizeUrl", required = true) String authorizeUrl,
-            @JsonProperty(value = "request", required = true) String request,
             @JsonProperty(value = "redirectUrl", required = true) String redirectUrl) {
         this.id = id;
-        this.ipvClientId = ipvClientId;
-        this.authorizeUrl = authorizeUrl;
-        this.request = request;
         this.redirectUrl = redirectUrl;
     }
 }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -191,7 +191,6 @@ class BuildCriOauthRequestHandlerTest {
         List<NameValuePair> queryParams = redirectUri.getQueryParams();
 
         assertEquals(CRI_ID, responseBody.get("id"));
-        assertEquals(IPV_CLIENT_ID, responseBody.get("ipvClientId"));
 
         Optional<NameValuePair> client_id =
                 queryParams.stream()
@@ -213,7 +212,6 @@ class BuildCriOauthRequestHandlerTest {
         jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
         assertSharedClaimsJWTIsValid(jweObject.getPayload().toString());
 
-        assertEquals(CRI_AUTHORIZE_URL, responseBody.get("authorizeUrl"));
         assertEquals(CRI_AUTHORIZE_URL, redirectUri.removeQuery().build().toString());
 
         assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
@@ -254,7 +252,6 @@ class BuildCriOauthRequestHandlerTest {
         List<NameValuePair> queryParams = redirectUri.getQueryParams();
 
         assertEquals(DCMAW_CRI_ID, responseBody.get("id"));
-        assertEquals(IPV_CLIENT_ID, responseBody.get("ipvClientId"));
 
         Optional<NameValuePair> client_id =
                 queryParams.stream()
@@ -277,7 +274,6 @@ class BuildCriOauthRequestHandlerTest {
         jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
         assertSharedClaimsJWTIsValid(jweObject.getPayload().toString());
 
-        assertEquals(CRI_AUTHORIZE_URL, responseBody.get("authorizeUrl"));
         assertEquals(CRI_AUTHORIZE_URL, redirectUri.removeQuery().build().toString());
 
         assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
@@ -364,7 +360,15 @@ class BuildCriOauthRequestHandlerTest {
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
         Map<String, String> responseBody = getResponseBodyAsMap(response).get("cri");
-        JWEObject jweObject = JWEObject.parse(responseBody.get("request"));
+
+        URIBuilder redirectUri = new URIBuilder(responseBody.get("redirectUrl"));
+        List<NameValuePair> queryParams = redirectUri.getQueryParams();
+
+        Optional<NameValuePair> request =
+                queryParams.stream().filter(param -> param.getName().equals("request")).findFirst();
+
+        assertTrue(request.isPresent());
+        JWEObject jweObject = JWEObject.parse(request.get().getValue());
         jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
 
         SignedJWT signedJWT = SignedJWT.parse(jweObject.getPayload().toString());
@@ -398,7 +402,15 @@ class BuildCriOauthRequestHandlerTest {
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
         Map<String, String> responseBody = getResponseBodyAsMap(response).get("cri");
-        JWEObject jweObject = JWEObject.parse(responseBody.get("request"));
+
+        URIBuilder redirectUri = new URIBuilder(responseBody.get("redirectUrl"));
+        List<NameValuePair> queryParams = redirectUri.getQueryParams();
+
+        Optional<NameValuePair> request =
+                queryParams.stream().filter(param -> param.getName().equals("request")).findFirst();
+
+        assertTrue(request.isPresent());
+        JWEObject jweObject = JWEObject.parse(request.get().getValue());
         jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
 
         SignedJWT signedJWT = SignedJWT.parse(jweObject.getPayload().toString());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Removed unused properties from the cri response.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Core-back now constructs a full redirect url and stores it under the `redirectUrl` property. This means all the other old ones are no longer needed. Core-front has already been updated to no longer expect this values, so this is just a cleanup PR.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1829](https://govukverify.atlassian.net/browse/PYIC-1829)

