### PR TITLE
PYIC-1834: Don't use signing for ci-storage-core-stub

### DIFF
--- a/.github/workflows/deploy-ci-storage-core-stub.yaml
+++ b/.github/workflows/deploy-ci-storage-core-stub.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - lambdas/contra-indicator-storage-core-stub/**
+      - .github/workflows/deploy-ci-storage-core-stub.yaml
 
 jobs:
   deploy:
@@ -59,9 +60,14 @@ jobs:
           role-to-assume: ${{ secrets.ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: Deploy to build environment
-        uses: alphagov/di-devplatform-upload-action@v3
-        with:
-          artifact-bucket-name: ci-core-stub-pipeline-githubartifactsourcebucket-concourse
-          signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
-          working-directory: ./lambdas/contra-indicator-storage-core-stub
+      - name: Upload lambdas to S3
+        working-directory: ./lambdas/contra-indicator-storage-core-stub
+        env:
+          ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+        run: sam package --s3-bucket="$ARTIFACT_BUCKET" --s3-prefix "ci-storage-core-stub" --output-template-file=cf-template.yaml
+
+      - name: Upload cloudformation template to S3
+        working-directory: ./lambdas/contra-indicator-storage-core-stub
+        env:
+          ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+        run: aws s3 cp cf-template.yaml "s3://$ARTIFACT_BUCKET/ci-storage-core-stub/template.yaml"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Don't use signing for ci-storage-core-stub

### Why did it change

As we're using Concourse to deploy the core-stub in the build env we
don't need to sign. Using the dev platform action means we try to sign,
and this fails due to AWS perms.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1834](https://govukverify.atlassian.net/browse/PYIC-1834)
