### PR TITLE
PYIX-1834: Deploy build stub to different bucket

### DIFF
--- a/.github/workflows/deploy-ci-storage-core-stub.yaml
+++ b/.github/workflows/deploy-ci-storage-core-stub.yaml
@@ -56,12 +56,12 @@ jobs:
       - name: Assume AWS role for build account
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.BUILD_CI_STORAGE_CORE_STUB_GH_ACTIONS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Deploy to build environment
         uses: alphagov/di-devplatform-upload-action@v3
         with:
-          artifact-bucket-name: ${{ secrets.BUILD_CI_STORAGE_CORE_STUB_ARTIFACT_BUCKET_NAME }}
+          artifact-bucket-name: ci-core-stub-pipeline-githubartifactsourcebucket-concourse
           signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
           working-directory: ./lambdas/contra-indicator-storage-core-stub


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Deploy build stub to different bucket

### Why did it change

The stub was failing to work in the build environment due to the
requirement of the secure-pipeline to include a permissions boundary for
the lambda. The permissions boundary does not allow cross account lambda
invoke.

We can get round this for now by using Concourse to deploy it to build.
This requires uploading the artifacts to a different bucket that
Concourse has permissions to read from. The bucket we're currently
deploying to is locked down to only be read by the secure pipeline.

This also changes the role we're assuming to do the deploying, as that
role has permissions on this bucket.

This is all temporary until the permissions boundary issue is resolved
(which it will need to be for core to use the new system), and then we
can go back to deploying how we were before.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1834](https://govukverify.atlassian.net/browse/PYIC-1834)
