### PR TITLE
PYIC-2054: Add expiration time to stored VCs

### DIFF
--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -155,8 +155,7 @@ public class RetrieveCriCredentialHandler
 
                 submitVcToCiStorage(vc, clientSessionDetailsDto.getGovukSigninJourneyId());
 
-                credentialIssuerService.persistUserCredentials(
-                        vc.serialize(), credentialIssuerId, userId);
+                credentialIssuerService.persistUserCredentials(vc, credentialIssuerId, userId);
             }
 
             updateVisitedCredentials(ipvSessionItem, credentialIssuerId, true, null);

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -16,14 +16,12 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
-import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.selectcri.SelectCriHandler;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -673,15 +671,5 @@ class SelectCriHandlerTest {
                 "test-jwk",
                 criIss,
                 new URI("http://example.com/redirect"));
-    }
-
-    private UserIssuedCredentialsItem createUserIssuedCredentialsItem(
-            String userId, String credentialIssuer, String credential, LocalDateTime dateCreated) {
-        UserIssuedCredentialsItem userIssuedCredentialsItem = new UserIssuedCredentialsItem();
-        userIssuedCredentialsItem.setUserId(userId);
-        userIssuedCredentialsItem.setCredentialIssuer(credentialIssuer);
-        userIssuedCredentialsItem.setCredential(credential);
-        userIssuedCredentialsItem.setDateCreated(dateCreated);
-        return userIssuedCredentialsItem;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/UserIssuedCredentialsItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/UserIssuedCredentialsItem.java
@@ -5,7 +5,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
@@ -14,7 +14,8 @@ public class UserIssuedCredentialsItem implements DynamodbItem {
     private String userId;
     private String credentialIssuer;
     private String credential;
-    private LocalDateTime dateCreated;
+    private Instant dateCreated;
+    private Instant expirationTime;
     private long ttl;
 
     @DynamoDbPartitionKey
@@ -35,12 +36,20 @@ public class UserIssuedCredentialsItem implements DynamodbItem {
         this.credentialIssuer = credentialIssuer;
     }
 
-    public LocalDateTime getDateCreated() {
+    public Instant getDateCreated() {
         return dateCreated;
     }
 
-    public void setDateCreated(LocalDateTime dateCreated) {
+    public void setDateCreated(Instant dateCreated) {
         this.dateCreated = dateCreated;
+    }
+
+    public Instant getExpirationTime() {
+        return expirationTime;
+    }
+
+    public void setExpirationTime(Instant expirationTime) {
+        this.expirationTime = expirationTime;
     }
 
     public String getCredential() {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -18,7 +18,7 @@ import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.UserIssuedCredentialsItem;
 
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -67,9 +67,9 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()));
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -104,7 +104,7 @@ class UserIdentityServiceTest {
         String criId = "criId";
         UserIssuedCredentialsItem credentialItem =
                 createUserIssuedCredentialsItem(
-                        "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now());
+                        "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now());
 
         when(mockDataStore.getItem(ipvSessionId, criId)).thenReturn(credentialItem);
 
@@ -122,12 +122,12 @@ class UserIdentityServiceTest {
                                 "user-id-1",
                                 "ukPassport",
                                 SIGNED_VC_1,
-                                LocalDateTime.parse("2022-01-25T12:28:56.414849")),
+                                Instant.parse("2022-01-25T12:28:56.414849Z")),
                         createUserIssuedCredentialsItem(
                                 "user-id-1",
                                 "fraud",
                                 SIGNED_VC_2,
-                                LocalDateTime.parse("2022-01-25T12:28:56.414849")));
+                                Instant.parse("2022-01-25T12:28:56.414849Z")));
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
@@ -135,10 +135,10 @@ class UserIdentityServiceTest {
                 userIdentityService.getUserIssuedDebugCredentials("user-id-1");
 
         assertEquals(
-                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"},\"evidence\":{\"validityScore\":2,\"strengthScore\":4,\"txn\":\"1e0f28c5-6329-46f0-bf0e-833cb9b58c9e\",\"type\":\"IdentityCheck\"}}",
+                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849Z\"},\"evidence\":{\"validityScore\":2,\"strengthScore\":4,\"txn\":\"1e0f28c5-6329-46f0-bf0e-833cb9b58c9e\",\"type\":\"IdentityCheck\"}}",
                 credentials.get("ukPassport"));
         assertEquals(
-                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"},\"evidence\":{\"txn\":\"some-uuid\",\"identityFraudScore\":1,\"type\":\"CriStubCheck\"}}",
+                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849Z\"},\"evidence\":{\"txn\":\"some-uuid\",\"identityFraudScore\":1,\"type\":\"CriStubCheck\"}}",
                 credentials.get("fraud"));
     }
 
@@ -153,13 +153,13 @@ class UserIdentityServiceTest {
                                 "ukPassport",
                                 generateVerifiableCredential(
                                         credentialVcClaim, "https://issuer.example.com"),
-                                LocalDateTime.parse("2022-01-25T12:28:56.414849")),
+                                Instant.parse("2022-01-25T12:28:56.414849Z")),
                         createUserIssuedCredentialsItem(
                                 "user-id-1",
                                 "fraud",
                                 generateVerifiableCredential(
                                         credentialVcClaim, "https://issuer.example.com"),
-                                LocalDateTime.parse("2022-01-25T12:28:56.414849")));
+                                Instant.parse("2022-01-25T12:28:56.414849Z")));
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
@@ -167,10 +167,10 @@ class UserIdentityServiceTest {
                 userIdentityService.getUserIssuedDebugCredentials("user-id-1");
 
         assertEquals(
-                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"}}",
+                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849Z\"}}",
                 credentials.get("ukPassport"));
         assertEquals(
-                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"}}",
+                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849Z\"}}",
                 credentials.get("fraud"));
     }
 
