### PR TITLE
PYIC-1905 Drop VCs if storage for CIs fails

### DIFF
--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -652,8 +653,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
     }
 
     @Test
-    void shouldReceive200ErrorJourneyResponseIfFailsToSubmitVCToCIStorageSystem()
-            throws CiPutException, JsonProcessingException, ParseException {
+    void shouldNotThrowIfFailsToSubmitVCToCIStorageSystem() throws CiPutException, ParseException {
         APIGatewayProxyRequestEvent input =
                 createRequestEvent(
                         Map.of(
@@ -678,12 +678,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                 .thenReturn(Collections.singletonList(signedJwt));
         doThrow(new RuntimeException("Ruh'oh")).when(ciStorageService).submitVC(any(), any());
 
-        APIGatewayProxyResponseEvent response = handler.handleRequest(input, context);
-        Integer statusCode = response.getStatusCode();
-        Map responseBody = getResponseBodyAsMap(response);
-
-        assertEquals(HTTPResponse.SC_OK, statusCode);
-        assertEquals("/journey/error", responseBody.get("journey"));
+        assertDoesNotThrow(() -> handler.handleRequest(input, context));
         verify(ciStorageService).submitVC(signedJwt, "test-journey-id");
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/CiPutException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/CiPutException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+public class CiPutException extends Exception {
+    public CiPutException(String message) {
+        super(message);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.GetCiRequest;
 import uk.gov.di.ipv.core.library.domain.GetCiResponse;
 import uk.gov.di.ipv.core.library.domain.PutCiRequest;
+import uk.gov.di.ipv.core.library.exceptions.CiPutException;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 
 import java.nio.ByteBuffer;
@@ -41,7 +42,8 @@ public class CiStorageService {
         this.configurationService = configurationService;
     }
 
-    public void submitVC(SignedJWT verifiableCredential, String govukSigninJourneyId) {
+    public void submitVC(SignedJWT verifiableCredential, String govukSigninJourneyId)
+            throws CiPutException {
         InvokeRequest request =
                 new InvokeRequest()
                         .withFunctionName(
@@ -58,6 +60,7 @@ public class CiStorageService {
 
         if (lambdaExecutionFailed(result)) {
             logLambdaExecutionError(result);
+            throw new CiPutException("Lambda execution failed");
         }
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiStorageServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiStorageServiceTest.java
@@ -12,13 +12,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
+import uk.gov.di.ipv.core.library.exceptions.CiPutException;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -58,20 +58,21 @@ class CiStorageServiceTest {
     }
 
     @Test
-    void submitVCDoesNotThrowIfLambdaExecutionFails() {
+    void submitVCThrowsExceptionIfLambdaExecutionFails() {
         InvokeResult result = new InvokeResult().withStatusCode(500);
         when(configurationService.getEnvironmentVariable(CI_STORAGE_PUT_LAMBDA_ARN))
                 .thenReturn(THE_ARN_OF_THE_PUT_LAMBDA);
         when(lambdaClient.invoke(requestCaptor.capture())).thenReturn(result);
 
-        assertDoesNotThrow(
+        assertThrows(
+                CiPutException.class,
                 () ->
                         ciStorageService.submitVC(
                                 SignedJWT.parse(SIGNED_VC_1), GOVUK_SIGNIN_JOURNEY_ID));
     }
 
     @Test
-    void submitVCDoesNotThrowIfLambdaThrowsAnError() {
+    void submitVCThrowsExceptionIfLambdaThrowsError() {
         InvokeResult result =
                 new InvokeResult()
                         .withStatusCode(200)
@@ -81,7 +82,8 @@ class CiStorageServiceTest {
                 .thenReturn(THE_ARN_OF_THE_PUT_LAMBDA);
         when(lambdaClient.invoke(requestCaptor.capture())).thenReturn(result);
 
-        assertDoesNotThrow(
+        assertThrows(
+                CiPutException.class,
                 () ->
                         ciStorageService.submitVC(
                                 SignedJWT.parse(SIGNED_VC_1), GOVUK_SIGNIN_JOURNEY_ID));


### PR DESCRIPTION
## Proposed changes

### What changed

If submitting to CI storage fails for whatever reason, throw an error and don't store the VC - treat it the same way as a VC storage failure and return journey error response.

### Why did it change

If storing a CI in the CI storage system fails for any reason we shouldn't use the VC that was issued in to attempt to meet an identity profile.

### Issue tracking
- [PYIC-1905](https://govukverify.atlassian.net/browse/PYIC-1905)

