### PR TITLE
PYIC-1642: Re-revert step function work

### DIFF
--- a/deploy/journey_engine.asl.json
+++ b/deploy/journey_engine.asl.json
@@ -1,0 +1,10 @@
+{
+  "StartAt": "ProcessJourneyStep",
+  "States": {
+    "ProcessJourneyStep": {
+      "Type": "Task",
+      "Resource": "${IPVProcessJourneyStepFunctionArn}",
+      "End": true
+    }
+  }
+}

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -89,6 +89,15 @@ Resources:
       Name: !Sub IPV Core Private API Gateway ${Environment}
       EndpointConfiguration:
         Type: PRIVATE
+      DefinitionBody:
+        openapi: "3.0.3" # workaround to get `sam validate` to work
+        paths: # workaround to get `sam validate` to work
+          /foo:
+            bar: baz # workaround to get `sam validate` to work
+        Fn::Transform:
+          Name: "AWS::Include"
+          Parameters:
+            Location: "../openAPI/core-back-internal.yaml"
       Auth:
         ResourcePolicy:
           CustomStatements:
@@ -899,6 +908,83 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref BuildDebugCredentialDataFunctionLogGroup
 
+  JourneyEngineStepFunction:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: journey_engine.asl.json
+      DefinitionSubstitutions:
+        IPVProcessJourneyStepFunctionArn: !GetAtt IPVProcessJourneyStepFunction.Arn
+      Events:
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
+            Path: /journey/{journeyStep}
+            Method: POST
+      Logging:
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt JourneyEngineStepFunctionLogGroup.Arn
+        IncludeExecutionData: true
+        Level: ALL
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref IPVProcessJourneyStepFunction
+        - Statement:
+            - Sid: CloudWatchLogsAccess
+              Effect: Allow
+              Action:
+                - "logs:CreateLogDelivery"
+                - "logs:GetLogDelivery"
+                - "logs:UpdateLogDelivery"
+                - "logs:DeleteLogDelivery"
+                - "logs:ListLogDeliveries"
+                - "logs:PutLogEvents"
+                - "logs:PutResourcePolicy"
+                - "logs:DescribeResourcePolicies"
+                - "logs:DescribeLogGroups"
+              Resource: "*"
+      Tracing:
+        Enabled: true
+      Type: EXPRESS
+
+  JourneyEngineStepFunctionApiGateWayIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: AllowApiGatewayToInvokeStartSyncExecution
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: 'states:StartSyncExecution'
+                Resource: !Ref JourneyEngineStepFunction
+
+  JourneyEngineStepFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/states/journey-engine-step-function-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  JourneyEngineStepFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref JourneyEngineStepFunctionLogGroup
+
   IPVProcessJourneyStepFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -929,14 +1015,6 @@ Resources:
             TableName: !Ref SessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
