### PR TITLE
PYIC-1889: Process CIs from storage service

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -37,10 +37,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_END;
@@ -153,7 +152,8 @@ class EvaluateGpg45ScoreHandlerTest {
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
                 .thenReturn(evidenceMap);
-        when(gpg45ProfileEvaluator.contraIndicatorsPresent(any())).thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.contraIndicatorsPresent(any(), any()))
+                .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(evidenceMap, Gpg45Profile.M1B))
                 .thenReturn(false);
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(evidenceMap, Gpg45Profile.M1A))
@@ -196,7 +196,7 @@ class EvaluateGpg45ScoreHandlerTest {
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
                 .thenReturn(evidenceMap);
-        when(gpg45ProfileEvaluator.contraIndicatorsPresent(evidenceMap))
+        when(gpg45ProfileEvaluator.contraIndicatorsPresent(eq(evidenceMap), any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(evidenceMap, Gpg45Profile.M1B))
                 .thenReturn(true);
@@ -216,7 +216,7 @@ class EvaluateGpg45ScoreHandlerTest {
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
                 .thenReturn(EVIDENCE_MAP);
-        when(gpg45ProfileEvaluator.contraIndicatorsPresent(EVIDENCE_MAP))
+        when(gpg45ProfileEvaluator.contraIndicatorsPresent(eq(EVIDENCE_MAP), any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(EVIDENCE_MAP, Gpg45Profile.M1B))
                 .thenReturn(false);
@@ -240,7 +240,7 @@ class EvaluateGpg45ScoreHandlerTest {
                 .thenReturn(FAILED_PASSPORT_CREDENTIALS);
         when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(FAILED_PASSPORT_CREDENTIALS))
                 .thenReturn(EVIDENCE_MAP);
-        when(gpg45ProfileEvaluator.contraIndicatorsPresent(EVIDENCE_MAP))
+        when(gpg45ProfileEvaluator.contraIndicatorsPresent(eq(EVIDENCE_MAP), any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(EVIDENCE_MAP, Gpg45Profile.M1B))
                 .thenReturn(false);
@@ -295,7 +295,7 @@ class EvaluateGpg45ScoreHandlerTest {
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
                 .thenReturn(EVIDENCE_MAP);
-        when(gpg45ProfileEvaluator.contraIndicatorsPresent(EVIDENCE_MAP))
+        when(gpg45ProfileEvaluator.contraIndicatorsPresent(eq(EVIDENCE_MAP), any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.credentialsSatisfyProfile(EVIDENCE_MAP, Gpg45Profile.M1B))
                 .thenReturn(false);
@@ -317,38 +317,13 @@ class EvaluateGpg45ScoreHandlerTest {
     }
 
     @Test
-    void shouldCallCIStorageSystemToGetCIs() throws Exception {
-        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
-                .thenReturn(EVIDENCE_MAP);
-
-        evaluateGpg45ScoresHandler.handleRequest(event, context);
-
-        verify(ciStorageService).getCIs(TEST_USER_ID, TEST_JOURNEY_ID);
-    }
-
-    @Test
-    void shouldNotThrowIfGetCIsThrows() throws Exception {
-        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        doThrow(new RuntimeException("Ruh'oh")).when(ciStorageService).getCIs(any(), any());
-
-        assertDoesNotThrow(() -> evaluateGpg45ScoresHandler.handleRequest(event, context));
-
-        verify(ciStorageService).getCIs(TEST_USER_ID, TEST_JOURNEY_ID);
-    }
-
-    @Test
     void shouldReturnJourneyErrorJourneyResponseIfCiAreFoundOnVcs()
             throws UnknownEvidenceTypeException, ParseException {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
                 .thenReturn(EVIDENCE_MAP);
-        when(gpg45ProfileEvaluator.contraIndicatorsPresent(EVIDENCE_MAP))
+        when(gpg45ProfileEvaluator.contraIndicatorsPresent(eq(EVIDENCE_MAP), any()))
                 .thenReturn(Optional.of(new JourneyResponse("/journey/pyi-no-match")));
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItem.java
@@ -2,12 +2,29 @@ package uk.gov.di.ipv.core.library.domain;
 
 import lombok.Data;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
 @Data
-public class ContraIndicatorItem {
+public class ContraIndicatorItem implements Comparable<ContraIndicatorItem> {
     private final String userId;
     private final String sortKey;
     private final String iss;
     private final String issuedAt;
     private final String ci;
     private final String ttl;
+
+    @Override
+    public int compareTo(ContraIndicatorItem other) {
+        Instant thisInstant = Instant.from(DateTimeFormatter.ISO_INSTANT.parse(this.issuedAt));
+        Instant otherInstant = Instant.from(DateTimeFormatter.ISO_INSTANT.parse(other.issuedAt));
+
+        if (thisInstant.isAfter(otherInstant)) {
+            return 1;
+        } else if (this.equals(other)) {
+            return 0;
+        } else {
+            return -1;
+        }
+    }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItemTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItemTest.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ContraIndicatorItemTest {
+    @Test
+    void canBeSortedByIssuedAt() {
+        ContraIndicatorItem item1 =
+                new ContraIndicatorItem(
+                        "userId", "sortKey", "issuer", "2022-09-20T07:00:00.000Z", "ci", "ttl");
+        ContraIndicatorItem item1Again =
+                new ContraIndicatorItem(
+                        "userId", "sortKey", "issuer", "2022-09-20T07:00:00.000Z", "ci", "ttl");
+        ContraIndicatorItem item2 =
+                new ContraIndicatorItem(
+                        "userId", "sortKey", "issuer", "2022-09-20T08:00:00.000Z", "ci", "ttl");
+        ContraIndicatorItem item3 =
+                new ContraIndicatorItem(
+                        "userId", "sortKey", "issuer", "2022-09-20T06:00:00.000Z", "ci", "ttl");
+
+        ArrayList<ContraIndicatorItem> toSort =
+                new ArrayList<>(List.of(item1, item2, item1Again, item3));
+
+        Collections.sort(toSort);
+
+        assertEquals(List.of(item3, item1, item1Again, item2), toSort);
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -40,32 +40,30 @@ class Gpg45ProfileEvaluatorTest {
     @Mock ClientSessionDetailsDto mockClientSessionDetails;
     @InjectMocks Gpg45ProfileEvaluator evaluator;
 
+    private static final Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>>
+            EMPTY_EVIDENCE_MAP =
+                    Map.of(
+                            CredentialEvidenceItem.EvidenceType.ACTIVITY,
+                            new ArrayList<>(),
+                            CredentialEvidenceItem.EvidenceType.EVIDENCE,
+                            new ArrayList<>(),
+                            CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
+                            new ArrayList<>(),
+                            CredentialEvidenceItem.EvidenceType.VERIFICATION,
+                            new ArrayList<>(),
+                            CredentialEvidenceItem.EvidenceType.DCMAW,
+                            new ArrayList<>());
+
     private final String M1A_PASSPORT_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJhdWQiOiJodHRwczpcL1wvaWRlbnRpdHkuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJuYmYiOjE2NTg4Mjk2NDcsImlzcyI6Imh0dHBzOlwvXC9yZXZpZXctcC5pbnRlZ3JhdGlvbi5hY2NvdW50Lmdvdi51ayIsImV4cCI6MTY1ODgzNjg0NywidmMiOnsiZXZpZGVuY2UiOlt7InZhbGlkaXR5U2NvcmUiOjIsInN0cmVuZ3RoU2NvcmUiOjQsImNpIjpudWxsLCJ0eG4iOiIxMjNhYjkzZC0zYTQzLTQ2ZWYtYTJjMS0zYzY0NDQyMDY0MDgiLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayJ9XSwiY3JlZGVudGlhbFN1YmplY3QiOnsicGFzc3BvcnQiOlt7ImV4cGlyeURhdGUiOiIyMDMwLTAxLTAxIiwiZG9jdW1lbnROdW1iZXIiOiIzMjE2NTQ5ODcifV0sIm5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl19fQ.MEYCIQC-2fwJVvFLM8SnCKk_5EHX_ZPdTN2-kaOxNjXky86LUgIhAIMZUuTztxyyqa3ZkyaqnkMl1vPl1HQ2FbQ9LxPQChn";
     private final String M1A_ADDRESS_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWEuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3MjAsImV4cCI6MTY1ODgzNjkyMCwidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIkFkZHJlc3NDcmVkZW50aWFsIl0sIkBjb250ZXh0IjpbImh0dHBzOlwvXC93d3cudzMub3JnXC8yMDE4XC9jcmVkZW50aWFsc1wvdjEiLCJodHRwczpcL1wvdm9jYWIubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsXC9jb250ZXh0c1wvaWRlbnRpdHktdjEuanNvbmxkIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImFkZHJlc3MiOlt7InVwcm4iOjEwMDEyMDAxMjA3NywiYnVpbGRpbmdOdW1iZXIiOiI4IiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInBvc3RhbENvZGUiOiJCQTIgNUFBIiwiYWRkcmVzc0NvdW50cnkiOiJHQiIsInZhbGlkRnJvbSI6IjIwMDAtMDEtMDEifV19fX0.MEQCIDGSdiAuPOEQGRlU_SGRWkVYt28oCVAVIuVWkAseN_RCAiBsdf5qS5BIsAoaebo8L60yaUuZjxU9mYloBa24IFWYsw";
     private final String M1A_FRAUD_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwiaWRlbnRpdHlGcmF1ZFNjb3JlIjoxLCJjaSI6W119XX19.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
-    private final String M1A_FRAUD_VC_WITH_A01 =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwiaWRlbnRpdHlGcmF1ZFNjb3JlIjoxLCJjaSI6WyJBMDEiXX1dfX0.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
     private final String M1A_KBV_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWsuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk5MTcsImV4cCI6MTY1ODgzNzExNywidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eG4iOiI3TEFLUlRBN0ZTIiwidmVyaWZpY2F0aW9uU2NvcmUiOjIsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIn0seyJhZGRyZXNzQ291bnRyeSI6IkdCIiwidXBybiI6MTAwMTIwMDEyMDc3LCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJ2YWxpZEZyb20iOiIyMDAwLTAxLTAxIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX19fQ.MEUCIAD3CkUQctCBxPIonRsYylmAsWsodyzpLlRzSTKvJBxHAiEAsewH-Ke7x8R3879-KQCwGAcYPt_14Wq7a6bvsb5tH_8";
     private final String M1B_DCMAW_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJhdWQiOiJodHRwczovL2lkZW50aXR5LmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwibmJmIjoxNjU4ODI5NjQ3LCJpc3MiOiJodHRwczovL3Jldmlldy1wLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwiZXhwIjoxNjU4ODM2ODQ3LCJ2YyI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InZhbHVlIjoiSm9lIFNobW9lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJEb2UgVGhlIEJhbGwiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk4NS0wMi0wOCJ9XSwiYWRkcmVzcyI6W3sidXBybiI6IjEwMDIyODEyOTI5Iiwib3JnYW5pc2F0aW9uTmFtZSI6IkZJTkNIIEdST1VQIiwic3ViQnVpbGRpbmdOYW1lIjoiVU5JVCAyQiIsImJ1aWxkaW5nTnVtYmVyICI6IjE2IiwiYnVpbGRpbmdOYW1lIjoiQ09ZIFBPTkQgQlVTSU5FU1MgUEFSSyIsImRlcGVuZGVudFN0cmVldE5hbWUiOiJLSU5HUyBQQVJLIiwic3RyZWV0TmFtZSI6IkJJRyBTVFJFRVQiLCJkb3VibGVEZXBlbmRlbnRBZGRyZXNzTG9jYWxpdHkiOiJTT01FIERJU1RSSUNUIiwiZGVwZW5kZW50QWRkcmVzc0xvY2FsaXR5IjoiTE9ORyBFQVRPTiIsImFkZHJlc3NMb2NhbGl0eSI6IkdSRUFUIE1JU1NFTkRFTiIsInBvc3RhbENvZGUiOiJIUDE2IDBBTCIsImFkZHJlc3NDb3VudHJ5IjoiR0IifV0sImRyaXZpbmdQZXJtaXQiOlt7InBlcnNvbmFsTnVtYmVyIjoiRE9FOTk4MDIwODVKOTlGRyIsImV4cGlyeURhdGUiOiIyMDIzLTAxLTE4IiwiaXNzdWVOdW1iZXIiOm51bGwsImlzc3VlZEJ5IjpudWxsLCJpc3N1ZURhdGUiOm51bGx9XSwiZXZpZGVuY2UiOlt7InR5cGUiOiJJZGVudGl0eUNoZWNrIiwidHhuIjoiZWEyZmVlZmUtNDVhMy00YTI5LTkyM2YtNjA0Y2Q0MDE3ZWMwIiwic3RyZW5ndGhTY29yZSI6MywidmFsaWRpdHlTY29yZSI6MiwiYWN0aXZpdHlIaXN0b3J5U2NvcmUiOiIxIiwiY2hlY2tEZXRhaWxzIjpbeyJjaGVja01ldGhvZCI6InZyaSIsImlkZW50aXR5Q2hlY2tQb2xpY3kiOiJwdWJsaXNoZWQiLCJhY3Rpdml0eUZyb20iOiIyMDE5LTAxLTAxIn0seyJjaGVja01ldGhvZCI6ImJ2ciIsImJpb21ldHJpY1ZlcmlmaWNhdGlvblByb2Nlc3NMZXZlbCI6Mn1dfV19fQ.Ul-eb7s76_F1M5D5maztKdvbrx1_1xGy53_pVZFGmSGJt7niWIe_87ykWm-o1HYaBKYMTvPmSS266ZBZ0t4Gwg";
-    private final String M1B_FRAUD_VC =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jldmlldy1mLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwic3ViIjoidXJuOnV1aWQ6ZTZlMmUzMjQtNWI2Ni00YWQ2LTgzMzgtODNmOWY4MzdlMzQ1IiwibmJmIjoxNjU4ODI5NzU4LCJleHAiOjE2NTg4MzY5NTgsInZjIjp7ImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImFkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb0JveE51bWJlciI6bnVsbCwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJpZCI6bnVsbCwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInN1YkJ1aWxkaW5nTmFtZSI6bnVsbH1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdLCJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJ0eG4iOiJSQjAwMDEwMzQ5MDA4NyIsImlkZW50aXR5RnJhdWRTY29yZSI6MiwiY2kiOltdfV19fQ.-0NrF3Sv2GwXPEpgAITdE-8SkzuihihEF8inTi_lzo_b-6urQl17pGeWwVyygQRJDbKpxm-Q5ZzXeQuTybLSZQ";
-    private final String M1B_FRAUD_VC_WITH_A01 =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jldmlldy1mLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwic3ViIjoidXJuOnV1aWQ6ZTZlMmUzMjQtNWI2Ni00YWQ2LTgzMzgtODNmOWY4MzdlMzQ1IiwibmJmIjoxNjU4ODI5NzU4LCJleHAiOjE2NTg4MzY5NTgsInZjIjp7ImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImFkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb0JveE51bWJlciI6bnVsbCwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJpZCI6bnVsbCwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInN1YkJ1aWxkaW5nTmFtZSI6bnVsbH1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdLCJldmlkZW5jZSI6W3sidHlwZSI6IklkZW50aXR5Q2hlY2siLCJ0eG4iOiJSQjAwMDEwMzQ5MDA4NyIsImlkZW50aXR5RnJhdWRTY29yZSI6MiwiY2kiOlsiQTAxIl19XX19.q1QDbqY9rGq6Y3moSFkvx46PjJPsefRoSfdfRB73rqlxTTlIzJO9W6z9tnJzA_ydd6JPnRvJJqdXQMLKK3NwGQ";
-    private final String PASSPORT_VC_FAILED =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDpmZDgwMTVmMy1mYjA5LTRiZjctYWU3ZS02MDMzNTAzOGRjYTgiLCJhdWQiOiJodHRwczpcL1wvaWRlbnRpdHkuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJuYmYiOjE2NTg4Mzk3NzIsImlzcyI6Imh0dHBzOlwvXC9yZXZpZXctcC5pbnRlZ3JhdGlvbi5hY2NvdW50Lmdvdi51ayIsImV4cCI6MTY1ODg0Njk3MiwidmMiOnsiZXZpZGVuY2UiOlt7InZhbGlkaXR5U2NvcmUiOjAsInN0cmVuZ3RoU2NvcmUiOjQsImNpIjpbIkQwMiJdLCJ0eG4iOiJlNmMwOTA3NC1hMjczLTRiOGMtOTVmOC0zYWE1YjI2NDgzMmUiLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayJ9XSwiY3JlZGVudGlhbFN1YmplY3QiOnsicGFzc3BvcnQiOlt7ImV4cGlyeURhdGUiOiIyMDI0LTA5LTI5IiwiZG9jdW1lbnROdW1iZXIiOiIxMjM0NTY3ODkifV0sIm5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoia3NkamhmcyJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6InFza2RqaGYifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODQtMDktMjgifV19LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXX19.MEUCIQDD0Y0ftHUJmhQ_oDX6wo23loLQ-_EZqoivq2eMoKPYiAIgcmaaGjV7KX8FYNJhPM_v7kWxl1WS9HBx6iiXsv0gODI";
-    private final String FRAUD_VC_FAILED =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jldmlldy1mLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwic3ViIjoidXJuOnV1aWQ6NDAyNWI4OTItZmZlOS00Y2RlLWFiZjMtMTk4MWE2YmE0OTJiIiwibmJmIjoxNjU4ODQwMDEyLCJleHAiOjE2NTg4NDcyMTIsInZjIjp7ImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImFkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiRE9XTklORyBTVFJFRVQiLCJwb0JveE51bWJlciI6bnVsbCwicG9zdGFsQ29kZSI6IlNXMUEgMkFBIiwiYnVpbGRpbmdOdW1iZXIiOiIxMCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJMT05ET04iLCJzdWJCdWlsZGluZ05hbWUiOm51bGx9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5NTktMDgtMjMifV19LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXSwiZXZpZGVuY2UiOlt7InR5cGUiOiJJZGVudGl0eUNoZWNrIiwidHhuIjoiUkIwMDAxMDM0OTc0NDMiLCJpZGVudGl0eUZyYXVkU2NvcmUiOjAsImNpIjpbIkEwMiJdfV19fQ.3zagaEUPfOj7r-tu8Vk20YZqm37bus4ahDys30sfIpSSSzwO4BWRJtiWokGsowHQuPhHeBrPpcBLmtvuocIvNg";
-    private final String KBV_VC_FAILED =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jldmlldy1rLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwic3ViIjoidXJuOnV1aWQ6YjhiNDU2ZjctOThkZS00ZGI5LThiYjMtNjljOTg1MTBmNGFkIiwibmJmIjoxNjU4OTA5MjkwLCJleHAiOjE2NTg5MTY0OTAsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJJZGVudGl0eUNoZWNrQ3JlZGVudGlhbCJdLCJldmlkZW5jZSI6W3sidHhuIjoiN0xCSDZaRExMRCIsInZlcmlmaWNhdGlvblNjb3JlIjowLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsImNpIjpbIkQwMiJdfV0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImFkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgifSx7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJ1cHJuIjoxMDAxMjAwMTIwNzcsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvc3RhbENvZGUiOiJCQTIgNUFBIiwiYnVpbGRpbmdOdW1iZXIiOiI4IiwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInZhbGlkRnJvbSI6IjIwMDAtMDEtMDEifV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfX19.Zox_Qghq941Lxga7CP6l-BgaqxKanplTQlqY1eRGsucfFoBWkkSMo0LPr-OLLowj4UET0HJAMUI8lgBmeGDHbQ";
-    private final String DCMAW_VC_FAILED =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDpzdWJJZGVudGl0eSIsImlzcyI6Imlzc3VlciIsImlhdCI6MTY0NzAxNzk5MCwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3ZvY2FiLmFjY291bnQuZ292LnVrL2NvbnRleHRzL2lkZW50aXR5LXYxLmpzb25sZCJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6Ik1PUkdBTiIsInR5cGUiOiJHaXZlbk5hbWUifSx7InZhbHVlIjoiU0FSQUggTUVSRURZVEgiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk3Ni0wMy0xMSJ9XSwiYWRkcmVzcyI6W3sidXBybiI6IjEwMDIyODEyOTI5Iiwib3JnYW5pc2F0aW9uTmFtZSI6IkZJTkNIIEdST1VQIiwic3ViQnVpbGRpbmdOYW1lIjoiVU5JVCAyQiIsImJ1aWxkaW5nTnVtYmVyICI6IjE2IiwiYnVpbGRpbmdOYW1lIjoiQ09ZIFBPTkQgQlVTSU5FU1MgUEFSSyIsImRlcGVuZGVudFN0cmVldE5hbWUiOiJLSU5HUyBQQVJLIiwic3RyZWV0TmFtZSI6IkJJRyBTVFJFRVQiLCJkb3VibGVEZXBlbmRlbnRBZGRyZXNzTG9jYWxpdHkiOiJTT01FIERJU1RSSUNUIiwiZGVwZW5kZW50QWRkcmVzc0xvY2FsaXR5IjoiTE9ORyBFQVRPTiIsImFkZHJlc3NMb2NhbGl0eSI6IkdSRUFUIE1JU1NFTkRFTiIsInBvc3RhbENvZGUiOiJIUDE2IDBBTCIsImFkZHJlc3NDb3VudHJ5IjoiR0IifV0sImRyaXZpbmdQZXJtaXQiOlt7InBlcnNvbmFsTnVtYmVyIjoiTU9SR0E3NTMxMTZTTTlJSiIsImlzc3VlTnVtYmVyIjpudWxsLCJpc3N1ZWRCeSI6bnVsbCwiaXNzdWVEYXRlIjpudWxsLCJleHBpcnlEYXRlIjoiMjAyMy0wMS0xOCJ9XX0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6ImJjZDIzNDYiLCJzdHJlbmd0aFNjb3JlIjozLCJ2YWxpZGl0eVNjb3JlIjowLCJhY3Rpdml0eUhpc3RvcnlTY29yZSI6IjEiLCJjaSI6WyJEMDIiXSwiZmFpbGVkQ2hlY2tEZXRhaWxzIjpbeyJjaGVja01ldGhvZCI6InZyaSIsImlkZW50aXR5Q2hlY2tQb2xpY3kiOiJwdWJsaXNoZWQiLCJhY3Rpdml0eUZyb20iOiIyMDE5LTAxLTAxIn0seyJjaGVja01ldGhvZCI6ImJ2ciIsImJpb21ldHJpY1ZlcmlmaWNhdGlvblByb2Nlc3NMZXZlbCI6Mn1dfV19fQ.u7k7xVJj7PC2BA5P4Z3hlfJb1IVKSwUuF-JiD2SpQp1kTFQS633Qh-JnlrgZVL_8DMrMa-R3TcQdysymB150tA";
-    private final String VC_WITH_BAD_EVIDENCE_BLOB =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwidGhpc0RvZXNOb3RNYWtlU2Vuc2VTY29yZSI6MSwiY2kiOltdfV19fQo.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
 
     @Test
     void credentialsSatisfyProfileShouldReturnTrueIfCredentialsSatisfyProfile() throws Exception {
@@ -615,18 +613,6 @@ class Gpg45ProfileEvaluatorTest {
 
     @Test
     void shouldCallCIStorageSystemToGetCIs() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
         when(mockClientSessionDetails.getUserId()).thenReturn("a-user-id");
         when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn("a-journey-id");
         when(mockConfigurationService.getCredentialIssuer(any()))
@@ -642,25 +628,13 @@ class Gpg45ProfileEvaluatorTest {
                         "123456789"));
         when(mockCiStorageService.getCIs("a-user-id", "a-journey-id")).thenReturn(ciItems);
 
-        evaluator.contraIndicatorsPresent(evidenceMap, mockClientSessionDetails);
+        evaluator.contraIndicatorsPresent(EMPTY_EVIDENCE_MAP, mockClientSessionDetails);
 
         verify(mockCiStorageService).getCIs("a-user-id", "a-journey-id");
     }
 
     @Test
     void shouldNotThrowIfGetCIsThrows() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
         when(mockClientSessionDetails.getUserId()).thenReturn("a-user-id");
         when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn("a-journey-id");
         doThrow(new RuntimeException("Ruh'oh"))
@@ -668,7 +642,9 @@ class Gpg45ProfileEvaluatorTest {
                 .getCIs("a-user-id", "a-journey-id");
 
         assertDoesNotThrow(
-                () -> evaluator.contraIndicatorsPresent(evidenceMap, mockClientSessionDetails));
+                () ->
+                        evaluator.contraIndicatorsPresent(
+                                EMPTY_EVIDENCE_MAP, mockClientSessionDetails));
 
         verify(mockCiStorageService).getCIs("a-user-id", "a-journey-id");
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Process CIs from storage service

### Why did it change

This adds logic to start using the CIs stored in the storage service to generate a journey response. The result is currently just compared to the existing logic and logged, rather than being acted upon. This can stay this way until we're ready to start using the system in prod.

This approach uses the issuer of the last known CI to determine which error page to show to a user. This should be consistent with current behaviour, but may not be sustainable long term.

This new logic is also light on tests. When we actually come to start using it, we can add more tests to give us better confidence in it.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1889](https://govukverify.atlassian.net/browse/PYIC-1889)
