### PR TITLE
PYIC-2057: Refactor the address cri selection

### DIFF
--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -96,6 +96,10 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
                 .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(List.of(new VcStatusDto("test-passport-iss", true)));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(new VisitedCredentialIssuerDetailsDto(CRI_PASSPORT, true, null));
@@ -149,8 +153,15 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
                 .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_FRAUD))
                 .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto("test-passport-iss", true),
+                                new VcStatusDto("test-address-iss", true)));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(
@@ -178,10 +189,19 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
                 .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_FRAUD))
                 .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_KBV))
                 .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss"));
+
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto("test-passport-iss", true),
+                                new VcStatusDto("test-address-iss", true),
+                                new VcStatusDto("test-fraud-iss", true)));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(
@@ -211,10 +231,20 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
                 .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_FRAUD))
                 .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_KBV))
                 .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss"));
+
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto("test-passport-iss", true),
+                                new VcStatusDto("test-address-iss", true),
+                                new VcStatusDto("test-fraud-iss", true),
+                                new VcStatusDto("test-kbv-iss", true)));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(
@@ -269,6 +299,8 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
                 .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-dcmaw-iss", true)));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -297,10 +329,15 @@ class SelectCriHandlerTest {
 
         when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
                 .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_FRAUD))
                 .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
         when(mockIpvSessionItem.getCurrentVcStatuses())
-                .thenReturn(List.of(new VcStatusDto("test-dcmaw-iss", true)));
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto("test-dcmaw-iss", true),
+                                new VcStatusDto("test-address-iss", true)));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
@@ -358,6 +395,8 @@ class SelectCriHandlerTest {
 
         when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
                 .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_FRAUD))
                 .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
 
@@ -435,10 +474,12 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
                 .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
-                                new VisitedCredentialIssuerDetailsDto("dcmaw", true, null),
+                                new VisitedCredentialIssuerDetailsDto("dcmaws", true, null),
                                 new VisitedCredentialIssuerDetailsDto(
                                         "address", false, "access_denied")));
         when(mockIpvSessionItem.getCurrentVcStatuses())
@@ -466,6 +507,8 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
                 .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_FRAUD))
                 .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
         when(mockConfigurationService.getCredentialIssuer(CRI_KBV))
@@ -482,6 +525,7 @@ class SelectCriHandlerTest {
                 .thenReturn(
                         List.of(
                                 new VcStatusDto("test-passport-iss", true),
+                                new VcStatusDto("test-address-iss", true),
                                 new VcStatusDto("test-fraud-iss", true),
                                 new VcStatusDto("test-kbv-iss", false)));
 
@@ -636,6 +680,7 @@ class SelectCriHandlerTest {
     }
 
     private void mockIpvSessionService() {
+
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(mockClientSessionDetailsDto);
         when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(mockIpvSessionItem);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the address cri check logic to use the getCriResponse method in same way as the rest of the cri checks.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The getCriResponse method makes use of the currentVcStatus list from the sessions when first checking if a cri should be the next step. This is going to be needed as the 1st check when we start introducing the new retry feature.

This change isn't adding any new functionality, its just a refactor to make the address CRI check work in the same way as the rest of the CRI's.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2057](https://govukverify.atlassian.net/browse/PYIC-2057)

