### PR TITLE
Add error event to journey engine for dcmaw oauth errors

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -218,6 +218,13 @@ CRI_DCMAW:
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+    error:
+      type: basic
+      name: error
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -218,6 +218,13 @@ CRI_DCMAW:
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+    error:
+      type: basic
+      name: error
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -225,6 +225,13 @@ CRI_DCMAW:
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+    error:
+      type: basic
+      name: error
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -218,6 +218,13 @@ CRI_DCMAW:
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+    error:
+      type: basic
+      name: error
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -264,6 +264,13 @@ CRI_DCMAW:
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+    error:
+      type: basic
+      name: error
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Override error event for the CRI_DCMAW state.


<!-- Describe the changes in detail - the "what"-->

### Why did it change
The dcmaw app now returns a different oauth error, so this event captures any other oauth error that we receive and will ensure we revert back to the MVP passport journey.


<!-- Describe the reason these changes were made - the "why" -->

