### PR TITLE
PYIC-2029: Enable passport doc check page in production environment

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -104,11 +104,11 @@ SELECT_CRI:
   events:
     ukPassport:
       type: basic
-      name: next
-      targetState: CRI_UK_PASSPORT
+      name: ukPassport
+      targetState: PASSPORT_DOC_CHECK_PAGE
       response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+        type: page
+        pageId: page-passport-doc-check
     address:
       type: basic
       name: address


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add the passport doc check page state into the production environment.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This page has already been added to the other environments. But its deployment to prod needs to be timed at the same time as the app relase.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2029](https://govukverify.atlassian.net/browse/PYIC-2029)

