### PR TITLE
BAU: Flag to disable warning of null Dynamo item

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -72,12 +72,16 @@ public class DataStore<T extends DynamodbItem> {
 
     public T getItem(String partitionValue, String sortValue) {
         var key = Key.builder().partitionValue(partitionValue).sortValue(sortValue).build();
-        return getItemByKey(key);
+        return getItemByKey(key, true);
     }
 
     public T getItem(String partitionValue) {
+        return getItem(partitionValue, true);
+    }
+
+    public T getItem(String partitionValue, boolean warnOnNull) {
         var key = Key.builder().partitionValue(partitionValue).build();
-        return getItemByKey(key);
+        return getItemByKey(key, warnOnNull);
     }
 
     public T getItemByIndex(String indexName, String value) throws DynamoDbException {
@@ -127,9 +131,9 @@ public class DataStore<T extends DynamodbItem> {
                 .build();
     }
 
-    private T getItemByKey(Key key) {
+    private T getItemByKey(Key key, boolean warnOnNull) {
         T result = table.getItem(key);
-        if (result == null) {
+        if (warnOnNull && result == null) {
             var message =
                     new MapMessage()
                             .with("datastore", "Null result retrieved from DynamoDB")

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ClientAuthJwtIdService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ClientAuthJwtIdService.java
@@ -34,7 +34,7 @@ public class ClientAuthJwtIdService {
     }
 
     public ClientAuthJwtIdItem getClientAuthJwtIdItem(String jwtId) {
-        return dataStore.getItem(jwtId);
+        return dataStore.getItem(jwtId, false);
     }
 
     public void persistClientAuthJwtId(String jwtId) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ClientAuthJwtIdServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ClientAuthJwtIdServiceTest.java
@@ -27,7 +27,7 @@ class ClientAuthJwtIdServiceTest {
         String testJwtId = "test-jwt-id";
         String testTimestamp = Instant.now().toString();
         ClientAuthJwtIdItem clientAuthJwtIdItem = new ClientAuthJwtIdItem(testJwtId, testTimestamp);
-        when(mockDataStore.getItem(testJwtId)).thenReturn(clientAuthJwtIdItem);
+        when(mockDataStore.getItem(testJwtId, false)).thenReturn(clientAuthJwtIdItem);
 
         ClientAuthJwtIdItem result = clientAuthJwtIdService.getClientAuthJwtIdItem(testJwtId);
 


### PR DESCRIPTION
## Proposed changes

### What changed

Overload the `getItem()` method of the `DataStore` class to provide a flag that will indicate if returning null should log a warning. This defaults to logging the warning.

### Why did it change

It is not common for us to retrieve an item from DynamoDb when we don't expect it to be there. We therefore log a warning when that happens. However there is a scenario where dynamo returning null is expected. This is when we check if a jwt id has previously been used. In that case we do not want to log a warning, as it is expected behaviour.

