### PR TITLE
PYIC-2202: Update userIdentityService to handle new passport version of DCMAW credential

### DIFF
--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -484,7 +484,7 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenMissingPassportProperty() {
+    void shouldReturnEmptyWhenMissingPassportProperty() throws HttpResponseExceptionWithErrorBody {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
@@ -517,20 +517,11 @@ class UserIdentityServiceTest {
                                 "test-issuer",
                                 URI.create("https://example.com/callback")));
 
-        HttpResponseExceptionWithErrorBody thrownError =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () ->
-                                userIdentityService.generateUserIdentity(
-                                        "user-id-1", "test-sub", "P2", currentVcStatuses));
+        UserIdentity credentials =
+                userIdentityService.generateUserIdentity(
+                        "user-id-1", "test-sub", "P2", currentVcStatuses);
 
-        assertEquals(500, thrownError.getResponseCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_GENERATE_PASSPORT_CLAIM.getCode(),
-                thrownError.getErrorBody().get("error"));
-        assertEquals(
-                ErrorResponse.FAILED_TO_GENERATE_PASSPORT_CLAIM.getMessage(),
-                thrownError.getErrorBody().get("error_description"));
+        assertNull(credentials.getPassportClaim());
     }
 
     @Test
@@ -1040,7 +1031,8 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenMissingDrivingPermitProperty() {
+    void shouldReturnEmptyWhenMissingDrivingPermitProperty()
+            throws HttpResponseExceptionWithErrorBody {
         List<UserIssuedCredentialsItem> userIssuedCredentialsItemList =
                 List.of(
                         createUserIssuedCredentialsItem(
@@ -1066,20 +1058,11 @@ class UserIdentityServiceTest {
                                 "dcmaw-issuer",
                                 URI.create("https://example.com/callback")));
 
-        HttpResponseExceptionWithErrorBody thrownError =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () ->
-                                userIdentityService.generateUserIdentity(
-                                        "user-id-1", "test-sub", "P2", currentVcStatuses));
+        UserIdentity credentials =
+                userIdentityService.generateUserIdentity(
+                        "user-id-1", "test-sub", "P2", currentVcStatuses);
 
-        assertEquals(500, thrownError.getResponseCode());
-        assertEquals(
-                ErrorResponse.FAILED_TO_GENERATE_DRIVING_PERMIT_CLAIM.getCode(),
-                thrownError.getErrorBody().get("error"));
-        assertEquals(
-                ErrorResponse.FAILED_TO_GENERATE_DRIVING_PERMIT_CLAIM.getMessage(),
-                thrownError.getErrorBody().get("error_description"));
+        assertNull(credentials.getDrivingPermitClaim());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Start looking at the DCMAW VC when trying to generate the passport claim.

Check that the VC is successful before using it to generate the passport claim.

Stop throwing exceptions if the passport or drivingPermit property cannot be found when generating passport/drivingPermit claim. Instead just logs a warning and returns an empty optional.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
DCMAW will soon release a new passport journey meaning that we could receive slightly different VC's. These changes ensure that the various user identity claims are still generated when we encounter the different possible DCMAW VC's.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2202](https://govukverify.atlassian.net/browse/PYIC-2202)

