### PR TITLE
PYIC-2143: Add CI's to the session to be mitigated

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -13,11 +13,13 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.MapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.AuditExtensionGpg45ProfileMatched;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
@@ -25,6 +27,7 @@ import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.dto.ContraIndicatorMitigationDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
@@ -45,8 +48,10 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE_TXN;
@@ -64,6 +69,7 @@ public class EvaluateGpg45ScoresHandler
     private final UserIdentityService userIdentityService;
     private final IpvSessionService ipvSessionService;
     private final Gpg45ProfileEvaluator gpg45ProfileEvaluator;
+    private final CiStorageService ciStorageService;
     private final ConfigurationService configurationService;
     private final AuditService auditService;
     private final String addressCriId;
@@ -73,11 +79,13 @@ public class EvaluateGpg45ScoresHandler
             UserIdentityService userIdentityService,
             IpvSessionService ipvSessionService,
             Gpg45ProfileEvaluator gpg45ProfileEvaluator,
+            CiStorageService ciStorageService,
             ConfigurationService configurationService,
             AuditService auditService) {
         this.userIdentityService = userIdentityService;
         this.ipvSessionService = ipvSessionService;
         this.gpg45ProfileEvaluator = gpg45ProfileEvaluator;
+        this.ciStorageService = ciStorageService;
         this.configurationService = configurationService;
         this.auditService = auditService;
 
@@ -86,6 +94,7 @@ public class EvaluateGpg45ScoresHandler
                 configurationService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public EvaluateGpg45ScoresHandler() {
         this.configurationService = new ConfigurationService();
         this.userIdentityService = new UserIdentityService(configurationService);
@@ -93,6 +102,7 @@ public class EvaluateGpg45ScoresHandler
         this.gpg45ProfileEvaluator =
                 new Gpg45ProfileEvaluator(
                         new CiStorageService(configurationService), configurationService);
+        this.ciStorageService = new CiStorageService(configurationService);
         this.auditService =
                 new AuditService(AuditService.getDefaultSqsClient(), configurationService);
 
@@ -123,46 +133,43 @@ public class EvaluateGpg45ScoresHandler
                     gpg45ProfileEvaluator.parseCredentials(
                             userIdentityService.getUserIssuedCredentials(userId));
 
-            Optional<JourneyResponse> contraIndicatorErrorJourneyResponse =
-                    gpg45ProfileEvaluator.getJourneyResponseForStoredCis(
-                            clientSessionDetailsDto, ipAddress);
-            if (contraIndicatorErrorJourneyResponse.isEmpty()) {
-                Gpg45Scores gpg45Scores = gpg45ProfileEvaluator.buildScore(credentials);
-                Optional<Gpg45Profile> matchedProfile =
-                        gpg45ProfileEvaluator.getFirstMatchingProfile(
-                                gpg45Scores, ACCEPTED_PROFILES);
-                JourneyResponse journeyResponse;
-                var message = new MapMessage();
+            List<ContraIndicatorItem> ciItems;
+            ciItems =
+                    ciStorageService.getCIs(
+                            clientSessionDetailsDto.getUserId(),
+                            clientSessionDetailsDto.getGovukSigninJourneyId(),
+                            ipAddress);
 
-                if (matchedProfile.isPresent()) {
-                    auditService.sendAuditEvent(
-                            buildProfileMatchedAuditEvent(
-                                    ipvSessionItem,
-                                    matchedProfile.get(),
-                                    gpg45Scores,
-                                    credentials,
-                                    ipAddress));
-                    ipvSessionItem.setVot(VOT_P2);
-                    journeyResponse = JOURNEY_END;
-                    message.with("lambdaResult", "A GPG45 profile has been met")
-                            .with("journeyResponse", JOURNEY_END);
-                } else {
-                    journeyResponse = JOURNEY_NEXT;
-                    message.with("lambdaResult", "No GPG45 profiles have been met")
-                            .with("journeyResponse", JOURNEY_NEXT);
-                }
+            JourneyResponse journeyResponse;
+            var message = new MapMessage();
 
-                updateSuccessfulVcStatuses(ipvSessionItem, credentials);
-
-                LOGGER.info(message);
-
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        HttpStatus.SC_OK, journeyResponse);
+            boolean ciMitigationJourneysEnabled =
+                    Boolean.parseBoolean(
+                            configurationService.getSsmParameter(CI_MITIGATION_JOURNEYS_ENABLED));
+            Optional<JourneyResponse> mitigationJourneyResponse =
+                    getNextMitigationJourneyResponse(
+                            ciMitigationJourneysEnabled, ipvSessionItem, ciItems);
+            if (mitigationJourneyResponse.isPresent()) {
+                journeyResponse = mitigationJourneyResponse.get();
             } else {
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        HttpStatus.SC_OK, contraIndicatorErrorJourneyResponse.get());
+                Optional<JourneyResponse> contraIndicatorErrorJourneyResponse =
+                        gpg45ProfileEvaluator.getJourneyResponseForStoredCis(
+                                clientSessionDetailsDto, ipAddress);
+                if (contraIndicatorErrorJourneyResponse.isEmpty()) {
+                    journeyResponse =
+                            checkForMatchingGpg45Profile(
+                                    message, ipvSessionItem, credentials, ipAddress);
+                } else {
+                    return ApiGatewayResponseGenerator.proxyJsonResponse(
+                            HttpStatus.SC_OK, contraIndicatorErrorJourneyResponse.get());
+                }
             }
 
+            updateSuccessfulVcStatuses(ipvSessionItem, credentials);
+
+            LOGGER.info(message);
+
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, journeyResponse);
         } catch (HttpResponseExceptionWithErrorBody e) {
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getResponseCode(), e.getErrorBody());
@@ -185,6 +192,94 @@ public class EvaluateGpg45ScoresHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
         }
