### PR TITLE
PYIC-2071: Remove extra properties from the drivingPermit claim

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.core.library.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.gson.Gson;
 import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jose.shaded.json.JSONObject;
@@ -365,6 +367,12 @@ public class UserIdentityService {
                                     .path(VC_CLAIM)
                                     .path(VC_CREDENTIAL_SUBJECT)
                                     .path(DRIVING_PERMIT_PROPERTY_NAME);
+
+                    if (drivingPermitNode instanceof ArrayNode) {
+                        ((ObjectNode) drivingPermitNode.get(0)).remove("fullAddress");
+                        ((ObjectNode) drivingPermitNode.get(0)).remove("issueDate");
+                    }
+
                     if (drivingPermitNode.isMissingNode()) {
                         LOGGER.error("Driving Permit property is missing from passport VC");
                         throw new HttpResponseExceptionWithErrorBody(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -871,7 +871,6 @@ class UserIdentityServiceTest {
 
         assertEquals("MORGA753116SM9IJ", drivingPermitClaim.get(0).get("personalNumber").asText());
         assertEquals("123456", drivingPermitClaim.get(0).get("issueNumber").asText());
-        assertEquals("2022-03-14", drivingPermitClaim.get(0).get("issueDate").asText());
         assertEquals("2023-01-18", drivingPermitClaim.get(0).get("expiryDate").asText());
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Remove the `fullAddress` and `issuedate` params from the drivingPermit claim
<!-- Describe the changes in detail - the "what"-->

### Why did it change
These params are not needed for the claim and removing them makes the drivingPermit claim match up with the expected data structure.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2071](https://govukverify.atlassian.net/browse/PYIC-2071)

