### PR TITLE
BAU - set cloudwatch alarms to off for dev

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1934,6 +1934,7 @@ Resources:
 
   CoreApiExternalGw5xxErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevelopment
     Properties:
       AlarmName: ExternalApiGateWay5xxAlarm
       ActionsEnabled: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
BAU - set cloudwatch alarms to off for dev
<!-- Describe the changes in detail - the "what"-->

### Why did it change
BAU - set cloudwatch alarms to off for dev
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