+    }
+
+    private JourneyResponse checkForMatchingGpg45Profile(
+            MapMessage message,
+            IpvSessionItem ipvSessionItem,
+            List<SignedJWT> credentials,
+            String ipAddress)
+            throws UnknownEvidenceTypeException, ParseException, SqsException {
+        Gpg45Scores gpg45Scores = gpg45ProfileEvaluator.buildScore(credentials);
+        Optional<Gpg45Profile> matchedProfile =
+                gpg45ProfileEvaluator.getFirstMatchingProfile(gpg45Scores, ACCEPTED_PROFILES);
+
+        if (matchedProfile.isPresent()) {
+            auditService.sendAuditEvent(
+                    buildProfileMatchedAuditEvent(
+                            ipvSessionItem,
+                            matchedProfile.get(),
+                            gpg45Scores,
+                            credentials,
+                            ipAddress));
+            ipvSessionItem.setVot(VOT_P2);
+
+            message.with("lambdaResult", "A GPG45 profile has been met")
+                    .with("journeyResponse", JOURNEY_END);
+            return JOURNEY_END;
+        } else {
+
+            message.with("lambdaResult", "No GPG45 profiles have been met")
+                    .with("journeyResponse", JOURNEY_NEXT);
+            return JOURNEY_NEXT;
+        }
+    }
+
+    private Optional<JourneyResponse> getNextMitigationJourneyResponse(
+            boolean ciMitigationJourneysEnabled,
+            IpvSessionItem ipvSessionItem,
+            List<ContraIndicatorItem> ciItems) {
+        if (ciMitigationJourneysEnabled) {
+            List<ContraIndicatorMitigationDetailsDto> currentMitigationDetails =
+                    ipvSessionItem.getContraIndicatorMitigationDetails();
+            boolean ciMitigationInProgress = isCiMitigationInProgress(currentMitigationDetails);
+
+            List<ContraIndicatorItem> newCiItems =
+                    ciItems.stream()
+                            .filter(
+                                    ciItem -> {
+                                        if (currentMitigationDetails != null) {
+                                            Optional<ContraIndicatorMitigationDetailsDto>
+                                                    matchingCI =
+                                                            currentMitigationDetails.stream()
+                                                                    .filter(
+                                                                            mitigationDetails ->
+                                                                                    mitigationDetails
+                                                                                            .getCi()
+                                                                                            .equals(
+                                                                                                    ciItem
+                                                                                                            .getCi()))
+                                                                    .findAny();
+                                            return matchingCI.isEmpty();
+                                        }
+                                        return true;
+                                    })
+                            .collect(Collectors.toList());
+
+            if (!newCiItems.isEmpty()) {
+                List<ContraIndicatorMitigationDetailsDto> newMitigationDetails = new ArrayList<>();
+
+                if (ipvSessionItem.getContraIndicatorMitigationDetails() != null) {
+                    newMitigationDetails.addAll(
+                            ipvSessionItem.getContraIndicatorMitigationDetails());
+                }
+
+                newCiItems.forEach(
+                        contraIndicatorItem ->
+                                newMitigationDetails.add(
+                                        new ContraIndicatorMitigationDetailsDto(
+                                                contraIndicatorItem.getCi())));
+
+                ipvSessionItem.setContraIndicatorMitigationDetails(newMitigationDetails);
+                ipvSessionService.updateIpvSession(ipvSessionItem);
+
+                return Optional.of(JOURNEY_NEXT);
+            } else if (ciMitigationInProgress) {
+                return Optional.of(JOURNEY_NEXT);
+            }
+        }
+
+        return Optional.empty();
     }
 
     @Tracing
