### PR TITLE
PYIC-1896 - add user id lists check for acess to the app journey

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -49,7 +49,6 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HE
 
 @ExtendWith(MockitoExtension.class)
 class EvaluateGpg45ScoreHandlerTest {
-
     private static final String TEST_SESSION_ID = "test-session-id";
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -16,6 +16,8 @@ public enum ConfigurationVariable {
     MAX_ALLOWED_AUTH_CLIENT_TTL("/%s/core/self/maxAllowedAuthClientTtl"),
     PASSPORT_CRI_ID("/%s/core/self/journey/passportCriId"),
     DCMAW_ENABLED("/%s/core/self/journey/dcmawEnabled"),
+    DCMAW_SHOULD_SEND_ALL_USERS("/%s/core/self/journey/dcmawShouldSendAllUsers"),
+    DCMAW_ALLOWED_USER_IDS("/%s/core/self/journey/dcmawAllowedUserIds"),
     AUTH_CODE_EXPIRY_SECONDS("/%s/core/self/authCodeExpirySeconds"),
     PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("/%s/core/clients/%s/publicKeyMaterialForCoreToVerify"),
     CRI_REDIRECT_URL("/%s/core/credentialIssuers/%s/ipvCoreRedirectUrl");


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the select-cri lambda to use the List of user ids SSM param to control which users are sent to the app journey.

The list of user id's will only be used if the `dcmawShouldSendAllUsers` param is set to false. If it is true, then the list of user ids are ignored and all users are sent to the app journey.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This will give us finer control over which users to send to the app journey to help with testing in different environments.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1896](https://govukverify.atlassian.net/browse/PYIC-1896)


