### PR TITLE
BAU: remove consistent read

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -86,7 +86,6 @@ public class DataStore<T extends DynamodbItem> {
         var queryConditional = QueryConditional.keyEqualTo(key);
         var queryEnhancedRequest =
                 QueryEnhancedRequest.builder()
-                        .consistentRead(true)
                         .queryConditional(queryConditional)
                         .build();
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -85,9 +85,7 @@ public class DataStore<T extends DynamodbItem> {
         var key = Key.builder().partitionValue(value).build();
         var queryConditional = QueryConditional.keyEqualTo(key);
         var queryEnhancedRequest =
-                QueryEnhancedRequest.builder()
-                        .queryConditional(queryConditional)
-                        .build();
+                QueryEnhancedRequest.builder().queryConditional(queryConditional).build();
 
         List<T> results =
                 index.query(queryEnhancedRequest).stream()


### PR DESCRIPTION
## Proposed changes

### What changed

Reverse consistent read from https://github.com/alphagov/di-ipv-core-back/pull/516.

### Why did it change

Consistent reads are not supported on global secondary indexes.
