### PR TITLE
PYIC-1904: recordedAt -> issuedAt

### DIFF
--- a/lambdas/contra-indicator-storage-core-stub/src/main/java/uk/gov/di/ipv/core/contraindicatorstoragecorestub/domain/ContraIndicatorItem.java
+++ b/lambdas/contra-indicator-storage-core-stub/src/main/java/uk/gov/di/ipv/core/contraindicatorstoragecorestub/domain/ContraIndicatorItem.java
@@ -12,7 +12,7 @@ public class ContraIndicatorItem {
     private String userId;
     private String sortKey;
     private String iss;
-    private String recordedAt;
+    private String issuedAt;
     private String ci;
     private String ttl;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItem.java
@@ -7,7 +7,7 @@ public class ContraIndicatorItem {
     private final String userId;
     private final String sortKey;
     private final String iss;
-    private final String recordedAt;
+    private final String issuedAt;
     private final String ci;
     private final String ttl;
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

recordedAt -> issuedAt

### Why did it change

The nbf claim of a JWT is confusingly mapped to the to the issuanceDate property of the underlying VC.

Originally we were storing this date to assist with the two year ttl. However, we’re using the ttl attribute in the DDB to manage that in keeping with how we do this elsewhere.

We’ve decided to keep this timestamp for flexibility in the future, but we should rename it to better reflect what it actually is.

See this contra-indicator PR for where the change is made: https://github.com/alphagov/di-ipv-contra-indicators/pull/47


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1904](https://govukverify.atlassian.net/browse/PYIC-1904)
