### PR TITLE
BAU: Add toString to JourneyResponse

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyResponse.java
@@ -18,4 +18,8 @@ public class JourneyResponse {
     public String getJourney() {
         return journey;
     }
+
+    public String toString() {
+        return journey;
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add `toString` to JourneyResponse

### Why did it change

We are logging the journey response, but using the default `Object.toString()` it is appearing as an object reference. Overriding with an implementation that returns the internal journey string will result in more useful logging.
