### PR TITLE
BAU: Reinstate build-client-oauth-response endpoint

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -219,6 +219,23 @@ paths:
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
 
+  /journey/build-client-oauth-response:
+    post:
+      description: "Called when the user has completed their user journey in IPV Core"
+      responses:
+        200:
+          description: "Authorization Code and details"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/journeyType"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildClientOauthResponseFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        type: "aws_proxy"
+
 components:
   schemas:
     journeyType:


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Reinstate build-client-oauth-response endpoint

### Why did it change

This endpoint is required and went missing a few weeks back. The API
gateways have kept the endpoint around which is odd. CloudFomration may
not remove endpoints that are no longer in the spec.
