### PR TITLE
BAU: Use DynamoDB consistent read

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -54,8 +54,8 @@ public class DataStore<T extends DynamodbItem> {
                 isRunningLocally
                         ? createLocalDbClient()
                         : DynamoDbClient.builder()
-                        .httpClient(UrlConnectionHttpClient.create())
-                        .build();
+                                .httpClient(UrlConnectionHttpClient.create())
+                                .build();
 
         return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
     }
@@ -82,18 +82,18 @@ public class DataStore<T extends DynamodbItem> {
 
     public T getItemByIndex(String indexName, String value) throws DynamoDbException {
         DynamoDbIndex<T> index = table.index(indexName);
-        var key= Key.builder().partitionValue(value).build();
+        var key = Key.builder().partitionValue(value).build();
         var queryConditional = QueryConditional.keyEqualTo(key);
-        var queryEnhancedRequest = QueryEnhancedRequest
-                .builder()
-                .consistentRead(true)
-                .queryConditional(queryConditional)
-                .build();
+        var queryEnhancedRequest =
+                QueryEnhancedRequest.builder()
+                        .consistentRead(true)
+                        .queryConditional(queryConditional)
+                        .build();
 
-        List<T> results = index.query(queryEnhancedRequest)
-                .stream()
-                .flatMap(page -> page.items().stream())
-                .collect(Collectors.toList());
+        List<T> results =
+                index.query(queryEnhancedRequest).stream()
+                        .flatMap(page -> page.items().stream())
+                        .collect(Collectors.toList());
 
         if (Objects.isNull(results) || results.isEmpty()) {
             return null;
@@ -103,9 +103,7 @@ public class DataStore<T extends DynamodbItem> {
 
     public List<T> getItems(String partitionValue) {
         var key = Key.builder().partitionValue(partitionValue).build();
-        return table
-                .query(QueryConditional.keyEqualTo(key))
-                .stream()
+        return table.query(QueryConditional.keyEqualTo(key)).stream()
                 .flatMap(page -> page.items().stream())
                 .collect(Collectors.toList());
     }
@@ -120,7 +118,7 @@ public class DataStore<T extends DynamodbItem> {
     }
 
     public T delete(String partitionValue) {
-        var key= Key.builder().partitionValue(partitionValue).build();
+        var key = Key.builder().partitionValue(partitionValue).build();
         return delete(key);
     }
 
@@ -135,10 +133,11 @@ public class DataStore<T extends DynamodbItem> {
     private T getItemByKey(Key key) {
         T result = table.getItem(key);
         if (result == null) {
-            var message = new MapMessage()
-                    .with("datastore", "Null result retrieved from DynamoDB")
-                    .with("table", table.describeTable().table().tableName())
-                    .with("field", key.partitionKeyValue().toString());
+            var message =
+                    new MapMessage()
+                            .with("datastore", "Null result retrieved from DynamoDB")
+                            .with("table", table.describeTable().table().tableName())
+                            .with("field", key.partitionKeyValue().toString());
             LOGGER.warn(message);
         }
         return result;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.persistence;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.MapMessage;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -13,8 +14,6 @@ import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
-import software.amazon.lambda.powertools.logging.LoggingUtils;
-import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.DynamodbItem;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
@@ -136,16 +135,11 @@ public class DataStore<T extends DynamodbItem> {
     private T getItemByKey(Key key) {
         T result = table.getItem(key);
         if (result == null) {
-            LoggingUtils.appendKey(
-                    LogHelper.LogField.DYNAMODB_TABLE_NAME.getFieldName(),
-                    table.describeTable().table().tableName());
-            LoggingUtils.appendKey(
-                    LogHelper.LogField.DYNAMODB_KEY_VALUE.getFieldName(),
-                    key.partitionKeyValue().toString());
-            LOGGER.warn("Null result retrieved out of DynamoDB");
-            LoggingUtils.removeKeys(
-                    LogHelper.LogField.DYNAMODB_TABLE_NAME.getFieldName(),
-                    LogHelper.LogField.DYNAMODB_KEY_VALUE.getFieldName());
+            var message = new MapMessage()
+                    .with("datastore", "Null result retrieved from DynamoDB")
+                    .with("table", table.describeTable().table().tableName())
+                    .with("field", key.partitionKeyValue().toString());
+            LOGGER.warn(message);
         }
         return result;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -12,7 +12,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -56,8 +55,8 @@ public class DataStore<T extends DynamodbItem> {
                 isRunningLocally
                         ? createLocalDbClient()
                         : DynamoDbClient.builder()
-                                .httpClient(UrlConnectionHttpClient.create())
-                                .build();
+                        .httpClient(UrlConnectionHttpClient.create())
+                        .build();
 
         return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
     }
@@ -73,26 +72,28 @@ public class DataStore<T extends DynamodbItem> {
     }
 
     public T getItem(String partitionValue, String sortValue) {
-        return getItemByKey(
-                Key.builder().partitionValue(partitionValue).sortValue(sortValue).build());
+        var key = Key.builder().partitionValue(partitionValue).sortValue(sortValue).build();
+        return getItemByKey(key);
     }
 
     public T getItem(String partitionValue) {
-        return getItemByKey(Key.builder().partitionValue(partitionValue).build());
+        var key = Key.builder().partitionValue(partitionValue).build();
+        return getItemByKey(key);
     }
 
     public T getItemByIndex(String indexName, String value) throws DynamoDbException {
         DynamoDbIndex<T> index = table.index(indexName);
-        var attVal = AttributeValue.builder().s(value).build();
-        var queryConditional =
-                QueryConditional.keyEqualTo(Key.builder().partitionValue(attVal).build());
-        var queryEnhancedRequest =
-                QueryEnhancedRequest.builder().queryConditional(queryConditional).build();
+        var key= Key.builder().partitionValue(value).build();
+        var queryConditional = QueryConditional.keyEqualTo(key);
+        var queryEnhancedRequest = QueryEnhancedRequest
+                .builder()
+                .queryConditional(queryConditional)
+                .build();
 
-        List<T> results =
-                index.query(queryEnhancedRequest).stream()
-                        .flatMap(page -> page.items().stream())
-                        .collect(Collectors.toList());
+        List<T> results = index.query(queryEnhancedRequest)
+                .stream()
+                .flatMap(page -> page.items().stream())
+                .collect(Collectors.toList());
 
         if (Objects.isNull(results) || results.isEmpty()) {
             return null;
@@ -101,10 +102,9 @@ public class DataStore<T extends DynamodbItem> {
     }
 
     public List<T> getItems(String partitionValue) {
+        var key = Key.builder().partitionValue(partitionValue).build();
         return table
-                .query(
-                        QueryConditional.keyEqualTo(
-                                Key.builder().partitionValue(partitionValue).build()))
+                .query(QueryConditional.keyEqualTo(key))
                 .stream()
                 .flatMap(page -> page.items().stream())
                 .collect(Collectors.toList());
@@ -115,11 +115,13 @@ public class DataStore<T extends DynamodbItem> {
     }
 
     public T delete(String partitionValue, String sortValue) {
-        return delete(Key.builder().partitionValue(partitionValue).sortValue(sortValue).build());
+        var key = Key.builder().partitionValue(partitionValue).sortValue(sortValue).build();
+        return delete(key);
     }
 
     public T delete(String partitionValue) {
-        return delete(Key.builder().partitionValue(partitionValue).build());
+        var key= Key.builder().partitionValue(partitionValue).build();
+        return delete(key);
     }
 
     private static DynamoDbClient createLocalDbClient() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -87,6 +87,7 @@ public class DataStore<T extends DynamodbItem> {
         var queryConditional = QueryConditional.keyEqualTo(key);
         var queryEnhancedRequest = QueryEnhancedRequest
                 .builder()
+                .consistentRead(true)
                 .queryConditional(queryConditional)
                 .build();
 


### PR DESCRIPTION
## Proposed changes

### What changed

Use consistent read when getting item by index.

Also:
  * minor update for readability by extracting the key building into its own var
  * use structured logging


### Why did it change

We are seeing the occasional failures whereby the client (Auth/Orc) is not able to retrieve our result because the token is not accepted. We think this may be due to the index with token key not being consistent. We will try using a consistent read here and see if the problem persists.


## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
