### PR TITLE
PYIC-1844: Update core to be able to retrieve and store a VC from the app stub

### DIFF
--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.ipv.core.library.validation.VerifiableCredentialJwtValidator;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -153,7 +154,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                 .thenReturn(new BearerAccessToken());
 
         when(credentialIssuerService.getVerifiableCredential(any(), any(), anyString()))
-                .thenReturn(SignedJWT.parse(SIGNED_VC_1));
+                .thenReturn(Collections.singletonList(SignedJWT.parse(SIGNED_VC_1)));
 
         mockServiceCallsAndSessionItem();
 
@@ -296,7 +297,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
 
         when(credentialIssuerService.getVerifiableCredential(
                         accessToken, passportIssuer, testApiKey))
-                .thenReturn(SignedJWT.parse(SIGNED_VC_1));
+                .thenReturn(Collections.singletonList(SignedJWT.parse(SIGNED_VC_1)));
 
         mockServiceCallsAndSessionItem();
 
@@ -410,7 +411,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
 
         when(credentialIssuerService.getVerifiableCredential(
                         accessToken, passportIssuer, testApiKey))
-                .thenReturn(SignedJWT.parse(SIGNED_VC_1));
+                .thenReturn(Collections.singletonList(SignedJWT.parse(SIGNED_VC_1)));
 
         mockServiceCallsAndSessionItem();
 
@@ -447,7 +448,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
 
         when(credentialIssuerService.getVerifiableCredential(
                         accessToken, passportIssuer, testApiKey))
-                .thenReturn(SignedJWT.parse(SIGNED_CONTRACT_INDICATORS));
+                .thenReturn(Collections.singletonList(SignedJWT.parse(SIGNED_CONTRACT_INDICATORS)));
 
         mockServiceCallsAndSessionItem();
 
@@ -499,7 +500,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
 
         when(credentialIssuerService.getVerifiableCredential(
                         accessToken, passportIssuer, testApiKey))
-                .thenReturn(SignedJWT.parse(SIGNED_ADDRESS_VC));
+                .thenReturn(Collections.singletonList(SignedJWT.parse(SIGNED_ADDRESS_VC)));
 
         mockServiceCallsAndSessionItem();
 

--- a/lambdas/validate-cri-credential/src/main/java/uk/gov/di/ipv/core/validatecricredential/validation/CriCheckValidator.java
+++ b/lambdas/validate-cri-credential/src/main/java/uk/gov/di/ipv/core/validatecricredential/validation/CriCheckValidator.java
@@ -22,6 +22,8 @@ public class CriCheckValidator {
     public static final String CRI_ID_STUB_FRAUD = "stubFraud";
     public static final String CRI_ID_KBV = "kbv";
     public static final String CRI_ID_STUB_KBV = "stubKbv";
+    public static final String CRI_ID_DCMAW = "dcmaw";
+    public static final String CRI_ID_STUB_DCMAW = "stubDcmaw";
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static final List<String> ADDRESS_CRI_TYPES =
@@ -30,6 +32,7 @@ public class CriCheckValidator {
             List.of(CRI_ID_UK_PASSPORT, CRI_ID_STUB_UK_PASSPORT);
     private static final List<String> FRAUD_CRI_TYPES = List.of(CRI_ID_FRAUD, CRI_ID_STUB_FRAUD);
     private static final List<String> KBV_CRI_TYPES = List.of(CRI_ID_KBV, CRI_ID_STUB_KBV);
+    private static final List<String> DCMAW_CRI_TYPES = List.of(CRI_ID_DCMAW, CRI_ID_STUB_DCMAW);
     public static final String EVIDENCE = "evidence";
     public static final int SERVER_ERROR = 500;
 
@@ -57,6 +60,8 @@ public class CriCheckValidator {
         } else if (FRAUD_CRI_TYPES.contains(credentialIssuerId)) {
             return new EvidenceValidator(new FraudEvidenceValidator()).validate(vcClaimJson);
         } else if (ADDRESS_CRI_TYPES.contains(credentialIssuerId)) {
+            return true;
+        } else if (DCMAW_CRI_TYPES.contains(credentialIssuerId)) {
             return true;
         } else {
             LOGGER.error("Credential issuer ID not recognised: '{}'", credentialIssuerId);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java
@@ -62,6 +62,13 @@ public interface TestFixtures {
     String SIGNED_CONTRACT_INDICATORS =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvaXNzdWVyLmV4YW1wbGUuY29tIiwic3ViIjoiaHR0cHM6XC9cL3N1YmplY3QuZXhhbXBsZS5jb20iLCJuYmYiOjE2NTYwODEzMDUsImV4cCI6MTY1NjA4MTkwNSwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6XC9cL3d3dy53My5vcmdcLzIwMThcL2NyZWRlbnRpYWxzXC92MSIsImh0dHBzOlwvXC92b2NhYi5sb25kb24uY2xvdWRhcHBzLmRpZ2l0YWxcL2NvbnRleHRzXC9pZGVudGl0eS12MS5qc29ubGQiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImFkZHJlc3MiOlt7ImRlcGVuZGVudEFkZHJlc3NMb2NhbGl0eSI6Ildlc3RtaW5zdGVyIiwiYWRkcmVzc0xvY2FsaXR5IjoiTG9uZG9uIiwiYnVpbGRpbmdOdW1iZXIiOiIxMCIsImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJwb3N0YWxDb2RlIjoiU1cxQTJBQSIsInZhbGlkRnJvbSI6IjIwMTktMDctMjQiLCJzdHJlZXROYW1lIjoiRG93bmluZ1N0cmVldCJ9LHsiYnVpbGRpbmdOdW1iZXIiOiIxMjMiLCJwb3N0YWxDb2RlIjoiTTM0IDFBQSJ9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjIwMjAtMDEtMDMifSx7InZhbHVlIjoiMjAyMS0wMS0wMyJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJBbGljZSJ9LHsidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiSmFuZSJ9LHsidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiTGF1cmEifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJEb2UifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJNdXNrIn1dfV19LCJldmlkZW5jZSI6W3sidmVyaWZpY2F0aW9uU2NvcmUiOiIwIiwiY2kiOlsiQTAyIiwiQTAzIl0sInR4biI6IkRTSkpTRUUyOTM5MiIsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dfX0.j9Uf6LF3Me3azBcAl9unPdKKyRz8MxiM_NN7r5n6zFTMuh4Yzfn_JWDfgifwU28eOB6p9JV0ON3rOrsmsW8Nxw";
 
+    Map<String, Object> DCMAW_SUCCESS_RESPONSE =
+            Map.of(
+                    "sub",
+                    "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+                    "https://vocab.account.gov.uk/v1/credentialJWT",
+                    List.of(SIGNED_VC_1));
+
     Map<String, Object> CREDENTIAL_ATTRIBUTES_1 =
             Map.of(
                     "name",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update core-back to handle the JSON structured VC being returned from the doc-checking app. Normally a CRI just returns a JWT in string format, however the doc checking app will return a JSON object containing an array of JWT strings.

This PR updates the retrieve-cri-oauth-access-token lambda to handle receiving a JSON response from the app.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The doc checking app system will return a VC in a different structure, so this PR will ensure ipv-core can retrieve and store these VC's.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1844](https://govukverify.atlassian.net/browse/PYIC-1844)

