### PR TITLE
PYIC-1995: Add documentId to ContraIndicatorItem

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItem.java
@@ -13,6 +13,7 @@ public class ContraIndicatorItem implements Comparable<ContraIndicatorItem> {
     private final String issuedAt;
     private final String ci;
     private final String ttl;
+    private final String documentId;
 
     @Override
     public int compareTo(ContraIndicatorItem other) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItemTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorItemTest.java
@@ -13,16 +13,40 @@ class ContraIndicatorItemTest {
     void canBeSortedByIssuedAt() {
         ContraIndicatorItem item1 =
                 new ContraIndicatorItem(
-                        "userId", "sortKey", "issuer", "2022-09-20T07:00:00.000Z", "ci", "ttl");
+                        "userId",
+                        "sortKey",
+                        "issuer",
+                        "2022-09-20T07:00:00.000Z",
+                        "ci",
+                        "ttl",
+                        null);
         ContraIndicatorItem item1Again =
                 new ContraIndicatorItem(
-                        "userId", "sortKey", "issuer", "2022-09-20T07:00:00.000Z", "ci", "ttl");
+                        "userId",
+                        "sortKey",
+                        "issuer",
+                        "2022-09-20T07:00:00.000Z",
+                        "ci",
+                        "ttl",
+                        null);
         ContraIndicatorItem item2 =
                 new ContraIndicatorItem(
-                        "userId", "sortKey", "issuer", "2022-09-20T08:00:00.000Z", "ci", "ttl");
+                        "userId",
+                        "sortKey",
+                        "issuer",
+                        "2022-09-20T08:00:00.000Z",
+                        "ci",
+                        "ttl",
+                        "passport/GB/HMPO/123456789");
         ContraIndicatorItem item3 =
                 new ContraIndicatorItem(
-                        "userId", "sortKey", "issuer", "2022-09-20T06:00:00.000Z", "ci", "ttl");
+                        "userId",
+                        "sortKey",
+                        "issuer",
+                        "2022-09-20T06:00:00.000Z",
+                        "ci",
+                        "ttl",
+                        null);
 
         ArrayList<ContraIndicatorItem> toSort =
                 new ArrayList<>(List.of(item1, item2, item1Again, item3));

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -638,7 +638,8 @@ class Gpg45ProfileEvaluatorTest {
                         "issuer",
                         "2022-09-14T15:03:46.795Z",
                         "X01",
-                        "123456789"));
+                        "123456789",
+                        null));
         when(mockCiStorageService.getCIs("a-user-id", "a-journey-id")).thenReturn(ciItems);
 
         evaluator.contraIndicatorsPresent(EMPTY_EVIDENCE_MAP, mockClientSessionDetails);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiStorageServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiStorageServiceTest.java
@@ -114,8 +114,8 @@ class CiStorageServiceTest {
                 new String(request.getPayload().array(), StandardCharsets.UTF_8));
         assertEquals(
                 List.of(
-                        new ContraIndicatorItem(TEST_USER_ID, null, null, null, "X01", null),
-                        new ContraIndicatorItem(TEST_USER_ID, null, null, null, "Z02", null)),
+                        new ContraIndicatorItem(TEST_USER_ID, null, null, null, "X01", null, null),
+                        new ContraIndicatorItem(TEST_USER_ID, null, null, null, "Z02", null, null)),
                 ciItems);
     }
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add documentId to ContraIndicatorItem
### Why did it change

The CI storage system may now return a document identifier with each contra indicator.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1995](https://govukverify.atlassian.net/browse/PYIC-1995)

