### PR TITLE
BAU: User powertools logging in retrieve-cri-credential lambda

### DIFF
--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -12,6 +12,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -93,6 +94,8 @@ public class RetrieveCriCredentialHandler
     }
 
     @Override
+    @Tracing
+    @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();


### PR DESCRIPTION

## Proposed changes

### What changed

Add the AWS powertools `@logging` annotation to the lambda handler for `retrieve-cri-credential`

### Why did it change

We noticed that the logs for the `retrieve-cri-credential` did not have all the fields we expect. This was due to missing the `@logging` annotation.
