### PR TITLE
PYIC-2077: Audit User's IP Address in AuditEvent

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -12,6 +12,7 @@
       "Resource": "${RetrieveCriOauthAccessTokenFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
+        "clientSourceIp.$": "$.clientSourceIp",
         "journey.$": "$.lambdaResult.journey"
       },
       "ResultPath": "$.lambdaResult",
@@ -22,6 +23,7 @@
       "Resource": "${RetrieveCriCredentialFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
+        "clientSourceIp.$": "$.clientSourceIp",
         "journey.$": "$.lambdaResult.journey"
       },
       "ResultPath": "$.lambdaResult",
@@ -32,6 +34,7 @@
       "Resource": "${IPVProcessJourneyStepFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
+        "clientSourceIp.$": "$.clientSourceIp",
         "journey.$": "$.lambdaResult.journey"
       },
       "ResultPath": "$.lambdaResult",

--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -12,7 +12,7 @@
       "Resource": "${RetrieveCriOauthAccessTokenFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
-        "clientSourceIp.$": "$.clientSourceIp",
+        "ipAddress.$": "$.ipAddress",
         "journey.$": "$.lambdaResult.journey"
       },
       "ResultPath": "$.lambdaResult",
@@ -23,7 +23,7 @@
       "Resource": "${RetrieveCriCredentialFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
-        "clientSourceIp.$": "$.clientSourceIp",
+        "ipAddress.$": "$.ipAddress",
         "journey.$": "$.lambdaResult.journey"
       },
       "ResultPath": "$.lambdaResult",
@@ -34,7 +34,7 @@
       "Resource": "${IPVProcessJourneyStepFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
-        "clientSourceIp.$": "$.clientSourceIp",
+        "ipAddress.$": "$.ipAddress",
         "journey.$": "$.lambdaResult.journey"
       },
       "ResultPath": "$.lambdaResult",

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -84,6 +84,7 @@ public class BuildClientOauthResponseHandler
 
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
+            String ipAddress = RequestHelper.getIpAddress(input);
             IpvSessionItem ipvSessionItem = sessionService.getIpvSession(ipvSessionId);
             String userId = sessionService.getUserId(ipvSessionId);
             ClientSessionDetailsDto clientSessionDetailsDto =
