### PR TITLE
PYIC-2058: continue on passport journey for returning users that have…

### DIFF
--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -247,6 +247,16 @@ public class SelectCriHandler
         Optional<VcStatusDto> vc = getVc(currentVcStatuses, criConfig.getAudienceForClients());
         if (vc.isEmpty()) {
             if (userHasNotVisited(visitedCredentialIssuers, criId)) {
+                CredentialIssuerConfig passportConfig =
+                        configurationService.getCredentialIssuer(passportCriId);
+                if (criId.equals(dcmawCriId)
+                        && getVc(currentVcStatuses, passportConfig.getAudienceForClients())
+                                .isPresent()) {
+                    LOGGER.info("User already has a passport VC so continuing a web journey");
+                    return Optional.of(
+                            getNextWebJourneyCri(
+                                    visitedCredentialIssuers, currentVcStatuses, userId));
+                }
                 return Optional.of(getJourneyResponse(journeyId));
             }
             var message =

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -360,6 +360,39 @@ class SelectCriHandlerTest {
     }
 
     @Test
+    void shouldReturnAddressdCriJourneyResponseIfUserHasNotVistedAppButAlreadyHasPassportVC()
+            throws JsonProcessingException, URISyntaxException {
+        mockIpvSessionService();
+
+        when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
+
+        when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_ADDRESS))
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(List.of(new VcStatusDto("test-passport-iss", true)));
+
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(Collections.emptyList());
+
+        when(mockConfigurationService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
+        when(mockConfigurationService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS))
+                .thenReturn("true");
+
+        APIGatewayProxyRequestEvent input = createRequestEvent();
+
+        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+
+        Map<String, String> responseBody = getResponseBodyAsMap(response);
+
+        assertEquals("/journey/address", responseBody.get("journey"));
+        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+    }
+
+    @Test
     void shouldReturnPyiNoMatchJourneyResponseIfUserHasVisitedDcmawAndAddressAndFraudSuccessfully()
             throws JsonProcessingException, URISyntaxException {
         mockIpvSessionService();

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -274,6 +274,8 @@ class SelectCriHandlerTest {
 
         when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
                 .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
 
         when(mockConfigurationService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigurationService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS))
@@ -573,6 +575,8 @@ class SelectCriHandlerTest {
 
         when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
                 .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
@@ -602,6 +606,8 @@ class SelectCriHandlerTest {
 
         when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
                 .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
@@ -662,6 +668,8 @@ class SelectCriHandlerTest {
 
         when(mockConfigurationService.getCredentialIssuer(CRI_DCMAW))
                 .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+        when(mockConfigurationService.getCredentialIssuer(CRI_PASSPORT))
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
 
         when(mockConfigurationService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigurationService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS))


### PR DESCRIPTION
… a passport VC

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Ignore mobile app journey if a returning user already has a passport VC.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
For a returning user, if they previously visited the app but decided not to continue on this journey then we loose track of this for a new session. The only thing we can track is wether they got a passport VC from their last journey attempt. If they have then we ignore the app journey and continue on the normal web passport journey.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2058](https://govukverify.atlassian.net/browse/PYIC-2058)

