### PR TITLE
BAU: Build lib jar deterministically

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -43,6 +43,11 @@ java {
 	withSourcesJar()
 }
 
+tasks.withType(Jar).configureEach { Jar jar ->
+	jar.preserveFileTimestamps = false
+	jar.reproducibleFileOrder = true
+}
+
 tasks.named('jar') {
 	manifest {
 		attributes('Implementation-Title': project.name,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Build lib jar deterministically

### Why did it change

When running `sam build`, the lib sub-project is jar-ified in the build process, and that jar is included in the artifact that `sam deploy` pushed into S3.

When `sam deploy` runs, it calculates a hash of the artifact it's about to push and checks if there are any artifacts in s3 that have the same hash. If there are it doesn't push the same files again.

Currently, `sam deploy` never matches the artifact hashes for our functions, and we push them all. Hundreds of MB.

The jar that is built for the lib sub-project is different every time, even with the same inputs. This results in the hashes for newly built artifacts being different for any project including the lib project. So all of them.

We can control how the jar is built and make it reproduceable. This should make the hashes of the artifacts the same (if there's been no change to the sources) and mean we don't push everything when we don't need to.

The jar changes every time due to timestamps that it includes, and the ordering of files within the jar (which is non-deterministic). These can be controlled with the configuration added here to the `build.gradle`
