### PR TITLE
PYIC-1881: Store in the session details of when a user returns from a CRI

### DIFF
--- a/lambdas/credentialissuererror/src/main/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandler.java
+++ b/lambdas/credentialissuererror/src/main/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandler.java
@@ -100,7 +100,7 @@ public class CredentialIssuerErrorHandler
 
             sendAuditEvent(credentialIssuerErrorDto, ipvSessionItem);
 
-            ipvSessionItem.addVisistedCredentialIssuerDetails(
+            ipvSessionItem.addVisitedCredentialIssuerDetails(
                     new VisitedCredentialIssuerDetailsDto(
                             credentialIssuerErrorDto.getCredentialIssuerId(),
                             false,

--- a/lambdas/credentialissuererror/src/main/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandler.java
+++ b/lambdas/credentialissuererror/src/main/java/uk/gov/di/ipv/core/credentialissuererror/CredentialIssuerErrorHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.AuditExtensionErrorParams;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerErrorDto;
+import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
@@ -98,6 +99,14 @@ public class CredentialIssuerErrorHandler
             }
 
             sendAuditEvent(credentialIssuerErrorDto, ipvSessionItem);
+
+            ipvSessionItem.addVisistedCredentialIssuerDetails(
+                    new VisitedCredentialIssuerDetailsDto(
+                            credentialIssuerErrorDto.getCredentialIssuerId(),
+                            false,
+                            credentialIssuerErrorDto.getError()));
+
+            sessionService.updateIpvSession(ipvSessionItem);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, journeyResponse);
         } catch (HttpResponseExceptionWithErrorBody e) {

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -283,7 +283,7 @@ public class RetrieveCriOauthAccessTokenHandler
             String criId,
             boolean returnedWithVc,
             String oauthError) {
-        ipvSessionItem.addVisistedCredentialIssuerDetails(
+        ipvSessionItem.addVisitedCredentialIssuerDetails(
                 new VisitedCredentialIssuerDetailsDto(criId, returnedWithVc, oauthError));
         ipvSessionService.updateIpvSession(ipvSessionItem);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/VisitedCredentialIssuerDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/VisitedCredentialIssuerDetailsDto.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import lombok.Data;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@DynamoDbBean
+@Data
+public class VisitedCredentialIssuerDetailsDto {
+    private String criId;
+    private boolean returnedWithVc;
+    private String oauthError;
+
+    public VisitedCredentialIssuerDetailsDto() {}
+
+    public VisitedCredentialIssuerDetailsDto(
+            String criId, boolean returnedWithVc, String oauthError) {
+        this.criId = criId;
+        this.returnedWithVc = returnedWithVc;
+        this.oauthError = oauthError;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -8,6 +8,10 @@ import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
+import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
@@ -23,6 +27,7 @@ public class IpvSessionItem implements DynamodbItem {
     private AccessTokenMetadata accessTokenMetadata;
     private String errorCode;
     private String errorDescription;
+    private List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails;
     private long ttl;
 
     @DynamoDbPartitionKey
@@ -115,6 +120,24 @@ public class IpvSessionItem implements DynamodbItem {
 
     public void setErrorDescription(String errorDescription) {
         this.errorDescription = errorDescription;
+    }
+
+    public List<VisitedCredentialIssuerDetailsDto> getVisitedCredentialIssuerDetails() {
+        return visitedCredentialIssuerDetails;
+    }
+
+    public void setVisitedCredentialIssuerDetails(
+            List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails) {
+        this.visitedCredentialIssuerDetails = visitedCredentialIssuerDetails;
+    }
+
+    public void addVisistedCredentialIssuerDetails(
+            VisitedCredentialIssuerDetailsDto visitedCredentialIssuerDetails) {
+        if (this.visitedCredentialIssuerDetails == null) {
+            this.visitedCredentialIssuerDetails = new ArrayList<>();
+        }
+
+        this.visitedCredentialIssuerDetails.add(visitedCredentialIssuerDetails);
     }
 
     public long getTtl() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -131,7 +131,7 @@ public class IpvSessionItem implements DynamodbItem {
         this.visitedCredentialIssuerDetails = visitedCredentialIssuerDetails;
     }
 
-    public void addVisistedCredentialIssuerDetails(
+    public void addVisitedCredentialIssuerDetails(
             VisitedCredentialIssuerDetailsDto visitedCredentialIssuerDetails) {
         if (this.visitedCredentialIssuerDetails == null) {
             this.visitedCredentialIssuerDetails = new ArrayList<>();

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.IPV_SESSIONS_TABLE_NAME;
@@ -80,6 +81,8 @@ public class IpvSessionService {
         String userState =
                 generateStartingState(clientSessionDetailsDto.isDebugJourney(), errorObject);
         ipvSessionItem.setUserState(userState);
+
+        ipvSessionItem.setVisitedCredentialIssuerDetails(Collections.emptyList());
 
         if (errorObject != null) {
             ipvSessionItem.setErrorCode(errorObject.getCode());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Store details of a visited CRI in the core-back session when a user returns. The criId, a boolean of wether a VC was returned, and then the type of OauthError that was returned if relavant are the fields we store in the list of visited CRI's.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This session data will be used by the cri-selector lambda to help it decide where to send the user next. We can't rely on VC's being present to tell us if a CRI has been visited so these details will be used instead.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1881](https://govukverify.atlassian.net/browse/PYIC-1881)

