### PR TITLE
PYIC-2023: Allow users with prefix to app

### DIFF
--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -44,6 +44,7 @@ public class SelectCriHandler
     private static final String CRI_START_JOURNEY = "/journey/%s";
     public static final String JOURNEY_FAIL = "/journey/fail";
     public static final String DCMAW_SUCCESS_PAGE = "dcmaw-success";
+    public static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
 
     private final ConfigurationService configurationService;
     private final IpvSessionService ipvSessionService;
@@ -278,6 +279,9 @@ public class SelectCriHandler
                     Boolean.parseBoolean(
                             configurationService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS));
             if (!shouldSendAllUsers) {
+                if (userId.startsWith(APP_JOURNEY_USER_ID_PREFIX)) {
+                    return true;
+                }
                 String userIds = configurationService.getSsmParameter(DCMAW_ALLOWED_USER_IDS);
                 List<String> dcmawAllowedUserIds = Arrays.asList(userIds.split(","));
                 return dcmawAllowedUserIds.contains(userId);


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow users with prefix to app

### Why did it change

We need to be able to send users with a random ID on an app journey. Using the same user IDs will mean they're likely to accrue CIs in the new storage system. This will be annoying and break functional tests.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2023](https://govukverify.atlassian.net/browse/PYIC-2023)