-      Events:
-        IPVCorePrivateAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCorePrivateAPI
-            Path: /journey/{journeyStep}
-            Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/lambdas/process-journey-step/build.gradle
+++ b/lambdas/process-journey-step/build.gradle
@@ -13,11 +13,15 @@ dependencies {
 	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jackson",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			project(":lib")
 
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
 			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
+
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2",
 			"org.mockito:mockito-core:4.1.0",

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -1,9 +1,8 @@
 package uk.gov.di.ipv.core.processjourneystep;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.google.gson.Gson;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -14,9 +13,10 @@ import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
+import uk.gov.di.ipv.core.library.domain.ApiGatewayTemplateMappingInput;
+import uk.gov.di.ipv.core.library.domain.ApiGatewayTemplateMappingOutput;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
-import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -31,19 +31,25 @@ import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownStat
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.PageResponse;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TIMEOUT;
 
-public class ProcessJourneyStepHandler
-        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+public class ProcessJourneyStepHandler implements RequestStreamHandler {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String JOURNEY_STEP_PARAM = "journeyStep";
     private static final String PYIC_TECHNICAL_ERROR_PAGE_ID = "pyi-technical";
     private static final String CORE_SESSION_TIMEOUT_STATE = "CORE_SESSION_TIMEOUT";
+    private static final Gson gson = new Gson();
 
     private final StateMachine stateMachine;
     private final IpvSessionService ipvSessionService;
@@ -72,43 +78,61 @@ public class ProcessJourneyStepHandler
     @Override
     @Tracing
     @Logging(clearState = true)
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
+    public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
+            throws IOException {
         LogHelper.attachComponentIdToLogs();
+        var input =
+                gson.fromJson(
+                        new BufferedReader(new InputStreamReader(inputStream)),
+                        ApiGatewayTemplateMappingInput.class);
+        ApiGatewayTemplateMappingOutput output = new ApiGatewayTemplateMappingOutput();
+        OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+
         try {
-            var ipvSessionId = RequestHelper.getIpvSessionId(input);
-            Map<String, String> pathParameters = input.getPathParameters();
+            var ipvSessionId = RequestHelper.getIpvSessionId(input.getHeaders());
+            Map<String, String> pathParameters = input.getParams();
 
             var errorResponse = validate(pathParameters);
             if (errorResponse.isPresent()) {
-                return ApiGatewayResponseGenerator.proxyJsonResponse(400, errorResponse.get());
+                output.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+                output.setBody(errorResponse.get().toJsonString());
+                writer.write(gson.toJson(output));
+                writer.close();
+                return;
             }
 
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
 
             if (ipvSessionItem == null) {
                 LOGGER.warn("Failed to find ipv-session");
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_ID);
+                output.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+                output.setBody(ErrorResponse.INVALID_SESSION_ID.toJsonString());
+                writer.write(gson.toJson(output));
+                writer.close();
+                return;
             }
 
             LogHelper.attachGovukSigninJourneyIdToLogs(
                     ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId());
 
-            String journeyStep = input.getPathParameters().get(JOURNEY_STEP_PARAM);
+            String journeyStep = input.getParams().get(JOURNEY_STEP_PARAM);
 
             Map<String, String> journeyStepResponse =
                     executeJourneyEvent(journeyStep, ipvSessionItem);
 
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_OK, journeyStepResponse);
+            output.setStatusCode(HttpStatus.SC_OK);
+            output.setBody(gson.toJson(journeyStepResponse));
+
         } catch (HttpResponseExceptionWithErrorBody e) {
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getResponseCode(), e.getErrorBody());
+            output.setStatusCode(e.getResponseCode());
+            output.setBody(gson.toJson(e.getErrorBody()));
         } catch (JourneyEngineException e) {
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_JOURNEY_ENGINE_STEP);
+            output.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            output.setBody(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.toJsonString());
         }
+
+        writer.write(gson.toJson(output));
+        writer.close();
     }
 
     @Tracing

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -1,8 +1,6 @@
 package uk.gov.di.ipv.core.processjourneystep;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
@@ -12,6 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.ApiGatewayTemplateMappingInput;
+import uk.gov.di.ipv.core.library.domain.ApiGatewayTemplateMappingOutput;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
@@ -21,10 +21,12 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachine;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineInitializer;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,6 +58,7 @@ class ProcessJourneyStepHandlerTest {
     private static final String PYI_NO_MATCH_STATE = "PYI_NO_MATCH";
     private static final String PYI_KBV_FAIL_STATE = "PYI_KBV_FAIL";
     private static final String CORE_SESSION_TIMEOUT_STATE = "CORE_SESSION_TIMEOUT";
+    public static final String END_STATE = "END";
 
     private static final String IPV_IDENTITY_START_PAGE = "page-ipv-identity-start";
     private static final String PYI_TECHNICAL_ERROR_PAGE = "pyi-technical";
@@ -86,192 +89,226 @@ class ProcessJourneyStepHandlerTest {
 
     @Test
     void shouldReturn400OnMissingParams() throws IOException {
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Collections.emptyMap(),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
-        event.setPathParameters(Collections.emptyMap());
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-        assertEquals(400, response.getStatusCode());
+        assertEquals(400, lambdaOutput.getStatusCode());
         assertEquals(
                 ErrorResponse.MISSING_JOURNEY_STEP_URL_PATH_PARAM.getCode(),
-                responseBody.get("code"));
+                outputBody.get("code"));
         assertEquals(
                 ErrorResponse.MISSING_JOURNEY_STEP_URL_PATH_PARAM.getMessage(),
-                responseBody.get("message"));
+                outputBody.get("message"));
     }
 
     @Test
     void shouldReturn400OnMissingJourneyStepParam() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