@@ -254,5 +349,17 @@ public class EvaluateGpg45ScoresHandler
             }
         }
         return txnIds;
+    }
+
+    private boolean isCiMitigationInProgress(
+            List<ContraIndicatorMitigationDetailsDto> currentMitigationDetails) {
+        if (currentMitigationDetails != null) {
+            Optional<ContraIndicatorMitigationDetailsDto> inProgressCiMitigation =
+                    currentMitigationDetails.stream()
+                            .filter(ContraIndicatorMitigationDetailsDto::isMitigatable)
+                            .findAny();
+            return inProgressCiMitigation.isPresent();
+        }
+        return false;
     }
 }

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -19,6 +19,8 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.AuditExtensionGpg45ProfileMatched;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
@@ -26,6 +28,7 @@ import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.dto.ContraIndicatorMitigationDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
@@ -40,6 +43,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +54,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.ACCEPTED_PROFILES;
@@ -58,8 +64,10 @@ import static uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler.
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC_WITH_CI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1B_DCMAW_VC;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1a_FRAUD_VC_WITH_CI_A01;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
 
@@ -135,6 +143,8 @@ class EvaluateGpg45ScoreHandlerTest {
         clientSessionDetailsDto.setGovukSigninJourneyId(TEST_JOURNEY_ID);
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
         ipvSessionItem.setIpvSessionId(TEST_SESSION_ID);
+        ipvSessionItem.setContraIndicatorMitigationDetails(
+                List.of(new ContraIndicatorMitigationDetailsDto("A01")));
     }
 
     @Test
