### PR TITLE
Add stub cri events to the staging journey engine

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -104,11 +104,18 @@ SELECT_CRI:
   events:
     ukPassport:
       type: basic
-      name: next
+      name: ukPassport
       targetState: CRI_UK_PASSPORT
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    stubUkPassport:
+      type: basic
+      name: stubUkPassport
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
     address:
       type: basic
       name: address
@@ -116,6 +123,13 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/address
+    stubddress:
+      type: basic
+      name: stubAddress
+      targetState: CRI_ADDRESS
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubAddress
     fraud:
       type: basic
       name: fraud
@@ -123,10 +137,24 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/fraud
+    stubFraud:
+      type: basic
+      name: stubFraud
+      targetState: CRI_FRAUD
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubFraud
     kbv:
       type: basic
       name: kbv
       targetState: PRE_KBV_TRANSITION_PAGE
+      response:
+        type: page
+        pageId: page-pre-kbv-transition
+    stubKbv:
+      type: basic
+      name: stubKbv
+      targetState: PRE_STUB_KBV_TRANSITION_PAGE
       response:
         type: page
         pageId: page-pre-kbv-transition
@@ -192,6 +220,17 @@ PRE_KBV_TRANSITION_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/kbv
+PRE_STUB_KBV_TRANSITION_PAGE:
+  name: PRE_STUB_KBV_TRANSITION_PAGE
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_KBV
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubKbv
 POST_DCMAW_SUCCESS_PAGE:
   name: POST_DCMAW_SUCCESS_PAGE
   parent: null


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add stub versions of the CRI events to the SELECT_CRI state for the staging environment journey engine.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This allows us to swap to the staging versions of our CRI's in the staging environment if we choose to. For clarity this PR won't actually cause the cri's we use to swap to the stub versions now, it just means that if they do the journey engine will continue to work.

If we want to swap to using a stub version then we need to update the journey cri id value within the SSM param to be the stub cri ID value.

I plan to do this temporarily with the fraud CRI to do some testing with the new app integration on a full journey route.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1982](https://govukverify.atlassian.net/browse/PYIC-1982)

