### PR TITLE
PYIC-1994

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaims.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaims.java
@@ -42,6 +42,10 @@ public class SharedClaims {
         return Optional.ofNullable(address);
     }
 
+    public void setAddress(Set<Address> address) {
+        this.address = address;
+    }
+
     public static class Builder {
 
         private Set<Name> name;

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/SharedClaimsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/SharedClaimsTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
@@ -45,5 +46,33 @@ class SharedClaimsTest {
         assertEquals(Optional.empty(), SharedClaims.empty().getName());
         assertEquals(Optional.empty(), SharedClaims.empty().getAddress());
         assertEquals(Optional.empty(), SharedClaims.empty().getBirthDate());
+    }
+
+    @Test
+    void shouldOverrideAddressAttributes() throws JsonProcessingException {
+        List<NameParts> namePartsList = Arrays.asList(new NameParts("Paul", "GivenName"));
+        Set<Name> nameSet = new HashSet<>();
+        Name names = new Name(namePartsList);
+        nameSet.add(names);
+
+        Set<Address> addressSet = new HashSet<>();
+        addressSet.add(new ObjectMapper().readValue(ADDRESS_JSON_1, Address.class));
+
+        Set<BirthDate> birthDaySet = new HashSet<>();
+        BirthDate birthDate = new BirthDate("2020-02-03");
+        birthDaySet.add(birthDate);
+
+        SharedClaims response =
+                new SharedClaims.Builder()
+                        .setName(nameSet)
+                        .setAddress(addressSet)
+                        .setBirthDate(birthDaySet)
+                        .build();
+
+        response.setAddress(null);
+
+        assertEquals(nameSet, response.getName().get());
+        assertEquals(Optional.empty(), response.getAddress());
+        assertEquals(birthDaySet, response.getBirthDate().get());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
@@ -33,13 +33,13 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.W3
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
 
 public class VerifiableCredentialGenerator {
-    public static String generateVerifiableCredential(Map<String, Object> vcClaim)
+    public static String generateVerifiableCredential(Map<String, Object> vcClaim, String issuer)
             throws Exception {
         Instant now = Instant.now();
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim(SUBJECT, "https://subject.example.com")
-                        .claim(ISSUER, "https://issuer.example.com")
+                        .claim(ISSUER, issuer)
                         .claim(NOT_BEFORE, now.getEpochSecond())
                         .claim(EXPIRATION_TIME, now.plusSeconds(600).getEpochSecond())
                         .claim(VC_CLAIM, vcClaim)

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -129,12 +129,14 @@ class UserIdentityServiceTest {
                         createUserIssuedCredentialsItem(
                                 "user-id-1",
                                 "ukPassport",
-                                generateVerifiableCredential(credentialVcClaim),
+                                generateVerifiableCredential(
+                                        credentialVcClaim, "https://issuer.example.com"),
                                 LocalDateTime.parse("2022-01-25T12:28:56.414849")),
                         createUserIssuedCredentialsItem(
                                 "user-id-1",
                                 "fraud",
-                                generateVerifiableCredential(credentialVcClaim),
+                                generateVerifiableCredential(
+                                        credentialVcClaim, "https://issuer.example.com"),
                                 LocalDateTime.parse("2022-01-25T12:28:56.414849")));
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
@@ -180,7 +182,8 @@ class UserIdentityServiceTest {
                         createUserIssuedCredentialsItem(
                                 "user-id-1",
                                 "ukPassport",
-                                generateVerifiableCredential(credentialVcClaim),
+                                generateVerifiableCredential(
+                                        credentialVcClaim, "https://issuer.example.com"),
                                 LocalDateTime.parse("2022-01-25T12:28:56.414849")));
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the shared_claims generation to remove extra address claims once we have a VC from the address CRI.

Also ensures that the contents of any failed VC are not included in the shared_claims.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The fraud CRI will not be able to handle receiving 2 address details in the shared_claims during a mobile journey. So IPV-core needs to only include the address details from the address VC in its shared claims.

Also now it is possible for a user to fail the app CRI but still receive a VC. So for this scenario we don't want to include the contents of this VC in the shared_claims.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1994](https://govukverify.atlassian.net/browse/PYIC-1994)