@@ -337,5 +347,278 @@ class EvaluateGpg45ScoreHandlerTest {
         assertEquals(
                 List.of("123ab93d-3a43-46ef-a2c1-3c6444206408", "RB000103490087", "abc1234"),
                 extension.getVcTxnIds());
+    }
+
+    @Test
+    void shouldRecordCiToBeMitigatedInSessionWhenNewCiIsReceived() throws Exception {
+        List<SignedJWT> parsedM1ACreds =
+                List.of(
+                        SignedJWT.parse(M1A_PASSPORT_VC),
+                        SignedJWT.parse(M1A_ADDRESS_VC),
+                        SignedJWT.parse(M1a_FRAUD_VC_WITH_CI_A01));
+        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
+        when(configurationService.getSsmParameter(
+                        ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED))
+                .thenReturn("true");
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(parsedM1ACreds);
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+
+        evaluateGpg45ScoresHandler.handleRequest(event, context);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+
+        IpvSessionItem ipvSessionItem = ipvSessionItemArgumentCaptor.getValue();
+        assertEquals(1, ipvSessionItem.getContraIndicatorMitigationDetails().size());
+        assertEquals("A01", ipvSessionItem.getContraIndicatorMitigationDetails().get(0).getCi());
+        assertEquals(
+                Collections.emptyList(),
+                ipvSessionItem
+                        .getContraIndicatorMitigationDetails()
+                        .get(0)
+                        .getMitigationJourneys());
+        assertTrue(ipvSessionItem.getContraIndicatorMitigationDetails().get(0).isMitigatable());
+    }
+
+    @Test
+    void shouldNotCheckGpg45ProfileIfNewCiIsReceived() throws Exception {
+        List<SignedJWT> parsedM1ACreds =
+                List.of(
+                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI),
+                        SignedJWT.parse(M1A_ADDRESS_VC),
+                        SignedJWT.parse(M1a_FRAUD_VC_WITH_CI_A01));
+        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
+        when(configurationService.getSsmParameter(
+                        ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED))
+                .thenReturn("true");
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(parsedM1ACreds);
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(ciStorageService.getCIs(any(), any(), any()))
+                .thenReturn(
+                        List.of(
+                                new ContraIndicatorItem(
+                                        "test-user",
+                                        "1234",
+                                        "test-iss",
+                                        "1234",
+                                        "A01",
+                                        "1234",
+                                        "1234"),
+                                new ContraIndicatorItem(
+                                        "test-user",
+                                        "1234",
+                                        "test-iss",
+                                        "1234",
+                                        "D02",
+                                        "1234",
+                                        "1234")));
+
+        evaluateGpg45ScoresHandler.handleRequest(event, context);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService, times(2))
+                .updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+
+        IpvSessionItem ipvSessionItem = ipvSessionItemArgumentCaptor.getValue();
+        assertEquals(2, ipvSessionItem.getContraIndicatorMitigationDetails().size());
+        assertEquals("A01", ipvSessionItem.getContraIndicatorMitigationDetails().get(0).getCi());
+        assertEquals(
+                Collections.emptyList(),
+                ipvSessionItem
+                        .getContraIndicatorMitigationDetails()
+                        .get(0)
+                        .getMitigationJourneys());
+        assertTrue(ipvSessionItem.getContraIndicatorMitigationDetails().get(0).isMitigatable());
+
+        verify(gpg45ProfileEvaluator, never()).getFirstMatchingProfile(any(), any());
+    }
+
+    @Test
+    void shouldNotCheckGpg45ProfileIfNewCiIsReceivedAndNoPreviousMitigation() throws Exception {
+        List<SignedJWT> parsedM1ACreds =
+                List.of(
+                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI),
+                        SignedJWT.parse(M1A_ADDRESS_VC),
+                        SignedJWT.parse(M1a_FRAUD_VC_WITH_CI_A01));
+        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
+        when(configurationService.getSsmParameter(
+                        ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED))
+                .thenReturn("true");
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(parsedM1ACreds);
+        ipvSessionItem.setContraIndicatorMitigationDetails(null);
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(ciStorageService.getCIs(any(), any(), any()))
+                .thenReturn(
+                        List.of(
+                                new ContraIndicatorItem(
+                                        "test-user",
+                                        "1234",
+                                        "test-iss",
+                                        "1234",
+                                        "A01",
+                                        "1234",
+                                        "1234")));
+
+        evaluateGpg45ScoresHandler.handleRequest(event, context);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService, times(2))
+                .updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+
+        IpvSessionItem ipvSessionItem = ipvSessionItemArgumentCaptor.getValue();
+        assertEquals(1, ipvSessionItem.getContraIndicatorMitigationDetails().size());
+        assertEquals("A01", ipvSessionItem.getContraIndicatorMitigationDetails().get(0).getCi());
+        assertEquals(
+                Collections.emptyList(),
+                ipvSessionItem
+                        .getContraIndicatorMitigationDetails()
+                        .get(0)
+                        .getMitigationJourneys());
+        assertTrue(ipvSessionItem.getContraIndicatorMitigationDetails().get(0).isMitigatable());
+
+        verify(gpg45ProfileEvaluator, never()).getFirstMatchingProfile(any(), any());
+    }
+
+    @Test
+    void shouldNotCheckGpg45ProfileIfMitigationInProgress() throws Exception {
+        List<SignedJWT> parsedM1ACreds =
+                List.of(SignedJWT.parse(M1A_PASSPORT_VC), SignedJWT.parse(M1A_ADDRESS_VC));
+        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
+        when(configurationService.getSsmParameter(
+                        ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED))
+                .thenReturn("true");
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(parsedM1ACreds);
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(ciStorageService.getCIs(any(), any(), any()))
+                .thenReturn(
+                        List.of(
+                                new ContraIndicatorItem(
+                                        "test-user",
+                                        "1234",
+                                        "test-iss",
+                                        "1234",
+                                        "A01",
+                                        "1234",
+                                        "1234")));
+
+        evaluateGpg45ScoresHandler.handleRequest(event, context);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+
+        IpvSessionItem ipvSessionItem = ipvSessionItemArgumentCaptor.getValue();
+        assertEquals(1, ipvSessionItem.getContraIndicatorMitigationDetails().size());
+        assertEquals("A01", ipvSessionItem.getContraIndicatorMitigationDetails().get(0).getCi());
+        assertEquals(
+                Collections.emptyList(),
+                ipvSessionItem
+                        .getContraIndicatorMitigationDetails()
+                        .get(0)
+                        .getMitigationJourneys());
+        assertTrue(ipvSessionItem.getContraIndicatorMitigationDetails().get(0).isMitigatable());
+
+        verify(gpg45ProfileEvaluator, never()).getFirstMatchingProfile(any(), any());
+    }
+
+    @Test
+    void shouldCheckGpg45ProfileIfMitigationHasCompleted() throws Exception {
+        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
+        when(configurationService.getSsmParameter(
+                        ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED))
+                .thenReturn("true");
+        ipvSessionItem.setContraIndicatorMitigationDetails(
+                List.of(
+                        new ContraIndicatorMitigationDetailsDto(
+                                "A01", Collections.emptyList(), false)));
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), anyString()))
+                .thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.of(Gpg45Profile.M1A));
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_END, journeyResponse);
+        verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+        IpvSessionItem updatedSessionItem = ipvSessionItemArgumentCaptor.getValue();
+
+        List<VcStatusDto> currentVcStatuses = updatedSessionItem.getCurrentVcStatuses();
+        assertEquals(5, currentVcStatuses.size());
+
+        assertTrue(currentVcStatuses.get(0).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-p.integration.account.gov.uk",
+                currentVcStatuses.get(0).getCriIss());
+        assertFalse(currentVcStatuses.get(1).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-a.integration.account.gov.uk",
+                currentVcStatuses.get(1).getCriIss());
+        assertTrue(currentVcStatuses.get(2).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-f.integration.account.gov.uk",
+                currentVcStatuses.get(2).getCriIss());
+        assertTrue(currentVcStatuses.get(3).getIsSuccessfulVc());
+        assertEquals("https://example.com/issuer", currentVcStatuses.get(3).getCriIss());
+        assertTrue(currentVcStatuses.get(4).getIsSuccessfulVc());
+        assertEquals("issuer", currentVcStatuses.get(4).getCriIss());
+    }
+
+    @Test
+    void shouldCheckGpg45ProfileWhenNoNewCiAndNoCurrentMitigationInProgress() throws Exception {
+        when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
+        when(configurationService.getSsmParameter(
+                        ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED))
+                .thenReturn("true");
+        ipvSessionItem.setContraIndicatorMitigationDetails(Collections.emptyList());
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), anyString()))
+                .thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.of(Gpg45Profile.M1A));
+
+        var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_END, journeyResponse);
+        verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+        IpvSessionItem updatedSessionItem = ipvSessionItemArgumentCaptor.getValue();
+
+        List<VcStatusDto> currentVcStatuses = updatedSessionItem.getCurrentVcStatuses();
+        assertEquals(5, currentVcStatuses.size());
+
+        assertTrue(currentVcStatuses.get(0).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-p.integration.account.gov.uk",
+                currentVcStatuses.get(0).getCriIss());
+        assertFalse(currentVcStatuses.get(1).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-a.integration.account.gov.uk",
+                currentVcStatuses.get(1).getCriIss());
+        assertTrue(currentVcStatuses.get(2).getIsSuccessfulVc());
+        assertEquals(
+                "https://review-f.integration.account.gov.uk",
+                currentVcStatuses.get(2).getCriIss());
+        assertTrue(currentVcStatuses.get(3).getIsSuccessfulVc());
+        assertEquals("https://example.com/issuer", currentVcStatuses.get(3).getCriIss());
+        assertTrue(currentVcStatuses.get(4).getIsSuccessfulVc());
+        assertEquals("issuer", currentVcStatuses.get(4).getCriIss());
     }
 }

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -152,7 +152,7 @@ class EvaluateGpg45ScoreHandlerTest {
         when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), anyString()))
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
@@ -194,7 +194,7 @@ class EvaluateGpg45ScoreHandlerTest {
     void shouldReturnJourneySessionEndIfScoresSatisfyM1BGpg45Profile() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), anyString()))
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.of(Gpg45Profile.M1B));
@@ -211,7 +211,7 @@ class EvaluateGpg45ScoreHandlerTest {
     void shouldReturnJourneyNextIfScoresDoNotSatisfyM1AGpg45Profile() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), anyString()))
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.empty());
@@ -278,8 +278,7 @@ class EvaluateGpg45ScoreHandlerTest {
     void shouldReturnJourneyErrorJourneyResponseIfCiAreFoundOnVcs() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(
-                        ipvSessionItem.getClientSessionDetails(), TEST_CLIENT_SOURCE_IP))
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.of(new JourneyResponse("/journey/pyi-no-match")));
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
@@ -293,8 +292,7 @@ class EvaluateGpg45ScoreHandlerTest {
     void shouldReturn500IfFailedToRetrieveCisFromStorageSystem() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(
-                        ipvSessionItem.getClientSessionDetails(), TEST_CLIENT_SOURCE_IP))
+        when(ciStorageService.getCIs(anyString(), anyString(), anyString()))
                 .thenThrow(CiRetrievalException.class);
 
         var response = evaluateGpg45ScoresHandler.handleRequest(event, context);
