### PR TITLE
BAU: Update int and prod logging levels to error

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -83,12 +83,12 @@ Mappings:
       provisionedConcurrency: 1
       ciStorageAccountId: 697519714716 # di-ipv-contra-indicators-integration
       environment: integration
-      criReturnStepFunctionLogLevel: OFF
+      criReturnStepFunctionLogLevel: ERROR
     "075701497069": # Production
       provisionedConcurrency: 1
       ciStorageAccountId: 442136572379 # di-ipv-contra-indicators-prod
       environment: production
-      criReturnStepFunctionLogLevel: OFF
+      criReturnStepFunctionLogLevel: ERROR
 
 Resources:
   JWKSParamRole:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update int and prod logging levels to error

### Why did it change

The template is failing to deploy with the level set to `OFF`. I believe this is due to the destination of the logs being defined.

```
Resource handler returned message: "Model validation failed
(#/LoggingConfiguration/Level: #: only 1 subschema matches out of 2)
#/LoggingConfiguration/Level: failed validation constraint for keyword
[enum] (#/LoggingConfiguration/Level)"
```

This change will only log failures.
