### PR TITLE
BAU: Increase SSM param store max age

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigurationService.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.BEARER_TOKEN_TTL;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ENVIRONMENT;
@@ -76,9 +77,10 @@ public class ConfigurationService {
         } else {
             this.ssmProvider =
                     ParamManager.getSsmProvider(
-                            SsmClient.builder()
-                                    .httpClient(UrlConnectionHttpClient.create())
-                                    .build());
+                                    SsmClient.builder()
+                                            .httpClient(UrlConnectionHttpClient.create())
+                                            .build())
+                            .defaultMaxAge(3, MINUTES);
 
             this.secretsManagerClient =
                     SecretsManagerClient.builder()


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Increase SSM param store max age

### Why did it change

In production we're seeing approximately one user per minute start a journey.

The default cache for the powertools ssm parameter provider is 5 seconds.

With our current level of traffic this means we're often not making use of the cache and are often pulling multiple values in a lambda (around 30-40ms each).

This problem is worse for lambdas that are only called once for a users journey through the system, such as initialise-ipv-session, build-client-oauth-response, issue-client-access-token and build-user-identity. It does however occur for more frequently called lambdas too.

Increasing the cache to 3 minutes would be long enough for the cache to be used more effectively. We rarely update these parameter values, and if we do 3 minutes doesn't feel too onerous an amount of time to have to wait for them to be picked up.

As an example, looking at an invocation of the initialise-ipv-session lambda, the param store is called 6 times with a total latency of 181ms. Total invocation time was 251ms. Increasing the cache would result in a 72% reduction in execution time.

Taking a random sample of 10 invocations of the initialise-ipv-session lamdba, 7 of them suffered from having an expired cache.
