### PR TITLE
Fix starting state for debug route

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -22,7 +22,7 @@ import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.IPV_SESSIONS
 public class IpvSessionService {
     private static final String INITIAL_IPV_JOURNEY_STATE = "INITIAL_IPV_JOURNEY";
     private static final String FAILED_CLIENT_JAR_STATE = "FAILED_CLIENT_JAR";
-    private static final String DEBUG_PAGE_STATE = "DEBUG_PAGE";
+    private static final String DEBUG_EVALUATE_GPG45_SCORES_STATE = "DEBUG_EVALUATE_GPG45_SCORES";
     private static final String VOT_P0 = "VOT_P0";
 
     private final DataStore<IpvSessionItem> dataStore;
@@ -133,7 +133,7 @@ public class IpvSessionService {
         if (errorObject != null) {
             return FAILED_CLIENT_JAR_STATE;
         } else {
-            return isDebugJourney ? DEBUG_PAGE_STATE : INITIAL_IPV_JOURNEY_STATE;
+            return isDebugJourney ? DEBUG_EVALUATE_GPG45_SCORES_STATE : INITIAL_IPV_JOURNEY_STATE;
         }
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class IpvSessionServiceTest {
     private static final String INITIAL_IPV_JOURNEY_STATE = "INITIAL_IPV_JOURNEY";
-    private static final String DEBUG_PAGE_STATE = "DEBUG_PAGE";
+    private static final String DEBUG_EVALUATE_GPG45_SCORES_STATE = "DEBUG_EVALUATE_GPG45_SCORES";
     private static final String FAILED_CLIENT_JAR_STATE = "FAILED_CLIENT_JAR";
     private static final String IPV_SUCCESS_PAGE_STATE = "IPV_SUCCESS_PAGE";
 
@@ -142,7 +142,9 @@ class IpvSessionServiceTest {
         assertEquals(
                 ipvSessionItemArgumentCaptor.getValue().getIpvSessionId(),
                 ipvSessionItem.getIpvSessionId());
-        assertEquals(DEBUG_PAGE_STATE, ipvSessionItemArgumentCaptor.getValue().getUserState());
+        assertEquals(
+                DEBUG_EVALUATE_GPG45_SCORES_STATE,
+                ipvSessionItemArgumentCaptor.getValue().getUserState());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Fix starting state for debug route.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The cri access token and credential retrieval logic has been split into their own lambdas.

Due to this change the starting state for a debug route needs changing. This new state has the next event to load the debug page now so this should be the 1st debug state we put new users into.
<!-- Describe the reason these changes were made - the "why" -->

