### PR TITLE
PYIC-2075: Send audit event when GPG45 profile matched

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1358,6 +1358,7 @@ Resources:
                 - EnvironmentConfiguration
                 - !Ref AWS::AccountId
                 - environment
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       Policies:
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
@@ -1371,7 +1372,16 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
         - Statement:
+            - Sid: kmsAuditEventQueueEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
             - Sid: invokeGetCiFunction
               Effect: Allow
               Action:

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
 	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
 			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			project(":lib")

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.google.gson.Gson;
+import com.nimbusds.jose.shaded.json.JSONArray;
+import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -12,21 +14,29 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.MapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
+import uk.gov.di.ipv.core.library.auditing.AuditEvent;
+import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
+import uk.gov.di.ipv.core.library.auditing.AuditExtensionGpg45ProfileMatched;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.CiStorageService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -38,6 +48,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE_TXN;
 
 public class EvaluateGpg45ScoresHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -49,23 +62,30 @@ public class EvaluateGpg45ScoresHandler
     public static final String VOT_P2 = "P2";
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Gson gson = new Gson();
+    public static final int ONLY = 0;
     private final UserIdentityService userIdentityService;
     private final IpvSessionService ipvSessionService;
     private final Gpg45ProfileEvaluator gpg45ProfileEvaluator;
     private final ConfigurationService configurationService;
+    private final AuditService auditService;
     private final String addressCriId;
+    private final String componentId;
 
     public EvaluateGpg45ScoresHandler(
             UserIdentityService userIdentityService,
             IpvSessionService ipvSessionService,
             Gpg45ProfileEvaluator gpg45ProfileEvaluator,
-            ConfigurationService configurationService) {
+            ConfigurationService configurationService,
+            AuditService auditService) {
         this.userIdentityService = userIdentityService;
         this.ipvSessionService = ipvSessionService;
         this.gpg45ProfileEvaluator = gpg45ProfileEvaluator;
         this.configurationService = configurationService;
+        this.auditService = auditService;
 
         addressCriId = configurationService.getSsmParameter(ADDRESS_CRI_ID);
+        componentId =
+                configurationService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
     }
 
     public EvaluateGpg45ScoresHandler() {
@@ -75,8 +95,12 @@ public class EvaluateGpg45ScoresHandler
         this.gpg45ProfileEvaluator =
                 new Gpg45ProfileEvaluator(
                         new CiStorageService(configurationService), configurationService);
+        this.auditService =
+                new AuditService(AuditService.getDefaultSqsClient(), configurationService);
 
         addressCriId = configurationService.getSsmParameter(ADDRESS_CRI_ID);
+        componentId =
+                configurationService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
     }
 
     @Override
@@ -96,19 +120,27 @@ public class EvaluateGpg45ScoresHandler
             String govukSigninJourneyId = clientSessionDetailsDto.getGovukSigninJourneyId();
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
-            List<String> credentials = userIdentityService.getUserIssuedCredentials(userId);
+            List<SignedJWT> credentials =
+                    gpg45ProfileEvaluator.parseCredentials(
+                            userIdentityService.getUserIssuedCredentials(userId));
 
             Optional<JourneyResponse> contraIndicatorErrorJourneyResponse =
                     gpg45ProfileEvaluator.getJourneyResponseForStoredCis(clientSessionDetailsDto);
             if (contraIndicatorErrorJourneyResponse.isEmpty()) {
-                boolean credentialsSatisfyProfile =
-                        gpg45ProfileEvaluator.credentialsSatisfyAnyProfile(
-                                gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(credentials),
-                                ACCEPTED_PROFILES);
+                Gpg45Scores gpg45Scores = gpg45ProfileEvaluator.buildScore(credentials);
+                Optional<Gpg45Profile> matchedProfile =
+                        gpg45ProfileEvaluator.getFirstMatchingProfile(
+                                gpg45Scores, ACCEPTED_PROFILES);
                 JourneyResponse journeyResponse;
                 var message = new MapMessage();
 
-                if (credentialsSatisfyProfile) {
+                if (matchedProfile.isPresent()) {
+                    auditService.sendAuditEvent(
+                            buildProfileMatchedAuditEvent(
+                                    ipvSessionItem,
+                                    matchedProfile.get(),
+                                    gpg45Scores,
+                                    credentials));
                     ipvSessionItem.setVot(VOT_P2);
                     journeyResponse = JOURNEY_END;
                     message.with("lambdaResult", "A GPG45 profile has been met")
@@ -147,12 +179,16 @@ public class EvaluateGpg45ScoresHandler
             LOGGER.error("Error when fetching CIs from storage system", e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_GET_STORED_CIS);
+        } catch (SqsException e) {
+            LOGGER.error("Failed to send audit event to SQS queue: {}", e.getMessage());
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
         }
     }
 
     @Tracing
-    private void updateSuccessfulVcStatuses(IpvSessionItem ipvSessionItem, List<String> credentials)
-            throws ParseException {
+    private void updateSuccessfulVcStatuses(
+            IpvSessionItem ipvSessionItem, List<SignedJWT> credentials) throws ParseException {
 
         // get list of success vc's
         List<VcStatusDto> currentVcStatusDtos = ipvSessionItem.getCurrentVcStatuses();
@@ -168,13 +204,11 @@ public class EvaluateGpg45ScoresHandler
         }
     }
 
-    private List<VcStatusDto> generateVcSuccessStatuses(List<String> credentials)
+    private List<VcStatusDto> generateVcSuccessStatuses(List<SignedJWT> credentials)
             throws ParseException {
         List<VcStatusDto> vcStatuses = new ArrayList<>();
 
-        for (String credential : credentials) {
-
-            SignedJWT signedJWT = SignedJWT.parse(credential);
+        for (SignedJWT signedJWT : credentials) {
 
             CredentialIssuerConfig addressCriConfig =
                     configurationService.getCredentialIssuer(addressCriId);
@@ -183,5 +217,39 @@ public class EvaluateGpg45ScoresHandler
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));
         }
         return vcStatuses;
+    }
+
+    private AuditEvent buildProfileMatchedAuditEvent(
+            IpvSessionItem ipvSessionItem,
+            Gpg45Profile gpg45Profile,
+            Gpg45Scores gpg45Scores,
+            List<SignedJWT> credentials)
+            throws ParseException {
+        AuditEventUser auditEventUser =
+                new AuditEventUser(
+                        ipvSessionItem.getClientSessionDetails().getUserId(),
+                        ipvSessionItem.getIpvSessionId(),
+                        ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId());
+        return new AuditEvent(
+                AuditEventTypes.IPV_GPG45_PROFILE_MATCHED,
+                componentId,
+                auditEventUser,
+                new AuditExtensionGpg45ProfileMatched(
+                        gpg45Profile, gpg45Scores, extractTxnIdsFromCredentials(credentials)));
+    }
+
+    private List<String> extractTxnIdsFromCredentials(List<SignedJWT> credentials)
+            throws ParseException {
+        List<String> txnIds = new ArrayList<>();
+        for (SignedJWT credential : credentials) {
+            var jwtClaimsSet = credential.getJWTClaimsSet();
+            var vc = (JSONObject) jwtClaimsSet.getClaim(VC_CLAIM);
+            var evidences = (JSONArray) vc.get(VC_EVIDENCE);
+            if (evidences != null) { // not all VCs have an evidence block
+                var evidence = (JSONObject) evidences.get(ONLY);
+                txnIds.add(evidence.getAsString(VC_EVIDENCE_TXN));
+            }
+        }
+        return txnIds;
     }
 }

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -5,24 +5,32 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.auditing.AuditEvent;
+import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
+import uk.gov.di.ipv.core.library.auditing.AuditExtensionGpg45ProfileMatched;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
-import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
-import uk.gov.di.ipv.core.library.domain.gpg45.domain.DcmawCheckMethod;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.CiStorageService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -32,20 +40,21 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.ACCEPTED_PROFILES;
 import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_END;
 import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.JOURNEY_NEXT;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_ADDRESS_VC;