@@ -182,7 +182,7 @@ class UserIdentityServiceTest {
                                 "user-id-1",
                                 "ukPassport",
                                 "invalid-verifiable-credential",
-                                LocalDateTime.parse("2022-01-25T12:28:56.414849")));
+                                Instant.parse("2022-01-25T12:28:56.414849Z")));
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
@@ -190,7 +190,7 @@ class UserIdentityServiceTest {
                 userIdentityService.getUserIssuedDebugCredentials("user-id-1");
 
         assertEquals(
-                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"}}",
+                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849Z\"}}",
                 credentials.get("ukPassport"));
     }
 
@@ -206,7 +206,7 @@ class UserIdentityServiceTest {
                                 "ukPassport",
                                 generateVerifiableCredential(
                                         credentialVcClaim, "https://issuer.example.com"),
-                                LocalDateTime.parse("2022-01-25T12:28:56.414849")));
+                                Instant.parse("2022-01-25T12:28:56.414849Z")));
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
@@ -214,7 +214,7 @@ class UserIdentityServiceTest {
                 userIdentityService.getUserIssuedDebugCredentials("user-id-1");
 
         assertEquals(
-                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849\"}}",
+                "{\"attributes\":{\"userId\":\"user-id-1\",\"dateCreated\":\"2022-01-25T12:28:56.414849Z\"}}",
                 credentials.get("ukPassport"));
     }
 
@@ -224,13 +224,13 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_VC_4, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_VC_4, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -262,13 +262,13 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_VC_4, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_VC_4, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -305,9 +305,9 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()));
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -329,11 +329,11 @@ class UserIdentityServiceTest {
                                 "user-id-1",
                                 "ukPassport",
                                 SIGNED_PASSPORT_VC_MISSING_NAME,
-                                LocalDateTime.now()),
+                                Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()));
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -377,11 +377,11 @@ class UserIdentityServiceTest {
                                 "user-id-1",
                                 "ukPassport",
                                 SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
-                                LocalDateTime.now()),
+                                Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()));
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -422,13 +422,13 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_VC_4, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_VC_4, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -463,9 +463,9 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()));
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -487,13 +487,13 @@ class UserIdentityServiceTest {
                                 "user-id-1",
                                 "ukPassport",
                                 SIGNED_PASSPORT_VC_MISSING_PASSPORT,
-                                LocalDateTime.now()),
+                                Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_VC_4, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_VC_4, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -563,13 +563,13 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_ADDRESS_VC, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_ADDRESS_VC, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -613,16 +613,16 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
                                 "user-id-1",
                                 "address",
                                 SIGNED_ADDRESS_VC_MISSING_ADDRESS_PROPERTY,
-                                LocalDateTime.now()));
+                                Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -663,13 +663,13 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", "GARBAGE", LocalDateTime.now()));
+                                "user-id-1", "address", "GARBAGE", Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -710,11 +710,11 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_ADDRESS_VC, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_ADDRESS_VC, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -733,9 +733,9 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()));
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()));
 
         when(mockDataStore.getItems(anyString())).thenReturn(userIssuedCredentialsItemList);
 
@@ -750,11 +750,11 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "a-users-id", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "a-users-id", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "a-users-id", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "a-users-id", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "a-users-id", "sausages", SIGNED_VC_3, LocalDateTime.now()));
+                                "a-users-id", "sausages", SIGNED_VC_3, Instant.now()));
 
         when(mockDataStore.getItems("a-users-id")).thenReturn(userIssuedCredentialsItemList);
 