-        event.setPathParameters(Collections.emptyMap());
-        event.setPathParameters(Map.of("InvalidStep", "any"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of("InvalidStep", "any"),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-        assertEquals(400, response.getStatusCode());
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
+
+        assertEquals(400, lambdaOutput.getStatusCode());
         assertEquals(
                 ErrorResponse.MISSING_JOURNEY_STEP_URL_PATH_PARAM.getCode(),
-                responseBody.get("code"));
+                outputBody.get("code"));
         assertEquals(
                 ErrorResponse.MISSING_JOURNEY_STEP_URL_PATH_PARAM.getMessage(),
-                responseBody.get("message"));
+                outputBody.get("message"));
     }
 
     @Test
     void shouldReturn400OnMissingIpvSessionIdHeader() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Collections.emptyMap(),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
-        assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), responseBody.get("error"));
+        assertEquals(400, lambdaOutput.getStatusCode());
+        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), outputBody.get("error"));
         assertEquals(
                 ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
-                responseBody.get("error_description"));
+                outputBody.get("error_description"));
     }
 
     @Test
     void shouldReturn400WhenInvalidSessionIdProvided() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
+        when(mockIpvSessionService.getIpvSession("1234")).thenReturn(null);
 
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(null);
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(400, response.getStatusCode());
-        assertEquals(ErrorResponse.INVALID_SESSION_ID.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.INVALID_SESSION_ID.getMessage(), responseBody.get("message"));
+        assertEquals(400, lambdaOutput.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_SESSION_ID.getCode(), outputBody.get("code"));
+        assertEquals(ErrorResponse.INVALID_SESSION_ID.getMessage(), outputBody.get("message"));
     }
 
     @Test
     void shouldReturn500WhenUnknownJourneyEngineStepProvided() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, INVALID_STEP);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, INVALID_STEP),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.setUserState(INITIAL_IPV_JOURNEY_STATE);
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
-
+        ipvSessionItem.setUserState(INITIAL_IPV_JOURNEY_STATE);
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        assertEquals(500, response.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getCode(), responseBody.get("code"));
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
+
+        assertEquals(500, lambdaOutput.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getCode(), outputBody.get("code"));
         assertEquals(
-                ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), responseBody.get("message"));
+                ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), outputBody.get("message"));
     }
 
     @Test
     void shouldReturn500WhenUserIsInUnknownState() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.setUserState("INVALID-STATE");
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
-
+        ipvSessionItem.setUserState("INVALID-STATE");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        assertEquals(500, response.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getCode(), responseBody.get("code"));
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
+
+        assertEquals(500, lambdaOutput.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getCode(), outputBody.get("code"));
         assertEquals(
-                ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), responseBody.get("message"));
+                ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), outputBody.get("message"));
     }
 
     @Test
     void shouldReturnIdentityStartPageResponseWhenRequired() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.setUserState(INITIAL_IPV_JOURNEY_STATE);
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
+        ipvSessionItem.setUserState(INITIAL_IPV_JOURNEY_STATE);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
+
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(IPV_IDENTITY_START_PAGE, outputBody.get("page"));
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(
                 IPV_IDENTITY_START_PAGE_STATE, sessionArgumentCaptor.getValue().getUserState());
