### PR TITLE
PYIC-2082: set new journeyType property to the user session

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.core.library.domain;
+
+public enum IpvJourneyTypes {
+    IPV_CORE_MAIN_JOURNEY("ipv-core-main-journey");
+
+    private final String value;
+
+    IpvJourneyTypes(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
@@ -32,6 +33,7 @@ public class IpvSessionItem implements DynamodbItem {
     private List<VcStatusDto> currentVcStatuses;
     private String vot;
     private long ttl;
+    private IpvJourneyTypes journeyType;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {
@@ -165,5 +167,13 @@ public class IpvSessionItem implements DynamodbItem {
 
     public void setTtl(long ttl) {
         this.ttl = ttl;
+    }
+
+    public IpvJourneyTypes getJourneyType() {
+        return journeyType;
+    }
+
+    public void setJourneyType(IpvJourneyTypes journeyType) {
+        this.journeyType = journeyType;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
@@ -86,6 +87,8 @@ public class IpvSessionService {
         ipvSessionItem.setVisitedCredentialIssuerDetails(Collections.emptyList());
 
         ipvSessionItem.setVot(VOT_P0);
+
+        ipvSessionItem.setJourneyType(IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY);
 
         if (errorObject != null) {
             ipvSessionItem.setErrorCode(errorObject.getCode());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add a new property to the users session in order to track which type of journey they are currently on. This is initialised to IPV_CORE_MAIN_JOURNEY when the session is created.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This value will be used to load the correct journey engine statemachine config file.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2082](https://govukverify.atlassian.net/browse/PYIC-2082)