@@ -97,7 +98,8 @@ public class BuildClientOauthResponseHandler
                     new AuditEventUser(
                             userId,
                             ipvSessionId,
-                            clientSessionDetailsDto.getGovukSigninJourneyId());
+                            clientSessionDetailsDto.getGovukSigninJourneyId(),
+                            ipAddress);
 
             ClientResponse clientResponse;
 

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -52,7 +52,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class BuildClientOauthResponseHandlerTest {
-    private static final Map<String, String> TEST_EVENT_HEADERS = Map.of("ipv-session-id", "12345");
+    private static final Map<String, String> TEST_EVENT_HEADERS =
+            Map.of("ipv-session-id", "12345", "ip-address", "192.168.1.100");
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Map<String, String> VALID_QUERY_PARAMS =
             Map.of(

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -114,6 +114,7 @@ public class BuildCriOauthRequestHandler
         LogHelper.attachComponentIdToLogs();
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
+            String ipAddress = RequestHelper.getIpAddress(input);
             Map<String, String> pathParameters = input.getPathParameters();
 
             var errorResponse = validate(pathParameters);
@@ -154,7 +155,7 @@ public class BuildCriOauthRequestHandler
             persistOauthState(ipvSessionItem, credentialIssuerConfig.getId(), oauthState);
 
             AuditEventUser auditEventUser =
-                    new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId);
+                    new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
             auditService.sendAuditEvent(
                     new AuditEvent(
                             AuditEventTypes.IPV_REDIRECT_TO_CRI, componentId, auditEventUser));

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -57,7 +57,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.buildcrioauthrequest.BuildCriOauthRequestHandler.SHARED_CLAIMS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
@@ -89,6 +88,7 @@ class BuildCriOauthRequestHandlerTest {
     public static final String VTM = "http://www.example.com/vtm";
     public static final String TEST_USER_ID = "test-user-id";
     public static final String OAUTH_STATE = "test-state";
+    public static final String TEST_IP_ADDRESS = "192.168.1.100";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -209,7 +209,7 @@ class BuildCriOauthRequestHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
         input.setPathParameters(Map.of("criId", CRI_ID));
-        input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
+        input.setHeaders(Map.of("ipv-session-id", SESSION_ID, "ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
 
@@ -279,7 +279,7 @@ class BuildCriOauthRequestHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
         input.setPathParameters(Map.of("criId", DCMAW_CRI_ID));
-        input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
+        input.setHeaders(Map.of("ipv-session-id", SESSION_ID, "ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
 
@@ -402,7 +402,7 @@ class BuildCriOauthRequestHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
         input.setPathParameters(Map.of("criId", CRI_ID));
-        input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
+        input.setHeaders(Map.of("ipv-session-id", SESSION_ID, "ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
         Map<String, String> responseBody = getResponseBodyAsMap(response).get("cri");
@@ -453,7 +453,7 @@ class BuildCriOauthRequestHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
         input.setPathParameters(Map.of("criId", CRI_ID));
-        input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
+        input.setHeaders(Map.of("ipv-session-id", SESSION_ID, "ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
         Map<String, String> responseBody = getResponseBodyAsMap(response).get("cri");
@@ -502,7 +502,7 @@ class BuildCriOauthRequestHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
         input.setPathParameters(Map.of("criId", CRI_ID));
-        input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
+        input.setHeaders(Map.of("ipv-session-id", SESSION_ID, "ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
         Map<String, String> responseBody = getResponseBodyAsMap(response).get("cri");
@@ -572,7 +572,7 @@ class BuildCriOauthRequestHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
         input.setPathParameters(Map.of("criId", CRI_ID));
-        input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
+        input.setHeaders(Map.of("ipv-session-id", SESSION_ID, "ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
         Map<String, String> responseBody = getResponseBodyAsMap(response).get("cri");
@@ -623,7 +623,7 @@ class BuildCriOauthRequestHandlerTest {
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
         input.setPathParameters(Map.of("criId", CRI_ID));
-        input.setHeaders(Map.of("ipv-session-id", SESSION_ID));
+        input.setHeaders(Map.of("ipv-session-id", SESSION_ID, "ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
         Map<String, String> responseBody = getResponseBodyAsMap(response).get("cri");
@@ -655,7 +655,7 @@ class BuildCriOauthRequestHandlerTest {
 
     private APIGatewayProxyRequestEvent createRequestEvent() {
         APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-        input.setHeaders(Map.of("ipv-session-id", "aSessionId"));
+        input.setHeaders(Map.of("ipv-session-id", "aSessionId", "ip-address", TEST_IP_ADDRESS));
         return input;
     }
 

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -80,7 +80,6 @@ public class BuildUserIdentityHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
-            String ipAddress = RequestHelper.getIpAddress(input);
             AccessToken accessToken =
                     AccessToken.parse(
                             RequestHelper.getHeaderByKey(
@@ -120,7 +119,7 @@ public class BuildUserIdentityHandler
                             userId,
                             ipvSessionId,
                             clientSessionDetails.getGovukSigninJourneyId(),
-                            ipAddress);
+                            null);
 
             String sub = userId;
             UserIdentity userIdentity =

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -80,6 +80,7 @@ public class BuildUserIdentityHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
+            String ipAddress = RequestHelper.getIpAddress(input);
             AccessToken accessToken =
                     AccessToken.parse(
                             RequestHelper.getHeaderByKey(
@@ -116,7 +117,10 @@ public class BuildUserIdentityHandler
             String userId = clientSessionDetails.getUserId();
             AuditEventUser auditEventUser =
                     new AuditEventUser(
-                            userId, ipvSessionId, clientSessionDetails.getGovukSigninJourneyId());
+                            userId,
+                            ipvSessionId,
+                            clientSessionDetails.getGovukSigninJourneyId(),
+                            ipAddress);
 
             String sub = userId;
             UserIdentity userIdentity =

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -57,6 +57,7 @@ class BuildUserIdentityHandlerTest {
     private static final String TEST_IPV_SESSION_ID = SecureTokenHelper.generate();
     private static final String TEST_ACCESS_TOKEN = "test-access-token";
     public static final String VTM = "http://www.example.com/vtm";
+    public static final String TEST_IP_ADDRESS = "192.168.1.100";
 
     @Mock private Context mockContext;
     @Mock private UserIdentityService mockUserIdentityService;
@@ -121,7 +122,11 @@ class BuildUserIdentityHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken(TEST_ACCESS_TOKEN);
         Map<String, String> headers =
-                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+                Map.of(
+                        "Authorization",
+                        accessToken.toAuthorizationHeader(),
+                        "ip-address",
+                        TEST_IP_ADDRESS);
         event.setHeaders(headers);
 
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
@@ -140,7 +145,11 @@ class BuildUserIdentityHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken(TEST_ACCESS_TOKEN);
         Map<String, String> headers =
-                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+                Map.of(
+                        "Authorization",
+                        accessToken.toAuthorizationHeader(),
+                        "ip-address",
+                        TEST_IP_ADDRESS);
         event.setHeaders(headers);
 
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
@@ -173,7 +182,11 @@ class BuildUserIdentityHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken(TEST_ACCESS_TOKEN);
         Map<String, String> headers =
-                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+                Map.of(
+                        "Authorization",
+                        accessToken.toAuthorizationHeader(),
+                        "ip-address",
+                        TEST_IP_ADDRESS);
         event.setHeaders(headers);
 
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
@@ -199,7 +212,9 @@ class BuildUserIdentityHandlerTest {
     @Test
     void shouldReturnErrorResponseWhenTokenIsNull() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> headers = Collections.singletonMap("Authorization", null);
+        Map<String, String> headers = new HashMap<>(Collections.emptyMap());
+        headers.put("Authorization", null);
+        headers.put("ip-address", TEST_IP_ADDRESS);
         event.setHeaders(headers);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
@@ -215,7 +230,8 @@ class BuildUserIdentityHandlerTest {
     @Test
     void shouldReturnErrorResponseWhenTokenIsMissingBearerPrefix() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, String> headers = Collections.singletonMap("Authorization", "11111111");
+        Map<String, String> headers =
+                Map.of("Authorization", "11111111", "ip-address", TEST_IP_ADDRESS);
         event.setHeaders(headers);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
@@ -232,6 +248,8 @@ class BuildUserIdentityHandlerTest {
     @Test
     void shouldReturnErrorResponseWhenTokenIsMissing() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, String> headers = Map.of("ip-address", TEST_IP_ADDRESS);
+        event.setHeaders(headers);
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
         responseBody = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
@@ -248,7 +266,11 @@ class BuildUserIdentityHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken(TEST_ACCESS_TOKEN);
         Map<String, String> headers =
-                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+                Map.of(
+                        "Authorization",
+                        accessToken.toAuthorizationHeader(),
+                        "ip-address",
+                        TEST_IP_ADDRESS);
         event.setHeaders(headers);
 
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
@@ -273,7 +295,11 @@ class BuildUserIdentityHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken(TEST_ACCESS_TOKEN);
         Map<String, String> headers =
-                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+                Map.of(
+                        "Authorization",
+                        accessToken.toAuthorizationHeader(),
+                        "ip-address",
+                        TEST_IP_ADDRESS);
         event.setHeaders(headers);
 
         AccessTokenMetadata revokedAccessTokenMetadata = new AccessTokenMetadata();
@@ -300,7 +326,11 @@ class BuildUserIdentityHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken(TEST_ACCESS_TOKEN);
         Map<String, String> headers =
-                Collections.singletonMap("Authorization", accessToken.toAuthorizationHeader());
+                Map.of(
+                        "Authorization",
+                        accessToken.toAuthorizationHeader(),
+                        "ip-address",
+                        TEST_IP_ADDRESS);
         event.setHeaders(headers);
 
         AccessTokenMetadata expiredAccessTokenMetadata = new AccessTokenMetadata();

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -110,7 +110,7 @@ public class EvaluateGpg45ScoresHandler
 
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(event);
-            String clientSourceIp = RequestHelper.getClientSourceIp(event);
+            String ipAddress = RequestHelper.getIpAddress(event);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientSessionDetailsDto clientSessionDetailsDto =
                     ipvSessionItem.getClientSessionDetails();
@@ -125,7 +125,7 @@ public class EvaluateGpg45ScoresHandler
 
             Optional<JourneyResponse> contraIndicatorErrorJourneyResponse =
                     gpg45ProfileEvaluator.getJourneyResponseForStoredCis(
-                            clientSessionDetailsDto, clientSourceIp);
+                            clientSessionDetailsDto, ipAddress);
             if (contraIndicatorErrorJourneyResponse.isEmpty()) {
                 Gpg45Scores gpg45Scores = gpg45ProfileEvaluator.buildScore(credentials);
                 Optional<Gpg45Profile> matchedProfile =
@@ -140,7 +140,8 @@ public class EvaluateGpg45ScoresHandler
                                     ipvSessionItem,
                                     matchedProfile.get(),
                                     gpg45Scores,
-                                    credentials));
+                                    credentials,
+                                    ipAddress));
                     ipvSessionItem.setVot(VOT_P2);
                     journeyResponse = JOURNEY_END;
                     message.with("lambdaResult", "A GPG45 profile has been met")
@@ -223,13 +224,15 @@ public class EvaluateGpg45ScoresHandler
             IpvSessionItem ipvSessionItem,
             Gpg45Profile gpg45Profile,
             Gpg45Scores gpg45Scores,
-            List<SignedJWT> credentials)
+            List<SignedJWT> credentials,
+            String ipAddress)
             throws ParseException {
         AuditEventUser auditEventUser =
                 new AuditEventUser(
                         ipvSessionItem.getClientSessionDetails().getUserId(),
                         ipvSessionItem.getIpvSessionId(),
-                        ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId());
+                        ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId(),
+                        ipAddress);
         return new AuditEvent(
                 AuditEventTypes.IPV_GPG45_PROFILE_MATCHED,
                 componentId,

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -110,6 +110,7 @@ public class EvaluateGpg45ScoresHandler
 
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(event);
+            String clientSourceIp = RequestHelper.getClientSourceIp(event);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientSessionDetailsDto clientSessionDetailsDto =
                     ipvSessionItem.getClientSessionDetails();
@@ -123,7 +124,8 @@ public class EvaluateGpg45ScoresHandler
                             userIdentityService.getUserIssuedCredentials(userId));
 
             Optional<JourneyResponse> contraIndicatorErrorJourneyResponse =
-                    gpg45ProfileEvaluator.getJourneyResponseForStoredCis(clientSessionDetailsDto);
+                    gpg45ProfileEvaluator.getJourneyResponseForStoredCis(
+                            clientSessionDetailsDto, clientSourceIp);
             if (contraIndicatorErrorJourneyResponse.isEmpty()) {
                 Gpg45Scores gpg45Scores = gpg45ProfileEvaluator.buildScore(credentials);
                 Optional<Gpg45Profile> matchedProfile =

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -60,8 +60,8 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1B_DCMAW_VC;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.CLIENT_SOURCE_IP_HEADER;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
 
 @ExtendWith(MockitoExtension.class)
 class EvaluateGpg45ScoreHandlerTest {
@@ -120,7 +120,7 @@ class EvaluateGpg45ScoreHandlerTest {
                 Map.of(
                         IPV_SESSION_ID_HEADER,
                         TEST_SESSION_ID,
-                        CLIENT_SOURCE_IP_HEADER,
+                        IP_ADDRESS_HEADER,
                         TEST_CLIENT_SOURCE_IP));
         for (String cred : CREDENTIALS) {
             PARSED_CREDENTIALS.add(SignedJWT.parse(cred));

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -61,6 +61,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
 @ExtendWith(MockitoExtension.class)
 class InitialiseIpvSessionHandlerTest {
 
+    public static final String TEST_IP_ADDRESS = "192.168.1.100";
     @Mock private Context mockContext;
 
     @Mock private IpvSessionService mockIpvSessionService;
@@ -127,6 +128,7 @@ class InitialiseIpvSessionHandlerTest {
         Map<String, Object> sessionParams =
                 Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
         event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);
@@ -147,6 +149,7 @@ class InitialiseIpvSessionHandlerTest {
     @Test
     void shouldReturn400IfMissingBody() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);
@@ -164,6 +167,7 @@ class InitialiseIpvSessionHandlerTest {
     void shouldReturn400IfInvalidBody() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("invalid-body");
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);
@@ -183,6 +187,7 @@ class InitialiseIpvSessionHandlerTest {
         Map<String, Object> sessionParams = Map.of("request", signedEncryptedJwt.serialize());
 
         event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);
@@ -203,6 +208,7 @@ class InitialiseIpvSessionHandlerTest {
         Map<String, Object> sessionParams = Map.of("clientId", "test-client");
 
         event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);
@@ -223,6 +229,7 @@ class InitialiseIpvSessionHandlerTest {
         Map<String, Object> sessionParams =
                 Map.of("clientId", "test-client", "request", signedJWT.serialize());
         event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);
@@ -253,6 +260,7 @@ class InitialiseIpvSessionHandlerTest {
         Map<String, Object> sessionParams =
                 Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
         event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -98,7 +98,7 @@ public class RetrieveCriCredentialHandler
     public Map<String, Object> handleRequest(Map<String, String> input, Context context) {
         LogHelper.attachComponentIdToLogs();
 
-        String clientSourceIp = StepFunctionHelpers.getClientSourceIp(input);
+        String ipAddress = StepFunctionHelpers.getIpAddress(input);
 
         IpvSessionItem ipvSessionItem;
         try {
@@ -126,7 +126,8 @@ public class RetrieveCriCredentialHandler
                     new AuditEventUser(
                             userId,
                             ipvSessionItem.getIpvSessionId(),
-                            clientSessionDetailsDto.getGovukSigninJourneyId());
+                            clientSessionDetailsDto.getGovukSigninJourneyId(),
+                            ipAddress);
             this.componentId =
                     configurationService.getSsmParameter(
                             ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
@@ -157,7 +158,7 @@ public class RetrieveCriCredentialHandler
                 sendIpvVcReceivedAuditEvent(auditEventUser, vc, isSuccessful);
 
                 submitVcToCiStorage(
-                        vc, clientSessionDetailsDto.getGovukSigninJourneyId(), clientSourceIp);
+                        vc, clientSessionDetailsDto.getGovukSigninJourneyId(), ipAddress);
 
                 credentialIssuerService.persistUserCredentials(vc, credentialIssuerId, userId);
             }
@@ -215,10 +216,9 @@ public class RetrieveCriCredentialHandler
     }
 
     @Tracing
-    private void submitVcToCiStorage(
-            SignedJWT vc, String govukSigninJourneyId, String clientSourceIp)
+    private void submitVcToCiStorage(SignedJWT vc, String govukSigninJourneyId, String ipAddress)
             throws CiPutException {
-        ciStorageService.submitVC(vc, govukSigninJourneyId, clientSourceIp);
+        ciStorageService.submitVC(vc, govukSigninJourneyId, ipAddress);
     }
 
     @Tracing

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -98,6 +98,8 @@ public class RetrieveCriCredentialHandler
     public Map<String, Object> handleRequest(Map<String, String> input, Context context) {
         LogHelper.attachComponentIdToLogs();
 
+        String clientSourceIp = StepFunctionHelpers.getClientSourceIp(input);
+
         IpvSessionItem ipvSessionItem;
         try {
             String ipvSessionId = StepFunctionHelpers.getIpvSessionId(input);
@@ -154,7 +156,8 @@ public class RetrieveCriCredentialHandler
 
                 sendIpvVcReceivedAuditEvent(auditEventUser, vc, isSuccessful);
 
-                submitVcToCiStorage(vc, clientSessionDetailsDto.getGovukSigninJourneyId());
+                submitVcToCiStorage(
+                        vc, clientSessionDetailsDto.getGovukSigninJourneyId(), clientSourceIp);
 
                 credentialIssuerService.persistUserCredentials(vc, credentialIssuerId, userId);
             }
@@ -212,9 +215,10 @@ public class RetrieveCriCredentialHandler
     }
 
     @Tracing
-    private void submitVcToCiStorage(SignedJWT vc, String govukSigninJourneyId)
+    private void submitVcToCiStorage(
+            SignedJWT vc, String govukSigninJourneyId, String clientSourceIp)
             throws CiPutException {
-        ciStorageService.submitVC(vc, govukSigninJourneyId);
+        ciStorageService.submitVC(vc, govukSigninJourneyId, clientSourceIp);
     }
 
     @Tracing

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -67,6 +67,7 @@ class RetrieveCriCredentialHandlerTest {
     public static final String ADDRESS_CRI_JOURNEY_ID = "address";
     public static final String TEST_USER_ID = "test-user-id";
     public static final String TEST_STATE = "test-state";
+    public static final String TEST_CLIENT_SOURCE_IP = "test.client.source.ip";
 
     @Mock private Context context;
     @Mock private CredentialIssuerService credentialIssuerService;
@@ -134,7 +135,7 @@ class RetrieveCriCredentialHandlerTest {
 
         testBearerAccessToken = BearerAccessToken.parse(ACCESS_TOKEN);
 
-        testInput = Map.of("ipvSessionId", testSessionId);
+        testInput = Map.of("ipvSessionId", testSessionId, "clientSourceIp", TEST_CLIENT_SOURCE_IP);
     }
 
     @Test
@@ -314,7 +315,7 @@ class RetrieveCriCredentialHandlerTest {
 
         doThrow(new CiPutException("Lambda execution failed"))
                 .when(ciStorageService)
-                .submitVC(any(SignedJWT.class), anyString());
+                .submitVC(any(SignedJWT.class), anyString(), anyString());
 
         handler.handleRequest(testInput, context);
 

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -67,7 +67,7 @@ class RetrieveCriCredentialHandlerTest {
     public static final String ADDRESS_CRI_JOURNEY_ID = "address";
     public static final String TEST_USER_ID = "test-user-id";
     public static final String TEST_STATE = "test-state";
-    public static final String TEST_CLIENT_SOURCE_IP = "test.client.source.ip";
+    public static final String TEST_IP_ADDRESS = "192.168.1.100";
 
     @Mock private Context context;
     @Mock private CredentialIssuerService credentialIssuerService;
@@ -135,7 +135,7 @@ class RetrieveCriCredentialHandlerTest {
 
         testBearerAccessToken = BearerAccessToken.parse(ACCESS_TOKEN);
 
-        testInput = Map.of("ipvSessionId", testSessionId, "clientSourceIp", TEST_CLIENT_SOURCE_IP);
+        testInput = Map.of("ipvSessionId", testSessionId, "ipAddress", TEST_IP_ADDRESS);
     }
 
     @Test

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -78,6 +78,8 @@ public class RetrieveCriOauthAccessTokenHandler
         IpvSessionItem ipvSessionItem = null;
         String credentialIssuerId = null;
 
+        String ipAddress = StepFunctionHelpers.getIpAddress(input);
+
         try {
             String ipvSessionId = StepFunctionHelpers.getIpvSessionId(input);
             ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
@@ -106,7 +108,8 @@ public class RetrieveCriOauthAccessTokenHandler
                     new AuditEventUser(
                             userId,
                             ipvSessionId,
-                            clientSessionDetailsDto.getGovukSigninJourneyId());
+                            clientSessionDetailsDto.getGovukSigninJourneyId(),
+                            ipAddress);
             String componentId =
                     configurationService.getSsmParameter(
                             ConfigurationVariable.AUDIENCE_FOR_CLIENTS);

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -106,7 +106,7 @@ public class ValidateOAuthCallbackHandler
 
             validate(request);
 
-            sendAuditEvent(ipvSessionItem, null);
+            sendAuditEvent(ipvSessionItem, null, request.getIpAddress());
 
             setIpvSessionCRIAuthorizationCode(
                     ipvSessionItem, new AuthorizationCode(request.getAuthorizationCode()));
@@ -148,7 +148,7 @@ public class ValidateOAuthCallbackHandler
                         .setErrorCode(error)
                         .setErrorDescription(errorDescription)
                         .build();
-        sendAuditEvent(ipvSessionItem, extensions);
+        sendAuditEvent(ipvSessionItem, extensions, request.getIpAddress());
 
         if (!ALLOWED_OAUTH_ERROR_CODES.contains(error)) {
             LOGGER.warn("Unknown Oauth error code received");
@@ -238,7 +238,8 @@ public class ValidateOAuthCallbackHandler
     }
 
     @Tracing
-    private void sendAuditEvent(IpvSessionItem ipvSessionItem, AuditExtensions extensions)
+    private void sendAuditEvent(
+            IpvSessionItem ipvSessionItem, AuditExtensions extensions, String ipAddress)
             throws SqsException {
         auditService.sendAuditEvent(
                 new AuditEvent(
@@ -247,7 +248,8 @@ public class ValidateOAuthCallbackHandler
                         new AuditEventUser(
                                 ipvSessionItem.getClientSessionDetails().getUserId(),
                                 ipvSessionItem.getIpvSessionId(),
-                                ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId()),
+                                ipvSessionItem.getClientSessionDetails().getGovukSigninJourneyId(),
+                                ipAddress),
                         extensions));
     }
 }

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -54,6 +54,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     private static final String TEST_ERROR_DESCRIPTION = "test error description";
     private static final String TEST_SESSION_ID = SecureTokenHelper.generate();
     public static final String TEST_USER_ID = "test-user-id";
+    public static final String TEST_IP_ADDRESS = "192.168.1.100";
     private static CredentialIssuerConfig credentialIssuerConfig;
     private static IpvSessionItem ipvSessionItem;
     @Mock private Context context;
@@ -281,6 +282,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 TEST_REDIRECT_URI,
                 TEST_OAUTH_STATE,
                 null,
-                null);
+                null,
+                TEST_IP_ADDRESS);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
@@ -20,11 +20,15 @@ public class AuditEventUser {
     @JsonProperty(value = "govuk_signin_journey_id")
     private final String govukSigninJourneyId;
 
+    @JsonProperty(value = "ip_address")
+    private final String ipAddress;
+
     public AuditEventUser(
             @JsonProperty(value = "user_id", required = false) String userId,
             @JsonProperty(value = "session_id", required = false) String sessionId,
             @JsonProperty(value = "govuk_signin_journey_id", required = false)
-                    String govukSigninJourneyId) {
+                    String govukSigninJourneyId,
+            @JsonProperty(value = "ip_address", required = false) String ipAddress) {
         this.userId = userId;
         this.sessionId = sessionId;
         if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
@@ -32,5 +36,6 @@ public class AuditEventUser {
         } else {
             this.govukSigninJourneyId = govukSigninJourneyId;
         }
+        this.ipAddress = ipAddress;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -15,6 +15,7 @@ public enum ErrorResponse {
     INVALID_CREDENTIAL_ISSUER_ID(1008, "Invalid credential issuer id"),
     INVALID_TOKEN_REQUEST(1009, "Invalid token request"),
     MISSING_IPV_SESSION_ID(1010, "Missing ipv session id header"),
+    MISSING_CLIENT_SOURCE_IP(1010, "Missing client source ip header"),
     FAILED_TO_GET_CREDENTIAL_FROM_ISSUER(1011, "Failed to get credential from issuer"),
     FAILED_TO_SAVE_CREDENTIAL(1012, "Failed to save credential"),
     FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -15,7 +15,7 @@ public enum ErrorResponse {
     INVALID_CREDENTIAL_ISSUER_ID(1008, "Invalid credential issuer id"),
     INVALID_TOKEN_REQUEST(1009, "Invalid token request"),
     MISSING_IPV_SESSION_ID(1010, "Missing ipv session id header"),
-    MISSING_CLIENT_SOURCE_IP(1010, "Missing client source ip header"),
+    MISSING_IP_ADDRESS(1010, "Missing ip address header"),
     FAILED_TO_GET_CREDENTIAL_FROM_ISSUER(1011, "Failed to get credential from issuer"),
     FAILED_TO_SAVE_CREDENTIAL(1012, "Failed to save credential"),
     FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/GetCiRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/GetCiRequest.java
@@ -8,6 +8,9 @@ public class GetCiRequest {
     @SerializedName(value = "govuk_signin_journey_id")
     private final String govukSigninJourneyId;
 
+    @SerializedName(value = "ip_address")
+    private final String clientSourceIp;
+
     @SerializedName(value = "user_id")
     private final String userId;
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/GetCiRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/GetCiRequest.java
@@ -9,7 +9,7 @@ public class GetCiRequest {
     private final String govukSigninJourneyId;
 
     @SerializedName(value = "ip_address")
-    private final String clientSourceIp;
+    private final String ipAddress;
 
     @SerializedName(value = "user_id")
     private final String userId;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/PutCiRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/PutCiRequest.java
@@ -8,6 +8,9 @@ public class PutCiRequest {
     @SerializedName(value = "govuk_signin_journey_id")
     private final String govukSigninJourneyId;
 
+    @SerializedName(value = "ip_address")
+    private final String clientSourceIp;
+
     @SerializedName(value = "signed_jwt")
     private final String signedJwt;
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/PutCiRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/PutCiRequest.java
@@ -9,7 +9,7 @@ public class PutCiRequest {
     private final String govukSigninJourneyId;
 
     @SerializedName(value = "ip_address")
-    private final String clientSourceIp;
+    private final String ipAddress;
 
     @SerializedName(value = "signed_jwt")
     private final String signedJwt;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -54,15 +54,14 @@ public class Gpg45ProfileEvaluator {
     }
 
     public Optional<JourneyResponse> getJourneyResponseForStoredCis(
-            ClientSessionDetailsDto sessionDetails, String clientSourceIp)
-            throws CiRetrievalException {
+            ClientSessionDetailsDto sessionDetails, String ipAddress) throws CiRetrievalException {
 
         List<ContraIndicatorItem> ciItems;
         ciItems =
                 ciStorageService.getCIs(
                         sessionDetails.getUserId(),
                         sessionDetails.getGovukSigninJourneyId(),
-                        clientSourceIp);
+                        ipAddress);
         LOGGER.info(
                 new MapMessage()
                         .with(LOG_DESCRIPTION_FIELD, "Retrieved user's CI items")

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -54,12 +54,15 @@ public class Gpg45ProfileEvaluator {
     }
 
     public Optional<JourneyResponse> getJourneyResponseForStoredCis(
-            ClientSessionDetailsDto sessionDetails) throws CiRetrievalException {
+            ClientSessionDetailsDto sessionDetails, String clientSourceIp)
+            throws CiRetrievalException {
 
         List<ContraIndicatorItem> ciItems;
         ciItems =
                 ciStorageService.getCIs(
-                        sessionDetails.getUserId(), sessionDetails.getGovukSigninJourneyId());
+                        sessionDetails.getUserId(),
+                        sessionDetails.getGovukSigninJourneyId(),
+                        clientSourceIp);
         LOGGER.info(
                 new MapMessage()
                         .with(LOG_DESCRIPTION_FIELD, "Retrieved user's CI items")

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerRequestDto.java
@@ -13,6 +13,7 @@ public class CredentialIssuerRequestDto {
     private String state;
     private String error;
     private String errorDescription;
+    private String ipAddress;
 
     public CredentialIssuerRequestDto() {}
 
@@ -23,7 +24,8 @@ public class CredentialIssuerRequestDto {
             String redirectUri,
             String state,
             String error,
-            String errorDescription) {
+            String errorDescription,
+            String ipAddress) {
         this.authorizationCode = authorizationCode;
         this.credentialIssuerId = credentialIssuerId;
         this.ipvSessionId = ipvSessionId;
@@ -31,6 +33,7 @@ public class CredentialIssuerRequestDto {
         this.state = state;
         this.error = error;
         this.errorDescription = errorDescription;
+        this.ipAddress = ipAddress;
     }
 
     public String getAuthorizationCode() {
@@ -87,5 +90,13 @@ public class CredentialIssuerRequestDto {
 
     public void setErrorDescription(String errorDescription) {
         this.errorDescription = errorDescription;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -104,13 +104,12 @@ public class RequestHelper {
 
     public static String getClientSourceIp(Map<String, String> headers)
             throws HttpResponseExceptionWithErrorBody {
-        String ipvSessionId = RequestHelper.getHeaderByKey(headers, CLIENT_SOURCE_IP_HEADER);
-        if (ipvSessionId == null) {
+        String clientSourceIp = RequestHelper.getHeaderByKey(headers, CLIENT_SOURCE_IP_HEADER);
+        if (clientSourceIp == null) {
             LOGGER.error("{} not present in header", CLIENT_SOURCE_IP_HEADER);
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_CLIENT_SOURCE_IP);
         }
-        LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
-        return ipvSessionId;
+        return clientSourceIp;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 public class RequestHelper {
 
     public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
+    public static final String CLIENT_SOURCE_IP_HEADER = "client-source-ip";
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -84,6 +85,11 @@ public class RequestHelper {
         return getIpvSessionId(event.getHeaders());
     }
 
+    public static String getClientSourceIp(APIGatewayProxyRequestEvent event)
+            throws HttpResponseExceptionWithErrorBody {
+        return getClientSourceIp(event.getHeaders());
+    }
+
     public static String getIpvSessionId(Map<String, String> headers)
             throws HttpResponseExceptionWithErrorBody {
         String ipvSessionId = RequestHelper.getHeaderByKey(headers, IPV_SESSION_ID_HEADER);
@@ -91,6 +97,18 @@ public class RequestHelper {
             LOGGER.error("{} not present in header", IPV_SESSION_ID_HEADER);
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
+        }
+        LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
+        return ipvSessionId;
+    }
+
+    public static String getClientSourceIp(Map<String, String> headers)
+            throws HttpResponseExceptionWithErrorBody {
+        String ipvSessionId = RequestHelper.getHeaderByKey(headers, CLIENT_SOURCE_IP_HEADER);
+        if (ipvSessionId == null) {
+            LOGGER.error("{} not present in header", CLIENT_SOURCE_IP_HEADER);
+            throw new HttpResponseExceptionWithErrorBody(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_CLIENT_SOURCE_IP);
         }
         LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
         return ipvSessionId;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 public class RequestHelper {
 
     public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
-    public static final String CLIENT_SOURCE_IP_HEADER = "client-source-ip";
+    public static final String IP_ADDRESS_HEADER = "ip-address";
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -85,9 +85,9 @@ public class RequestHelper {
         return getIpvSessionId(event.getHeaders());
     }
 
-    public static String getClientSourceIp(APIGatewayProxyRequestEvent event)
+    public static String getIpAddress(APIGatewayProxyRequestEvent event)
             throws HttpResponseExceptionWithErrorBody {
-        return getClientSourceIp(event.getHeaders());
+        return getIpAddress(event.getHeaders());
     }
 
     public static String getIpvSessionId(Map<String, String> headers)
@@ -102,14 +102,14 @@ public class RequestHelper {
         return ipvSessionId;
     }
 
-    public static String getClientSourceIp(Map<String, String> headers)
+    public static String getIpAddress(Map<String, String> headers)
             throws HttpResponseExceptionWithErrorBody {
-        String clientSourceIp = RequestHelper.getHeaderByKey(headers, CLIENT_SOURCE_IP_HEADER);
-        if (clientSourceIp == null) {
-            LOGGER.error("{} not present in header", CLIENT_SOURCE_IP_HEADER);
+        String ipAddress = RequestHelper.getHeaderByKey(headers, IP_ADDRESS_HEADER);
+        if (ipAddress == null) {
+            LOGGER.error("{} not present in header", IP_ADDRESS_HEADER);
             throw new HttpResponseExceptionWithErrorBody(
-                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_CLIENT_SOURCE_IP);
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IP_ADDRESS);
         }
-        return clientSourceIp;
+        return ipAddress;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
@@ -14,7 +14,7 @@ public class StepFunctionHelpers {
     public static final String JOURNEY = "journey";
     public static final String MESSAGE = "message";
     public static final String STATUS_CODE = "statusCode";
-    public static final String CLIENT_SOURCE_IP = "clientSourceIp";
+    public static final String IP_ADDRESS = "ipAddress";
 
     private StepFunctionHelpers() {
         throw new IllegalStateException("Utility class");
@@ -34,8 +34,8 @@ public class StepFunctionHelpers {
         return ipvSessionId;
     }
 
-    public static String getClientSourceIp(Map<String, String> input) {
-        return input.get(CLIENT_SOURCE_IP);
+    public static String getIpAddress(Map<String, String> input) {
+        return input.get(IP_ADDRESS);
     }
 
     public static String getJourneyStep(Map<String, String> input)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
@@ -14,6 +14,7 @@ public class StepFunctionHelpers {
     public static final String JOURNEY = "journey";
     public static final String MESSAGE = "message";
     public static final String STATUS_CODE = "statusCode";
+    public static final String CLIENT_SOURCE_IP = "clientSourceIp";
 
     private StepFunctionHelpers() {
         throw new IllegalStateException("Utility class");
@@ -31,6 +32,10 @@ public class StepFunctionHelpers {
         LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
 
         return ipvSessionId;
+    }
+
+    public static String getClientSourceIp(Map<String, String> input) {
+        return input.get(CLIENT_SOURCE_IP);
     }
 
     public static String getJourneyStep(Map<String, String> input)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
@@ -42,7 +42,8 @@ public class CiStorageService {
         this.configurationService = configurationService;
     }
 
-    public void submitVC(SignedJWT verifiableCredential, String govukSigninJourneyId)
+    public void submitVC(
+            SignedJWT verifiableCredential, String govukSigninJourneyId, String clientSourceIp)
             throws CiPutException {
         InvokeRequest request =
                 new InvokeRequest()
@@ -53,6 +54,7 @@ public class CiStorageService {
                                 gson.toJson(
                                         new PutCiRequest(
                                                 govukSigninJourneyId,
+                                                clientSourceIp,
                                                 verifiableCredential.serialize())));
 
         LOGGER.info("Sending VC to CI storage system");
@@ -64,14 +66,18 @@ public class CiStorageService {
         }
     }
 
-    public List<ContraIndicatorItem> getCIs(String userId, String govukSigninJourneyId)
+    public List<ContraIndicatorItem> getCIs(
+            String userId, String govukSigninJourneyId, String clientSourceIp)
             throws CiRetrievalException {
         InvokeRequest request =
                 new InvokeRequest()
                         .withFunctionName(
                                 configurationService.getEnvironmentVariable(
                                         CI_STORAGE_GET_LAMBDA_ARN))
-                        .withPayload(gson.toJson(new GetCiRequest(govukSigninJourneyId, userId)));
+                        .withPayload(
+                                gson.toJson(
+                                        new GetCiRequest(
+                                                govukSigninJourneyId, clientSourceIp, userId)));
 
         LOGGER.info("Retrieving CIs from CI storage system");
         InvokeResult result = lambdaClient.invoke(request);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
@@ -43,7 +43,7 @@ public class CiStorageService {
     }
 
     public void submitVC(
-            SignedJWT verifiableCredential, String govukSigninJourneyId, String clientSourceIp)
+            SignedJWT verifiableCredential, String govukSigninJourneyId, String ipAddress)
             throws CiPutException {
         InvokeRequest request =
                 new InvokeRequest()
@@ -54,7 +54,7 @@ public class CiStorageService {
                                 gson.toJson(
                                         new PutCiRequest(
                                                 govukSigninJourneyId,
-                                                clientSourceIp,
+                                                ipAddress,
                                                 verifiableCredential.serialize())));
 
         LOGGER.info("Sending VC to CI storage system");
@@ -67,7 +67,7 @@ public class CiStorageService {
     }
 
     public List<ContraIndicatorItem> getCIs(
-            String userId, String govukSigninJourneyId, String clientSourceIp)
+            String userId, String govukSigninJourneyId, String ipAddress)
             throws CiRetrievalException {
         InvokeRequest request =
                 new InvokeRequest()
@@ -76,8 +76,7 @@ public class CiStorageService {
                                         CI_STORAGE_GET_LAMBDA_ARN))
                         .withPayload(
                                 gson.toJson(
-                                        new GetCiRequest(
-                                                govukSigninJourneyId, clientSourceIp, userId)));
+                                        new GetCiRequest(govukSigninJourneyId, ipAddress, userId)));
 
         LOGGER.info("Retrieving CIs from CI storage system");
         InvokeResult result = lambdaClient.invoke(request);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionGpg45ProfileMatchedTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/auditing/AuditExtensionGpg45ProfileMatchedTest.java
@@ -43,7 +43,8 @@ class AuditExtensionGpg45ProfileMatchedTest {
                         new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2),
                         List.of("txn1", "txn2", "txn3"));
 
-        AuditEventUser user = new AuditEventUser("user-id", "session-id", "journey-id");
+        AuditEventUser user =
+                new AuditEventUser("user-id", "session-id", "journey-id", "ip-address");
 
         AuditEvent auditEvent =
                 new AuditEvent(
@@ -56,7 +57,8 @@ class AuditExtensionGpg45ProfileMatchedTest {
                         + "\"user\":{"
                         + "\"user_id\":\"user-id\","
                         + "\"session_id\":\"session-id\","
-                        + "\"govuk_signin_journey_id\":\"journey-id\""
+                        + "\"govuk_signin_journey_id\":\"journey-id\","
+                        + "\"ip_address\":\"ip-address\""
                         + "},"
                         + "\"extensions\":{"
                         + "\"gpg45Profile\":\"M1A\","

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -34,6 +34,7 @@ class Gpg45ProfileEvaluatorTest {
 
     public static final String TEST_USER_ID = "test-user-id";
     public static final String TEST_JOURNEY_ID = "test-journey-id";
+    public static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
     @Mock CiStorageService mockCiStorageService;
     @Mock ConfigurationService mockConfigurationService;
     @Mock ClientSessionDetailsDto mockClientSessionDetails;
@@ -72,10 +73,15 @@ class Gpg45ProfileEvaluatorTest {
     void getJourneyResponseForStoredCisShouldReturnEmptyOptionalIfNoCis() throws Exception {
         when(mockClientSessionDetails.getUserId()).thenReturn(TEST_USER_ID);
         when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn(TEST_JOURNEY_ID);
-        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID)).thenReturn(List.of());
+        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
+                .thenReturn(List.of());
         when(mockConfigurationService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
 
-        assertTrue(evaluator.getJourneyResponseForStoredCis(mockClientSessionDetails).isEmpty());
+        assertTrue(
+                evaluator
+                        .getJourneyResponseForStoredCis(
+                                mockClientSessionDetails, TEST_CLIENT_SOURCE_IP)
+                        .isEmpty());
     }
 
     @Test
@@ -97,10 +103,14 @@ class Gpg45ProfileEvaluatorTest {
         when(mockConfigurationService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
         when(mockClientSessionDetails.getUserId()).thenReturn(TEST_USER_ID);
         when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn(TEST_JOURNEY_ID);
-        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID))
+        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(List.of(contraIndicatorItem));
 
-        assertTrue(evaluator.getJourneyResponseForStoredCis(mockClientSessionDetails).isEmpty());
+        assertTrue(
+                evaluator
+                        .getJourneyResponseForStoredCis(
+                                mockClientSessionDetails, TEST_CLIENT_SOURCE_IP)
+                        .isEmpty());
     }
 
     @Test
@@ -138,12 +148,13 @@ class Gpg45ProfileEvaluatorTest {
         when(kbvConfig.getAudienceForClients()).thenReturn("kbvIssuer");
         when(mockClientSessionDetails.getUserId()).thenReturn(TEST_USER_ID);
         when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn(TEST_JOURNEY_ID);
-        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID))
+        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(new ArrayList<>(List.of(otherCiItem, kbvCiItem)));
 
         assertEquals(
                 Optional.of(JOURNEY_RESPONSE_PYI_KBV_FAIL),
-                evaluator.getJourneyResponseForStoredCis(mockClientSessionDetails));
+                evaluator.getJourneyResponseForStoredCis(
+                        mockClientSessionDetails, TEST_CLIENT_SOURCE_IP));
     }
 
     @Test
@@ -181,12 +192,13 @@ class Gpg45ProfileEvaluatorTest {
         when(kbvConfig.getAudienceForClients()).thenReturn("kbvIssuer");
         when(mockClientSessionDetails.getUserId()).thenReturn(TEST_USER_ID);
         when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn(TEST_JOURNEY_ID);
-        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID))
+        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(new ArrayList<>(List.of(otherCiItem, kbvCiItem)));
 
         assertEquals(
                 Optional.of(JOURNEY_RESPONSE_PYI_NO_MATCH),
-                evaluator.getJourneyResponseForStoredCis(mockClientSessionDetails));
+                evaluator.getJourneyResponseForStoredCis(
+                        mockClientSessionDetails, TEST_CLIENT_SOURCE_IP));
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -17,8 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.CLIENT_SOURCE_IP_HEADER;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
 
 class RequestHelperTest {
 
@@ -107,46 +107,46 @@ class RequestHelperTest {
     }
 
     @Test
-    void getClientSourceIpShouldReturnClientSourceIp() throws HttpResponseExceptionWithErrorBody {
+    void getIpAddressShouldReturnIpAddress() throws HttpResponseExceptionWithErrorBody {
         var event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of(CLIENT_SOURCE_IP_HEADER, "a-client-source-ip"));
+        event.setHeaders(Map.of(IP_ADDRESS_HEADER, "a-client-source-ip"));
 
-        assertEquals("a-client-source-ip", RequestHelper.getClientSourceIp(event));
+        assertEquals("a-client-source-ip", RequestHelper.getIpAddress(event));
     }
 
     @Test
-    void getClientSourceIpShouldThrowIfClientSourceIpIsNull() {
+    void getIpAddressShouldThrowIfIpAddressIsNull() {
         var event = new APIGatewayProxyRequestEvent();
         HashMap<String, String> headers = new HashMap<>();
-        headers.put(CLIENT_SOURCE_IP_HEADER, null);
+        headers.put(IP_ADDRESS_HEADER, null);
 
         event.setHeaders(headers);
 
         var exception =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> RequestHelper.getClientSourceIp(event));
+                        () -> RequestHelper.getIpAddress(event));
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
-                ErrorResponse.MISSING_CLIENT_SOURCE_IP.getMessage(),
+                ErrorResponse.MISSING_IP_ADDRESS.getMessage(),
                 exception.getErrorResponse().getMessage());
     }
 
     @Test
-    void getClientSourceIpIdShouldThrowIfClientSourceIpIsEmptyString() {
+    void getIpAddressIdShouldThrowIfIpAddressIsEmptyString() {
         var event = new APIGatewayProxyRequestEvent();
 
-        event.setHeaders(Map.of(CLIENT_SOURCE_IP_HEADER, ""));
+        event.setHeaders(Map.of(IP_ADDRESS_HEADER, ""));
 
         var exception =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> RequestHelper.getClientSourceIp(event));
+                        () -> RequestHelper.getIpAddress(event));
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
-                ErrorResponse.MISSING_CLIENT_SOURCE_IP.getMessage(),
+                ErrorResponse.MISSING_IP_ADDRESS.getMessage(),
                 exception.getErrorResponse().getMessage());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.CLIENT_SOURCE_IP_HEADER;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
 
 class RequestHelperTest {
@@ -102,6 +103,50 @@ class RequestHelperTest {
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
                 ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                exception.getErrorResponse().getMessage());
+    }
+
+    @Test
+    void getClientSourceIpShouldReturnClientSourceIp() throws HttpResponseExceptionWithErrorBody {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of(CLIENT_SOURCE_IP_HEADER, "a-client-source-ip"));
+
+        assertEquals("a-client-source-ip", RequestHelper.getClientSourceIp(event));
+    }
+
+    @Test
+    void getClientSourceIpShouldThrowIfClientSourceIpIsNull() {
+        var event = new APIGatewayProxyRequestEvent();
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CLIENT_SOURCE_IP_HEADER, null);
+
+        event.setHeaders(headers);
+
+        var exception =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> RequestHelper.getClientSourceIp(event));
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(
+                ErrorResponse.MISSING_CLIENT_SOURCE_IP.getMessage(),
+                exception.getErrorResponse().getMessage());
+    }
+
+    @Test
+    void getClientSourceIpIdShouldThrowIfClientSourceIpIsEmptyString() {
+        var event = new APIGatewayProxyRequestEvent();
+
+        event.setHeaders(Map.of(CLIENT_SOURCE_IP_HEADER, ""));
+
+        var exception =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> RequestHelper.getClientSourceIp(event));
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(
+                ErrorResponse.MISSING_CLIENT_SOURCE_IP.getMessage(),
                 exception.getErrorResponse().getMessage());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
@@ -53,6 +53,13 @@ class StepFunctionHelpersTest {
     }
 
     @Test
+    void getClientSourceIpShouldReturnClientSourceIP() throws Exception {
+        Map<String, String> input = Map.of("clientSourceIp", "something");
+
+        assertEquals("something", StepFunctionHelpers.getClientSourceIp(input));
+    }
+
+    @Test
     void generateErrorOutputMapShouldGenerateAnErrorOutputMap() {
         Map<String, Object> expected =
                 Map.of(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
@@ -53,10 +53,10 @@ class StepFunctionHelpersTest {
     }
 
     @Test
-    void getClientSourceIpShouldReturnClientSourceIP() throws Exception {
-        Map<String, String> input = Map.of("clientSourceIp", "something");
+    void getIpAddressShouldReturnIpAddress() throws Exception {
+        Map<String, String> input = Map.of("ipAddress", "something");
 
-        assertEquals("something", StepFunctionHelpers.getClientSourceIp(input));
+        assertEquals("something", StepFunctionHelpers.getIpAddress(input));
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
@@ -100,7 +100,11 @@ class AuditServiceTest {
                         .build();
 
         AuditEventUser auditEventUser =
-                new AuditEventUser("someUserId", "someSessionId", "someGovukSigninJourneyId");
+                new AuditEventUser(
+                        "someUserId",
+                        "someSessionId",
+                        "someGovukSigninJourneyId",
+                        "someIp.Address");
 
         auditService.sendAuditEvent(AuditEventTypes.IPV_JOURNEY_START, extensions, auditEventUser);
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiStorageServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiStorageServiceTest.java
@@ -33,6 +33,7 @@ class CiStorageServiceTest {
     public static final String THE_ARN_OF_THE_GET_LAMBDA = "the:arn:of:the:get:lambda";
     public static final String GOVUK_SIGNIN_JOURNEY_ID = "a-journey-id";
     public static final String TEST_USER_ID = "a-user-id";
+    public static final String CLIENT_SOURCE_IP = "a-client-source-ip";
     @Captor ArgumentCaptor<InvokeRequest> requestCaptor;
 
     @Mock AWSLambda lambdaClient;
@@ -46,14 +47,15 @@ class CiStorageServiceTest {
         when(lambdaClient.invoke(requestCaptor.capture()))
                 .thenReturn(new InvokeResult().withStatusCode(200));
 
-        ciStorageService.submitVC(SignedJWT.parse(SIGNED_VC_1), GOVUK_SIGNIN_JOURNEY_ID);
+        ciStorageService.submitVC(
+                SignedJWT.parse(SIGNED_VC_1), GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP);
         InvokeRequest request = requestCaptor.getValue();
 
         assertEquals(THE_ARN_OF_THE_PUT_LAMBDA, request.getFunctionName());
         assertEquals(
                 String.format(
-                        "{\"govuk_signin_journey_id\":\"%s\",\"signed_jwt\":\"%s\"}",
-                        GOVUK_SIGNIN_JOURNEY_ID, SIGNED_VC_1),
+                        "{\"govuk_signin_journey_id\":\"%s\",\"ip_address\":\"%s\",\"signed_jwt\":\"%s\"}",
+                        GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP, SIGNED_VC_1),
                 new String(request.getPayload().array(), StandardCharsets.UTF_8));
     }
 
@@ -68,7 +70,9 @@ class CiStorageServiceTest {
                 CiPutException.class,
                 () ->
                         ciStorageService.submitVC(
-                                SignedJWT.parse(SIGNED_VC_1), GOVUK_SIGNIN_JOURNEY_ID));
+                                SignedJWT.parse(SIGNED_VC_1),
+                                GOVUK_SIGNIN_JOURNEY_ID,
+                                CLIENT_SOURCE_IP));
     }
 
     @Test
@@ -86,7 +90,9 @@ class CiStorageServiceTest {
                 CiPutException.class,
                 () ->
                         ciStorageService.submitVC(
-                                SignedJWT.parse(SIGNED_VC_1), GOVUK_SIGNIN_JOURNEY_ID));
+                                SignedJWT.parse(SIGNED_VC_1),
+                                GOVUK_SIGNIN_JOURNEY_ID,
+                                CLIENT_SOURCE_IP));
     }
 
     @Test
@@ -105,14 +111,14 @@ class CiStorageServiceTest {
                                                         .getBytes(StandardCharsets.UTF_8))));
 
         List<ContraIndicatorItem> ciItems =
-                ciStorageService.getCIs(TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID);
+                ciStorageService.getCIs(TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP);
         InvokeRequest request = requestCaptor.getValue();
 
         assertEquals(THE_ARN_OF_THE_GET_LAMBDA, request.getFunctionName());
         assertEquals(
                 String.format(
-                        "{\"govuk_signin_journey_id\":\"%s\",\"user_id\":\"%s\"}",
-                        GOVUK_SIGNIN_JOURNEY_ID, TEST_USER_ID),
+                        "{\"govuk_signin_journey_id\":\"%s\",\"ip_address\":\"%s\",\"user_id\":\"%s\"}",
+                        GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP, TEST_USER_ID),
                 new String(request.getPayload().array(), StandardCharsets.UTF_8));
         assertEquals(
                 List.of(
@@ -130,7 +136,9 @@ class CiStorageServiceTest {
 
         assertThrows(
                 CiRetrievalException.class,
-                () -> ciStorageService.getCIs(TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID));
+                () ->
+                        ciStorageService.getCIs(
+                                TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
     }
 
     @Test
@@ -146,6 +154,8 @@ class CiStorageServiceTest {
 
         assertThrows(
                 CiRetrievalException.class,
-                () -> ciStorageService.getCIs(TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID));
+                () ->
+                        ciStorageService.getCIs(
+                                TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CredentialIssuerServiceTest.java
@@ -62,6 +62,7 @@ class CredentialIssuerServiceTest {
     private static final String TEST_IPV_SESSION_ID = SecureTokenHelper.generate();
     public static final String OAUTH_STATE = "oauth-state";
     public static final String TEST_AUTH_CODE = "test-auth-code";
+    public static final String TEST_IP_ADDRESS = "192.168.1.100";
 
     @Mock private DataStore<UserIssuedCredentialsItem> mockDataStore;
     @Mock private ConfigurationService mockConfigurationService;
@@ -97,7 +98,8 @@ class CredentialIssuerServiceTest {
                         "http://www.example.com/redirect",
                         OAUTH_STATE,
                         null,
-                        null);
+                        null,
+                        TEST_IP_ADDRESS);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -130,7 +132,8 @@ class CredentialIssuerServiceTest {
                         "http://www.example.com/redirect",
                         OAUTH_STATE,
                         null,
-                        null);
+                        null,
+                        TEST_IP_ADDRESS);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -163,7 +166,8 @@ class CredentialIssuerServiceTest {
                         "http://www.example.com/redirect",
                         OAUTH_STATE,
                         null,
-                        null);
+                        null,
+                        TEST_IP_ADDRESS);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -198,7 +202,8 @@ class CredentialIssuerServiceTest {
                         "http://www.example.com/redirect",
                         OAUTH_STATE,
                         null,
-                        null);
+                        null,
+                        TEST_IP_ADDRESS);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
 
@@ -232,7 +237,8 @@ class CredentialIssuerServiceTest {
                         "http://www.example.com/redirect",
                         OAUTH_STATE,
                         null,
-                        null);
+                        null,
+                        TEST_IP_ADDRESS);
         CredentialIssuerConfig credentialIssuerConfig =
                 getStubCredentialIssuerConfig(wmRuntimeInfo);
         CredentialIssuerException exception =

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -81,14 +81,14 @@ paths:
             Fn::Sub: |
               #set($inputRoot = $input.path('$'))
               {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\"#foreach($key in $inputRoot.keySet()), \"$key\": \"$inputRoot.get($key)\"#end}",
+                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\"#foreach($key in $inputRoot.keySet()), \"$key\": \"$inputRoot.get($key)\"#end}",
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CriReturnStepFunction.Name}"
               }
           application/x-www-form-urlencoded:
             Fn::Sub: |
               #set($bodyParts = $util.urlDecode($input.path('$')).split('&'))
               {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\"#foreach( $token in $bodyParts )#set( $keyVal = $token.split('=') ), \"$keyVal[0]\": \"$keyVal[1]\"#end}",
+                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\"#foreach( $token in $bodyParts )#set( $keyVal = $token.split('=') ), \"$keyVal[0]\": \"$keyVal[1]\"#end}",
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CriReturnStepFunction.Name}"
               }
         responses:
@@ -136,7 +136,7 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"journey\": \"/journey/$input.params('journeyStep')\"}",
+                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\", \"journey\": \"/journey/$input.params('journeyStep')\"}",
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${JourneyEngineStepFunction.Name}"
               }
         responses:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Get's the `ip-address` from the `ip-address` header, and add's it to the `AuditEvent`
- This sends the parameter `ip_address` to the CI Storage Lambda's (Both put and get) so that the Client Source IP can be included as part of the AuditEvent (AuditUser).

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- To ensure we are Auditing the Client Source IP

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2077](https://govukverify.atlassian.net/browse/PYIC-2077)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
