### PR TITLE
PYIC-2059 Delete all of user's VCs if any expire within session timeout

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -126,7 +126,8 @@ public class InitialiseIpvSessionHandler
             LogHelper.attachGovukSigninJourneyIdToLogs(
                     clientSessionDetailsDto.getGovukSigninJourneyId());
 
-            userIdentityService.deleteUserIssuedCredentials(clientSessionDetailsDto.getUserId());
+            userIdentityService.deleteUserIssuedCredentialsIfAnyExpired(
+                    clientSessionDetailsDto.getUserId());
 
             IpvSessionItem ipvSessionItem =
                     ipvSessionService.generateIpvSession(clientSessionDetailsDto, null);

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -141,7 +141,7 @@ class InitialiseIpvSessionHandlerTest {
         verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
         assertEquals(AuditEventTypes.IPV_JOURNEY_START, auditEventCaptor.getValue().getEventName());
 
-        verify(mockUserIdentityService).deleteUserIssuedCredentials("test-user-id");
+        verify(mockUserIdentityService).deleteUserIssuedCredentialsIfAnyExpired("test-user-id");
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
@@ -173,6 +173,21 @@ class DataStoreTest {
     }
 
     @Test
+    void shouldGetItemsFromDynamoDbTableViaLessThanOrEqualFilterExpression() {
+        when(mockDynamoDbTable.query(any(QueryEnhancedRequest.class))).thenReturn(mockPageIterable);
+        when(mockPageIterable.stream()).thenReturn(Stream.empty());
+
+        dataStore.getItemsWithAttributeLessThanOrEqualValue(
+                "partition-key-12345", "an-attribute", "a-value");
+
+        verify(mockDynamoDbEnhancedClient)
+                .table(
+                        eq(TEST_TABLE_NAME),
+                        ArgumentMatchers.<TableSchema<AuthorizationCodeItem>>any());
+        verify(mockDynamoDbTable).query(any(QueryEnhancedRequest.class));
+    }
+
+    @Test
     void shouldUpdateItemInDynamoDbTable() {
         dataStore.update(authorizationCodeItem);
 


### PR DESCRIPTION
## Proposed changes

### What changed

On initialising a user's IPV session, check if they have any stored VCs that are due to expire within the session timeout. If there are, clear all of their stored VCs (not just expired ones). Otherwise keep them all.

### Why did it change

For Save & Return we want to keep the user's stored VCs so they can continue their journey. However, if there are stored VCs that have expired or may expire in the course of the user's journey, we should delete them. Because the VCs are all linked (eg. address feeds into fraud) and may have different expiration times, it's safer to delete all of them if any one has expired.

### Issue tracking
- [PYIC-2059](https://govukverify.atlassian.net/browse/PYIC-2059)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

