### PR TITLE
BAU: Deserialize input directly in validate callback lambda

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
@@ -15,7 +15,6 @@ public class CredentialIssuerRequestDto {
     private String errorDescription;
 
     public CredentialIssuerRequestDto() {}
-    ;
 
     public CredentialIssuerRequestDto(
             String authorizationCode,

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.core.library.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.Optional;
@@ -16,15 +14,17 @@ public class CredentialIssuerRequestDto {
     private String error;
     private String errorDescription;
 
-    @JsonCreator
+    public CredentialIssuerRequestDto() {}
+    ;
+
     public CredentialIssuerRequestDto(
-            @JsonProperty(value = "authorization_code") String authorizationCode,
-            @JsonProperty(value = "credential_issuer_id") String credentialIssuerId,
-            @JsonProperty(value = "ipv_session_id") String ipvSessionId,
-            @JsonProperty(value = "redirect_uri") String redirectUri,
-            @JsonProperty(value = "state") String state,
-            @JsonProperty(value = "error") String error,
-            @JsonProperty(value = "error_description") String errorDescription) {
+            String authorizationCode,
+            String credentialIssuerId,
+            String ipvSessionId,
+            String redirectUri,
+            String state,
+            String error,
+            String errorDescription) {
         this.authorizationCode = authorizationCode;
         this.credentialIssuerId = credentialIssuerId;
         this.ipvSessionId = ipvSessionId;

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -55,64 +55,6 @@ paths:
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
 
-  /journey/cri/validate-callback:
-    post:
-      description: |
-        A temporary duplication of /journey/cri/callback. Once deployed, the frontend can be pointed at the /callback
-        endpoint rather than this one.
-      responses:
-        200:
-          description: "Returns a journey or error response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/journeyType"
-      x-amazon-apigateway-integration:
-        type: "aws"
-        credentials:
-          Fn::GetAtt: CriReturnStepFunctionApiGateWayIamRole.Arn
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:states:action/StartSyncExecution
-        passthroughBehavior: "when_no_match"
-        requestTemplates:
-          application/json:
-            Fn::Sub: |
-              #set($inputRoot = $input.path('$'))
-              {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\"#foreach($key in $inputRoot.keySet()), \"$key\": \"$inputRoot.get($key)\"#end}",
-                "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CriReturnStepFunction.Name}"
-              }
-          application/x-www-form-urlencoded:
-            Fn::Sub: |
-              #set($bodyParts = $util.urlDecode($input.path('$')).split('&'))
-              {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\"#foreach( $token in $bodyParts )#set( $keyVal = $token.split('=') ), \"$keyVal[0]\": \"$keyVal[1]\"#end}",
-                "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CriReturnStepFunction.Name}"
-              }
-        responses:
-          default:
-            statusCode: 200
-            responseTemplates:
-              application/json: |
-                #set ($bodyObj = $util.parseJson($input.body))
-
-                #if ($bodyObj.status == "SUCCEEDED")
-                  #set($lambdaOutputObj = $util.parseJson($bodyObj.output))
-                  #set($context.responseOverride.status = $lambdaOutputObj.statusCode)
-                  $bodyObj.output
-
-                #elseif ($bodyObj.status == "FAILED")
-                  #set($context.responseOverride.status = 500)
-                  {
-                    "cause": "$bodyObj.cause",
-                    "error": "$bodyObj.error"
-                  }
-                #else
-                  #set($context.responseOverride.status = 504)
-                  $bodyObj
-                #end
-
   /journey/cri/callback:
     post:
       description: |


### PR DESCRIPTION
**Not to be merged before https://github.com/alphagov/di-ipv-core-front/pull/474**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Deserialize input directly in validate callback lambda

### Why did it change

Previously the frontend was sending the oauth parameters to the backend
in `snake_case`. The java object we use to represent the request uses
field names with camel case. This mismatch meant that we needed to use
the `@JsonProperty` annotation to map one to the other.

When defining the input type for a lambda handler you can not rely on
Jackson annotations. If there is a mismatch between the Jackson version
the lambda runtime is using under the hood, and the version you're using
for your annotations, they won't be applied on deserialization. This
resulted in objects with all null values.

To get around this, the validate-oauth-callback lambda was receiving the
input as a stream and then handling the deserialisation within the
lambda.

The frontend has now been updated to send the parameters as a JSON body,
and matching the format expected in the backend. This means we can now
use the inbuilt deserialization of the lambda runtime.
