### PR TITLE
BAU: Add missing log subscription filter

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1460,6 +1460,14 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
     Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref ValidateOAuthCallbackFunctionLogGroup
+
+  ValidateOAuthCallbackFunctionFunctionLogGroupSubscriptionFilterOld:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopment
+    Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref ValidateOAuthCallbackFunctionLogGroup


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

For the `validate-oauth-callback` lambda add the new `prodpython` log subscription filter endpoint as the main one and rename the old one, marking it old.

### Why did it change

We are supposed to be dual running all our log subscriptions to two endpoints. The `validate-oauth-callback` lambda was only pointing to the old one.
