### PR TITLE
PYIC-1864: Update debug journey for fail pages

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachine.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachine.java
@@ -5,12 +5,11 @@ import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownStat
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public class StateMachine {
 
-    private Map<String, State> states = new HashMap<>();
+    private Map<String, State> states;
 
     public StateMachine(StateMachineInitializer initializer) throws IOException {
         this.states = initializer.initialize();

--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -195,6 +195,60 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+DEBUG_EVALUATE_GPG45_SCORES:
+  name: DEBUG_EVALUATE_GPG45_SCORES
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    end:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    pyi-no-match:
+      type: basic
+      name: pyi-no-match
+      targetState: DEBUG_PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    pyi-kbv-fail:
+      type: basic
+      name: pyi-kbv-fail
+      targetState: DEBUG_PYI_KBV_FAIL
+      response:
+        type: page
+        pageId: pyi-kbv-fail
+DEBUG_PYI_NO_MATCH:
+  name: DEBUG_PYI_NO_MATCH
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+DEBUG_PYI_KBV_FAIL:
+  name: DEBUG_PYI_KBV_FAIL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_PAGE
       response:
         type: page

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -195,6 +195,60 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+DEBUG_EVALUATE_GPG45_SCORES:
+  name: DEBUG_EVALUATE_GPG45_SCORES
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    end:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    pyi-no-match:
+      type: basic
+      name: pyi-no-match
+      targetState: DEBUG_PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    pyi-kbv-fail:
+      type: basic
+      name: pyi-kbv-fail
+      targetState: DEBUG_PYI_KBV_FAIL
+      response:
+        type: page
+        pageId: pyi-kbv-fail
+DEBUG_PYI_NO_MATCH:
+  name: DEBUG_PYI_NO_MATCH
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+DEBUG_PYI_KBV_FAIL:
+  name: DEBUG_PYI_KBV_FAIL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_PAGE
       response:
         type: page

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -195,6 +195,60 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+DEBUG_EVALUATE_GPG45_SCORES:
+  name: DEBUG_EVALUATE_GPG45_SCORES
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    end:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    pyi-no-match:
+      type: basic
+      name: pyi-no-match
+      targetState: DEBUG_PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    pyi-kbv-fail:
+      type: basic
+      name: pyi-kbv-fail
+      targetState: DEBUG_PYI_KBV_FAIL
+      response:
+        type: page
+        pageId: pyi-kbv-fail
+DEBUG_PYI_NO_MATCH:
+  name: DEBUG_PYI_NO_MATCH
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+DEBUG_PYI_KBV_FAIL:
+  name: DEBUG_PYI_KBV_FAIL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_PAGE
       response:
         type: page

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -195,6 +195,60 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+DEBUG_EVALUATE_GPG45_SCORES:
+  name: DEBUG_EVALUATE_GPG45_SCORES
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    end:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    pyi-no-match:
+      type: basic
+      name: pyi-no-match
+      targetState: DEBUG_PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    pyi-kbv-fail:
+      type: basic
+      name: pyi-kbv-fail
+      targetState: DEBUG_PYI_KBV_FAIL
+      response:
+        type: page
+        pageId: pyi-kbv-fail
+DEBUG_PYI_NO_MATCH:
+  name: DEBUG_PYI_NO_MATCH
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+DEBUG_PYI_KBV_FAIL:
+  name: DEBUG_PYI_KBV_FAIL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_PAGE
       response:
         type: page

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -195,6 +195,60 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+DEBUG_EVALUATE_GPG45_SCORES:
+  name: DEBUG_EVALUATE_GPG45_SCORES
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    end:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+    pyi-no-match:
+      type: basic
+      name: pyi-no-match
+      targetState: DEBUG_PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    pyi-kbv-fail:
+      type: basic
+      name: pyi-kbv-fail
+      targetState: DEBUG_PYI_KBV_FAIL
+      response:
+        type: page
+        pageId: pyi-kbv-fail
+DEBUG_PYI_NO_MATCH:
+  name: DEBUG_PYI_NO_MATCH
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: DEBUG_PAGE
+      response:
+        type: page
+        pageId: page-ipv-debug
+DEBUG_PYI_KBV_FAIL:
+  name: DEBUG_PYI_KBV_FAIL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_PAGE
       response:
         type: page

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -55,6 +55,7 @@ class ProcessJourneyStepHandlerTest {
     private static final String PRE_KBV_TRANSITION_PAGE_STATE = "PRE_KBV_TRANSITION_PAGE";
     private static final String IPV_SUCCESS_PAGE_STATE = "IPV_SUCCESS_PAGE";
     private static final String DEBUG_PAGE_STATE = "DEBUG_PAGE";
+    private static final String DEBUG_EVALUATE_GPG45_SCORES = "DEBUG_EVALUATE_GPG45_SCORES";
     private static final String PYI_NO_MATCH_STATE = "PYI_NO_MATCH";
     private static final String PYI_KBV_FAIL_STATE = "PYI_KBV_FAIL";
     private static final String CORE_SESSION_TIMEOUT_STATE = "CORE_SESSION_TIMEOUT";
@@ -761,7 +762,7 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnDebugPageResponseWhenRequired() throws IOException {
+    void shouldReturnDebugEvaluateGpg45ScoresJourneyWhenRequired() throws IOException {
         var input =
                 new ApiGatewayTemplateMappingInput(
                         Map.of("input", "body"),
@@ -791,10 +792,10 @@ class ProcessJourneyStepHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(DEBUG_PAGE_STATE, sessionArgumentCaptor.getValue().getUserState());
+        assertEquals(DEBUG_EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(200, lambdaOutput.getStatusCode());
-        assertEquals(DEBUG_PAGE, outputBody.get("page"));
+        assertEquals("/journey/evaluate-gpg45-scores", outputBody.get("journey"));
     }
 
     @Test


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update debug journey for fail pages

### Why did it change

Previously the validation of the gpg45 scores and contra indicators was
being done immediately after the user returned from a CRI. This meant
the debug journey flow worked with the "no-match" pages we show.

Now, we're evaluating the scores just before we send a user to a CRI.
This means that the debug flow misses the opportunity to show the
"no-match" pages before going back to the debug page.

This is breaking our smoke tests.

This updates the debug flow to emulate the acutal flow, by running the
gpg45 evaluator lambda before going returning to the debug page.

There's a good chance this will break other smoke tests, as it will
start showing the "no-match" pages after a visit to a stub CRI. This is
probably what we want though and the tests will need fixing up.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1864](https://govukverify.atlassian.net/browse/PYIC-1864)
