### PR TITLE
PYIC-1865: Start storing CIs in prod

### DIFF
--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -31,7 +31,6 @@ import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
-import uk.gov.di.ipv.core.library.service.CiStorageService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.CredentialIssuerService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -85,8 +84,6 @@ class RetrieveCriOauthAccessTokenHandlerTest {
 
     @Mock private IpvSessionItem ipvSessionItem;
 
-    @Mock private CiStorageService ciStorageService;
-
     @InjectMocks private RetrieveCriOauthAccessTokenHandler handler;
 
     private static CredentialIssuerConfig passportIssuer;
@@ -129,8 +126,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
     }
 
     @Test
-    void shouldReceive200AndJourneyResponseOnSuccessfulRequest()
-            throws JsonProcessingException, SqsException {
+    void shouldReceive200AndJourneyResponseOnSuccessfulRequest() throws Exception {
 
         APIGatewayProxyRequestEvent input =
                 createRequestEvent(
@@ -243,8 +239,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                                 credentialIssuerService,
                                 configurationService,
                                 ipvSessionService,
-                                auditService,
-                                ciStorageService)
+                                auditService)
                         .handleRequest(input, context);
         assert400Response(response, ErrorResponse.MISSING_OAUTH_STATE);
     }
@@ -271,8 +266,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                                 credentialIssuerService,
                                 configurationService,
                                 ipvSessionService,
-                                auditService,
-                                ciStorageService)
+                                auditService)
                         .handleRequest(input, context);
         assert400Response(response, ErrorResponse.INVALID_OAUTH_STATE);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/CiPutException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/CiPutException.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class CiPutException extends Exception {
+    public CiPutException(String message) {
+        super(message);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.GetCiRequest;
 import uk.gov.di.ipv.core.library.domain.GetCiResponse;
 import uk.gov.di.ipv.core.library.domain.PutCiRequest;
+import uk.gov.di.ipv.core.library.exceptions.CiPutException;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 
 import java.nio.ByteBuffer;
@@ -41,7 +42,8 @@ public class CiStorageService {
         this.configurationService = configurationService;
     }
 
-    public void submitVC(SignedJWT verifiableCredential, String govukSigninJourneyId) {
+    public void submitVC(SignedJWT verifiableCredential, String govukSigninJourneyId)
+            throws CiPutException {
         InvokeRequest request =
                 new InvokeRequest()
                         .withFunctionName(
@@ -58,6 +60,7 @@ public class CiStorageService {
 
         if (lambdaExecutionFailed(result)) {
             logLambdaExecutionError(result);
+            throw new CiPutException("Lambda execution failed");
         }
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiStorageServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiStorageServiceTest.java
@@ -12,13 +12,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
+import uk.gov.di.ipv.core.library.exceptions.CiPutException;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -58,20 +58,21 @@ class CiStorageServiceTest {
     }
 
     @Test
-    void submitVCDoesNotThrowIfLambdaExecutionFails() {
+    void submitVCThrowsIfLambdaExecutionFails() {
         InvokeResult result = new InvokeResult().withStatusCode(500);
         when(configurationService.getEnvironmentVariable(CI_STORAGE_PUT_LAMBDA_ARN))
                 .thenReturn(THE_ARN_OF_THE_PUT_LAMBDA);
         when(lambdaClient.invoke(requestCaptor.capture())).thenReturn(result);
 
-        assertDoesNotThrow(
+        assertThrows(
+                CiPutException.class,
                 () ->
                         ciStorageService.submitVC(
                                 SignedJWT.parse(SIGNED_VC_1), GOVUK_SIGNIN_JOURNEY_ID));
     }
 
     @Test
-    void submitVCDoesNotThrowIfLambdaThrowsAnError() {
+    void submitVCThrowsIfLambdaThrowsAnError() {
         InvokeResult result =
                 new InvokeResult()
                         .withStatusCode(200)
@@ -81,7 +82,8 @@ class CiStorageServiceTest {
                 .thenReturn(THE_ARN_OF_THE_PUT_LAMBDA);
         when(lambdaClient.invoke(requestCaptor.capture())).thenReturn(result);
 
-        assertDoesNotThrow(
+        assertThrows(
+                CiPutException.class,
                 () ->
                         ciStorageService.submitVC(
                                 SignedJWT.parse(SIGNED_VC_1), GOVUK_SIGNIN_JOURNEY_ID));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Start storing CIs in prod

### Why did it change

This removes the check on the environment and starts storing contra-indicators in the production environment.

It also removes the error handling around the call to the new system. This means that if there is an issue the users journey will be interrupted.

Any VCs submitted to the CI storage system that result in an error will get dropped, as per the RFC.

This won't get merged until the document identifier PR has been merged (https://github.com/alphagov/di-ipv-contra-indicators/pull/48), and the correct permissions have been added to the secure pipeline permissions boundary (https://govukverify.atlassian.net/browse/PLAT-265)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1865](https://govukverify.atlassian.net/browse/PYIC-1865)
