### PR TITLE
Fix vot claim P0 value

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -23,7 +23,7 @@ public class IpvSessionService {
     private static final String INITIAL_IPV_JOURNEY_STATE = "INITIAL_IPV_JOURNEY";
     private static final String FAILED_CLIENT_JAR_STATE = "FAILED_CLIENT_JAR";
     private static final String DEBUG_EVALUATE_GPG45_SCORES_STATE = "DEBUG_EVALUATE_GPG45_SCORES";
-    private static final String VOT_P0 = "VOT_P0";
+    private static final String VOT_P0 = "P0";
 
     private final DataStore<IpvSessionItem> dataStore;
     private final ConfigurationService configurationService;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Fix `vot` initial value when setting up the user session.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Accidentally used the var name as the value. The initial value should just be P0. This value is used if a user journey fails.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

