### PR TITLE
BAU Fix debug journey state issue

### DIFF
--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -45,6 +45,8 @@ public class RetrieveCriOauthAccessTokenHandler
             new JourneyResponse("/journey/error");
     private static final String RETRIEVE_CRI_OAUTH_ACCESS_TOKEN_STATE =
             "RETRIEVE_CRI_OAUTH_ACCESS_TOKEN";
+    private static final String DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN_STATE =
+            "DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN";
 
     private final CredentialIssuerService credentialIssuerService;
     private final ConfigurationService configurationService;
@@ -140,7 +142,11 @@ public class RetrieveCriOauthAccessTokenHandler
 
             // Staging out the change here - skip the journey state to get us back on track
             if (authCodeIsNotInSession) {
-                ipvSessionItem.setUserState(RETRIEVE_CRI_OAUTH_ACCESS_TOKEN_STATE);
+                if (clientSessionDetailsDto.isDebugJourney())
+                    ipvSessionItem.setUserState(DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN_STATE);
+                else {
+                    ipvSessionItem.setUserState(RETRIEVE_CRI_OAUTH_ACCESS_TOKEN_STATE);
+                }
             }
             ipvSessionService.updateIpvSession(ipvSessionItem);
 


### PR DESCRIPTION
## Proposed changes

### What changed

Set user state correctly for the debug journey

### Why did it change

As we stage out the changes for [PYIC-1655](https://govukverify.atlassian.net/browse/PYIC-1655) we have to temporarily manually set the user state to keep the journey on track. We were not setting this correctly for the debug journey causing it to fail the smoke tests. This PR fixes that.

### Issue tracking
- [PYIC-2043](https://govukverify.atlassian.net/browse/PYIC-2043)
