### PR TITLE
PYIC-1834: Move CI storage core stub to own stack

### DIFF
--- a/.github/workflows/deploy-ci-storage-core-stub.yaml
+++ b/.github/workflows/deploy-ci-storage-core-stub.yaml
@@ -1,0 +1,67 @@
+name: Build, package and ship ci storage core stub
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - lambdas/contra-indicator-storage-core-stub/**
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: adopt
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
+      - uses: actions/setup-python@v3 # Required for SAM CLI
+        with:
+          python-version: "3.8"
+
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+
+      - name: SAM build
+        working-directory: ./lambdas/contra-indicator-storage-core-stub
+        run: sam build
+
+      - name: Assume AWS role for dev account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_CI_STORAGE_CORE_STUB_GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Deploy to dev environment
+        uses: alphagov/di-devplatform-upload-action@v3
+        with:
+          artifact-bucket-name: ${{ secrets.DEV_CI_STORAGE_CORE_STUB_ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+          working-directory: ./lambdas/contra-indicator-storage-core-stub
+
+      - name: Assume AWS role for build account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.BUILD_CI_STORAGE_CORE_STUB_GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Deploy to build environment
+        uses: alphagov/di-devplatform-upload-action@v3
+        with:
+          artifact-bucket-name: ${{ secrets.BUILD_CI_STORAGE_CORE_STUB_ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
+          working-directory: ./lambdas/contra-indicator-storage-core-stub

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -42,9 +42,7 @@ Conditions:
       - !Equals [ !Ref Environment, "integration"]
       - !Equals [ !Ref Environment, "production"]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
-  IsDevelopmentOrBuild: !Or
-      - !Condition IsDevelopment
-      - !Equals [ !Ref Environment, "build" ]
+
 
 # The AWS Account Id is used in the following mapping section because we have
 # multiple developer environments and it is undesirable to have to keep this
@@ -61,18 +59,6 @@ Mappings:
       provisionedConcurrency: 1
     "075701497069": # Production
       provisionedConcurrency: 1
-
-  CIStorageCoreStubAccountMappings:
-    "130355686670": # di-ipv-dev
-      ciStorageAccountId: 322814139578 # di-ipv-cri-dev
-    "457601271792": # di-ipv-core-build
-      ciStorageAccountId: 755415363251 # di-ipv-contra-indicators-build
-    "335257547869": # di-ipv-core-staging
-      ciStorageAccountId: XXXXXXXXXXXX # Not deployed to staging
-    "991138514218": # di-ipv-core-integration
-      ciStorageAccountId: XXXXXXXXXXXX # Not deployed to integration
-    "075701497069": # di-ipv-core-production
-      ciStorageAccountId: XXXXXXXXXXXX # Not deployed to production
 
 Resources:
   JWKSParamRole:
@@ -1261,87 +1247,6 @@ Resources:
             Condition:
               ArnLike:
                 "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
-
-  CIStorageCoreStubFunction:
-    Type: AWS::Serverless::Function
-    Condition: IsDevelopmentOrBuild
-    DependsOn:
-      - CIStorageCoreStubFunctionLogGroup
-    Properties:
-      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
-      # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
-      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
-      FunctionName: !Sub "ci-storage-core-stub-${Environment}"
-      Handler: uk.gov.di.ipv.core.contraindicatorstoragecorestub.ContraIndicatorStorageCoreStubHandler::handleRequest
-      Runtime: java11
-      PackageType: Zip
-      CodeUri: ../lambdas/contra-indicator-storage-core-stub
-      Architectures:
-        - arm64
-      MemorySize: 2048
-      Tracing: Active
-      Environment:
-        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
-        Variables:
-          ENVIRONMENT: !Sub "${Environment}"
-          POWERTOOLS_SERVICE_NAME: !Sub contra-indicator-storage-core-stub-${Environment}
-          CI_STORAGE_GET_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraindicators-${env}"
-            - contra_indicator_storage_account_id: !FindInMap
-                - CIStorageCoreStubAccountMappings
-                - !Ref AWS::AccountId
-                - ciStorageAccountId
-              env: !Ref Environment
-          CI_STORAGE_PUT_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraindicators-${env}"
-            - contra_indicator_storage_account_id: !FindInMap
-                - CIStorageCoreStubAccountMappings
-                - !Ref AWS::AccountId
-                - ciStorageAccountId
-              env: !Ref Environment
-      Policies:
-        - Statement:
-            - Sid: invokeInvokeCiSystemFunctions
-              Effect: Allow
-              Action:
-                - 'lambda:InvokeFunction'
-              Resource:
-                - !Sub
-                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraindicators-${env}"
-                  - contra_indicator_storage_account_id: !FindInMap
-                      - CIStorageCoreStubAccountMappings
-                      - !Ref AWS::AccountId
-                      - ciStorageAccountId
-                    env: !Ref Environment
-                - !Sub
-                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraindicators-${env}"
-                  - contra_indicator_storage_account_id: !FindInMap
-                      - CIStorageCoreStubAccountMappings
-                      - !Ref AWS::AccountId
-                      - ciStorageAccountId
-                    env: !Ref Environment
-      Events:
-        Get:
-          Type: Api
-          Properties:
-            RestApiId: !Ref IPVCoreExternalAPI
-            Path: /contra-indicator-storage-core-stub
-            Method: GET
-        Post:
-          Type: Api
-          Properties:
-            RestApiId: !Ref IPVCoreExternalAPI
-            Path: /contra-indicator-storage-core-stub
-            Method: POST
-      AutoPublishAlias: live
-
-  CIStorageCoreStubFunctionLogGroup:
-    Condition: IsDevelopmentOrBuild
-    Type: AWS::Logs::LogGroup
-    Properties:
-      RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/ci-storage-core-stub-${Environment}"
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
 Outputs:
   IPVCorePrivateAPIGatewayID:

--- a/lambdas/contra-indicator-storage-core-stub/samconfig.toml
+++ b/lambdas/contra-indicator-storage-core-stub/samconfig.toml
@@ -1,0 +1,110 @@
+version = 0.1
+
+[dev.deploy.parameters]
+stack_name = "ci-storage-core-stub-development"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-development"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev\""
+parallel = "true"
+
+[dev-danh.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-danh"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-danh"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-danh\""
+parallel = "true"
+
+[dev-danp.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-danp"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-danp"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-danp\""
+parallel = "true"
+
+[dev-chrisw.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-chrisw"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-chrisw"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-chrisw\""
+parallel = "true"
+
+[dev-amrits.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-amrits"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-amrits"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-amrits\""
+parallel = "true"
+
+[dev-lait.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-lait"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-lait"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-lait\""
+parallel = "true"
+
+[dev-kerrr.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-kerrr"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-kerrr"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-kerrr\""
+parallel = "true"
+
+[dev-derrenw.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-derrenw"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-derrenw"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-derrenw\""
+parallel = "true"
+
+[dev-patrickb.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-patrickb"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-patrickb"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-patrickb\""
+parallel = "true"
+
+[dev-vamh.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-vamh"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-vamh"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-vamh\""
+parallel = "true"
+
+[dev-wojciecho.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-wojciecho"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-wojciecho"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-wojciecho\""
+parallel = "true"
+
+[dev-aprilm.deploy.parameters]
+stack_name = "ci-storage-core-stub-dev-aprilm"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-ec647gpjuo2w"
+s3_prefix = "ci-storage-core-stub-aprilm"
+region = "eu-west-2"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Environment=\"dev-aprilm\""
+parallel = "true"
+

--- a/lambdas/contra-indicator-storage-core-stub/template.yaml
+++ b/lambdas/contra-indicator-storage-core-stub/template.yaml
@@ -1,0 +1,129 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: A stack for the CI storage systems core stub
+Globals:
+  Function:
+    Environment:
+      Variables:
+        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+    CodeSigningConfigArn: !If
+      - UseCodeSigning
+      - !Ref CodeSigningConfigArn
+      - !Ref AWS::NoValue
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
+
+Parameters:
+  Environment:
+    Type: String
+
+  CodeSigningConfigArn:
+    Type: String
+    Description: >
+      The ARN of the Code Signing Config to use, provided by the deployment pipeline
+    Default: "none"
+
+  PermissionsBoundary:
+    Type: String
+    Description: >
+      The ARN of the permissions boundary to apply to any role created by the template
+    Default: "none"
+
+Conditions:
+  UseCodeSigning:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref CodeSigningConfigArn
+          - "none"
+
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
+
+Mappings:
+  CIStorageCoreStubAccountMappings:
+    "130355686670": # di-ipv-dev
+      ciStorageAccountId: 322814139578 # di-ipv-cri-dev
+    "457601271792": # di-ipv-core-build
+      ciStorageAccountId: 755415363251 # di-ipv-contra-indicators-build
+
+Resources:
+  CIStorageCoreStubAPI:
+    Type: AWS::Serverless::Api
+    Properties:
+      # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
+      StageName: !Sub ${Environment}
+
+  CIStorageCoreStubFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+      # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
+      # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
+      FunctionName: !Sub "ci-storage-core-stub-${Environment}"
+      Handler: uk.gov.di.ipv.core.contraindicatorstoragecorestub.ContraIndicatorStorageCoreStubHandler::handleRequest
+      Runtime: java11
+      PackageType: Zip
+      CodeUri: ./
+      Architectures:
+        - arm64
+      MemorySize: 2048
+      Tracing: Active
+      Environment:
+        # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+        Variables:
+          ENVIRONMENT: !Sub "${Environment}"
+          POWERTOOLS_SERVICE_NAME: !Sub contra-indicator-storage-core-stub-${Environment}
+          CI_STORAGE_GET_LAMBDA_ARN: !Sub
+            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraindicators-${env}"
+            - contra_indicator_storage_account_id: !FindInMap
+                - CIStorageCoreStubAccountMappings
+                - !Ref AWS::AccountId
+                - ciStorageAccountId
+              env: !Ref Environment
+          CI_STORAGE_PUT_LAMBDA_ARN: !Sub
+            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraindicators-${env}"
+            - contra_indicator_storage_account_id: !FindInMap
+                - CIStorageCoreStubAccountMappings
+                - !Ref AWS::AccountId
+                - ciStorageAccountId
+              env: !Ref Environment
+      Policies:
+        - Statement:
+            - Sid: invokeInvokeCiSystemFunctions
+              Effect: Allow
+              Action:
+                - 'lambda:InvokeFunction'
+              Resource:
+                - !Sub
+                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraindicators-${env}"
+                  - contra_indicator_storage_account_id: !FindInMap
+                      - CIStorageCoreStubAccountMappings
+                      - !Ref AWS::AccountId
+                      - ciStorageAccountId
+                    env: !Ref Environment
+                - !Sub
+                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraindicators-${env}"
+                  - contra_indicator_storage_account_id: !FindInMap
+                      - CIStorageCoreStubAccountMappings
+                      - !Ref AWS::AccountId
+                      - ciStorageAccountId
+                    env: !Ref Environment
+      Events:
+        Get:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CIStorageCoreStubAPI
+            Path: /contra-indicator-storage-core-stub
+            Method: GET
+        Post:
+          Type: Api
+          Properties:
+            RestApiId: !Ref CIStorageCoreStubAPI
+            Path: /contra-indicator-storage-core-stub
+            Method: POST
+      AutoPublishAlias: live

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -83,31 +83,3 @@ paths:
             statusCode: 200
             responseTemplates:
               application/json: "{\"healthcheck\": \"ok\"}"
-
-  /contra-indicator-storage-core-stub:
-    get:
-      description: "Get the contra-indicator-storage core stub"
-      responses:
-        200:
-          description: "The html"
-          content:
-            text/html:
-              schema:
-                type: "string"
-      x-amazon-apigateway-integration:
-        type: "aws_proxy"
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CIStorageCoreStubFunction.Arn}:live/invocations
-        passthroughBehavior: "when_no_match"
-    post:
-      description: "Store a new contra-indicator"
-      responses:
-        302:
-          description: "Redirect back to the get page"
-      x-amazon-apigateway-integration:
-        type: "aws_proxy"
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CIStorageCoreStubFunction.Arn}:live/invocations
-        passthroughBehavior: "when_no_match"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Move CI storage core stub to own stack

### Why did it change

This moves the CloudFormation to deploy the CI storage core stub to its
own stack. This means it can be deployed independently of the core,
which is a good thing. Less risk of it being deployed to an undesired
environment, and less complexity in the templates.

Two new secure pipelines have been created in the dev and build accounts
to do the actual deploy. This commit includes a new GitHub workflow to
build the stub and push the artifacts to those accounts for the
pipelines to pick up and deploy.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1834](https://govukverify.atlassian.net/browse/PYIC-1834)