### PR TITLE
PYIC-1861: Update gpg45 evaluator to check if we meet the M1B profile

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -79,11 +79,19 @@ public class EvaluateGpg45ScoresHandler
                 // only have responsibility for ending the journey if we have met a profile.
                 journeyResponse = failedJourneyResponse.get();
             } else {
-                journeyResponse =
+                boolean doCredentialsMeetM1BProfile =
                         gpg45ProfileEvaluator.credentialsSatisfyProfile(
-                                        credentials, Gpg45Profile.M1A)
-                                ? new JourneyResponse(JOURNEY_END)
-                                : new JourneyResponse(JOURNEY_NEXT);
+                                credentials, Gpg45Profile.M1B);
+
+                if (doCredentialsMeetM1BProfile) {
+                    journeyResponse = new JourneyResponse(JOURNEY_END);
+                } else {
+                    journeyResponse =
+                            gpg45ProfileEvaluator.credentialsSatisfyProfile(
+                                            credentials, Gpg45Profile.M1A)
+                                    ? new JourneyResponse(JOURNEY_END)
+                                    : new JourneyResponse(JOURNEY_NEXT);
+                }
             }
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, journeyResponse);

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/domain/CredentialEvidenceItem.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/domain/CredentialEvidenceItem.java
@@ -13,15 +13,32 @@ import static uk.gov.di.ipv.core.evaluategpg45scores.validation.FraudEvidenceVal
 
 @Getter
 public class CredentialEvidenceItem {
-    private Integer activityScore;
+    private Integer activityHistoryScore;
     private Integer identityFraudScore;
     private Integer strengthScore;
     private Integer validityScore;
     private Integer verificationScore;
+    private List<DcmawCheckMethod> checkDetails;
+    private List<DcmawCheckMethod> failedCheckDetails;
     private List<String> ci;
 
+    public CredentialEvidenceItem(EvidenceType evidenceType, int score) {
+        if (EvidenceType.ACTIVITY.equals(evidenceType)) {
+            this.activityHistoryScore = score;
+        } else if (EvidenceType.IDENTITY_FRAUD.equals(evidenceType)) {
+            this.identityFraudScore = score;
+        } else if (EvidenceType.VERIFICATION.equals(evidenceType)) {
+            this.verificationScore = score;
+        }
+    }
+
+    public CredentialEvidenceItem(int strengthScore, int validityScore) {
+        this.strengthScore = strengthScore;
+        this.validityScore = validityScore;
+    }
+
     public EvidenceType getType() throws UnknownEvidenceTypeException {
-        if (isActivity()) {
+        if (isActivityHistory()) {
             return EvidenceType.ACTIVITY;
         } else if (isIdentityFraud()) {
             return EvidenceType.IDENTITY_FRAUD;
@@ -46,46 +63,57 @@ public class CredentialEvidenceItem {
     }
 
     private int numberOfContraIndicators() {
-        return ci.size();
+        if (ci != null) {
+            return ci.size();
+        }
+        return 0;
     }
 
-    private boolean isActivity() {
-        return activityScore != null
+    private boolean isActivityHistory() {
+        return activityHistoryScore != null
                 && identityFraudScore == null
                 && strengthScore == null
                 && validityScore == null
-                && verificationScore == null;
+                && verificationScore == null
+                && checkDetails == null
+                && failedCheckDetails == null;
     }
 
     private boolean isIdentityFraud() {
         return identityFraudScore != null
-                && activityScore == null
+                && activityHistoryScore == null
                 && strengthScore == null
                 && validityScore == null
-                && verificationScore == null;
+                && verificationScore == null
+                && checkDetails == null
+                && failedCheckDetails == null;
     }
 
     private boolean isEvidence() {
         return strengthScore != null
                 && validityScore != null
-                && activityScore == null
+                && activityHistoryScore == null
                 && identityFraudScore == null
-                && verificationScore == null;
+                && verificationScore == null
+                && checkDetails == null
+                && failedCheckDetails == null;
     }
 
     private boolean isVerification() {
         return verificationScore != null
-                && activityScore == null
+                && activityHistoryScore == null
                 && identityFraudScore == null
                 && strengthScore == null
-                && validityScore == null;
+                && validityScore == null
+                && checkDetails == null
+                && failedCheckDetails == null;
     }
 
     @Getter
     public enum EvidenceType {
         ACTIVITY(
-                generateComparator(CredentialEvidenceItem::getActivityScore),
-                CredentialEvidenceItem::getActivityScore),
+                generateComparator(CredentialEvidenceItem::getActivityHistoryScore),
+                CredentialEvidenceItem::getActivityHistoryScore),
         IDENTITY_FRAUD(
                 generateComparator(CredentialEvidenceItem::getIdentityFraudScore),
                 CredentialEvidenceItem::getIdentityFraudScore),

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/domain/DcmawCheckMethod.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/domain/DcmawCheckMethod.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.domain;
+
+import lombok.Getter;
+
+@Getter
+public class DcmawCheckMethod {
+    private String checkMethod;
+    private String identityCheckPolicy;
+    private String activityFrom;
+    private Integer biometricVerificationProcessLevel;
+}

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/domain/DcmawScores.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/domain/DcmawScores.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.core.evaluategpg45scores.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@Getter
+@Setter
+@ExcludeFromGeneratedCoverageReport
+public class DcmawScores {
+    int strengthScore;
+    int validityScore;
+    int activityScore;
+    int verificationScore;
+}

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -73,7 +73,24 @@ class EvaluateGpg45ScoreHandlerTest {
     void shouldReturnJourneySessionEndIfScoresSatisfyM1AGpg45Profile() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1B))
+                .thenReturn(false);
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1A))
+                .thenReturn(true);
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_END, journeyResponse.getJourney());
+        verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
+    }
+
+    @Test
+    void shouldReturnJourneySessionEndIfScoresSatisfyM1BGpg45Profile() throws Exception {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1B))
                 .thenReturn(true);
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
@@ -118,6 +135,8 @@ class EvaluateGpg45ScoreHandlerTest {
     void shouldReturnJourneyNextIfScoresDoNotSatisfyM1AGpg45Profile() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1B))