-import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FAILED_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_VC;
@@ -65,16 +74,8 @@ class EvaluateGpg45ScoreHandlerTest {
                     M1A_FRAUD_VC,
                     M1A_VERIFICATION_VC,
                     M1B_DCMAW_VC);
-    public static final List<String> FAILED_PASSPORT_CREDENTIALS =
-            List.of(
-                    M1A_FAILED_PASSPORT_VC,
-                    M1A_ADDRESS_VC,
-                    M1A_FRAUD_VC,
-                    M1A_VERIFICATION_VC,
-                    M1B_DCMAW_VC);
-    public static final Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>>
-            EVIDENCE_MAP = generateEvidenceMap();
     public static CredentialIssuerConfig addressConfig = null;
+    private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
 
     static {
         try {
@@ -103,6 +104,7 @@ class EvaluateGpg45ScoreHandlerTest {
     @Mock private Gpg45ProfileEvaluator gpg45ProfileEvaluator;
     @Mock private CiStorageService ciStorageService;
     @Mock private ConfigurationService configurationService;
+    @Mock private AuditService auditService;
     @InjectMocks private EvaluateGpg45ScoresHandler evaluateGpg45ScoresHandler;
 
     private final Gson gson = new Gson();
@@ -110,8 +112,11 @@ class EvaluateGpg45ScoreHandlerTest {
     private IpvSessionItem ipvSessionItem;
 
     @BeforeAll
-    static void setUp() {
+    static void setUp() throws Exception {
         event.setHeaders(Map.of(IPV_SESSION_ID_HEADER, TEST_SESSION_ID));
+        for (String cred : CREDENTIALS) {
+            PARSED_CREDENTIALS.add(SignedJWT.parse(cred));
+        }
     }
 
     @BeforeEach
@@ -121,41 +126,18 @@ class EvaluateGpg45ScoreHandlerTest {
         clientSessionDetailsDto.setUserId(TEST_USER_ID);
         clientSessionDetailsDto.setGovukSigninJourneyId(TEST_JOURNEY_ID);
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
+        ipvSessionItem.setIpvSessionId(TEST_SESSION_ID);
     }
 
     @Test
     void shouldReturnJourneySessionEndIfScoresSatisfyM1AGpg45Profile() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
-
         when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
-                .thenReturn(evidenceMap);
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
         when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
-        when(gpg45ProfileEvaluator.credentialsSatisfyAnyProfile(evidenceMap, ACCEPTED_PROFILES))
-                .thenReturn(true);
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.of(Gpg45Profile.M1A));
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
         JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
@@ -163,41 +145,41 @@ class EvaluateGpg45ScoreHandlerTest {
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         assertEquals(JOURNEY_END, journeyResponse);
         verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+        IpvSessionItem updatedSessionItem = ipvSessionItemArgumentCaptor.getValue();
+
+        List<VcStatusDto> currentVcStatuses = updatedSessionItem.getCurrentVcStatuses();
+        assertEquals(5, currentVcStatuses.size());
+
+        assertTrue(currentVcStatuses.get(0).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-p.integration.account.gov.uk",
+                currentVcStatuses.get(0).getCriIss());
+        assertFalse(currentVcStatuses.get(1).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-a.integration.account.gov.uk",
+                currentVcStatuses.get(1).getCriIss());
+        assertTrue(currentVcStatuses.get(2).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-f.integration.account.gov.uk",
+                currentVcStatuses.get(2).getCriIss());
+        assertTrue(currentVcStatuses.get(3).getIsSuccessfulVc());
+        assertEquals("https://example.com/issuer", currentVcStatuses.get(3).getCriIss());
+        assertTrue(currentVcStatuses.get(4).getIsSuccessfulVc());
+        assertEquals("issuer", currentVcStatuses.get(4).getCriIss());
     }
 
     @Test
     void shouldReturnJourneySessionEndIfScoresSatisfyM1BGpg45Profile() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                Collections.singletonList(
-                                        new CredentialEvidenceItem(
-                                                CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                                2,
-                                                Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                                Collections.singletonList(
-                                        new CredentialEvidenceItem(
-                                                3,
-                                                2,
-                                                1,
-                                                2,
-                                                Collections.singletonList(new DcmawCheckMethod()),
-                                                null,
-                                                Collections.emptyList())));
-
-        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
-                .thenReturn(evidenceMap);
         when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
-        when(gpg45ProfileEvaluator.credentialsSatisfyAnyProfile(evidenceMap, ACCEPTED_PROFILES))
-                .thenReturn(true);
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.of(Gpg45Profile.M1B));
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
         JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
@@ -209,37 +191,12 @@ class EvaluateGpg45ScoreHandlerTest {
 
     @Test
     void shouldReturnJourneyNextIfScoresDoNotSatisfyM1AGpg45Profile() throws Exception {
-        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
-                .thenReturn(EVIDENCE_MAP);
         when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
-        when(gpg45ProfileEvaluator.credentialsSatisfyAnyProfile(EVIDENCE_MAP, ACCEPTED_PROFILES))
-                .thenReturn(false);
-
-        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
-        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(JOURNEY_NEXT, journeyResponse);
-        verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
-    }
-
-    @Test
-    void shouldReturnJourneyNextIfScoresDoNotSatisfyM1AGpg45ProfileAndPassportScoresAreNotValid()
-            throws Exception {
-        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
-                .thenReturn(FAILED_PASSPORT_CREDENTIALS);
-        when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(FAILED_PASSPORT_CREDENTIALS))
-                .thenReturn(EVIDENCE_MAP);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.empty());
-        when(gpg45ProfileEvaluator.credentialsSatisfyAnyProfile(EVIDENCE_MAP, ACCEPTED_PROFILES))
-                .thenReturn(false);
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
         JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
@@ -264,9 +221,7 @@ class EvaluateGpg45ScoreHandlerTest {
     @Test
     void shouldReturn500IfFailedToParseCredentials() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
-                .thenThrow(new ParseException("Whoops", 0));
+        when(gpg45ProfileEvaluator.buildScore(any())).thenThrow(new ParseException("Whoops", 0));
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
         Map<String, Object> responseMap =
@@ -285,13 +240,7 @@ class EvaluateGpg45ScoreHandlerTest {
     @Test
     void shouldReturn500IfCredentialOfUnknownType() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.parseGpg45ScoresFromCredentials(CREDENTIALS))
-                .thenReturn(EVIDENCE_MAP);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
-                .thenReturn(Optional.empty());
-        when(gpg45ProfileEvaluator.credentialsSatisfyAnyProfile(EVIDENCE_MAP, ACCEPTED_PROFILES))
-                .thenThrow(new UnknownEvidenceTypeException());
+        when(gpg45ProfileEvaluator.buildScore(any())).thenThrow(new UnknownEvidenceTypeException());
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
         Map<String, Object> responseMap =
@@ -342,15 +291,43 @@ class EvaluateGpg45ScoreHandlerTest {
                 ErrorResponse.FAILED_TO_GET_STORED_CIS.getMessage(), responseMap.get("message"));
     }
 
-    private static Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>>
-            generateEvidenceMap() {
-        return Map.of(
-                CredentialEvidenceItem.EvidenceType.ACTIVITY, new ArrayList<>(),
-                CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD, new ArrayList<>(),
-                CredentialEvidenceItem.EvidenceType.VERIFICATION, new ArrayList<>(),
-                CredentialEvidenceItem.EvidenceType.DCMAW, new ArrayList<>());
+    @Test
+    void shouldSendAuditEventWhenProfileMatched() throws Exception {
+        List<SignedJWT> parsedM1ACreds =
+                List.of(
+                        SignedJWT.parse(M1A_PASSPORT_VC),
+                        SignedJWT.parse(M1A_ADDRESS_VC),
+                        SignedJWT.parse(M1A_FRAUD_VC),
+                        SignedJWT.parse(M1A_VERIFICATION_VC));
+        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(parsedM1ACreds);
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
+                .thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.of(Gpg45Profile.M1A));
+        when(gpg45ProfileEvaluator.buildScore(any()))
+                .thenReturn(new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2));
+
+        evaluateGpg45ScoresHandler.handleRequest(event, context);
+
+        ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(auditService).sendAuditEvent(auditEventCaptor.capture());
+        AuditEvent auditEvent = auditEventCaptor.getValue();
+
+        assertEquals(AuditEventTypes.IPV_GPG45_PROFILE_MATCHED, auditEvent.getEventName());
+
+        AuditEventUser user = auditEvent.getUser();
+        assertEquals(TEST_USER_ID, user.getUserId());
+        assertEquals(TEST_JOURNEY_ID, user.getGovukSigninJourneyId());
+        assertEquals(TEST_SESSION_ID, user.getSessionId());
+
+        AuditExtensionGpg45ProfileMatched extension =
+                (AuditExtensionGpg45ProfileMatched) auditEvent.getExtensions();
+        assertEquals(Gpg45Profile.M1A, extension.getGpg45Profile());
+        assertEquals(new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2), extension.getGpg45Scores());
+        assertEquals(
+                List.of("123ab93d-3a43-46ef-a2c1-3c6444206408", "RB000103490087", "abc1234"),
+                extension.getVcTxnIds());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventTypes.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventTypes.java
@@ -4,11 +4,12 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 
 @ExcludeFromGeneratedCoverageReport
 public enum AuditEventTypes {
+    IPV_CRI_ACCESS_TOKEN_EXCHANGED,
+    IPV_CRI_AUTH_RESPONSE_RECEIVED,
+    IPV_GPG45_PROFILE_MATCHED,
+    IPV_IDENTITY_ISSUED,
+    IPV_JOURNEY_END,
     IPV_JOURNEY_START,
     IPV_REDIRECT_TO_CRI,
-    IPV_VC_RECEIVED,
-    IPV_JOURNEY_END,
-    IPV_IDENTITY_ISSUED,
-    IPV_CRI_AUTH_RESPONSE_RECEIVED,
-    IPV_CRI_ACCESS_TOKEN_EXCHANGED
+    IPV_VC_RECEIVED
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionGpg45ProfileMatched.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionGpg45ProfileMatched.java
@@ -1,0 +1,31 @@
+package uk.gov.di.ipv.core.library.auditing;
+
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
+
+import java.util.List;
+
+public class AuditExtensionGpg45ProfileMatched implements AuditExtensions {
+    private final Gpg45Profile gpg45Profile;
+    private final Gpg45Scores gpg45Scores;
+    private final List<String> vcTxnIds;
+
+    public AuditExtensionGpg45ProfileMatched(
+            Gpg45Profile gpg45Profile, Gpg45Scores gpg45Scores, List<String> vcTxnIds) {
+        this.gpg45Profile = gpg45Profile;
+        this.gpg45Scores = gpg45Scores;
+        this.vcTxnIds = vcTxnIds;
+    }
+
+    public Gpg45Profile getGpg45Profile() {
+        return gpg45Profile;
+    }
+
+    public Gpg45Scores getGpg45Scores() {
+        return gpg45Scores;
+    }
+
+    public List<String> getVcTxnIds() {
+        return vcTxnIds;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -45,7 +45,8 @@ public enum ErrorResponse {
     FAILED_TO_GENERATE_PASSPORT_CLAIM(1036, "Failed to generate the passport claim"),
     FAILED_TO_GENERATE_DRIVING_PERMIT_CLAIM(1037, "Failed to generate the driving permit claim"),
     FAILED_TO_DETERMINE_CREDENTIAL_TYPE(1038, "Failed to determine type of credential"),
-    FAILED_TO_GET_STORED_CIS(1039, "Failed to get stored CIS");
+    FAILED_TO_GET_STORED_CIS(1039, "Failed to get stored CIS"),
+    FAILED_TO_SEND_AUDIT_EVENT(1040, "Failed to send audit event");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialConstants.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialConstants.java
@@ -14,5 +14,6 @@ public class VerifiableCredentialConstants {
     public static final String IDENTITY_CHECK_CREDENTIAL_TYPE = "IdentityCheckCredential";
     public static final String VC_CREDENTIAL_SUBJECT = "credentialSubject";
     public static final String VC_EVIDENCE = "evidence";
+    public static final String VC_EVIDENCE_TXN = "txn";
     public static final String VC_CLAIM = "vc";
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Profile.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Profile.java
@@ -69,22 +69,22 @@ public enum Gpg45Profile {
      */
     public boolean isSatisfiedBy(Gpg45Scores target) {
         return satisfactoryEvidence(target)
-                && (scores.activity() <= target.activity())
-                && (scores.fraud() <= target.fraud())
-                && (scores.verification() <= target.verification());
+                && (scores.getActivity() <= target.getActivity())
+                && (scores.getFraud() <= target.getFraud())
+                && (scores.getVerification() <= target.getVerification());
     }
 
     private boolean satisfactoryEvidence(Gpg45Scores target) {
-        if (scores.evidences().size() > target.evidences().size()) {
+        if (scores.getEvidences().size() > target.getEvidences().size()) {
             return false;
         }
 
-        for (int i = 0; i < scores.evidences().size(); i++) {
+        for (int i = 0; i < scores.getEvidences().size(); i++) {
             var sourceEvidence = scores.getEvidence(i);
             var targetEvidence = target.getEvidence(i);
 
-            if ((targetEvidence.strength() < sourceEvidence.strength())
-                    || (targetEvidence.validity() < sourceEvidence.validity())) {
+            if ((targetEvidence.getStrength() < sourceEvidence.getStrength())
+                    || (targetEvidence.getValidity() < sourceEvidence.getValidity())) {
                 return false;
             }
         }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
@@ -65,25 +65,25 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
         this.evidences =
                 evidence.stream()
                         .sorted(
-                                Comparator.comparing(Evidence::strength)
-                                        .thenComparing(Evidence::validity)
+                                Comparator.comparing(Evidence::getStrength)
+                                        .thenComparing(Evidence::getValidity)
                                         .reversed())
                         .collect(Collectors.toList());
     }
 
-    public int activity() {
+    public int getActivity() {
         return activity;
     }
 
-    public int fraud() {
+    public int getFraud() {
         return fraud;
     }
 
-    public int verification() {
+    public int getVerification() {
         return verification;
     }
 
-    public List<Evidence> evidences() {
+    public List<Evidence> getEvidences() {
         return evidences;
     }
 
@@ -119,15 +119,15 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
 
         return new Gpg45Scores(
                 diffEvidence(other),
-                other.activity() - activity,
-                other.fraud() - fraud,
-                other.verification() - verification);
+                other.getActivity() - activity,
+                other.getFraud() - fraud,
+                other.getVerification() - verification);
     }
 
     private List<Gpg45Scores.Evidence> diffEvidence(Gpg45Scores target) {
 
         var evidenceDiff = new ArrayList<Evidence>();
-        var maxEvidence = Math.max(evidences.size(), target.evidences().size());
+        var maxEvidence = Math.max(evidences.size(), target.getEvidences().size());
 
         for (int i = 0; i < maxEvidence; i++) {
             var sourceEvidence = getEvidence(i);
@@ -135,8 +135,8 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
 
             evidenceDiff.add(
                     new Gpg45Scores.Evidence(
-                            targetEvidence.strength() - sourceEvidence.strength(),
-                            targetEvidence.validity() - sourceEvidence.validity()));
+                            targetEvidence.getStrength() - sourceEvidence.getStrength(),
+                            targetEvidence.getValidity() - sourceEvidence.getValidity()));
         }
         return evidenceDiff;
     }
@@ -160,35 +160,35 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
         var diff = difference(other);
         int negativeCount = 0;
         int positiveCount = 0;
-        for (Evidence e : diff.evidences()) {
-            if (e.strength() < 0) {
-                negativeCount += e.strength();
+        for (Evidence e : diff.getEvidences()) {
+            if (e.getStrength() < 0) {
+                negativeCount += e.getStrength();
             } else {
-                positiveCount += e.strength();
+                positiveCount += e.getStrength();
             }
-            if (e.validity() < 0) {
-                negativeCount += e.validity();
+            if (e.getValidity() < 0) {
+                negativeCount += e.getValidity();
             } else {
-                positiveCount += e.validity();
+                positiveCount += e.getValidity();
             }
         }
 
-        if (diff.activity() < 0) {
-            negativeCount += diff.activity();
+        if (diff.getActivity() < 0) {
+            negativeCount += diff.getActivity();
         } else {
-            positiveCount += diff.activity();
+            positiveCount += diff.getActivity();
         }
 
-        if (diff.fraud() < 0) {
-            negativeCount += diff.fraud();
+        if (diff.getFraud() < 0) {
+            negativeCount += diff.getFraud();
         } else {
-            positiveCount += diff.fraud();
+            positiveCount += diff.getFraud();
         }
 
-        if (diff.verification() < 0) {
-            negativeCount += diff.verification();
+        if (diff.getVerification() < 0) {
+            negativeCount += diff.getVerification();
         } else {
-            positiveCount += diff.verification();
+            positiveCount += diff.getVerification();
         }
 
         if (negativeCount < 0) {
@@ -246,11 +246,11 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
             this.validity = validity;
         }
 
-        public int validity() {
+        public int getValidity() {
             return validity;
         }
 
-        public int strength() {
+        public int getStrength() {
             return strength;
         }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionGpg45ProfileMatchedTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionGpg45ProfileMatchedTest.java
@@ -1,0 +1,79 @@
+package uk.gov.di.ipv.core.library.auditing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class AuditExtensionGpg45ProfileMatchedTest {
+
+    private static final ObjectMapper om = new ObjectMapper();
+    private static MockedStatic<Clock> clockMock;
+
+    @BeforeAll
+    public static void setup() {
+        clockMock = mockStatic(Clock.class);
+        Clock spyClock = spy(Clock.class);
+        clockMock.when(Clock::systemUTC).thenReturn(spyClock);
+        when(spyClock.instant()).thenReturn(Instant.ofEpochSecond(1666170506));
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        clockMock.close();
+    }
+
+    @Test
+    void shouldSerializeToTheCorrectJson() throws Exception {
+        AuditExtensionGpg45ProfileMatched extension =
+                new AuditExtensionGpg45ProfileMatched(
+                        Gpg45Profile.M1A,
+                        new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2),
+                        List.of("txn1", "txn2", "txn3"));
+
+        AuditEventUser user = new AuditEventUser("user-id", "session-id", "journey-id");
+
+        AuditEvent auditEvent =
+                new AuditEvent(
+                        AuditEventTypes.IPV_GPG45_PROFILE_MATCHED, "component-id", user, extension);
+
+        String expected =
+                "{"
+                        + "\"event_name\":\"IPV_GPG45_PROFILE_MATCHED\","
+                        + "\"component_id\":\"component-id\","
+                        + "\"user\":{"
+                        + "\"user_id\":\"user-id\","
+                        + "\"session_id\":\"session-id\","
+                        + "\"govuk_signin_journey_id\":\"journey-id\""
+                        + "},"
+                        + "\"extensions\":{"
+                        + "\"gpg45Profile\":\"M1A\","
+                        + "\"gpg45Scores\":{"
+                        + "\"evidences\":[{"
+                        + "\"strength\":4,"
+                        + "\"validity\":2"
+                        + "}],"
+                        + "\"activity\":0,"
+                        + "\"fraud\":1,"
+                        + "\"verification\":2"
+                        + "},"
+                        + "\"vcTxnIds\":[\"txn1\",\"txn2\",\"txn3\"]"
+                        + "},"
+                        + "\"timestamp\":1666170506"
+                        + "}";
+
+        assertEquals(expected, om.writeValueAsString(auditEvent));
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -1,30 +1,24 @@
 package uk.gov.di.ipv.core.library.domain.gpg45;
 
+import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
-import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
-import uk.gov.di.ipv.core.library.domain.gpg45.domain.DcmawCheckMethod;
-import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.service.CiStorageService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
-import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.KBV_CRI_ID;
@@ -41,23 +35,6 @@ class Gpg45ProfileEvaluatorTest {
     @Mock ClientSessionDetailsDto mockClientSessionDetails;
     @InjectMocks Gpg45ProfileEvaluator evaluator;
 
-    @Mock private Gpg45Profile profile1;
-    @Mock private Gpg45Profile profile2;
-
-    private static final Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>>
-            EMPTY_EVIDENCE_MAP =
-                    Map.of(
-                            CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                            new ArrayList<>(),
-                            CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                            new ArrayList<>(),
-                            CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                            new ArrayList<>(),
-                            CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                            new ArrayList<>(),
-                            CredentialEvidenceItem.EvidenceType.DCMAW,
-                            new ArrayList<>());
-
     private final String M1A_PASSPORT_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJhdWQiOiJodHRwczpcL1wvaWRlbnRpdHkuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJuYmYiOjE2NTg4Mjk2NDcsImlzcyI6Imh0dHBzOlwvXC9yZXZpZXctcC5pbnRlZ3JhdGlvbi5hY2NvdW50Lmdvdi51ayIsImV4cCI6MTY1ODgzNjg0NywidmMiOnsiZXZpZGVuY2UiOlt7InZhbGlkaXR5U2NvcmUiOjIsInN0cmVuZ3RoU2NvcmUiOjQsImNpIjpudWxsLCJ0eG4iOiIxMjNhYjkzZC0zYTQzLTQ2ZWYtYTJjMS0zYzY0NDQyMDY0MDgiLCJ0eXBlIjoiSWRlbnRpdHlDaGVjayJ9XSwiY3JlZGVudGlhbFN1YmplY3QiOnsicGFzc3BvcnQiOlt7ImV4cGlyeURhdGUiOiIyMDMwLTAxLTAxIiwiZG9jdW1lbnROdW1iZXIiOiIzMjE2NTQ5ODcifV0sIm5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl19fQ.MEYCIQC-2fwJVvFLM8SnCKk_5EHX_ZPdTN2-kaOxNjXky86LUgIhAIMZUuTztxyyqa3ZkyaqnkMl1vPl1HQ2FbQ9LxPQChn";
     private final String M1A_ADDRESS_VC =
@@ -70,357 +47,21 @@ class Gpg45ProfileEvaluatorTest {
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJhdWQiOiJodHRwczovL2lkZW50aXR5LmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwibmJmIjoxNjU4ODI5NjQ3LCJpc3MiOiJodHRwczovL3Jldmlldy1wLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwiZXhwIjoxNjU4ODM2ODQ3LCJ2YyI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InZhbHVlIjoiSm9lIFNobW9lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJEb2UgVGhlIEJhbGwiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk4NS0wMi0wOCJ9XSwiYWRkcmVzcyI6W3sidXBybiI6IjEwMDIyODEyOTI5Iiwib3JnYW5pc2F0aW9uTmFtZSI6IkZJTkNIIEdST1VQIiwic3ViQnVpbGRpbmdOYW1lIjoiVU5JVCAyQiIsImJ1aWxkaW5nTnVtYmVyICI6IjE2IiwiYnVpbGRpbmdOYW1lIjoiQ09ZIFBPTkQgQlVTSU5FU1MgUEFSSyIsImRlcGVuZGVudFN0cmVldE5hbWUiOiJLSU5HUyBQQVJLIiwic3RyZWV0TmFtZSI6IkJJRyBTVFJFRVQiLCJkb3VibGVEZXBlbmRlbnRBZGRyZXNzTG9jYWxpdHkiOiJTT01FIERJU1RSSUNUIiwiZGVwZW5kZW50QWRkcmVzc0xvY2FsaXR5IjoiTE9ORyBFQVRPTiIsImFkZHJlc3NMb2NhbGl0eSI6IkdSRUFUIE1JU1NFTkRFTiIsInBvc3RhbENvZGUiOiJIUDE2IDBBTCIsImFkZHJlc3NDb3VudHJ5IjoiR0IifV0sImRyaXZpbmdQZXJtaXQiOlt7InBlcnNvbmFsTnVtYmVyIjoiRE9FOTk4MDIwODVKOTlGRyIsImV4cGlyeURhdGUiOiIyMDIzLTAxLTE4IiwiaXNzdWVOdW1iZXIiOm51bGwsImlzc3VlZEJ5IjpudWxsLCJpc3N1ZURhdGUiOm51bGx9XSwiZXZpZGVuY2UiOlt7InR5cGUiOiJJZGVudGl0eUNoZWNrIiwidHhuIjoiZWEyZmVlZmUtNDVhMy00YTI5LTkyM2YtNjA0Y2Q0MDE3ZWMwIiwic3RyZW5ndGhTY29yZSI6MywidmFsaWRpdHlTY29yZSI6MiwiYWN0aXZpdHlIaXN0b3J5U2NvcmUiOiIxIiwiY2hlY2tEZXRhaWxzIjpbeyJjaGVja01ldGhvZCI6InZyaSIsImlkZW50aXR5Q2hlY2tQb2xpY3kiOiJwdWJsaXNoZWQiLCJhY3Rpdml0eUZyb20iOiIyMDE5LTAxLTAxIn0seyJjaGVja01ldGhvZCI6ImJ2ciIsImJpb21ldHJpY1ZlcmlmaWNhdGlvblByb2Nlc3NMZXZlbCI6Mn1dfV19fQ.Ul-eb7s76_F1M5D5maztKdvbrx1_1xGy53_pVZFGmSGJt7niWIe_87ykWm-o1HYaBKYMTvPmSS266ZBZ0t4Gwg";
 
     @Test
-    void credentialsSatisfyProfileShouldReturnTrueIfCredentialsSatisfyProfile() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
-
-        assertTrue(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
+    void getFirstMatchingProfileShouldReturnSatisfiedProfile() throws Exception {
+        Gpg45Scores m1aScores = new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2);
+        assertEquals(
+                Optional.of(Gpg45Profile.M1A),
+                evaluator.getFirstMatchingProfile(
+                        m1aScores, List.of(Gpg45Profile.M1B, Gpg45Profile.M1A, Gpg45Profile.V1D)));
     }
 
     @Test
-    void credentialsSatisfyAnyProfileShouldReturnTrueIfOneProfileIsMet() throws Exception {
-        when(profile1.isSatisfiedBy(any())).thenReturn(false);
-        when(profile2.isSatisfiedBy(any())).thenReturn(true);
-        when(profile2.getLabel()).thenReturn("M1B");
-
-        assertTrue(
-                evaluator.credentialsSatisfyAnyProfile(
-                        EMPTY_EVIDENCE_MAP, List.of(profile1, profile2)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnTrueIfCredentialsM1BSatisfyProfile()
-            throws Exception {
-        DcmawCheckMethod dcmawCheckMethod = new DcmawCheckMethod();
-        dcmawCheckMethod.setBiometricVerificationProcessLevel(3);
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        3,
-                                        2,
-                                        1,
-                                        3,
-                                        Collections.singletonList(dcmawCheckMethod),
-                                        null,
-                                        Collections.emptyList())));
-
-        assertTrue(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1B)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnTrueIfCredentialsSatisfyProfileAndOnlyA01CI()
-            throws Exception {
-
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.singletonList("A01"))),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
-
-        assertTrue(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
-    }
-
-    @Test
-    void
-            credentialsSatisfyAnyProfileShouldReturnTrueIfCredentialsSatisfyProfileAndOnlyA01CIForTheM1BProfile()
-                    throws Exception {
-        DcmawCheckMethod dcmawCheckMethod = new DcmawCheckMethod();
-        dcmawCheckMethod.setBiometricVerificationProcessLevel(3);
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.singletonList("A01"))),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        3,
-                                        2,
-                                        1,
-                                        2,
-                                        Collections.singletonList(dcmawCheckMethod),
-                                        null,
-                                        Collections.emptyList())));
-
-        assertTrue(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1B)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnFalseIfNoCredentialsFound() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW, new ArrayList<>());
-
-        assertFalse(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnFalseIfOnlyPassportCredential() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                                Collections.singletonList(
-                                        new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW, new ArrayList<>());
-
-        assertFalse(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnFalseIfOnlyOnlyPassportAndFraudCredential()
-            throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                                Collections.singletonList(
-                                        new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                Collections.singletonList(
-                                        new CredentialEvidenceItem(
-                                                CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                                2,
-                                                Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW, new ArrayList<>());
-
-        assertFalse(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnFalseIfOnlyOnlyAppCredential() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                                Collections.singletonList(
-                                        new CredentialEvidenceItem(
-                                                3,
-                                                2,
-                                                1,
-                                                2,
-                                                Collections.singletonList(new DcmawCheckMethod()),
-                                                null,
-                                                Collections.emptyList())));
-        assertFalse(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1B)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnFalseIfFailedPassportCredential()
-            throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(4, 0, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
-        assertFalse(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnFalseIfFailedFraudCredentialWithCI()
-            throws Exception {
-
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        0,
-                                        Collections.singletonList("D02"))),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
-
-        assertFalse(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnFalseIfFailedKbvCredential() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        0,
-                                        Collections.singletonList("D02"))),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
-
-        assertFalse(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldReturnFalseIfFailedAppCredential() throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                                        1,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(3, 0, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
-
-        assertFalse(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1B)));
-    }
-
-    @Test
-    void credentialsSatisfyAnyProfileShouldUseHighestScoringValuesForCredentials()
-            throws Exception {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                Map.of(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.EVIDENCE,
-                        Collections.singletonList(
-                                new CredentialEvidenceItem(4, 2, Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                        List.of(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        0,
-                                        Collections.singletonList("D02")),
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                        List.of(
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        1,
-                                        Collections.emptyList()),
-                                new CredentialEvidenceItem(
-                                        CredentialEvidenceItem.EvidenceType.VERIFICATION,
-                                        2,
-                                        Collections.emptyList())),
-                        CredentialEvidenceItem.EvidenceType.DCMAW,
-                        new ArrayList<>());
-
-        assertTrue(evaluator.credentialsSatisfyAnyProfile(evidenceMap, List.of(Gpg45Profile.M1A)));
+    void getFirstMatchingProfileShouldReturnEmptyOptionalIfNoProfilesMatched() throws Exception {
+        Gpg45Scores lowScores = new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 0);
+        assertEquals(
+                Optional.empty(),
+                evaluator.getFirstMatchingProfile(
+                        lowScores, List.of(Gpg45Profile.M1B, Gpg45Profile.M1A, Gpg45Profile.V1D)));
     }
 
     @Test
@@ -524,114 +165,75 @@ class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
-    void parseGpg45ScoresFromCredentialsShouldReturnCredentialItemsMapOnValidPassportCredential()
-            throws UnknownEvidenceTypeException, ParseException {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                evaluator.parseGpg45ScoresFromCredentials(List.of(M1A_PASSPORT_VC));
+    void buildScoreShouldReturnCorrectScoreForPassportCredential() throws Exception {
+        Gpg45Scores builtScores = evaluator.buildScore(List.of(SignedJWT.parse(M1A_PASSPORT_VC)));
+        Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_42, 0, 0, 0);
 
-        List<CredentialEvidenceItem> evidenceItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.EVIDENCE);
-
-        assertEquals(1, evidenceItems.size());
-        assertEquals(4, evidenceItems.get(0).getEvidenceScore().strength());
-        assertEquals(2, evidenceItems.get(0).getEvidenceScore().validity());
+        assertEquals(expectedScores, builtScores);
     }
 
     @Test
-    void
-            parseGpg45ScoresFromCredentialsShouldReturnCredentialItemsMapOnValidPassportAndAddressCredentials()
-                    throws UnknownEvidenceTypeException, ParseException {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                evaluator.parseGpg45ScoresFromCredentials(List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC));
+    void buildScoreShouldReturnCorrectScoreForPassportAndAddressCredentials() throws Exception {
 
-        List<CredentialEvidenceItem> evidenceItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.EVIDENCE);
-        List<CredentialEvidenceItem> fraudItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD);
-        List<CredentialEvidenceItem> verificationItems =
-                evidenceMap.get((CredentialEvidenceItem.EvidenceType.VERIFICATION));
+        Gpg45Scores builtScores =
+                evaluator.buildScore(
+                        List.of(SignedJWT.parse(M1A_PASSPORT_VC), SignedJWT.parse(M1A_ADDRESS_VC)));
+        Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_42, 0, 0, 0);
 
-        assertEquals(1, evidenceItems.size());
-        assertEquals(4, evidenceItems.get(0).getEvidenceScore().strength());
-        assertEquals(2, evidenceItems.get(0).getEvidenceScore().validity());
-
-        assertEquals(0, fraudItems.size());
-        assertEquals(0, verificationItems.size());
+        assertEquals(expectedScores, builtScores);
     }
 
     @Test
-    void
-            parseGpg45ScoresFromCredentialsShouldReturnCredentialItemsMapOnValidPassportAndAddressAndFraudCredentials()
-                    throws UnknownEvidenceTypeException, ParseException {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                evaluator.parseGpg45ScoresFromCredentials(
-                        List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC));
+    void buildScoreShouldReturnCorrectScoreForPassportAndAddressAndFraudCredentials()
+            throws Exception {
 
-        List<CredentialEvidenceItem> evidenceItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.EVIDENCE);
-        List<CredentialEvidenceItem> fraudItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD);
-        List<CredentialEvidenceItem> verificationItems =
-                evidenceMap.get((CredentialEvidenceItem.EvidenceType.VERIFICATION));
+        Gpg45Scores builtScores =
+                evaluator.buildScore(
+                        List.of(
+                                SignedJWT.parse(M1A_PASSPORT_VC),
+                                SignedJWT.parse(M1A_ADDRESS_VC),
+                                SignedJWT.parse(M1A_FRAUD_VC)));
+        Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 0);
 
-        assertEquals(1, evidenceItems.size());
-        assertEquals(4, evidenceItems.get(0).getEvidenceScore().strength());
-        assertEquals(2, evidenceItems.get(0).getEvidenceScore().validity());
-
-        assertEquals(1, fraudItems.size());
-        assertEquals(1, fraudItems.get(0).getIdentityFraudScore());
-
-        assertEquals(0, verificationItems.size());
+        assertEquals(expectedScores, builtScores);
     }
 
     @Test
-    void
-            parseGpg45ScoresFromCredentialsShouldReturnCredentialItemsMapOnValidPassportAndAddressAndFraudAndKbvCredentials()
-                    throws UnknownEvidenceTypeException, ParseException {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                evaluator.parseGpg45ScoresFromCredentials(
+    void buildScoreShouldReturnCorrectScoreForPassportAndAddressAndFraudAndKbvCredentials()
+            throws Exception {
+
+        Gpg45Scores builtScores =
+                evaluator.buildScore(
+                        List.of(
+                                SignedJWT.parse(M1A_PASSPORT_VC),
+                                SignedJWT.parse(M1A_ADDRESS_VC),
+                                SignedJWT.parse(M1A_FRAUD_VC),
+                                SignedJWT.parse(M1A_KBV_VC)));
+        Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2);
+
+        assertEquals(expectedScores, builtScores);
+    }
+
+    @Test
+    void buildScoreShouldReturnCorrectScoreForDcmawCredential() throws Exception {
+        Gpg45Scores builtScores = evaluator.buildScore(List.of(SignedJWT.parse(M1B_DCMAW_VC)));
+        Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_32, 1, 0, 2);
+
+        assertEquals(expectedScores, builtScores);
+    }
+
+    @Test
+    void parseCredentialsParsesCredentials() throws Exception {
+        List<String> expected = List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC, M1A_KBV_VC);
+
+        List<SignedJWT> parsedCredentials =
+                evaluator.parseCredentials(
                         List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC, M1A_KBV_VC));
 
-        List<CredentialEvidenceItem> evidenceItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.EVIDENCE);
-        List<CredentialEvidenceItem> fraudItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD);
-        List<CredentialEvidenceItem> verificationItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.VERIFICATION);
+        // reserializing for ease of assertions. SignedJWT.equals() checks equality by reference
+        List<String> reserializedCredentials =
+                parsedCredentials.stream().map(SignedJWT::serialize).collect(Collectors.toList());
 
-        assertEquals(1, evidenceItems.size());
-        assertEquals(4, evidenceItems.get(0).getEvidenceScore().strength());
-        assertEquals(2, evidenceItems.get(0).getEvidenceScore().validity());
-
-        assertEquals(1, fraudItems.size());
-        assertEquals(1, fraudItems.get(0).getIdentityFraudScore());
-
-        assertEquals(1, verificationItems.size());
-        assertEquals(2, verificationItems.get(0).getVerificationScore());
-    }
-
-    @Test
-    void parseGpg45ScoresFromCredentialsShouldReturnCredentialItemsMapForADcmawCredential()
-            throws UnknownEvidenceTypeException, ParseException {
-        Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap =
-                evaluator.parseGpg45ScoresFromCredentials(List.of(M1B_DCMAW_VC));
-
-        List<CredentialEvidenceItem> evidenceItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.EVIDENCE);
-        List<CredentialEvidenceItem> fraudItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD);
-        List<CredentialEvidenceItem> verificationItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.VERIFICATION);
-        List<CredentialEvidenceItem> dcmawItems =
-                evidenceMap.get(CredentialEvidenceItem.EvidenceType.DCMAW);
-
-        assertEquals(0, evidenceItems.size());
-        assertEquals(0, fraudItems.size());
-        assertEquals(0, verificationItems.size());
-
-        assertEquals(1, dcmawItems.size());
-        assertEquals(3, dcmawItems.get(0).getEvidenceScore().strength());
-        assertEquals(2, dcmawItems.get(0).getEvidenceScore().validity());
-        assertEquals(1, dcmawItems.get(0).getActivityHistoryScore());
+        assertEquals(expected, reserializedCredentials);
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Send audit event when GPG45 profile matched

### Why did it change
We currently don't send an audit message when a user has matched against a GPG45 profile.

This adds that audit event, with details of the profile, the scores achieved, and the txn ID's from the VC's used.

We send the full evidence block of the VCs in audit events when we fetch them from CRIs, so the txn's here can be used to find those audit events and get more details.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2075](https://govukverify.atlassian.net/browse/PYIC-2075)
