### PR TITLE
BAU Skip deploy of cloudwatch alarms in dev environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1730,6 +1730,7 @@ Resources:
 
   CoreApiGw5xxErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevelopment
     Properties:
         AlarmName: ApiGateWay5xxAlarm
         ActionsEnabled: true


### PR DESCRIPTION
## Proposed changes

### What changed

Skip deploy of cloudwatch alarms in dev environments

### Why did it change

Fixes deploy to dev environments - we don't need cloudwatch alarms
