### PR TITLE
PYIC-2062: Add levelOfConfidence property to the IPV_IDENTITY_ISSUED event

### DIFF
--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
+import uk.gov.di.ipv.core.library.auditing.AuditExtensionsUserIdentity;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
@@ -125,9 +126,15 @@ public class BuildUserIdentityHandler
                             ipvSessionItem.getVot(),
                             ipvSessionItem.getCurrentVcStatuses());
 
+            AuditExtensionsUserIdentity extensions =
+                    new AuditExtensionsUserIdentity(ipvSessionItem.getVot());
+
             auditService.sendAuditEvent(
                     new AuditEvent(
-                            AuditEventTypes.IPV_IDENTITY_ISSUED, componentId, auditEventUser));
+                            AuditEventTypes.IPV_IDENTITY_ISSUED,
+                            componentId,
+                            auditEventUser,
+                            extensions));
 
             ipvSessionService.revokeAccessToken(ipvSessionItem);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionsUserIdentity.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionsUserIdentity.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.core.library.auditing;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@Getter
+public class AuditExtensionsUserIdentity implements AuditExtensions {
+    @JsonProperty("levelOfConfidence")
+    private final String levelOfConfidence;
+
+    public AuditExtensionsUserIdentity(
+            @JsonProperty(value = "levelOfConfidence") String levelOfConfidence) {
+        this.levelOfConfidence = levelOfConfidence;
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add the level of confidence property to the IPV_IDENTITY_ISSUED audit event.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This new property will help with auditing and tracking of which identities that are issued are successful or failed leaving from ipv-core.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2062](https://govukverify.atlassian.net/browse/PYIC-2062)