-
-        assertEquals(200, response.getStatusCode());
-        assertEquals(IPV_IDENTITY_START_PAGE, pageResponse.get("page"));
     }
 
     @Test
     void shouldReturnEvaluateGpg45ScoresWhenIpvIdentityStartPageState() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -282,29 +319,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> criResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, criResponse.get("journey"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, outputBody.get("journey"));
     }
 
     @Test
     void shouldReturnEvaluateGpg45ScoresWhenCriUkPassportState() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -315,29 +356,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> criResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, criResponse.get("journey"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, outputBody.get("journey"));
     }
 
     @Test
     void shouldReturnCriErrorPageResponseIfPassportCriFails() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, ERROR);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, ERROR),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -348,29 +393,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnEvaluateGpg45ScoresWhenCriAddressState() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -385,29 +434,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> criResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, criResponse.get("journey"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, outputBody.get("journey"));
     }
 
     @Test
     void shouldReturnCriErrorPageResponseIfAddressCriFails() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, ERROR);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, ERROR),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -418,29 +471,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnEvaluateGpg45ScoresWhenCriFraudState() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -451,29 +508,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> journeyResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, journeyResponse.get("journey"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, outputBody.get("journey"));
     }
 
     @Test
     void shouldReturnPreKbvTransitionPageResponseWhenRequired() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, "kbv");
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, "kbv"),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -487,10 +548,13 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -498,19 +562,20 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(
                 PRE_KBV_TRANSITION_PAGE_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PRE_KBV_TRANSITION_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PRE_KBV_TRANSITION_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnCriKbvJourneyResponseWhenRequired() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -524,29 +589,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> criResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(CRI_KBV_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/cri/build-oauth-request/kbv", criResponse.get("journey"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals("/journey/cri/build-oauth-request/kbv", outputBody.get("journey"));
     }
 
     @Test
     void shouldReturnCriErrorPageResponseIfFraudCriFails() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, ERROR);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, ERROR),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -557,29 +626,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnEvaluateGpg45ScoresWhenCriKbvState() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -593,30 +666,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-
         assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, pageResponse.get("journey"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, outputBody.get("journey"));
     }
 
     @Test
     void shouldReturnCriErrorPageResponseIfKbvCriFails() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, ERROR);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, ERROR),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -627,29 +703,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnEndSessionJourneyResponseWhenRequired() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -663,24 +743,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> journeyResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/build-client-oauth-response", journeyResponse.get("journey"));
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(END_STATE, sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals("/journey/build-client-oauth-response", outputBody.get("journey"));
     }
 
     @Test
     void shouldReturnDebugPageResponseWhenRequired() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -691,24 +780,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(DEBUG_PAGE, pageResponse.get("page"));
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(DEBUG_PAGE_STATE, sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(DEBUG_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnPYITechnicalPageIfErrorOccursOnDebugJourney() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, ERROR);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, ERROR),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -719,29 +817,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnPYINoMatchPageIfErrorOccursOnDebugJourney() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, FAIL);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, FAIL),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -752,29 +854,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(PYI_NO_MATCH_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_NO_MATCH_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_NO_MATCH_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnErrorPageResponseWhenRequired() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -789,24 +895,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> journeyResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/build-client-oauth-response", journeyResponse.get("journey"));
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(END_STATE, sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals("/journey/build-client-oauth-response", outputBody.get("journey"));
     }
 
     @Test
     void shouldReturnPYINoMatchPageIfPassportCriVCValidationReturnsFail() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, FAIL);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, FAIL),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -817,29 +932,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(PYI_NO_MATCH_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_NO_MATCH_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_NO_MATCH_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnPYINoMatchPageIfFraudCriVCValidationReturnsFail() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, FAIL);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, FAIL),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -850,29 +969,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(PYI_NO_MATCH_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_NO_MATCH_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_NO_MATCH_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnPYIKbvFailPageIfKbvCriVCValidationReturnsFail() throws IOException {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, FAIL);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, FAIL),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -886,30 +1009,33 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-
         assertEquals(PYI_KBV_FAIL_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_KBV_FAIL_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_KBV_FAIL_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnErrorPageIfSessionHasExpired() throws Exception {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -922,35 +1048,39 @@ class ProcessJourneyStepHandlerTest {
         when(mockConfigurationService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("99");
         when(mockIpvSessionService.getIpvSession("1234")).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> pageResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
+
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
 
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
 
         IpvSessionItem capturedIpvSessionItem = sessionArgumentCaptor.getValue();
-        assertEquals(CORE_SESSION_TIMEOUT_STATE, capturedIpvSessionItem.getUserState());
+        assertEquals(CORE_SESSION_TIMEOUT_STATE, sessionArgumentCaptor.getValue().getUserState());
         assertEquals(OAuth2Error.ACCESS_DENIED.getCode(), capturedIpvSessionItem.getErrorCode());
         assertEquals(
                 OAuth2Error.ACCESS_DENIED.getDescription(),
                 capturedIpvSessionItem.getErrorDescription());
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, pageResponse.get("page"));
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, outputBody.get("page"));
     }
 
     @Test
     void shouldReturnSessionEndJourneyIfStateIsSessionTimeout() throws Exception {
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
-        Map<String, String> pathParameters = new HashMap<>();
-        pathParameters.put(JOURNEY_STEP, NEXT);
-        event.setPathParameters(pathParameters);
-
-        event.setHeaders(Map.of("ipv-session-id", "1234"));
+        var input =
+                new ApiGatewayTemplateMappingInput(
+                        Map.of("input", "body"),
+                        Map.of("ipv-session-id", "1234"),
+                        Map.of(JOURNEY_STEP, NEXT),
+                        Collections.emptyMap());
+        InputStream inputStream = new ByteArrayInputStream(objectMapper.writeValueAsBytes(input));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -961,12 +1091,20 @@ class ProcessJourneyStepHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockIpvSessionService.getIpvSession("1234")).thenReturn(ipvSessionItem);
 
-        APIGatewayProxyResponseEvent response =
-                processJourneyStepHandler.handleRequest(event, mockContext);
-        Map<String, String> journeyResponse =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        processJourneyStepHandler.handleRequest(inputStream, outputStream, mockContext);
 
-        assertEquals(200, response.getStatusCode());
-        assertEquals("/journey/build-client-oauth-response", journeyResponse.get("journey"));
+        ApiGatewayTemplateMappingOutput lambdaOutput =
+                objectMapper.readValue(
+                        outputStream.toByteArray(), ApiGatewayTemplateMappingOutput.class);
+        Map<String, Object> outputBody =
+                objectMapper.readValue(lambdaOutput.getBody(), new TypeReference<>() {});
+
+        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
+        assertEquals(END_STATE, sessionArgumentCaptor.getValue().getUserState());
+
+        assertEquals(200, lambdaOutput.getStatusCode());
+        assertEquals("/journey/build-client-oauth-response", outputBody.get("journey"));
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ApiGatewayTemplateMappingInput.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ApiGatewayTemplateMappingInput.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+@ExcludeFromGeneratedCoverageReport
+public class ApiGatewayTemplateMappingInput {
+    private Map<String, String> body;
+    private Map<String, String> headers;
+    private Map<String, String> params;
+    private Map<String, String> query;
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ApiGatewayTemplateMappingOutput.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ApiGatewayTemplateMappingOutput.java
@@ -1,0 +1,13 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@Getter
+@Setter
+@ExcludeFromGeneratedCoverageReport
+public class ApiGatewayTemplateMappingOutput {
+    private int statusCode;
+    private String body;
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -2,8 +2,10 @@ package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@ExcludeFromGeneratedCoverageReport
 public enum ErrorResponse {
     MISSING_QUERY_PARAMETERS(1000, "Missing query parameters for auth request"),
     MISSING_AUTHORIZATION_CODE(1003, "Missing authorization code"),
@@ -59,6 +61,10 @@ public enum ErrorResponse {
 
     public int getCode() {
         return code;
+    }
+
+    public String toJsonString() {
+        return String.format("{\"code\":%d,\"message\":\"%s\"}", code, message);
     }
 
     public String getMessage() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -81,8 +81,12 @@ public class RequestHelper {
 
     public static String getIpvSessionId(APIGatewayProxyRequestEvent event)
             throws HttpResponseExceptionWithErrorBody {
-        String ipvSessionId =
-                RequestHelper.getHeaderByKey(event.getHeaders(), IPV_SESSION_ID_HEADER);
+        return getIpvSessionId(event.getHeaders());
+    }
+
+    public static String getIpvSessionId(Map<String, String> headers)
+            throws HttpResponseExceptionWithErrorBody {
+        String ipvSessionId = RequestHelper.getHeaderByKey(headers, IPV_SESSION_ID_HEADER);
         if (ipvSessionId == null) {
             LOGGER.error("{} not present in header", IPV_SESSION_ID_HEADER);
             throw new HttpResponseExceptionWithErrorBody(

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -105,7 +105,7 @@ paths:
 
   /journey/{journeyStep}:
     post:
-      description: Called when the user selects a journey event.
+      description: Called when the user selects a journey event. Triggers an express step function
       responses:
         200:
           description: "Returns either a redirect journey eventResponse or a page eventResponse "
@@ -114,12 +114,42 @@ paths:
               schema:
                 $ref: "#/components/schemas/journeyType"
       x-amazon-apigateway-integration:
+        type: "aws"
+        credentials:
+          Fn::GetAtt: JourneyEngineStepFunctionApiGateWayIamRole.Arn
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${IPVJourneyEngineFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:states:action/StartSyncExecution
         passthroughBehavior: "when_no_match"
-        type: "aws_proxy"
-
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "input": "{\"body\": $util.escapeJavaScript($input.json('$')), \"headers\": {#foreach($header in $input.params().header.keySet())\"$header\": \"$util.escapeJavaScript($input.params().header.get($header))\"#if($foreach.hasNext),#end#end},\"params\": {#foreach($param in $input.params().path.keySet())\"$param\": \"$util.escapeJavaScript($input.params().path.get($param))\"#if($foreach.hasNext),#end#end},\"query\": {#foreach($queryParam in $input.params().querystring.keySet())\"$queryParam\": \"$util.escapeJavaScript($input.params().querystring.get($queryParam))\"#if($foreach.hasNext),#end#end}}",
+                "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${JourneyEngineStepFunction.Name}"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set ($bodyObj = $util.parseJson($input.body))
+                
+                #if ($bodyObj.status == "SUCCEEDED")
+                  #set($lambdaOutput = $util.parseJson($bodyObj.output))
+                  #set($context.responseOverride.status = $lambdaOutput.statusCode)
+                  $lambdaOutput.body
+                
+                #elseif ($bodyObj.status == "FAILED")
+                  #set($context.responseOverride.status = 500)
+                  {
+                    "cause": "$bodyObj.cause",
+                    "error": "$bodyObj.error"
+                  }
+                #else
+                  #set($context.responseOverride.status = 500)
+                  $bodyObj
+                #end
 
   /journey/cri/build-oauth-request/{criId}:
     post:
@@ -149,7 +179,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/journeyType"
       x-amazon-apigateway-integration:
-        httpMethod: "GET"
+        httpMethod: "POST"
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ValidateCriCredentialFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -120,6 +120,24 @@ paths:
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
 
+
+  /journey/cri/build-oauth-request/{criId}:
+    post:
+      description: Called when the frontend begins the CRI journey.
+      responses:
+        200:
+          description: "Returns the id, ipvClientId and authorizationUrl for a CRI."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/journeyType"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildCriOauthRequestFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        type: "aws_proxy"
+
   /journey/cri/validate/{criId}:
     post:
       description: "Returns a next or fail journey step, depending on if a CRI check meets requirements to continue the journey"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Re-revert step function work

### Why did it change

This re-applies the previously reverted work to embed the
process-journey-step lambda in a step function.

The original PR failed to deploy to staging for non obvious reasons and
was reverted to prevent blocking the pipeline.

This PR is to try again, and be able to investigate if it fails to
deploy again.

The original PR is here:
https://github.com/alphagov/di-ipv-core-back/pull/386

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1642](https://govukverify.atlassian.net/browse/PYIC-1642)