+                .thenReturn(false);
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1A))
                 .thenReturn(false);
 
@@ -145,6 +164,8 @@ class EvaluateGpg45ScoreHandlerTest {
     void shouldReturn500IfFailedToParseCredentials() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1B))
+                .thenReturn(false);
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1A))
                 .thenThrow(new ParseException("Whoops", 0));
 
@@ -166,6 +187,8 @@ class EvaluateGpg45ScoreHandlerTest {
     void shouldReturn500IfCredentialOfUnknownType() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1B))
+                .thenReturn(false);
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(CREDENTIALS, Gpg45Profile.M1A))
                 .thenThrow(new UnknownEvidenceTypeException());
 

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -27,13 +27,20 @@ class Gpg45ProfileEvaluatorTest {
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwiaWRlbnRpdHlGcmF1ZFNjb3JlIjoxLCJjaSI6WyJBMDEiXX1dfX0.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
     private final String M1A_KBV_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWsuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk5MTcsImV4cCI6MTY1ODgzNzExNywidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eG4iOiI3TEFLUlRBN0ZTIiwidmVyaWZpY2F0aW9uU2NvcmUiOjIsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIn0seyJhZGRyZXNzQ291bnRyeSI6IkdCIiwidXBybiI6MTAwMTIwMDEyMDc3LCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJ2YWxpZEZyb20iOiIyMDAwLTAxLTAxIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX19fQ.MEUCIAD3CkUQctCBxPIonRsYylmAsWsodyzpLlRzSTKvJBxHAiEAsewH-Ke7x8R3879-KQCwGAcYPt_14Wq7a6bvsb5tH_8";
-
+    private final String M1B_DCMAW_VC =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJhdWQiOiJodHRwczovL2lkZW50aXR5LmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwibmJmIjoxNjU4ODI5NjQ3LCJpc3MiOiJodHRwczovL3Jldmlldy1wLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwiZXhwIjoxNjU4ODM2ODQ3LCJ2YyI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InZhbHVlIjoiSm9lIFNobW9lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJEb2UgVGhlIEJhbGwiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk4NS0wMi0wOCJ9XSwiYWRkcmVzcyI6W3sidXBybiI6IjEwMDIyODEyOTI5Iiwib3JnYW5pc2F0aW9uTmFtZSI6IkZJTkNIIEdST1VQIiwic3ViQnVpbGRpbmdOYW1lIjoiVU5JVCAyQiIsImJ1aWxkaW5nTnVtYmVyICI6IjE2IiwiYnVpbGRpbmdOYW1lIjoiQ09ZIFBPTkQgQlVTSU5FU1MgUEFSSyIsImRlcGVuZGVudFN0cmVldE5hbWUiOiJLSU5HUyBQQVJLIiwic3RyZWV0TmFtZSI6IkJJRyBTVFJFRVQiLCJkb3VibGVEZXBlbmRlbnRBZGRyZXNzTG9jYWxpdHkiOiJTT01FIERJU1RSSUNUIiwiZGVwZW5kZW50QWRkcmVzc0xvY2FsaXR5IjoiTE9ORyBFQVRPTiIsImFkZHJlc3NMb2NhbGl0eSI6IkdSRUFUIE1JU1NFTkRFTiIsInBvc3RhbENvZGUiOiJIUDE2IDBBTCIsImFkZHJlc3NDb3VudHJ5IjoiR0IifV0sImRyaXZpbmdQZXJtaXQiOlt7InBlcnNvbmFsTnVtYmVyIjoiRE9FOTk4MDIwODVKOTlGRyIsImV4cGlyeURhdGUiOiIyMDIzLTAxLTE4IiwiaXNzdWVOdW1iZXIiOm51bGwsImlzc3VlZEJ5IjpudWxsLCJpc3N1ZURhdGUiOm51bGx9XSwiZXZpZGVuY2UiOlt7InR5cGUiOiJJZGVudGl0eUNoZWNrIiwidHhuIjoiZWEyZmVlZmUtNDVhMy00YTI5LTkyM2YtNjA0Y2Q0MDE3ZWMwIiwic3RyZW5ndGhTY29yZSI6MywidmFsaWRpdHlTY29yZSI6MiwiYWN0aXZpdHlIaXN0b3J5U2NvcmUiOiIxIiwiY2hlY2tEZXRhaWxzIjpbeyJjaGVja01ldGhvZCI6InZyaSIsImlkZW50aXR5Q2hlY2tQb2xpY3kiOiJwdWJsaXNoZWQiLCJhY3Rpdml0eUZyb20iOiIyMDE5LTAxLTAxIn0seyJjaGVja01ldGhvZCI6ImJ2ciIsImJpb21ldHJpY1ZlcmlmaWNhdGlvblByb2Nlc3NMZXZlbCI6Mn1dfV19fQ.Ul-eb7s76_F1M5D5maztKdvbrx1_1xGy53_pVZFGmSGJt7niWIe_87ykWm-o1HYaBKYMTvPmSS266ZBZ0t4Gwg";
+    private final String M1B_FRAUD_VC =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jldmlldy1mLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwic3ViIjoidXJuOnV1aWQ6ZTZlMmUzMjQtNWI2Ni00YWQ2LTgzMzgtODNmOWY4MzdlMzQ1IiwibmJmIjoxNjU4ODI5NzU4LCJleHAiOjE2NTg4MzY5NTgsInZjIjp7ImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImFkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb0JveE51bWJlciI6bnVsbCwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJpZCI6bnVsbCwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInN1YkJ1aWxkaW5nTmFtZSI6bnVsbH1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdLCJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJ0eG4iOiJSQjAwMDEwMzQ5MDA4NyIsImlkZW50aXR5RnJhdWRTY29yZSI6MiwiY2kiOltdfV19fQ.-0NrF3Sv2GwXPEpgAITdE-8SkzuihihEF8inTi_lzo_b-6urQl17pGeWwVyygQRJDbKpxm-Q5ZzXeQuTybLSZQ";
+    private final String M1B_FRAUD_VC_WITH_A01 =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jldmlldy1mLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwic3ViIjoidXJuOnV1aWQ6ZTZlMmUzMjQtNWI2Ni00YWQ2LTgzMzgtODNmOWY4MzdlMzQ1IiwibmJmIjoxNjU4ODI5NzU4LCJleHAiOjE2NTg4MzY5NTgsInZjIjp7ImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImFkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb0JveE51bWJlciI6bnVsbCwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJpZCI6bnVsbCwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInN1YkJ1aWxkaW5nTmFtZSI6bnVsbH1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdLCJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJ0eG4iOiJSQjAwMDEwMzQ5MDA4NyIsImlkZW50aXR5RnJhdWRTY29yZSI6MiwiY2kiOlsiQTAxIl19XX19.q1QDbqY9rGq6Y3moSFkvx46PjJPsefRoSfdfRB73rqlxTTlIzJO9W6z9tnJzA_ydd6JPnRvJJqdXQMLKK3NwGQ";
     private final String PASSPORT_VC_FAILED =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDpmZDgwMTVmMy1mYjA5LTRiZjctYWU3ZS02MDMzNTAzOGRjYTgiLCJhdWQiOiJodHRwczpcL1wvaWRlbnRpdHkuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJuYmYiOjE2NTg4Mzk3NzIsImlzcyI6Imh0dHBzOlwvXC9yZXZpZXctcC5pbnRlZ3JhdGlvbi5hY2NvdW50Lmdvdi51ayIsImV4cCI6MTY1ODg0Njk3MiwidmMiOnsiZXZpZGVuY2UiOlt7InZhbGlkaXR5U2NvcmUiOjAsInN0cmVuZ3RoU2NvcmUiOjQsImNpIjpbIkQwMiJdLCJ0eG4iOiJlNmMwOTA3NC1hMjczLTRiOGMtOTVmOC0zYWE1YjI2NDgzMmUiLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayJ9XSwiY3JlZGVudGlhbFN1YmplY3QiOnsicGFzc3BvcnQiOlt7ImV4cGlyeURhdGUiOiIyMDI0LTA5LTI5IiwiZG9jdW1lbnROdW1iZXIiOiIxMjM0NTY3ODkifV0sIm5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoia3NkamhmcyJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6InFza2RqaGYifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODQtMDktMjgifV19LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXX19.MEUCIQDD0Y0ftHUJmhQ_oDX6wo23loLQ-_EZqoivq2eMoKPYiAIgcmaaGjV7KX8FYNJhPM_v7kWxl1WS9HBx6iiXsv0gODI";
     private final String FRAUD_VC_FAILED =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDo0MDI1Yjg5Mi1mZmU5LTRjZGUtYWJmMy0xOTgxYTZiYTQ5MmIiLCJuYmYiOjE2NTg4NDAwMTIsImV4cCI6MTY1ODg0NzIxMiwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJET1dOSU5HIFNUUkVFVCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiU1cxQSAyQUEiLCJidWlsZGluZ051bWJlciI6IjEwIiwiaWQiOm51bGwsImFkZHJlc3NMb2NhbGl0eSI6IkxPTkRPTiIsInN1YkJ1aWxkaW5nTmFtZSI6bnVsbH1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdLCJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJ0eG4iOiJSQjAwMDEwMzQ5NzQ0MyIsImlkZW50aXR5RnJhdWRTY29yZSI6MSwiY2kiOlsiQTAyIl19XX19.MEYCIQCRMVowC7JDu1e1jAmNB-isSb4qmlU4lbNJx5bL5n_fjwIhAPf5Yqx-iHzWPeuaevM0D0x3HYVJ-2KFGDyJEo6PwI4g";
     private final String KBV_VC_FAILED =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWsuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDpiOGI0NTZmNy05OGRlLTRkYjktOGJiMy02OWM5ODUxMGY0YWQiLCJuYmYiOjE2NTg5MDkyOTAsImV4cCI6MTY1ODkxNjQ5MCwidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eG4iOiI3TEJINlpETExEIiwidmVyaWZpY2F0aW9uU2NvcmUiOjAsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIn0seyJhZGRyZXNzQ291bnRyeSI6IkdCIiwidXBybiI6MTAwMTIwMDEyMDc3LCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJ2YWxpZEZyb20iOiIyMDAwLTAxLTAxIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX19fQ.MEYCIQCS7vwI_4ILb9opo6ObpuKnLXzSGSGOQhlPOgM1PTI2KwIhAPzpJK4vDC2ztnKK00EPqI8wvbeSMM7TVyku_pm7yRQZ";
+    private final String DCMAW_VC_FAILED =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDpzdWJJZGVudGl0eSIsImlzcyI6Imlzc3VlciIsImlhdCI6MTY0NzAxNzk5MCwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3ZvY2FiLmFjY291bnQuZ292LnVrL2NvbnRleHRzL2lkZW50aXR5LXYxLmpzb25sZCJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6Ik1PUkdBTiIsInR5cGUiOiJHaXZlbk5hbWUifSx7InZhbHVlIjoiU0FSQUggTUVSRURZVEgiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk3Ni0wMy0xMSJ9XSwiYWRkcmVzcyI6W3sidXBybiI6IjEwMDIyODEyOTI5Iiwib3JnYW5pc2F0aW9uTmFtZSI6IkZJTkNIIEdST1VQIiwic3ViQnVpbGRpbmdOYW1lIjoiVU5JVCAyQiIsImJ1aWxkaW5nTnVtYmVyICI6IjE2IiwiYnVpbGRpbmdOYW1lIjoiQ09ZIFBPTkQgQlVTSU5FU1MgUEFSSyIsImRlcGVuZGVudFN0cmVldE5hbWUiOiJLSU5HUyBQQVJLIiwic3RyZWV0TmFtZSI6IkJJRyBTVFJFRVQiLCJkb3VibGVEZXBlbmRlbnRBZGRyZXNzTG9jYWxpdHkiOiJTT01FIERJU1RSSUNUIiwiZGVwZW5kZW50QWRkcmVzc0xvY2FsaXR5IjoiTE9ORyBFQVRPTiIsImFkZHJlc3NMb2NhbGl0eSI6IkdSRUFUIE1JU1NFTkRFTiIsInBvc3RhbENvZGUiOiJIUDE2IDBBTCIsImFkZHJlc3NDb3VudHJ5IjoiR0IifV0sImRyaXZpbmdQZXJtaXQiOlt7InBlcnNvbmFsTnVtYmVyIjoiTU9SR0E3NTMxMTZTTTlJSiIsImlzc3VlTnVtYmVyIjpudWxsLCJpc3N1ZWRCeSI6bnVsbCwiaXNzdWVEYXRlIjpudWxsLCJleHBpcnlEYXRlIjoiMjAyMy0wMS0xOCJ9XX0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6ImJjZDIzNDYiLCJzdHJlbmd0aFNjb3JlIjozLCJ2YWxpZGl0eVNjb3JlIjowLCJhY3Rpdml0eUhpc3RvcnlTY29yZSI6IjEiLCJjaSI6W10sImZhaWxlZENoZWNrRGV0YWlscyI6W3siY2hlY2tNZXRob2QiOiJ2cmkiLCJpZGVudGl0eUNoZWNrUG9saWN5IjoicHVibGlzaGVkIiwiYWN0aXZpdHlGcm9tIjoiMjAxOS0wMS0wMSJ9LHsiY2hlY2tNZXRob2QiOiJidnIiLCJiaW9tZXRyaWNWZXJpZmljYXRpb25Qcm9jZXNzTGV2ZWwiOjJ9XX1dfX0.E8xSlxvlzXkk21ro7TKipDwqSk32hmGrh4xHBeo-GEydWqdXUnSaRJOtLp7QLMAownm-8d0SbDq7_Vuin9_rvA";
     private final String VC_WITH_BAD_EVIDENCE_BLOB =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwidGhpc0RvZXNOb3RNYWtlU2Vuc2VTY29yZSI6MSwiY2kiOltdfV19fQo.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
 
@@ -46,12 +53,30 @@ class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
+    void credentialsSatisfyProfileShouldReturnTrueIfCredentialsM1BSatisfyProfile()
+            throws Exception {
+        assertTrue(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(M1B_DCMAW_VC, M1A_ADDRESS_VC, M1B_FRAUD_VC), Gpg45Profile.M1B));
+    }
+
+    @Test
     void credentialsSatisfyProfileShouldReturnTrueIfCredentialsSatisfyProfileAndOnlyA01CI()
             throws Exception {
         assertTrue(
                 evaluator.credentialsSatisfyProfile(
                         List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC_WITH_A01, M1A_KBV_VC),
                         Gpg45Profile.M1A));
