### PR TITLE
BAU: Don't log attaching fields to logs

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -3,14 +3,15 @@ package uk.gov.di.ipv.core.library.helpers;
 import com.amazonaws.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.MapMessage;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @ExcludeFromGeneratedCoverageReport
 public class LogHelper {
     private static final Logger LOGGER = LogManager.getLogger();
-    public static final String CORE_COMPONENT_ID = "core";
 
+    public static final String CORE_COMPONENT_ID = "core";
     public static final String GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE = "unknown";
 
     public enum LogField {
@@ -75,24 +76,15 @@ public class LogHelper {
     }
 
     public static void logOauthError(String message, String errorCode, String errorDescription) {
-        LoggingUtils.appendKey(LogField.ERROR_CODE_LOG_FIELD.getFieldName(), errorCode);
-        LoggingUtils.appendKey(
-                LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName(), errorDescription);
-        LOGGER.error(message);
-        LoggingUtils.removeKeys(
-                LogField.ERROR_CODE_LOG_FIELD.getFieldName(),
-                LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName());
-    }
-
-    public static void logInfoMessageWithFieldAndValue(
-            String message, LogField logField, String logFieldValue) {
-        LoggingUtils.appendKey(logField.getFieldName(), logFieldValue);
-        LOGGER.info(message);
-        LoggingUtils.removeKey(logField.getFieldName());
+        var mapMessage =
+                new MapMessage()
+                        .with(LogField.ERROR_CODE_LOG_FIELD.getFieldName(), errorCode)
+                        .with(LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName(), errorDescription)
+                        .with("description", message);
+        LOGGER.error(mapMessage);
     }
 
     private static void attachFieldToLogs(LogField field, String value) {
         LoggingUtils.appendKey(field.getFieldName(), value);
-        LOGGER.info("{} attached to logs", field.getFieldName());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -13,6 +13,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.MapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.DebugCredentialAttributes;
@@ -110,10 +111,13 @@ public class UserIdentityService {
     public void deleteUserIssuedCredentials(String userId) {
         List<UserIssuedCredentialsItem> credentialIssuerItems = dataStore.getItems(userId);
         if (!credentialIssuerItems.isEmpty()) {
-            LogHelper.logInfoMessageWithFieldAndValue(
-                    "Deleting existing issued VCs",
-                    LogHelper.LogField.NUMBER_OF_VCS,
-                    String.valueOf(credentialIssuerItems.size()));
+            var message =
+                    new MapMessage()
+                            .with("description", "Deleting existing issued VCs")
+                            .with(
+                                    LogHelper.LogField.NUMBER_OF_VCS.getFieldName(),
+                                    String.valueOf(credentialIssuerItems.size()));
+            LOGGER.info(message);
         }
         for (UserIssuedCredentialsItem item : credentialIssuerItems) {
             dataStore.delete(item.getUserId(), item.getCredentialIssuer());


### PR DESCRIPTION
## Proposed changes

### What changed

Stop creating log entry when we attach a field to the logs.

### Why did it change

This was put in when we had very little logging and helped make sure that we had at least one log message for a lambda run. We have since made sure there is a proper log message for every lambda run and this is now just causing clutter.

