### PR TITLE
BAU: Add new cri retrival lambda to journey engine for debug route

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -265,10 +265,23 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
+        response:
+          type: journey
+          journeyStepId: /journey/cri/credential
+
+DEBUG_RETRIEVE_CRI_CREDENTIAL:
+  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -265,10 +265,23 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
+      response:
+        type: journey
+        journeyStepId: /journey/cri/credential
+
+DEBUG_RETRIEVE_CRI_CREDENTIAL:
+  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -272,10 +272,23 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
+      response:
+        type: journey
+        journeyStepId: /journey/cri/credential
+
+DEBUG_RETRIEVE_CRI_CREDENTIAL:
+  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -265,10 +265,23 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
+      response:
+        type: journey
+        journeyStepId: /journey/cri/credential
+
+DEBUG_RETRIEVE_CRI_CREDENTIAL:
+  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
   parent: null

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -311,10 +311,23 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
+      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
+      response:
+        type: journey
+        journeyStepId: /journey/cri/credential
+
+DEBUG_RETRIEVE_CRI_CREDENTIAL:
+  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
+  parent: null
+  events:
+    next:
+      type: basic
+      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
+
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
   parent: null

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -58,6 +58,8 @@ class ProcessJourneyStepHandlerTest {
     private static final String PRE_KBV_TRANSITION_PAGE_STATE = "PRE_KBV_TRANSITION_PAGE";
     private static final String IPV_SUCCESS_PAGE_STATE = "IPV_SUCCESS_PAGE";
     private static final String DEBUG_PAGE_STATE = "DEBUG_PAGE";
+    private static final String DEBUG_RETRIEVE_CRI_CREDENTIAL_STATE =
+            "DEBUG_RETRIEVE_CRI_CREDENTIAL";
     private static final String DEBUG_EVALUATE_GPG45_SCORES = "DEBUG_EVALUATE_GPG45_SCORES";
     private static final String PYI_NO_MATCH_STATE = "PYI_NO_MATCH";
     private static final String PYI_KBV_FAIL_STATE = "PYI_KBV_FAIL";
@@ -818,7 +820,7 @@ class ProcessJourneyStepHandlerTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.setUserState(DEBUG_PAGE_STATE);
+        ipvSessionItem.setUserState(DEBUG_RETRIEVE_CRI_CREDENTIAL_STATE);
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add the new retrieve cri credential state in for the debug journey.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The access token & credential retrieval logic now belongs in 2 separate lambdas. The 2nd lambda to retrieve the credential wasn't being called in a debug journey. These new states ensure the 2nd lambda is called.
<!-- Describe the reason these changes were made - the "why" -->