+    }
+
+    @Test
+    void
+            credentialsSatisfyProfileShouldReturnTrueIfCredentialsSatisfyProfileAndOnlyA01CIForTheM1BProfile()
+                    throws Exception {
+        assertTrue(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(M1B_DCMAW_VC, M1A_ADDRESS_VC, M1B_FRAUD_VC_WITH_A01),
+                        Gpg45Profile.M1B));
     }
 
     @Test
@@ -82,6 +107,11 @@ class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
+    void credentialsSatisfyProfileShouldReturnFalseIfOnlyOnlyAppCredential() throws Exception {
+        assertFalse(evaluator.credentialsSatisfyProfile(List.of(M1B_DCMAW_VC), Gpg45Profile.M1B));
+    }
+
+    @Test
     void credentialsSatisfyProfileShouldReturnFalseIfFailedPassportCredential() throws Exception {
         assertFalse(
                 evaluator.credentialsSatisfyProfile(
@@ -106,10 +136,33 @@ class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
+    void credentialsSatisfyProfileShouldReturnFalseIfFailedAppCredential() throws Exception {
+        assertFalse(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(DCMAW_VC_FAILED, M1A_ADDRESS_VC, M1B_FRAUD_VC), Gpg45Profile.M1B));
+    }
+
+    @Test
     void credentialsSatisfyProfileShouldUseHighestScoringValuesForCredentials() throws Exception {
         assertTrue(
                 evaluator.credentialsSatisfyProfile(
                         List.of(
+                                M1A_PASSPORT_VC,
+                                M1A_ADDRESS_VC,
+                                FRAUD_VC_FAILED,
+                                M1A_FRAUD_VC,
+                                KBV_VC_FAILED,
+                                M1A_KBV_VC),
+                        Gpg45Profile.M1A));
+    }
+
+    @Test
+    void credentialsSatisfyProfileShouldUseHighestScoringValuesForCredentialsIncludingFailedAppVC()
+            throws Exception {
+        assertTrue(
+                evaluator.credentialsSatisfyProfile(
+                        List.of(
+                                DCMAW_VC_FAILED,
                                 M1A_PASSPORT_VC,
                                 M1A_ADDRESS_VC,
                                 FRAUD_VC_FAILED,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the GPG45 Evaluator lambda to track if the credentials gathered match the M1A or the M1B profile.

The DCMAW credential will be responsible for contributing the **EVIDENCE, VERIFICATION, ACTIVITY** parts of the GPG45 profile scoring. For this when we parse the gathered VC's and try to extract their various "evidence" blocks, we convert the 1 single DCMAW VC into multiple CriEvidenceItems with their own individual gpg45 score values for each type.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
When running a journey that uses the new DCMAW app system, it will be targettting a new GPG45 profile - M1B. These changes will ensure that when we are looking at the VC's gathered so far we are hecking if we have met the criteria for either M1A or M1B profiles.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1861](https://govukverify.atlassian.net/browse/PYIC-1861)