@@ -772,10 +772,7 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> credentialItem =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1",
-                                testCredentialIssuer,
-                                SIGNED_VC_1,
-                                LocalDateTime.now()));
+                                "user-id-1", testCredentialIssuer, SIGNED_VC_1, Instant.now()));
 
         when(mockDataStore.getItems(userId)).thenReturn(credentialItem);
 
@@ -792,11 +789,11 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "dcmaw", SIGNED_DCMAW_VC, LocalDateTime.now()),
+                                "user-id-1", "dcmaw", SIGNED_DCMAW_VC, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_VC_4, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_VC_4, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(
@@ -835,11 +832,11 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "dcmaw", SIGNED_DCMAW_VC, LocalDateTime.now()),
+                                "user-id-1", "dcmaw", SIGNED_DCMAW_VC, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_VC_4, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_VC_4, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(
@@ -863,13 +860,13 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_VC_4, LocalDateTime.now()));
+                                "user-id-1", "address", SIGNED_VC_4, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
@@ -904,15 +901,15 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "dcmaw", SIGNED_DCMAW_VC, LocalDateTime.now()),
+                                "user-id-1", "dcmaw", SIGNED_DCMAW_VC, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_VC_4, LocalDateTime.now()),
+                                "user-id-1", "address", SIGNED_VC_4, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()));
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()));
 
         List<VcStatusDto> currentVcStatuses =
                 List.of(
@@ -1003,7 +1000,7 @@ class UserIdentityServiceTest {
                                 "user-id-1",
                                 "dcmaw",
                                 SIGNED_DCMAW_VC_MISSING_DRIVING_PERMIT_PROPERTY,
-                                LocalDateTime.now()));
+                                Instant.now()));
 
         List<VcStatusDto> currentVcStatuses = List.of(new VcStatusDto("dcmaw-issuer", true));
 
@@ -1043,15 +1040,15 @@ class UserIdentityServiceTest {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "ukPassport", SIGNED_VC_1, LocalDateTime.now()),
+                                "user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "fraud", SIGNED_VC_2, LocalDateTime.now()),
+                                "user-id-1", "fraud", SIGNED_VC_2, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "kbv", SIGNED_VC_3, LocalDateTime.now()),
+                                "user-id-1", "kbv", SIGNED_VC_3, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "address", SIGNED_ADDRESS_VC, LocalDateTime.now()),
+                                "user-id-1", "address", SIGNED_ADDRESS_VC, Instant.now()),
                         createUserIssuedCredentialsItem(
-                                "user-id-1", "dcmaw", "GARBAGE", LocalDateTime.now()));
+                                "user-id-1", "dcmaw", "GARBAGE", Instant.now()));
 
         List<VcStatusDto> currentVcStatuses = List.of(new VcStatusDto("dcmaw-issuer", true));
 
@@ -1087,12 +1084,13 @@ class UserIdentityServiceTest {
     }
 
     private UserIssuedCredentialsItem createUserIssuedCredentialsItem(
-            String userId, String credentialIssuer, String credential, LocalDateTime dateCreated) {
+            String userId, String credentialIssuer, String credential, Instant dateCreated) {
         UserIssuedCredentialsItem userIssuedCredentialsItem = new UserIssuedCredentialsItem();
         userIssuedCredentialsItem.setUserId(userId);
         userIssuedCredentialsItem.setCredentialIssuer(credentialIssuer);
         userIssuedCredentialsItem.setCredential(credential);
         userIssuedCredentialsItem.setDateCreated(dateCreated);
+        userIssuedCredentialsItem.setExpirationTime(dateCreated.plusSeconds(1000L));
         return userIssuedCredentialsItem;
     }
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add expiration time to stored VCs

### Why did it change

If we’re going to dump stored VCs that are expiring before the end of the users current session, we’ll need to compare the exp claim in the VC against the users session end time. We’ll need to do this for all their VCs when they start a session.

Rather than having to pull all the VCs from Dynamo and then parse them, we can just store the VCs expiration time as a DDB attribute when we store them. We’ve already got it in it’s parsed form at that point so this adds no extra computation, other than storing an extra field.

Once we have this, we can use Dynamo’s filtering capability to just delete expiring VCs, without having to pull everything back, parse them, compare the expiration time and then delete certain VCs.

This also changes `LocalDateTime` to `Instant` in the Bean class for `UserIssuedCredentialsItem`. `LocalDateTime` doesn't represent a specific point on the timeline - it has no timezone associated with it so naturally has ambiguity. `LocalDateTime.now()` will give you a BST time. We should be using UTC to prevent time weirdness. `Instant` is aligned with UTC and so represents an actual moment in time.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2054](https://govukverify.atlassian.net/browse/PYIC-2054)