@@ -320,7 +318,7 @@ class EvaluateGpg45ScoreHandlerTest {
         when(configurationService.getCredentialIssuer(any())).thenReturn(addressConfig);
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(parsedM1ACreds);
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), anyString()))
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
@@ -537,7 +535,7 @@ class EvaluateGpg45ScoreHandlerTest {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), anyString()))
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
@@ -584,7 +582,7 @@ class EvaluateGpg45ScoreHandlerTest {
         ipvSessionItem.setContraIndicatorMitigationDetails(Collections.emptyList());
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), anyString()))
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.of(Gpg45Profile.M1A));

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -21,7 +21,8 @@ public enum ConfigurationVariable {
     AUTH_CODE_EXPIRY_SECONDS("/%s/core/self/authCodeExpirySeconds"),
     PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("/%s/core/clients/%s/publicKeyMaterialForCoreToVerify"),
     CI_SCORING_CONFIG("/%s/core/self/ci-scoring-config"),
-    CI_SCORING_THRESHOLD("/%s/core/self/ciScoringThreshold");
+    CI_SCORING_THRESHOLD("/%s/core/self/ciScoringThreshold"),
+    CI_MITIGATION_JOURNEYS_ENABLED("/%s/core/self/journey/ciMitigationsEnabled");
 
     private final String value;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ContraIndicatorMitigationDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/ContraIndicatorMitigationDetailsDto.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.Collections;
+import java.util.List;
+
+@DynamoDbBean
+@ExcludeFromGeneratedCoverageReport
+@Getter
+@Setter
+public class ContraIndicatorMitigationDetailsDto {
+    private String ci;
+    private List<MitigationJourneyDetailsDto> mitigationJourneys;
+    private boolean mitigatable;
+
+    public ContraIndicatorMitigationDetailsDto() {}
+
+    public ContraIndicatorMitigationDetailsDto(
+            String ci, List<MitigationJourneyDetailsDto> mitigationJourneys, boolean mitigatable) {
+        this.ci = ci;
+        this.mitigationJourneys = mitigationJourneys;
+        this.mitigatable = mitigatable;
+    }
+
+    public ContraIndicatorMitigationDetailsDto(String ci) {
+        this.ci = ci;
+        this.mitigationJourneys = Collections.emptyList();
+        this.mitigatable = true;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/MitigationJourneyDetailsDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/MitigationJourneyDetailsDto.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@DynamoDbBean
+@ExcludeFromGeneratedCoverageReport
+@Getter
+@Setter
+public class MitigationJourneyDetailsDto {
+    private String mitigationJourneyId;
+    private boolean complete;
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.dto.ContraIndicatorMitigationDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
@@ -34,6 +35,7 @@ public class IpvSessionItem implements DynamodbItem {
     private String vot;
     private long ttl;
     private IpvJourneyTypes journeyType;
+    private List<ContraIndicatorMitigationDetailsDto> contraIndicatorMitigationDetails;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {
@@ -175,5 +177,14 @@ public class IpvSessionItem implements DynamodbItem {
 
     public void setJourneyType(IpvJourneyTypes journeyType) {
         this.journeyType = journeyType;
+    }
+
+    public List<ContraIndicatorMitigationDetailsDto> getContraIndicatorMitigationDetails() {
+        return contraIndicatorMitigationDetails;
+    }
+
+    public void setContraIndicatorMitigationDetails(
+            List<ContraIndicatorMitigationDetailsDto> contraIndicatorMitigationDetails) {
+        this.contraIndicatorMitigationDetails = contraIndicatorMitigationDetails;
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -13,7 +13,6 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.service.CiStorageService;
 import uk.gov.di.ipv.core.library.service.ConfigurationService;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,17 +70,9 @@ class Gpg45ProfileEvaluatorTest {
 
     @Test
     void getJourneyResponseForStoredCisShouldReturnEmptyOptionalIfNoCis() throws Exception {
-        when(mockClientSessionDetails.getUserId()).thenReturn(TEST_USER_ID);
-        when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn(TEST_JOURNEY_ID);
-        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
-                .thenReturn(List.of());
         when(mockConfigurationService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
 
-        assertTrue(
-                evaluator
-                        .getJourneyResponseForStoredCis(
-                                mockClientSessionDetails, TEST_CLIENT_SOURCE_IP)
-                        .isEmpty());
+        assertTrue(evaluator.getJourneyResponseForStoredCis(List.of()).isEmpty());
     }
 
     @Test
@@ -101,16 +92,9 @@ class Gpg45ProfileEvaluatorTest {
         ciScoresMap.put("Y03", new ContraIndicatorScore("Y03", 2, -2, null));
         when(mockConfigurationService.getContraIndicatorScoresMap()).thenReturn(ciScoresMap);
         when(mockConfigurationService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
-        when(mockClientSessionDetails.getUserId()).thenReturn(TEST_USER_ID);
-        when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn(TEST_JOURNEY_ID);
-        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
-                .thenReturn(List.of(contraIndicatorItem));
 
         assertTrue(
-                evaluator
-                        .getJourneyResponseForStoredCis(
-                                mockClientSessionDetails, TEST_CLIENT_SOURCE_IP)
-                        .isEmpty());
+                evaluator.getJourneyResponseForStoredCis(List.of(contraIndicatorItem)).isEmpty());
     }
 
     @Test
@@ -146,15 +130,10 @@ class Gpg45ProfileEvaluatorTest {
         when(mockConfigurationService.getSsmParameter(KBV_CRI_ID)).thenReturn("kbv");
         when(mockConfigurationService.getCredentialIssuer("kbv")).thenReturn(kbvConfig);
         when(kbvConfig.getAudienceForClients()).thenReturn("kbvIssuer");
-        when(mockClientSessionDetails.getUserId()).thenReturn(TEST_USER_ID);
-        when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn(TEST_JOURNEY_ID);
-        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
-                .thenReturn(new ArrayList<>(List.of(otherCiItem, kbvCiItem)));
 
         assertEquals(
                 Optional.of(JOURNEY_RESPONSE_PYI_KBV_FAIL),
-                evaluator.getJourneyResponseForStoredCis(
-                        mockClientSessionDetails, TEST_CLIENT_SOURCE_IP));
+                evaluator.getJourneyResponseForStoredCis(List.of(otherCiItem, kbvCiItem)));
     }
 
     @Test
@@ -190,15 +169,10 @@ class Gpg45ProfileEvaluatorTest {
         when(mockConfigurationService.getSsmParameter(KBV_CRI_ID)).thenReturn("kbv");
         when(mockConfigurationService.getCredentialIssuer("kbv")).thenReturn(kbvConfig);
         when(kbvConfig.getAudienceForClients()).thenReturn("kbvIssuer");
-        when(mockClientSessionDetails.getUserId()).thenReturn(TEST_USER_ID);
-        when(mockClientSessionDetails.getGovukSigninJourneyId()).thenReturn(TEST_JOURNEY_ID);
-        when(mockCiStorageService.getCIs(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
-                .thenReturn(new ArrayList<>(List.of(otherCiItem, kbvCiItem)));
 
         assertEquals(
                 Optional.of(JOURNEY_RESPONSE_PYI_NO_MATCH),
-                evaluator.getJourneyResponseForStoredCis(
-                        mockClientSessionDetails, TEST_CLIENT_SOURCE_IP));
+                evaluator.getJourneyResponseForStoredCis(List.of(otherCiItem, kbvCiItem)));
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Store in the user session when a CI should be mitigated. This new feature will be hidden behind a SSM param feature flag to ensure this isn't used in any environments before the rest of the required work is complete.

When a CI is returned from the CI storage system it is added to the session to be mitigated. If no new CI's are received but there is still a CI in the session still marked as mitigatable then it skips all the CI scoring and gpg45 profile checking.

If the CI in the session is no longer mitigatable or there aren't any CI's at all then the normal CI scoring and gpg45 profile checking is done.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
This new data in the session will be used by the `select-cri` lambda to decide when to send a user on a mitigation journey. When the user is in a mitigation journey, most of the normal logic of the evaluate gpg45 lambda can be skipped. The select-cri lambda will be responsible for updating this new session field to be not "mitigatable" once all the mitigation journeys have been completed.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2143](https://govukverify.atlassian.net/browse/PYIC-2143)

