### PR TITLE
PYIC-1841: Split the type of journey types depending on wether we are sending the user to the app system or not

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -14,6 +14,7 @@ public enum ConfigurationVariable {
     JWT_TTL_SECONDS("/%s/core/self/jwtTtlSeconds"),
     MAX_ALLOWED_AUTH_CLIENT_TTL("/%s/core/self/maxAllowedAuthClientTtl"),
     PASSPORT_CRI_ID("/%s/core/self/journey/passportCriId"),
+    DCMAW_ENABLED("/%s/core/self/journey/dcmawEnabled"),
     AUTH_CODE_EXPIRY_SECONDS("/%s/core/self/authCodeExpirySeconds"),
     PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("/%s/core/clients/%s/publicKeyMaterialForCoreToVerify");
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Load boolean `dcmawEnabled` SSM param to control wether we send users to the app system or not.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We want to be able to control wether we send users to the app or not via config. The selec-cri lambda will now load this boolean param from SSM and run different journey checks depending on the value. For now this will result in the same journey but will be expanded upon in further PR's.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1841](https://govukverify.atlassian.net/browse/PYIC-1841)

