### PR TITLE
BAU: Use 'production' instead of 'prod'

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -83,7 +83,7 @@ Mappings:
     "075701497069": # Production
       provisionedConcurrency: 1
       ciStorageAccountId: 442136572379 # di-ipv-contra-indicators-prod
-      environment: prod
+      environment: production
 
 Resources:
   JWKSParamRole:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use 'production' instead of 'prod'

### Why did it change

The lambdas in the CI storage account are suffixed with 'production' and not 'prod'.

Without this change we'd be calling non-existant lambdas in prod.
