### PR TITLE
Update missing additional user identity claims as WARN level logs

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -232,7 +232,7 @@ public class UserIdentityService {
                 }
             }
         }
-        LOGGER.info("Failed to generate identity claim");
+        LOGGER.warn("Failed to generate identity claim");
         return Optional.empty();
     }
 
@@ -272,7 +272,7 @@ public class UserIdentityService {
             }
             return Optional.of(addressNode);
         }
-        LOGGER.error("Failed to find Address CRI credential");
+        LOGGER.warn("Failed to find Address CRI credential");
         return Optional.empty();
     }
 
@@ -316,7 +316,7 @@ public class UserIdentityService {
             return Optional.of(passportNode);
         }
 
-        LOGGER.error("Failed to find Passport CRI credential");
+        LOGGER.warn("Failed to find Passport CRI credential");
         return Optional.empty();
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update log level of log messages when we can't generate one of the user identity additional claims.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This is expected to happen for certain journeys. For example on app journeys we will no longer be able to generate the passport claims.
<!-- Describe the reason these changes were made - the "why" -->

