### PR TITLE
PYIC-2044 Update lambda to handle oauth error callback

### DIFF
--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -49,6 +49,9 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     private static final String TEST_CREDENTIAL_ISSUER_ID = "PassportIssuer";
     private static final String TEST_AUTHORIZATION_CODE = "test-authorization-code";
     private static final String TEST_OAUTH_STATE = "oauth-state";
+    private static final String TEST_OAUTH_ACCESS_DENIED_ERROR = OAuth2Error.ACCESS_DENIED_CODE;
+    private static final String TEST_OAUTH_SERVER_ERROR = OAuth2Error.SERVER_ERROR_CODE;
+    private static final String TEST_ERROR_DESCRIPTION = "test error description";
     private static final String TEST_SESSION_ID = SecureTokenHelper.generate();
     public static final String TEST_USER_ID = "test-user-id";
     public static final String TEST_COMPONENT_ID = "http://ipv-core-test.example.com";
@@ -258,6 +261,54 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         assertEquals(
                 OAuth2Error.SERVER_ERROR_CODE,
                 updatedIpvSessionItem.getVisitedCredentialIssuerDetails().get(0).getOauthError());
+    }
+
+    @Test
+    void shouldReceiveAccessDeniedJourneyResponseWhenOauthErrorAccessDenied()
+            throws JsonProcessingException {
+        APIGatewayProxyRequestEvent input =
+                createRequestEvent(
+                        Map.of(
+                                "credential_issuer_id",
+                                TEST_CREDENTIAL_ISSUER_ID,
+                                "error",
+                                TEST_OAUTH_ACCESS_DENIED_ERROR,
+                                "error_description",
+                                TEST_ERROR_DESCRIPTION),
+                        Map.of("ipv-session-id", TEST_SESSION_ID));
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+
+        Integer statusCode = response.getStatusCode();
+        Map responseBody = getResponseBodyAsMap(response);
+        assertEquals(HTTPResponse.SC_OK, statusCode);
+        assertEquals("/journey/access-denied", responseBody.get("journey"));
+    }
+
+    @Test
+    void shouldReceiveJourneyErrorJourneyResponseWhenAnyOtherOauthError()
+            throws JsonProcessingException {
+        APIGatewayProxyRequestEvent input =
+                createRequestEvent(
+                        Map.of(
+                                "credential_issuer_id",
+                                TEST_CREDENTIAL_ISSUER_ID,
+                                "error",
+                                TEST_OAUTH_SERVER_ERROR,
+                                "error_description",
+                                TEST_ERROR_DESCRIPTION),
+                        Map.of("ipv-session-id", TEST_SESSION_ID));
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+
+        Integer statusCode = response.getStatusCode();
+        Map responseBody = getResponseBodyAsMap(response);
+        assertEquals(HTTPResponse.SC_OK, statusCode);
+        assertEquals("/journey/error", responseBody.get("journey"));
     }
 
     private Map getResponseBodyAsMap(APIGatewayProxyResponseEvent response)

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -54,7 +54,6 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     private static final String TEST_ERROR_DESCRIPTION = "test error description";
     private static final String TEST_SESSION_ID = SecureTokenHelper.generate();
     public static final String TEST_USER_ID = "test-user-id";
-    public static final String TEST_COMPONENT_ID = "http://ipv-core-test.example.com";
     private static ClientSessionDetailsDto clientSessionDetailsDto;
     private static CredentialIssuerSessionDetailsDto credentialIssuerSessionDetailsDto;
     private static CredentialIssuerConfig credentialIssuerConfig;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
@@ -18,16 +18,24 @@ public class CredentialIssuerRequestDto {
 
     private final String state;
 
+    private final String error;
+
+    private final String errorDescription;
+
     public CredentialIssuerRequestDto(
             @JsonProperty(value = "authorization_code") String authorizationCode,
             @JsonProperty(value = "credential_issuer_id") String credentialIssuerId,
             @JsonProperty(value = "ipv_session_id") String ipvSessionId,
             @JsonProperty(value = "redirect_uri") String redirectUri,
-            @JsonProperty(value = "state") String state) {
+            @JsonProperty(value = "state") String state,
+            @JsonProperty(value = "error") String error,
+            @JsonProperty(value = "error_description") String errorDescription) {
         this.authorizationCode = authorizationCode;
         this.credentialIssuerId = credentialIssuerId;
         this.ipvSessionId = ipvSessionId;
         this.redirectUri = redirectUri;
         this.state = state;
+        this.error = error;
+        this.errorDescription = errorDescription;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+import java.util.Optional;
+
 @ExcludeFromGeneratedCoverageReport
 @Getter
 public class CredentialIssuerRequestDto {
@@ -18,9 +20,9 @@ public class CredentialIssuerRequestDto {
 
     private final String state;
 
-    private final String error;
+    private final Optional<String> error;
 
-    private final String errorDescription;
+    private final Optional<String> errorDescription;
 
     public CredentialIssuerRequestDto(
             @JsonProperty(value = "authorization_code") String authorizationCode,
@@ -35,7 +37,7 @@ public class CredentialIssuerRequestDto {
         this.ipvSessionId = ipvSessionId;
         this.redirectUri = redirectUri;
         this.state = state;
-        this.error = error;
-        this.errorDescription = errorDescription;
+        this.error = Optional.ofNullable(error);
+        this.errorDescription = Optional.ofNullable(errorDescription);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -94,7 +94,9 @@ class CredentialIssuerServiceTest {
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
                         "http://www.example.com/redirect",
-                        OAUTH_STATE);
+                        OAUTH_STATE,
+                        null,
+                        null);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -125,7 +127,9 @@ class CredentialIssuerServiceTest {
                         "dcmaw",
                         TEST_IPV_SESSION_ID,
                         "http://www.example.com/redirect",
-                        OAUTH_STATE);
+                        OAUTH_STATE,
+                        null,
+                        null);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -156,7 +160,9 @@ class CredentialIssuerServiceTest {
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
                         "http://www.example.com/redirect",
-                        OAUTH_STATE);
+                        OAUTH_STATE,
+                        null,
+                        null);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -189,7 +195,9 @@ class CredentialIssuerServiceTest {
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
                         "http://www.example.com/redirect",
-                        OAUTH_STATE);
+                        OAUTH_STATE,
+                        null,
+                        null);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -221,7 +229,9 @@ class CredentialIssuerServiceTest {
                         "cred_issuer_id_1",
                         TEST_IPV_SESSION_ID,
                         "http://www.example.com/redirect",
-                        OAUTH_STATE);
+                        OAUTH_STATE,
+                        null,
+                        null);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
         CredentialIssuerException exception =


### PR DESCRIPTION
## Proposed changes

### What changed

Handle oauth errors in the new validate-callback lambda, following the behaviour of the existing cri-error lambda.

### Why did it change

The new validate-callback lambda will be responsible for handling both oauth success and error callbacks. This will replace the cri-error lambda, so the frontend has a single endpoint to call in both scenarios.

Note while we stage out the changes, the cri-error lambda remains in place and will be removed in a follow-up PR once the frontend changes are merged.

### Issue tracking
- [PYIC-2044](https://govukverify.atlassian.net/browse/PYIC-2044)

Co-authored by @Danomanic 

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed