### PR TITLE
Remove old csls subscription filters

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -190,14 +190,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref IPVCorePrivateAPILogGroup
 
-  IPVCorePrivateAPILogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref IPVCorePrivateAPILogGroup
-
   IPVCoreExternalAPI:
     Type: AWS::Serverless::Api
     DependsOn:
@@ -240,14 +232,6 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref IPVCoreExternalAPILogGroup
-
-  IPVCoreExternalAPILogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref IPVCoreExternalAPILogGroup
 
@@ -314,14 +298,6 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref IssueClientAccessTokenFunctionLogGroup
-
-  IssueClientAccessTokenFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref IssueClientAccessTokenFunctionLogGroup
 
@@ -395,14 +371,6 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref BuildClientOauthResponseFunctionLogGroup
-
-  BuildClientOauthResponseFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref BuildClientOauthResponseFunctionLogGroup
 
@@ -488,14 +456,6 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref InitialiseIpvSessionFunctionLogGroup
-
-  InitialiseIpvSessionFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref InitialiseIpvSessionFunctionLogGroup
 
@@ -614,14 +574,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref RetrieveCriOauthAccessTokenFunctionLogGroup
 
-  RetrieveCriOauthAccessTokenFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref RetrieveCriOauthAccessTokenFunctionLogGroup
-
   RetrieveCriCredentialFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -737,14 +689,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref RetrieveCriCredentialFunctionLogGroup
 
-  RetrieveCriCredentialFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref RetrieveCriCredentialFunctionLogGroup
-
   BuildCriOauthRequestFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -833,14 +777,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref BuildCriOauthRequestFunctionLogGroup
 
-  BuildCriOauthRequestFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref BuildCriOauthRequestFunctionLogGroup
-
   BuildUserIdentityFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -922,14 +858,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref BuildUserIdentityFunctionLogGroup
 
-  BuildUserIdentityFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref BuildUserIdentityFunctionLogGroup
-
   GetCredentialIssuerConfig:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -987,14 +915,6 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref GetCredentialIssuerFunctionLogGroup
-
-  GetCredentialIssuerFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref GetCredentialIssuerFunctionLogGroup
 
@@ -1060,14 +980,6 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref BuildDebugCredentialDataFunctionLogGroup
-
-  BuildDebugCredentialDataFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref BuildDebugCredentialDataFunctionLogGroup
 
@@ -1165,14 +1077,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref CriReturnStepFunctionLogGroup
 
-  CriReturnStepFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref CriReturnStepFunctionLogGroup
-
   JourneyEngineStepFunction:
     Type: AWS::Serverless::StateMachine
     Properties:
@@ -1258,14 +1162,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref JourneyEngineStepFunctionLogGroup
 
-  JourneyEngineStepFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref JourneyEngineStepFunctionLogGroup
-
   IPVProcessJourneyStepFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -1317,14 +1213,6 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref IPVProcessJourneyStepFunctionLogGroup
-
-  IPVProcessJourneyStepFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref IPVProcessJourneyStepFunctionLogGroup
 
@@ -1432,14 +1320,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref EvaluateGpg45ScoresFunctionLogGroup
 
-  EvaluateGpg45ScoresFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref EvaluateGpg45ScoresFunctionLogGroup
-
   SelectCriFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -1503,14 +1383,6 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-      FilterPattern: ""
-      LogGroupName: !Ref SelectCriFunctionLogGroup
-
-  SelectCriFunctionFunctionLogGroupSubscriptionFilterOld:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
       FilterPattern: ""
       LogGroupName: !Ref SelectCriFunctionLogGroup
 
@@ -1586,7 +1458,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
     Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref ValidateOAuthCallbackFunctionLogGroup
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
We have been dual publishing to 2 csls endpoints, however the old one is no longer needed and can be removed.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
New csls endpoint is the only one required, so the old subscription filter can be removed.
<!-- Describe the reason these changes were made - the "why" -->

