### PR TITLE
BAU: Call lambdas directly in CRI return step function

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -7,16 +7,6 @@
       "ResultPath": "$.lambdaResult",
       "Next": "RouteJourneyResponse"
     },
-    "ProcessJourneyStep": {
-      "Type": "Task",
-      "Resource": "${IPVProcessJourneyStepFunctionArn}",
-      "Parameters": {
-        "ipvSessionId.$": "$.ipvSessionId",
-        "journey.$": "$.lambdaResult.journey"
-      },
-      "ResultPath": "$.lambdaResult",
-      "Next": "RouteJourneyResponse"
-    },
     "RetrieveCriOauthAccessToken": {
       "Type": "Task",
       "Resource": "${RetrieveCriOauthAccessTokenFunctionArn}",
@@ -30,6 +20,16 @@
     "RetrieveCriCredential": {
       "Type": "Task",
       "Resource": "${RetrieveCriCredentialFunctionArn}",
+      "Parameters": {
+        "ipvSessionId.$": "$.ipvSessionId",
+        "journey.$": "$.lambdaResult.journey"
+      },
+      "ResultPath": "$.lambdaResult",
+      "Next": "RouteJourneyResponse"
+    },
+    "ProcessJourneyStep": {
+      "Type": "Task",
+      "Resource": "${IPVProcessJourneyStepFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
         "journey.$": "$.lambdaResult.journey"

--- a/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build-statemachine-config.yaml
@@ -6,10 +6,10 @@ CRI_STATE:
     next:
       type: basic
       name: next
-      targetState: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
+      targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey
-        journeyStepId: /journey/cri/access-token
+        journeyStepId: /journey/evaluate-gpg45-scores
     error:
       type: basic
       name: error
@@ -181,6 +181,9 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_KBV:
+  name: CRI_KBV
+  parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
   parent: null
@@ -221,17 +224,6 @@ POST_DCMAW_SUCCESS_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubAddress
-CRI_KBV:
-  name: CRI_KBV
-  parent: CRI_STATE
-  events:
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_KBV_FAIL
-      response:
-        type: page
-        pageId: pyi-kbv-fail
 CRI_DCMAW:
   name: CRI_DCMAW
   parent: CRI_STATE
@@ -272,45 +264,6 @@ CORE_SESSION_TIMEOUT:
   name: CORE_SESSION_TIMEOUT
   parent: END_JOURNEY
 
-#Callback from CRI States
-RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-RETRIEVE_CRI_CREDENTIAL:
-  name: RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
 #debug page state
 DEBUG_PAGE:
   name: DEBUG_PAGE
@@ -319,48 +272,10 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
-      targetState: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-      response:
-        type: journey
-        journeyStepId: /journey/cri/access-token
-
-DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-DEBUG_RETRIEVE_CRI_CREDENTIAL:
-  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev-statemachine-config.yaml
@@ -6,10 +6,10 @@ CRI_STATE:
     next:
       type: basic
       name: next
-      targetState: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
+      targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey
-        journeyStepId: /journey/cri/access-token
+        journeyStepId: /journey/evaluate-gpg45-scores
     error:
       type: basic
       name: error
@@ -17,13 +17,6 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-technical
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_NO_MATCH
-      response:
-        type: page
-        pageId: pyi-no-match
     access-denied:
       type: basic
       name: access-denied
@@ -181,6 +174,9 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_KBV:
+  name: CRI_KBV
+  parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
   parent: null
@@ -221,17 +217,6 @@ POST_DCMAW_SUCCESS_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubAddress
-CRI_KBV:
-  name: CRI_KBV
-  parent: CRI_STATE
-  events:
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_KBV_FAIL
-      response:
-        type: page
-        pageId: pyi-kbv-fail
 CRI_DCMAW:
   name: CRI_DCMAW
   parent: CRI_STATE
@@ -272,45 +257,6 @@ CORE_SESSION_TIMEOUT:
   name: CORE_SESSION_TIMEOUT
   parent: END_JOURNEY
 
-#Callback from CRI States
-RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-RETRIEVE_CRI_CREDENTIAL:
-  name: RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
 #debug page state
 DEBUG_PAGE:
   name: DEBUG_PAGE
@@ -319,48 +265,10 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
-      targetState: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-      response:
-        type: journey
-        journeyStepId: /journey/cri/access-token
-
-DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-DEBUG_RETRIEVE_CRI_CREDENTIAL:
-  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration-statemachine-config.yaml
@@ -6,10 +6,10 @@ CRI_STATE:
     next:
       type: basic
       name: next
-      targetState: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
+      targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey
-        journeyStepId: /journey/cri/access-token
+        journeyStepId: /journey/evaluate-gpg45-scores
     error:
       type: basic
       name: error
@@ -17,13 +17,6 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-technical
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_NO_MATCH
-      response:
-        type: page
-        pageId: pyi-no-match
     access-denied:
       type: basic
       name: access-denied
@@ -216,6 +209,9 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_KBV:
+  name: CRI_KBV
+  parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
   parent: null
@@ -285,17 +281,6 @@ POST_DCMAW_SUCCESS_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/address
-CRI_KBV:
-  name: CRI_KBV
-  parent: CRI_STATE
-  events:
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_KBV_FAIL
-      response:
-        type: page
-        pageId: pyi-kbv-fail
 CRI_DCMAW:
   name: CRI_DCMAW
   parent: CRI_STATE
@@ -336,45 +321,6 @@ CORE_SESSION_TIMEOUT:
   name: CORE_SESSION_TIMEOUT
   parent: END_JOURNEY
 
-#Callback from CRI States
-RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-RETRIEVE_CRI_CREDENTIAL:
-  name: RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
 #debug page state
 DEBUG_PAGE:
   name: DEBUG_PAGE
@@ -383,48 +329,10 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
-      targetState: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-      response:
-        type: journey
-        journeyStepId: /journey/cri/access-token
-
-DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-DEBUG_RETRIEVE_CRI_CREDENTIAL:
-  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production-statemachine-config.yaml
@@ -6,10 +6,10 @@ CRI_STATE:
     next:
       type: basic
       name: next
-      targetState: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
+      targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey
-        journeyStepId: /journey/cri/access-token
+        journeyStepId: /journey/evaluate-gpg45-scores
     error:
       type: basic
       name: error
@@ -17,13 +17,6 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-technical
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_NO_MATCH
-      response:
-        type: page
-        pageId: pyi-no-match
     access-denied:
       type: basic
       name: access-denied
@@ -181,6 +174,9 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_KBV:
+  name: CRI_KBV
+  parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
   parent: null
@@ -221,17 +217,6 @@ POST_DCMAW_SUCCESS_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/address
-CRI_KBV:
-  name: CRI_KBV
-  parent: CRI_STATE
-  events:
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_KBV_FAIL
-      response:
-        type: page
-        pageId: pyi-kbv-fail
 CRI_DCMAW:
   name: CRI_DCMAW
   parent: CRI_STATE
@@ -272,45 +257,6 @@ CORE_SESSION_TIMEOUT:
   name: CORE_SESSION_TIMEOUT
   parent: END_JOURNEY
 
-#Callback from CRI States
-RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-RETRIEVE_CRI_CREDENTIAL:
-  name: RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
 #debug page state
 DEBUG_PAGE:
   name: DEBUG_PAGE
@@ -319,48 +265,10 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
-      targetState: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-      response:
-        type: journey
-        journeyStepId: /journey/cri/access-token
-
-DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-DEBUG_RETRIEVE_CRI_CREDENTIAL:
-  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging-statemachine-config.yaml
@@ -6,10 +6,10 @@ CRI_STATE:
     next:
       type: basic
       name: next
-      targetState: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
+      targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey
-        journeyStepId: /journey/cri/access-token
+        journeyStepId: /journey/evaluate-gpg45-scores
     error:
       type: basic
       name: error
@@ -17,13 +17,6 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-technical
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_NO_MATCH
-      response:
-        type: page
-        pageId: pyi-no-match
     access-denied:
       type: basic
       name: access-denied
@@ -216,6 +209,9 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_KBV:
+  name: CRI_KBV
+  parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
   parent: null
@@ -285,17 +281,6 @@ POST_DCMAW_SUCCESS_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/address
-CRI_KBV:
-  name: CRI_KBV
-  parent: CRI_STATE
-  events:
-    fail:
-      type: basic
-      name: fail
-      targetState: PYI_KBV_FAIL
-      response:
-        type: page
-        pageId: pyi-kbv-fail
 CRI_DCMAW:
   name: CRI_DCMAW
   parent: CRI_STATE
@@ -336,44 +321,6 @@ CORE_SESSION_TIMEOUT:
   name: CORE_SESSION_TIMEOUT
   parent: END_JOURNEY
 
-RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-RETRIEVE_CRI_CREDENTIAL:
-  name: RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
 #debug page state
 DEBUG_PAGE:
   name: DEBUG_PAGE
@@ -382,48 +329,10 @@ DEBUG_PAGE:
     next:
       type: basic
       name: next
-      targetState: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-      response:
-        type: journey
-        journeyStepId: /journey/cri/access-token
-
-DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN:
-  name: DEBUG_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: DEBUG_RETRIEVE_CRI_CREDENTIAL
-      response:
-        type: journey
-        journeyStepId: /journey/cri/credential
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
-
-DEBUG_RETRIEVE_CRI_CREDENTIAL:
-  name: DEBUG_RETRIEVE_CRI_CREDENTIAL
-  parent: null
-  events:
-    next:
-      type: basic
-      name: next
       targetState: DEBUG_EVALUATE_GPG45_SCORES
       response:
         type: journey
         journeyStepId: /journey/evaluate-gpg45-scores
-    error:
-      type: basic
-      name: error
-      targetState: CRI_ERROR
-      response:
-        type: page
-        pageId: pyi-technical
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -34,7 +34,6 @@ import static uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers.STATUS_CODE
 
 @ExtendWith(MockitoExtension.class)
 class ProcessJourneyStepHandlerTest {
-    private static final String FAIL = "fail";
     private static final String NEXT = "/journey/next";
     private static final String ERROR = "error";
     private static final String ACCESS_DENIED = "access-denied";
@@ -50,13 +49,9 @@ class ProcessJourneyStepHandlerTest {
     private static final String CRI_DCMAW_STATE = "CRI_DCMAW";
     private static final String CRI_ERROR_STATE = "CRI_ERROR";
     private static final String EVALUATE_GPG45_SCORES = "EVALUATE_GPG45_SCORES";
-    private static final String RETRIEVE_CRI_CREDENTIAL = "RETRIEVE_CRI_CREDENTIAL";
-    private static final String RETRIEVE_CRI_OAUTH_ACCESS_TOKEN = "RETRIEVE_CRI_OAUTH_ACCESS_TOKEN";
     private static final String PRE_KBV_TRANSITION_PAGE_STATE = "PRE_KBV_TRANSITION_PAGE";
     private static final String IPV_SUCCESS_PAGE_STATE = "IPV_SUCCESS_PAGE";
     private static final String DEBUG_PAGE_STATE = "DEBUG_PAGE";
-    private static final String DEBUG_RETRIEVE_CRI_CREDENTIAL_STATE =
-            "DEBUG_RETRIEVE_CRI_CREDENTIAL";
     private static final String DEBUG_EVALUATE_GPG45_SCORES = "DEBUG_EVALUATE_GPG45_SCORES";
     private static final String PYI_NO_MATCH_STATE = "PYI_NO_MATCH";
     private static final String PYI_KBV_FAIL_STATE = "PYI_KBV_FAIL";
@@ -69,9 +64,6 @@ class ProcessJourneyStepHandlerTest {
     private static final String PYI_KBV_FAIL_PAGE = "pyi-kbv-fail";
     private static final String PRE_KBV_TRANSITION_PAGE = "page-pre-kbv-transition";
     public static final String JOURNEY_EVALUATE_GPG_45_SCORES = "/journey/evaluate-gpg45-scores";
-    public static final String JOURNEY_RETRIEVE_CRI_CREDENTIAL = "/journey/cri/credential";
-    public static final String JOURNEY_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN =
-            "/journey/cri/access-token";
 
     @Mock private Context mockContext;
     @Mock private IpvSessionService mockIpvSessionService;
@@ -184,7 +176,7 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnRetrieveCriOAuthAccessTokenWhenCriUkPassportState() {
+    void shouldReturnEvaluateGpg45ScoresWhenCriUkPassportState() {
         Map<String, String> input = Map.of(JOURNEY, NEXT, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(CRI_UK_PASSPORT_STATE);
@@ -194,14 +186,13 @@ class ProcessJourneyStepHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(
-                RETRIEVE_CRI_OAUTH_ACCESS_TOKEN, sessionArgumentCaptor.getValue().getUserState());
+        assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(JOURNEY_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN, output.get("journey"));
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, output.get("journey"));
     }
 
     @Test
-    void shouldReturnCriErrorPageResponseIfPassportCriFails() {
+    void shouldReturnCriErrorPageResponseIfPassportCriErrors() {
         Map<String, String> input = Map.of(JOURNEY, ERROR, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(CRI_UK_PASSPORT_STATE);
@@ -217,7 +208,7 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnRetrieveCriOAuthAccessTokenWhenCriAddressState() {
+    void shouldReturnEvaluateGpg45ScoresWhenCriAddressState() {
         Map<String, String> input = Map.of(JOURNEY, NEXT, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(CRI_ADDRESS_STATE);
@@ -227,30 +218,13 @@ class ProcessJourneyStepHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(
-                RETRIEVE_CRI_OAUTH_ACCESS_TOKEN, sessionArgumentCaptor.getValue().getUserState());
+        assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(JOURNEY_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN, output.get("journey"));
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, output.get("journey"));
     }
 
     @Test
-    void shouldReturnRetrieveCriCredentialsWhenValidateOAuthCallback() {
-        Map<String, String> input = Map.of(JOURNEY, NEXT, IPV_SESSION_ID, "1234");
-
-        mockIpvSessionItemAndTimeout(RETRIEVE_CRI_OAUTH_ACCESS_TOKEN);
-
-        Map<String, Object> output = processJourneyStepHandler.handleRequest(input, mockContext);
-
-        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
-                ArgumentCaptor.forClass(IpvSessionItem.class);
-        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(RETRIEVE_CRI_CREDENTIAL, sessionArgumentCaptor.getValue().getUserState());
-
-        assertEquals(JOURNEY_RETRIEVE_CRI_CREDENTIAL, output.get("journey"));
-    }
-
-    @Test
-    void shouldReturnCriErrorPageResponseIfAddressCriFails() {
+    void shouldReturnCriErrorPageResponseIfAddressCriErrors() {
         Map<String, String> input = Map.of(JOURNEY, ERROR, IPV_SESSION_ID, "1234");
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -273,7 +247,7 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnRetrieveCriOAuthAccessTokenWhenCriFraudState() {
+    void shouldReturnEvaluateGpg45ScoresWhenCriFraudState() {
         Map<String, String> input = Map.of(JOURNEY, NEXT, IPV_SESSION_ID, "1234");
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -290,10 +264,9 @@ class ProcessJourneyStepHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(
-                RETRIEVE_CRI_OAUTH_ACCESS_TOKEN, sessionArgumentCaptor.getValue().getUserState());
+        assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(JOURNEY_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN, output.get("journey"));
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, output.get("journey"));
     }
 
     @Test
@@ -356,27 +329,10 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnRetrieveCriOAuthAccessTokenWhenCriKbvState() {
+    void shouldReturnEvaluateGpg45ScoresWhenCriKbvState() {
         Map<String, String> input = Map.of(JOURNEY, NEXT, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(CRI_KBV_STATE);
-
-        Map<String, Object> output = processJourneyStepHandler.handleRequest(input, mockContext);
-
-        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
-                ArgumentCaptor.forClass(IpvSessionItem.class);
-        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(
-                RETRIEVE_CRI_OAUTH_ACCESS_TOKEN, sessionArgumentCaptor.getValue().getUserState());
-
-        assertEquals(JOURNEY_RETRIEVE_CRI_OAUTH_ACCESS_TOKEN, output.get("journey"));
-    }
-
-    @Test
-    void shouldReturnEvaluateGpg45ScoresWhenRetrieveCriCredentialState() {
-        Map<String, String> input = Map.of(JOURNEY, NEXT, IPV_SESSION_ID, "1234");
-
-        mockIpvSessionItemAndTimeout(RETRIEVE_CRI_CREDENTIAL);
 
         Map<String, Object> output = processJourneyStepHandler.handleRequest(input, mockContext);
 
@@ -389,7 +345,7 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnCriErrorPageResponseIfKbvCriFails() {
+    void shouldReturnCriErrorPageResponseIfKbvCriErrors() {
         Map<String, String> input = Map.of(JOURNEY, ERROR, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(CRI_KBV_STATE);
@@ -424,7 +380,7 @@ class ProcessJourneyStepHandlerTest {
     void shouldReturnDebugEvaluateGpg45ScoresJourneyWhenRequired() {
         Map<String, String> input = Map.of(JOURNEY, NEXT, IPV_SESSION_ID, "1234");
 
-        mockIpvSessionItemAndTimeout(DEBUG_RETRIEVE_CRI_CREDENTIAL_STATE);
+        mockIpvSessionItemAndTimeout(DEBUG_PAGE_STATE);
 
         Map<String, Object> output = processJourneyStepHandler.handleRequest(input, mockContext);
 
@@ -433,7 +389,7 @@ class ProcessJourneyStepHandlerTest {
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(DEBUG_EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals("/journey/evaluate-gpg45-scores", output.get("journey"));
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, output.get("journey"));
     }
 
     @Test
@@ -453,8 +409,8 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnPYINoMatchPageIfErrorOccursOnDebugJourney() {
-        Map<String, String> input = Map.of(JOURNEY, FAIL, IPV_SESSION_ID, "1234");
+    void shouldReturnPYINoMatchPageIfAccessDeniedOccursOnDebugJourney() {
+        Map<String, String> input = Map.of(JOURNEY, ACCESS_DENIED, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(DEBUG_PAGE_STATE);
 
@@ -485,8 +441,8 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnPYINoMatchPageIfPassportCriVCValidationReturnsFail() {
-        Map<String, String> input = Map.of(JOURNEY, FAIL, IPV_SESSION_ID, "1234");
+    void shouldReturnPYINoMatchPageIfCriStateReceivesAccessDenied() {
+        Map<String, String> input = Map.of(JOURNEY, ACCESS_DENIED, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(CRI_UK_PASSPORT_STATE);
 
@@ -501,8 +457,8 @@ class ProcessJourneyStepHandlerTest {
     }
 
     @Test
-    void shouldReturnPYINoMatchPageIfFraudCriVCValidationReturnsFail() {
-        Map<String, String> input = Map.of(JOURNEY, FAIL, IPV_SESSION_ID, "1234");
+    void shouldReturnPYITechnicalPageIfCriStateReceivesError() {
+        Map<String, String> input = Map.of(JOURNEY, ERROR, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(CRI_FRAUD_STATE);
 
@@ -511,29 +467,13 @@ class ProcessJourneyStepHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(PYI_NO_MATCH_STATE, sessionArgumentCaptor.getValue().getUserState());
+        assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals(PYI_NO_MATCH_PAGE, output.get("page"));
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("page"));
     }
 
     @Test
-    void shouldReturnPYIKbvFailPageIfKbvCriVCValidationReturnsFail() {
-        Map<String, String> input = Map.of(JOURNEY, FAIL, IPV_SESSION_ID, "1234");
-
-        mockIpvSessionItemAndTimeout(CRI_KBV_STATE);
-
-        Map<String, Object> output = processJourneyStepHandler.handleRequest(input, mockContext);
-
-        ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
-                ArgumentCaptor.forClass(IpvSessionItem.class);
-        verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertEquals(PYI_KBV_FAIL_STATE, sessionArgumentCaptor.getValue().getUserState());
-
-        assertEquals(PYI_KBV_FAIL_PAGE, output.get("page"));
-    }
-
-    @Test
-    void shouldReturnPyiNoMatchPageIfInSelectCRIStateAndRetursPyiNoMatchJourney() {
+    void shouldReturnPyiNoMatchPageIfInSelectCRIStateAndReturnsPyiNoMatchJourney() {
         Map<String, String> input = Map.of(JOURNEY, PYI_NO_MATCH_PAGE, IPV_SESSION_ID, "1234");
 
         mockIpvSessionItemAndTimeout(SELECT_CRI_STATE);
@@ -561,7 +501,7 @@ class ProcessJourneyStepHandlerTest {
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
         assertEquals(EVALUATE_GPG45_SCORES, sessionArgumentCaptor.getValue().getUserState());
 
-        assertEquals("/journey/evaluate-gpg45-scores", output.get("journey"));
+        assertEquals(JOURNEY_EVALUATE_GPG_45_SCORES, output.get("journey"));
     }
 
     @Test

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -39,7 +39,8 @@ import static uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers.JOURNEY;
 public class RetrieveCriOauthAccessTokenHandler
         implements RequestHandler<Map<String, String>, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final Map<String, Object> JOURNEY_NEXT = Map.of(JOURNEY, "/journey/next");
+    private static final Map<String, Object> JOURNEY_CREDENTIAL =
+            Map.of(JOURNEY, "/journey/cri/credential");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
     private final CredentialIssuerService credentialIssuerService;
     private final ConfigurationService configurationService;
@@ -126,7 +127,7 @@ public class RetrieveCriOauthAccessTokenHandler
                             .with("criId", credentialIssuerId);
             LOGGER.info(message);
 
-            return JOURNEY_NEXT;
+            return JOURNEY_CREDENTIAL;
         } catch (CredentialIssuerException e) {
             if (ipvSessionItem != null) {
                 setVisitedCredentials(

--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -123,7 +123,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         assertEquals(
                 AuditEventTypes.IPV_CRI_ACCESS_TOKEN_EXCHANGED, auditEvents.get(0).getEventName());
 
-        assertEquals("/journey/next", output.get("journey"));
+        assertEquals("/journey/cri/credential", output.get("journey"));
     }
 
     @Test

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -41,7 +41,8 @@ public class ValidateOAuthCallbackHandler
         implements RequestHandler<CredentialIssuerRequestDto, Map<String, Object>> {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final Map<String, Object> JOURNEY_NEXT = Map.of(JOURNEY, "/journey/next");
+    private static final Map<String, Object> JOURNEY_ACCESS_TOKEN =
+            Map.of(JOURNEY, "/journey/cri/access-token");
     private static final Map<String, Object> JOURNEY_ACCESS_DENIED =
             Map.of(JOURNEY, "/journey/access-denied");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
@@ -112,7 +113,7 @@ public class ValidateOAuthCallbackHandler
 
             ipvSessionService.updateIpvSession(ipvSessionItem);
 
-            return JOURNEY_NEXT;
+            return JOURNEY_ACCESS_TOKEN;
         } catch (HttpResponseExceptionWithErrorBody e) {
             ErrorResponse errorResponse = e.getErrorResponse();
 

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -1,8 +1,6 @@
 package uk.gov.di.ipv.core.credentialissuer;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
@@ -55,10 +53,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     private static final String TEST_OAUTH_SERVER_ERROR = OAuth2Error.SERVER_ERROR_CODE;
     private static final String TEST_ERROR_DESCRIPTION = "test error description";
     private static final String TEST_SESSION_ID = SecureTokenHelper.generate();
-    private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final String TEST_USER_ID = "test-user-id";
-    private static final TypeReference<Map<String, Object>> mapStringObject =
-            new TypeReference<>() {};
     private static CredentialIssuerConfig credentialIssuerConfig;
     private static IpvSessionItem ipvSessionItem;
     @Mock private Context context;
@@ -105,7 +100,8 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        underTest.handleRequest(validCredentialIssuerRequestDto(), context);
+        Map<String, Object> output =
+                underTest.handleRequest(validCredentialIssuerRequestDto(), context);
 
         ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
         verify(mockAuditService, times(1)).sendAuditEvent(auditEventCaptor.capture());
@@ -123,6 +119,8 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                         .getValue()
                         .getCredentialIssuerSessionDetails()
                         .getAuthorizationCode());
+
+        assertEquals("/journey/cri/access-token", output.get("journey"));
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CredentialIssuerService.java
@@ -193,7 +193,7 @@ public class CredentialIssuerService {
                 return vcJwts;
             } else {
                 LOGGER.error(
-                        "Error retrieving credential: Unknown response type recieved from CRI - {}",
+                        "Error retrieving credential: Unknown response type received from CRI - {}",
                         responseContentType);
                 throw new CredentialIssuerException(
                         HTTPResponse.SC_SERVER_ERROR,


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Call lambdas directly in CRI return step function

### Why did it change

This updates the lambdas in the CRI return step function to call each other directly, rather than by calling the process journey step lambda.

This does mean that we'll lose a couple of states, namely `RETRIEVE_CRI_OAUTH_ACCESS_TOKEN` and `RETRIEVE_CRI_CREDENTIAL`, but I'm not sure that it matters much. If there are errors we need to investigate we'll be able to see from the lambda logs where the journey broke down.
