### PR TITLE
PYIC-1971

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -105,10 +105,10 @@ SELECT_CRI:
     stubUkPassport:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT
+      targetState: PASSPORT_DOC_CHECK_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+        type: page
+        pageId: page-passport-doc-check
     stubAddress:
       type: basic
       name: address
@@ -174,6 +174,24 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+PASSPORT_DOC_CHECK_PAGE:
+  name: PASSPORT_DOC_CHECK_PAGE
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -105,10 +105,10 @@ SELECT_CRI:
     stubUkPassport:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT
+      targetState: PASSPORT_DOC_CHECK_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+        type: page
+        pageId: page-passport-doc-check
     stubAddress:
       type: basic
       name: address
@@ -174,6 +174,24 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+PASSPORT_DOC_CHECK_PAGE:
+  name: PASSPORT_DOC_CHECK_PAGE
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -105,10 +105,10 @@ SELECT_CRI:
     ukPassport:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT
+      targetState: PASSPORT_DOC_CHECK_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+        type: page
+        pageId: page-passport-doc-check
     address:
       type: basic
       name: address
@@ -181,6 +181,24 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+PASSPORT_DOC_CHECK_PAGE:
+  name: PASSPORT_DOC_CHECK_PAGE
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -174,6 +174,24 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+PASSPORT_DOC_CHECK_PAGE:
+  name: PASSPORT_DOC_CHECK_PAGE
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -105,17 +105,17 @@ SELECT_CRI:
     ukPassport:
       type: basic
       name: ukPassport
-      targetState: CRI_UK_PASSPORT
+      targetState: PASSPORT_DOC_CHECK_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+        type: page
+        pageId: page-passport-doc-check
     stubUkPassport:
       type: basic
       name: stubUkPassport
-      targetState: CRI_UK_PASSPORT
+      targetState: STUB_PASSPORT_DOC_CHECK_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+        type: page
+        pageId: page-passport-doc-check
     address:
       type: basic
       name: address
@@ -209,6 +209,42 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+PASSPORT_DOC_CHECK_PAGE:
+  name: PASSPORT_DOC_CHECK_PAGE
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+STUB_PASSPORT_DOC_CHECK_PAGE:
+  name: STUB_PASSPORT_DOC_CHECK_PAGE
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: null


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add new passport doc check page to the journey engine to be displayed before sending the user to the passport CRI.

NOTE: This has not been enabled in the production yaml file. We only want to display this page in prod when other content has been changed in the prior auth stages to ipv-core. This should happen during the go-live of the app journey.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This introduces a new page prior to the passport CRI where we give the option for the user to confirm if they are happy to continue forward using their passport document to verify their identity or not.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1971](https://govukverify.atlassian.net/browse/PYIC-1971)

