### PR TITLE
BAU: fix app verification score value

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/DcmawCheckMethod.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/DcmawCheckMethod.java
@@ -1,8 +1,12 @@
 package uk.gov.di.ipv.core.library.domain.gpg45.domain;
 
 import lombok.Getter;
+import lombok.Setter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @Getter
+@Setter
+@ExcludeFromGeneratedCoverageReport
 public class DcmawCheckMethod {
     private String checkMethod;
     private String identityCheckPolicy;

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -77,6 +77,8 @@ class Gpg45ProfileEvaluatorTest {
     @Test
     void credentialsSatisfyProfileShouldReturnTrueIfCredentialsM1BSatisfyProfile()
             throws Exception {
+        DcmawCheckMethod dcmawCheckMethod = new DcmawCheckMethod();
+        dcmawCheckMethod.setBiometricVerificationProcessLevel(3);
         Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
                 Map.of(
                         CredentialEvidenceItem.EvidenceType.ACTIVITY,
@@ -97,8 +99,8 @@ class Gpg45ProfileEvaluatorTest {
                                         3,
                                         2,
                                         1,
-                                        2,
-                                        Collections.singletonList(new DcmawCheckMethod()),
+                                        3,
+                                        Collections.singletonList(dcmawCheckMethod),
                                         null,
                                         Collections.emptyList())));
 
@@ -138,6 +140,8 @@ class Gpg45ProfileEvaluatorTest {
     void
             credentialsSatisfyProfileShouldReturnTrueIfCredentialsSatisfyProfileAndOnlyA01CIForTheM1BProfile()
                     throws Exception {
+        DcmawCheckMethod dcmawCheckMethod = new DcmawCheckMethod();
+        dcmawCheckMethod.setBiometricVerificationProcessLevel(3);
         Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
                 Map.of(
                         CredentialEvidenceItem.EvidenceType.ACTIVITY,
@@ -159,7 +163,7 @@ class Gpg45ProfileEvaluatorTest {
                                         2,
                                         1,
                                         2,
-                                        Collections.singletonList(new DcmawCheckMethod()),
+                                        Collections.singletonList(dcmawCheckMethod),
                                         null,
                                         Collections.emptyList())));
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
The biometrickVerificationProcessLevel has now increased to 3 for the app. This means that the verifcation score of the VC should be 3 as well. Previously we had just implied the verification score to be 2 if the VC was successful.

This change now makes it that we directly read the biometrickVerificationProcessLevel value and set the verification score to that value instead of an implied value. However if the VC has the failedCheckDetails property then the verification score is implied to be 0.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The verifcation score of the app VC has changed, so this PR ensures that we now match the correct verification score received by the app's BiometricVerificationProcessLevel value.
<!-- Describe the reason these changes were made - the "why" -->

