### PR TITLE
BAU: Re-instate build-oauth-request endpoint

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -120,6 +120,24 @@ paths:
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
 
+
+  /journey/cri/build-oauth-request/{criId}:
+    post:
+      description: Called when the frontend begins the CRI journey.
+      responses:
+        200:
+          description: "Returns the id, ipvClientId and authorizationUrl for a CRI."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/journeyType"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildCriOauthRequestFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        type: "aws_proxy"
+
   /journey/cri/validate/{criId}:
     post:
       description: "Returns a next or fail journey step, depending on if a CRI check meets requirements to continue the journey"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Re-instate build-oauth-request endpoint

### Why did it change

The build-oauth-request endpoint in the openAPI spec for the internal
API got dropped by mistake a while back. Somehow the change hasn't
proliferated to production.

A fresh deploy to my dev account brought this to my attention. We should
put it back.
