### PR TITLE
PYIC-2009: Fix vot claim for app journey and add dcmaw id's to list of CRIs to try build the identity claim from

### DIFF
--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -117,7 +117,8 @@ public class BuildUserIdentityHandler
                             userId, ipvSessionId, clientSessionDetails.getGovukSigninJourneyId());
 
             String sub = userId;
-            UserIdentity userIdentity = userIdentityService.generateUserIdentity(userId, sub);
+            UserIdentity userIdentity =
+                    userIdentityService.generateUserIdentity(userId, sub, ipvSessionItem.getVot());
 
             auditService.sendAuditEvent(
                     new AuditEvent(

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -123,7 +123,8 @@ class BuildUserIdentityHandlerTest {
 
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
                 .thenReturn(Optional.ofNullable(ipvSessionItem));
-        when(mockUserIdentityService.generateUserIdentity(any(), any())).thenReturn(userIdentity);
+        when(mockUserIdentityService.generateUserIdentity(any(), any(), any()))
+                .thenReturn(userIdentity);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
 
@@ -141,7 +142,8 @@ class BuildUserIdentityHandlerTest {
 
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
                 .thenReturn(Optional.ofNullable(ipvSessionItem));
-        when(mockUserIdentityService.generateUserIdentity(any(), any())).thenReturn(userIdentity);
+        when(mockUserIdentityService.generateUserIdentity(any(), any(), any()))
+                .thenReturn(userIdentity);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
         UserIdentity responseBody =
@@ -172,7 +174,7 @@ class BuildUserIdentityHandlerTest {
 
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
                 .thenReturn(Optional.ofNullable(ipvSessionItem));
-        when(mockUserIdentityService.generateUserIdentity(any(), any()))
+        when(mockUserIdentityService.generateUserIdentity(any(), any(), any()))
                 .thenThrow(
                         new HttpResponseExceptionWithErrorBody(
                                 500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM));

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -54,6 +54,7 @@ public class EvaluateGpg45ScoresHandler
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
     public static final JourneyResponse JOURNEY_END = new JourneyResponse("/journey/end");
     public static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
+    public static final String VOT_P2 = "P2";
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Gson gson = new Gson();
     private final UserIdentityService userIdentityService;
@@ -111,13 +112,19 @@ public class EvaluateGpg45ScoresHandler
                     gpg45ProfileEvaluator.contraIndicatorsPresent(
                             evidenceMap, clientSessionDetailsDto);
             if (contraIndicatorErrorJourneyResponse.isEmpty()) {
-                updateSuccessfulVcStatuses(ipvSessionItem, credentials);
-
-                JourneyResponse journeyResponse =
+                boolean credentialsSatisfyProfile =
                         gpg45ProfileEvaluator.credentialsSatisfyAnyProfile(
-                                        evidenceMap, ACCEPTED_PROFILES)
-                                ? JOURNEY_END
-                                : JOURNEY_NEXT;
+                                evidenceMap, ACCEPTED_PROFILES);
+                JourneyResponse journeyResponse;
+                if (credentialsSatisfyProfile) {
+                    ipvSessionItem.setVot(VOT_P2);
+
+                    journeyResponse = JOURNEY_END;
+                } else {
+                    journeyResponse = JOURNEY_NEXT;
+                }
+
+                updateSuccessfulVcStatuses(ipvSessionItem, credentials);
 
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         HttpStatus.SC_OK, journeyResponse);

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -284,7 +284,6 @@ class EvaluateGpg45ScoreHandlerTest {
 
     @Test
     void shouldReturn500IfCredentialOfUnknownType() throws Exception {
-        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -30,6 +30,7 @@ public class IpvSessionItem implements DynamodbItem {
     private String errorDescription;
     private List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails;
     private List<VcStatusDto> currentVcStatuses;
+    private String vot;
     private long ttl;
 
     @DynamoDbPartitionKey
@@ -148,6 +149,14 @@ public class IpvSessionItem implements DynamodbItem {
 
     public void setCurrentVcStatuses(List<VcStatusDto> currentVcStatusDtos) {
         this.currentVcStatuses = currentVcStatusDtos;
+    }
+
+    public String getVot() {
+        return vot;
+    }
+
+    public void setVot(String vot) {
+        this.vot = vot;
     }
 
     public long getTtl() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -23,6 +23,7 @@ public class IpvSessionService {
     private static final String INITIAL_IPV_JOURNEY_STATE = "INITIAL_IPV_JOURNEY";
     private static final String FAILED_CLIENT_JAR_STATE = "FAILED_CLIENT_JAR";
     private static final String DEBUG_PAGE_STATE = "DEBUG_PAGE";
+    private static final String VOT_P0 = "VOT_P0";
 
     private final DataStore<IpvSessionItem> dataStore;
     private final ConfigurationService configurationService;
@@ -83,6 +84,8 @@ public class IpvSessionService {
         ipvSessionItem.setUserState(userState);
 
         ipvSessionItem.setVisitedCredentialIssuerDetails(Collections.emptyList());
+
+        ipvSessionItem.setVot(VOT_P0);
 
         if (errorObject != null) {
             ipvSessionItem.setErrorCode(errorObject.getCode());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -69,7 +69,7 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P2");
 
         assertEquals(SIGNED_VC_1, credentials.getVcs().get(0));
         assertEquals(SIGNED_VC_2, credentials.getVcs().get(1));
@@ -210,26 +210,9 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P2");
 
         assertEquals(VectorOfTrust.P2.toString(), credentials.getVot());
-    }
-
-    @Test
-    void shouldSetVotClaimToP0OnMissingRequiredVC() throws HttpResponseExceptionWithErrorBody {
-        List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
-                List.of(
-                        createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
-                        createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()));
-
-        when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
-
-        UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
-
-        assertEquals(VectorOfTrust.P0.toString(), credentials.getVot());
     }
 
     @Test
@@ -248,7 +231,7 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P2");
 
         IdentityClaim identityClaim = credentials.getIdentityClaim();
 
@@ -270,7 +253,7 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P0");
 
         assertNull(credentials.getIdentityClaim());
     }
@@ -294,7 +277,9 @@ class UserIdentityServiceTest {
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> userIdentityService.generateUserIdentity("user-id-1", "test-sub"));
+                        () ->
+                                userIdentityService.generateUserIdentity(
+                                        "user-id-1", "test-sub", "P2"));
 
         assertEquals(500, thrownError.getResponseCode());
         assertEquals(
@@ -324,7 +309,9 @@ class UserIdentityServiceTest {
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> userIdentityService.generateUserIdentity("user-id-1", "test-sub"));
+                        () ->
+                                userIdentityService.generateUserIdentity(
+                                        "user-id-1", "test-sub", "P2"));
 
         assertEquals(500, thrownError.getResponseCode());
         assertEquals(
@@ -351,7 +338,7 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P2");
 
         JsonNode passportClaim = credentials.getPassportClaim();
 
@@ -371,7 +358,7 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P0");
 
         assertNull(credentials.getPassportClaim());
     }
@@ -397,7 +384,9 @@ class UserIdentityServiceTest {
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> userIdentityService.generateUserIdentity("user-id-1", "test-sub"));
+                        () ->
+                                userIdentityService.generateUserIdentity(
+                                        "user-id-1", "test-sub", "P2"));
 
         assertEquals(500, thrownError.getResponseCode());
         assertEquals(
@@ -413,28 +402,9 @@ class UserIdentityServiceTest {
         when(mockConfigurationService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P2");
 
         assertEquals("test-sub", credentials.getSub());
-    }
-
-    @Test
-    void shouldSetVotClaimToP0OnFailedIdentityCheck() throws HttpResponseExceptionWithErrorBody {
-        List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
-                List.of(
-                        createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
-                        createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
-                        createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_4, LocalDateTime.now()));
-
-        when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
-
-        UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
-
-        assertEquals(VectorOfTrust.P0.toString(), credentials.getVot());
     }
 
     @Test
@@ -442,7 +412,7 @@ class UserIdentityServiceTest {
         when(mockConfigurationService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P2");
 
         assertEquals("mock-vtm-claim", credentials.getVtm());
     }
@@ -464,7 +434,7 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
         UserIdentity userIdentity =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P2");
 
         JsonNode userIdentityJsonNode =
                 objectMapper.readTree(objectMapper.writeValueAsString(userIdentity));
@@ -502,7 +472,9 @@ class UserIdentityServiceTest {
         HttpResponseExceptionWithErrorBody thrownException =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> userIdentityService.generateUserIdentity("user-id-1", "test-sub"));
+                        () ->
+                                userIdentityService.generateUserIdentity(
+                                        "user-id-1", "test-sub", "P2"));
 
         assertEquals(500, thrownException.getResponseCode());
         assertEquals(
@@ -531,7 +503,9 @@ class UserIdentityServiceTest {
         HttpResponseExceptionWithErrorBody thrownException =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> userIdentityService.generateUserIdentity("user-id-1", "test-sub"));
+                        () ->
+                                userIdentityService.generateUserIdentity(
+                                        "user-id-1", "test-sub", "P2"));
 
         assertEquals(500, thrownException.getResponseCode());
         assertEquals(
@@ -556,7 +530,7 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
         UserIdentity credentials =
-                userIdentityService.generateUserIdentity("user-id-1", "test-sub");
+                userIdentityService.generateUserIdentity("user-id-1", "test-sub", "P0");
 
         assertNull(credentials.getAddressClaim());
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Set the VOT value during the evaluate-gpg45-scores lambda when a profile has been met. The vot value is stored in the session and loaded from there when needed. The value is initialised to P0 when a new session is created.

Fixed the generation of the additional identity claims. Now if we fail to generate one of the claims, it will just log that it couldn't generate the claim. These claims are now returned as Optional's and only added to the overall identity if present.

Also added the app ID's to the list of CRI's that will be looked into when generating the Identity claim. NOTE - There is a small scenario here that could result in the app's failed VC being used to get the name/DOB value's for this claim. But I will address that in a separate PR.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
The VOT and user identity claim generation had previously been hardcoded to expect a passport journey so was failing for an app journey.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2009](https://govukverify.atlassian.net/browse/PYIC-2009)

