### PR TITLE
PYIC-1783: Add new kbv thin file error page to the journey engine

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -165,6 +165,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: pyi-kbv-fail
+    pyi-kbv-thin-file:
+      type: basic
+      name: pyi-kbv-thin-file
+      targetState: PYI_KBV_THIN_FILE
+      response:
+        type: page
+        pageId: pyi-kbv-thin-file
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -251,6 +258,9 @@ PYI_NO_MATCH:
   parent: END_JOURNEY
 PYI_KBV_FAIL:
   name: PYI_KBV_FAIL
+  parent: END_JOURNEY
+PYI_KBV_THIN_FILE:
+  name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
 CRI_ERROR:
   name: CRI_ERROR

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -165,6 +165,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: pyi-kbv-fail
+    pyi-kbv-thin-file:
+      type: basic
+      name: pyi-kbv-thin-file
+      targetState: PYI_KBV_THIN_FILE
+      response:
+        type: page
+        pageId: pyi-kbv-thin-file
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -251,6 +258,9 @@ PYI_NO_MATCH:
   parent: END_JOURNEY
 PYI_KBV_FAIL:
   name: PYI_KBV_FAIL
+  parent: END_JOURNEY
+PYI_KBV_THIN_FILE:
+  name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
 CRI_ERROR:
   name: CRI_ERROR

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -200,6 +200,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: pyi-kbv-fail
+    pyi-kbv-thin-file:
+      type: basic
+      name: pyi-kbv-thin-file
+      targetState: PYI_KBV_THIN_FILE
+      response:
+        type: page
+        pageId: pyi-kbv-thin-file
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -315,6 +322,9 @@ PYI_NO_MATCH:
   parent: END_JOURNEY
 PYI_KBV_FAIL:
   name: PYI_KBV_FAIL
+  parent: END_JOURNEY
+PYI_KBV_THIN_FILE:
+  name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
 CRI_ERROR:
   name: CRI_ERROR

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -165,6 +165,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: pyi-kbv-fail
+    pyi-kbv-thin-file:
+      type: basic
+      name: pyi-kbv-thin-file
+      targetState: PYI_KBV_THIN_FILE
+      response:
+        type: page
+        pageId: pyi-kbv-thin-file
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -251,6 +258,9 @@ PYI_NO_MATCH:
   parent: END_JOURNEY
 PYI_KBV_FAIL:
   name: PYI_KBV_FAIL
+  parent: END_JOURNEY
+PYI_KBV_THIN_FILE:
+  name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
 CRI_ERROR:
   name: CRI_ERROR

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -200,6 +200,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: pyi-kbv-fail
+    pyi-kbv-thin-file:
+      type: basic
+      name: pyi-kbv-thin-file
+      targetState: PYI_KBV_THIN_FILE
+      response:
+        type: page
+        pageId: pyi-kbv-thin-file
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
@@ -315,6 +322,9 @@ PYI_NO_MATCH:
   parent: END_JOURNEY
 PYI_KBV_FAIL:
   name: PYI_KBV_FAIL
+  parent: END_JOURNEY
+PYI_KBV_THIN_FILE:
+  name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
 CRI_ERROR:
   name: CRI_ERROR

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -222,7 +222,7 @@ public class SelectCriHandler
     }
 
     private JourneyResponse getJourneyKbvFailResponse() {
-        return new JourneyResponse("/journey/pyi-kbv-fail");
+        return new JourneyResponse("/journey/pyi-kbv-thin-file");
     }
 
     private Optional<JourneyResponse> getCriResponse(

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -459,7 +459,7 @@ class SelectCriHandlerTest {
     }
 
     @Test
-    void shouldReturnKbvFailErrorJourneyResponseIfUserHasAPreviouslyFailedVisitKbv()
+    void shouldReturnKbvThinFileErrorJourneyResponseIfUserHasAPreviouslyFailedVisitKbvWithoutCis()
             throws JsonProcessingException, URISyntaxException {
         mockIpvSessionService();
 
@@ -493,7 +493,7 @@ class SelectCriHandlerTest {
 
         Map<String, String> responseBody = getResponseBodyAsMap(response);
 
-        assertEquals("/journey/pyi-kbv-fail", responseBody.get("journey"));
+        assertEquals("/journey/pyi-kbv-thin-file", responseBody.get("journey"));
         assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add new kbv thin-file error page to the journey engine.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This error page will only be displayed if the KBV CRI returns a failed VC without CI's. If CI's are returned then this will be caught in the evaluate-gpg45-scores lambda and the normal kbv-fail error page is displayed.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-1783](https://govukverify.atlassian.net/browse/PYIC-1783)

