### PR TITLE
PYIC-1869: Update core-back to send and validate against the new redirectUri structure for the app

### DIFF
--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -56,7 +56,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.buildcrioauthrequest.BuildCriOauthRequestHandler.SHARED_CLAIMS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_FRONT_CALLBACK_URL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_2;
@@ -124,7 +123,8 @@ class BuildCriOauthRequestHandlerTest {
                         IPV_CLIENT_ID,
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
-                        "http://www.example.com/audience");
+                        "http://www.example.com/audience",
+                        URI.create("http://www.example.com/callback/criId"));
 
         dcmawCredentialIssuerConfig =
                 new CredentialIssuerConfig(
@@ -136,7 +136,8 @@ class BuildCriOauthRequestHandlerTest {
                         IPV_CLIENT_ID,
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
-                        "http://www.example.com/audience");
+                        "http://www.example.com/audience",
+                        URI.create("http://www.example.com/callback/criId"));
 
         clientSessionDetailsDto = new ClientSessionDetailsDto();
         clientSessionDetailsDto.setUserId(TEST_USER_ID);
@@ -167,8 +168,6 @@ class BuildCriOauthRequestHandlerTest {
             throws Exception {
         when(configurationService.getCredentialIssuer(CRI_ID)).thenReturn(credentialIssuerConfig);
         when(configurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("callbackUrl");
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
@@ -228,8 +227,6 @@ class BuildCriOauthRequestHandlerTest {
         when(configurationService.getCredentialIssuer(DCMAW_CRI_ID))
                 .thenReturn(dcmawCredentialIssuerConfig);
         when(configurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("callbackUrl");
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
@@ -342,8 +339,6 @@ class BuildCriOauthRequestHandlerTest {
     void shouldDeduplicateSharedClaims() throws Exception {
         when(configurationService.getCredentialIssuer(CRI_ID)).thenReturn(credentialIssuerConfig);
         when(configurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("callbackUrl");
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
@@ -384,8 +379,6 @@ class BuildCriOauthRequestHandlerTest {
     void shouldNotDeduplicateSharedClaimsIfFullNameDifferent() throws Exception {
         when(configurationService.getCredentialIssuer(CRI_ID)).thenReturn(credentialIssuerConfig);
         when(configurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("callbackUrl");
         when(configurationService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);

--- a/lambdas/get-credential-issuer-config/src/test/java/uk/gov/di/ipv/core/getcredentialisserconfig/GetCredentialIssuerConfigHandlerTest.java
+++ b/lambdas/get-credential-issuer-config/src/test/java/uk/gov/di/ipv/core/getcredentialisserconfig/GetCredentialIssuerConfigHandlerTest.java
@@ -40,7 +40,8 @@ class GetCredentialIssuerConfigHandlerTest {
                             "ipv-core",
                             EC_PUBLIC_JWK,
                             RSA_ENCRYPTION_PUBLIC_JWK,
-                            "test-audience"),
+                            "test-audience",
+                            URI.create("testRedirectUrl")),
                     new CredentialIssuerConfig(
                             "test2",
                             "Any",
@@ -50,7 +51,8 @@ class GetCredentialIssuerConfigHandlerTest {
                             "ipv-core",
                             EC_PUBLIC_JWK,
                             RSA_ENCRYPTION_PUBLIC_JWK,
-                            "test-audience"));
+                            "test-audience",
+                            URI.create("test2RedirectUrl")));
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -113,7 +113,8 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                         "ipv-core",
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
-                        "test-audience");
+                        "test-audience",
+                        new URI("http://www.example.com/credential-issuers/callback/criId"));
 
         clientSessionDetailsDto =
                 new ClientSessionDetailsDto(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -16,7 +16,8 @@ public enum ConfigurationVariable {
     PASSPORT_CRI_ID("/%s/core/self/journey/passportCriId"),
     DCMAW_ENABLED("/%s/core/self/journey/dcmawEnabled"),
     AUTH_CODE_EXPIRY_SECONDS("/%s/core/self/authCodeExpirySeconds"),
-    PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("/%s/core/clients/%s/publicKeyMaterialForCoreToVerify");
+    PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("/%s/core/clients/%s/publicKeyMaterialForCoreToVerify"),
+    CRI_REDIRECT_URL("/%s/core/credentialIssuers/%s/ipvCoreRedirectUrl");
 
     private final String value;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -35,7 +35,6 @@ public enum ErrorResponse {
     FAILED_TO_PARSE_ISSUED_CREDENTIALS(1024, "Failed to parse issued credentials"),
     CREDENTIAL_SUBJECT_MISSING(1025, "Credential subject missing from verified credential"),
     INVALID_SESSION_REQUEST(1026, "Failed to parse the session start request"),
-    FAILED_TO_BUILD_CORE_FRONT_CALLBACK_URL(1027, "Failed to build Core Front Callback Url"),
     FAILED_TO_ENCRYPT_JWT(1028, "Failed to encrypt JWT"),
     MISSING_OAUTH_STATE(1030, "Missing OAuth state in Response"),
     INVALID_OAUTH_STATE(1031, "Invalid OAuth State"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -23,6 +23,7 @@ public class CredentialIssuerConfig {
     private String vcVerifyingPublicJwk;
     private String jarEncryptionPublicJwk;
     private String audienceForClients;
+    private URI ipvCoreRedirectUrl;
 
     public CredentialIssuerConfig() {}
 
@@ -36,7 +37,8 @@ public class CredentialIssuerConfig {
             String ipvClientId,
             String vcVerifyingPublicJwk,
             String jarEncryptionPublicJwk,
-            String audienceForClients) {
+            String audienceForClients,
+            URI ipvCoreRedirectUrl) {
         this.id = id;
         this.name = name;
         this.tokenUrl = tokenUrl;
@@ -46,6 +48,7 @@ public class CredentialIssuerConfig {
         this.vcVerifyingPublicJwk = vcVerifyingPublicJwk;
         this.jarEncryptionPublicJwk = jarEncryptionPublicJwk;
         this.audienceForClients = audienceForClients;
+        this.ipvCoreRedirectUrl = ipvCoreRedirectUrl;
     }
 
     public String getId() {
@@ -92,6 +95,10 @@ public class CredentialIssuerConfig {
 
     public String getAudienceForClients() {
         return audienceForClients;
+    }
+
+    public URI getIpvCoreRedirectUrl() {
+        return ipvCoreRedirectUrl;
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/AuthorizationRequestHelper.java
@@ -26,7 +26,6 @@ import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.List;
 import java.util.Objects;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
@@ -35,8 +34,6 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SE
 public class AuthorizationRequestHelper {
 
     public static final String SHARED_CLAIMS = "shared_claims";
-    public static final String PARAM_ID = "id";
-    public static final List<String> DCMAW_CRI_IDS = List.of("dcmaw", "stubDcmaw");
 
     private AuthorizationRequestHelper() {}
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -125,6 +125,7 @@ public class ConfigurationService {
                                 "%s/%s",
                                 getEnvironmentVariable(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX),
                                 credentialIssuerId));
+
         return new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -64,6 +64,7 @@ class ConfigurationServiceTest {
 
     public static final String TEST_TOKEN_URL = "testTokenUrl";
     public static final String TEST_CREDENTIAL_URL = "testCredentialUrl";
+    public static final String TEST_REDIRECT_URL = "http:example.com/callbackUrl/testCri";
     public static final String TEST_CERT =
             "MIIC/TCCAeWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwHhcNMjExMjE3MTEwNTM5WhcNMjIxMjE3MTEwNTM5WjAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDYIxWKwYNoz2MIDvYb2ip4nhCOGUccufIqwSHXl5FBOoOxOZh1rV57sWhdKO/hyZYbF5YUYTwzV4rW7DgLkfx0sN/p5igk74BZRSXvV/s+XCkVC5c0NDhNGh6WK5rc8Qbm0Ad5vEO1JpQih5y2mPGCwfLBqcY8AC7fwZinP/4YoMTCtEk5ueA0HwZLHXOEMWl/QCkj7WlSBL4i6ozk4So3RFL4awYP6nvhY7OLAcad7g/ZW0dXvztPOJnT9rwi1p6BNoD/Zk6jMJHhbvKyGsluUy7PYVGYCQ36Uuzby2Jq8cG5qNS+CBjy0/d/RmrClKd7gcnLY/J5NOC+YSynoHXRAgMBAAGjKjAoMA4GA1UdDwEB/wQEAwIFoDAWBgNVHSUBAf8EDDAKBggrBgEFBQcDBDANBgkqhkiG9w0BAQsFAAOCAQEAvHT2AGTymh02A9HWrnGm6PEXx2Ye3NXV9eJNU1z6J298mS2kYq0Z4D0hj9i8+IoCQRbWOxLTAWBNt/CmH7jWltE4uqoAwTZD6mDgkC2eo5dY+RcuydsvJNfTcvUOyi47KKGGEcddfLti4NuX51BQIY5vSBfqZXt8+y28WuWqBMh6eny2wJtxNHo20wQei5g7w19lqwJu2F+l/ykX9K5DHjhXqZUJ77YWmY8sy/WROLjOoZZRy6YuzV8S/+c/nsPzqDAkD4rpWwASjsEDaTcH22xpGq5XUAf1hwwNsuiyXKGUHCxafYYS781LR8pLg6DpEAgcn8tBbq6MoiEGVeOp7Q==";
 
@@ -139,7 +140,8 @@ class ConfigurationServiceTest {
                         "ipv-core",
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
-                        "test-audience");
+                        "test-audience",
+                        URI.create(TEST_REDIRECT_URL));
 
         assertEquals(expected.getTokenUrl(), result.getTokenUrl());
         assertEquals(expected.getCredentialUrl(), result.getCredentialUrl());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -47,7 +47,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_FRONT_CALLBACK_URL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.DCMAW_SUCCESS_RESPONSE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
@@ -79,8 +78,6 @@ class CredentialIssuerServiceTest {
     @Test
     void validTokenResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(mockConfigurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("http://www.example.com/redirect");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -112,8 +109,6 @@ class CredentialIssuerServiceTest {
     @Test
     void validTokenResponseForAppJourney(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(mockConfigurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("http://www.example.com/redirect");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -145,8 +140,6 @@ class CredentialIssuerServiceTest {
     @Test
     void validTokenResponseWithoutApiKey(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(mockConfigurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("http://www.example.com/redirect");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -178,8 +171,6 @@ class CredentialIssuerServiceTest {
     @Test
     void tokenErrorResponse(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(mockConfigurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("http://www.example.com/redirect");
         var errorJson =
                 "{ \"error\": \"invalid_request\", \"error_description\": \"Request was missing the 'redirect_uri' parameter.\", \"error_uri\": \"See the full API docs at https://authorization-server.com/docs/access_token\"}";
         stubFor(
@@ -217,8 +208,6 @@ class CredentialIssuerServiceTest {
     @Test
     void invalidHeaderThrowsCredentialIssuerException(WireMockRuntimeInfo wmRuntimeInfo) {
         when(mockConfigurationService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(mockConfigurationService.getSsmParameter(CORE_FRONT_CALLBACK_URL))
-                .thenReturn("http://www.example.com/redirect");
         stubFor(
                 post("/token")
                         .willReturn(
@@ -433,7 +422,11 @@ class CredentialIssuerServiceTest {
                 "ipv-core",
                 EC_PUBLIC_JWK,
                 RSA_ENCRYPTION_PUBLIC_JWK,
-                "test-audience");
+                "test-audience",
+                URI.create(
+                        "http://localhost:"
+                                + wmRuntimeInfo.getHttpPort()
+                                + "/credential-issuer/callback?id=StubPassport"));
     }
 
     private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
For the app system set the redirectUri param to use URL path params instead of query params for the criId.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The app system was incorrectly constructing the redirect uri due to us adding a query param. We realised that a better alternative would be to use a URL path parameter instead of a query parameter.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1869](https://govukverify.atlassian.net/browse/PYIC-1869)

