### PR TITLE
BAU: User StringMapMessage

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -12,7 +12,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.buildclientoauthresponse.domain.ClientDetails;
@@ -134,7 +134,7 @@ public class BuildClientOauthResponseHandler
                     new AuditEvent(AuditEventTypes.IPV_JOURNEY_END, componentId, auditEventUser));
 
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with(
                                     "lambdaResult",
                                     "Successfully generated ipv client oauth response.")

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -17,7 +17,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.buildcrioauthrequest.domain.CriDetails;
@@ -161,7 +161,7 @@ public class BuildCriOauthRequestHandler
                             AuditEventTypes.IPV_REDIRECT_TO_CRI, componentId, auditEventUser));
 
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with("lambdaResult", "Successfully generated ipv cri oauth request.")
                             .with("redirectUri", criResponse.getCri().getRedirectUrl());
             LOGGER.info(message);

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -12,7 +12,7 @@ import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -142,7 +142,7 @@ public class BuildUserIdentityHandler
             ipvSessionService.revokeAccessToken(ipvSessionItem);
 
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with("lambdaResult", "Successfully generated user identity response.")
                             .with("vot", ipvSessionItem.getVot());
             LOGGER.info(message);

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -14,7 +14,7 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -149,7 +149,7 @@ public class InitialiseIpvSessionHandler
                     Map.of(IPV_SESSION_ID_KEY, ipvSessionItem.getIpvSessionId());
 
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with("lambdaResult", "Successfully generated a new IPV Core session")
                             .with(IPV_SESSION_ID_KEY, ipvSessionItem.getIpvSessionId());
             LOGGER.info(message);

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -16,7 +16,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -157,7 +157,7 @@ public class IssueClientAccessTokenHandler
                 BearerAccessToken bearerAccessToken =
                         accessTokenResponse.getTokens().getBearerAccessToken();
                 var message =
-                        new MapMessage()
+                        new StringMapMessage()
                                 .with("accessToken", bearerAccessToken.getValue())
                                 .with(
                                         "sha256AccessToken",
@@ -169,7 +169,7 @@ public class IssueClientAccessTokenHandler
                     ipvSessionItem, accessTokenResponse.getTokens().getBearerAccessToken());
 
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with(
                                     "lambdaResult",
                                     "Successfully generated IPV client access token.");

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -6,7 +6,7 @@ import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -142,7 +142,7 @@ public class ProcessJourneyStepHandler
         ipvSessionItem.setUserState(updatedStateValue);
         ipvSessionService.updateIpvSession(ipvSessionItem);
         var message =
-                new MapMessage()
+                new StringMapMessage()
                         .with("journeyEngine", "State transition")
                         .with("event", journeyStep)
                         .with("from", oldState)
@@ -157,7 +157,7 @@ public class ProcessJourneyStepHandler
         ipvSessionItem.setUserState(CORE_SESSION_TIMEOUT_STATE);
         ipvSessionService.updateIpvSession(ipvSessionItem);
         var message =
-                new MapMessage()
+                new StringMapMessage()
                         .with("journeyEngine", "State transition")
                         .with("event", "timeout")
                         .with("from", oldState)

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -10,7 +10,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -166,7 +166,7 @@ public class RetrieveCriCredentialHandler
             updateVisitedCredentials(ipvSessionItem, credentialIssuerId, true, null);
 
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with("lambdaResult", "Successfully retrieved CRI credential.")
                             .with("criId", credentialIssuerId);
             LOGGER.info(message);

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -7,7 +7,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -125,7 +125,7 @@ public class RetrieveCriOauthAccessTokenHandler
             ipvSessionService.updateIpvSession(ipvSessionItem);
 
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with("lambdaResult", "Successfully retrieved cri access token.")
                             .with("criId", credentialIssuerId);
             LOGGER.info(message);

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -7,7 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -108,7 +108,7 @@ public class SelectCriHandler
             }
 
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with("lambdaResult", "Successfully found next step for user")
                             .with("journeyResponse", response.getJourney());
             LOGGER.info(message);
@@ -260,7 +260,7 @@ public class SelectCriHandler
                 return Optional.of(getJourneyResponse(journeyId));
             }
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with(
                                     "message",
                                     "User has a previous failed visit to a cri due to an oauth error")
@@ -276,7 +276,7 @@ public class SelectCriHandler
             return Optional.of(getJourneyPyiNoMatchResponse());
         } else if (Boolean.FALSE.equals(vc.get().getIsSuccessfulVc())) {
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with(
                                     "message",
                                     "User has a previous failed visit to a cri due to a failed identity check")

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponse.java
@@ -3,7 +3,7 @@ package uk.gov.di.ipv.core.library.domain;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -48,7 +48,7 @@ public class SharedClaimsResponse {
                 });
 
         var message =
-                new MapMessage()
+                new StringMapMessage()
                         .with("sharedClaims", "built")
                         .with("names", nameSet.size())
                         .with("birthDates", birthDateSet.size())

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -7,7 +7,7 @@ import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
@@ -51,7 +51,7 @@ public class Gpg45ProfileEvaluator {
             List<ContraIndicatorItem> ciItems) {
         List<ContraIndicatorItem> contraIndicatorItems = new ArrayList<>(ciItems);
         LOGGER.info(
-                new MapMessage()
+                new StringMapMessage()
                         .with(LOG_DESCRIPTION_FIELD, "Retrieved user's CI items")
                         .with("numberOfItems", ciItems.size()));
 
@@ -69,7 +69,7 @@ public class Gpg45ProfileEvaluator {
             ciScore += scoresConfig.getDetectedScore();
         }
         LOGGER.info(
-                new MapMessage()
+                new StringMapMessage()
                         .with(LOG_DESCRIPTION_FIELD, "Calculated user's CI score")
                         .with("score", ciScore));
 
@@ -101,7 +101,7 @@ public class Gpg45ProfileEvaluator {
                             boolean profileMet = profile.isSatisfiedBy(gpg45Scores);
                             if (profileMet) {
                                 var message =
-                                        new MapMessage()
+                                        new StringMapMessage()
                                                 .with(
                                                         LOG_DESCRIPTION_FIELD,
                                                         "GPG45 profile has been met")

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -3,7 +3,7 @@ package uk.gov.di.ipv.core.library.helpers;
 import com.amazonaws.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
@@ -77,7 +77,7 @@ public class LogHelper {
 
     public static void logOauthError(String message, String errorCode, String errorDescription) {
         var mapMessage =
-                new MapMessage()
+                new StringMapMessage()
                         .with(LogField.ERROR_CODE_LOG_FIELD.getFieldName(), errorCode)
                         .with(LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName(), errorDescription)
                         .with("description", message);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -2,7 +2,7 @@ package uk.gov.di.ipv.core.library.persistence;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -158,7 +158,7 @@ public class DataStore<T extends DynamodbItem> {
         T result = table.getItem(key);
         if (warnOnNull && result == null) {
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with("datastore", "Null result retrieved from DynamoDB")
                             .with("table", table.describeTable().table().tableName())
                             .with("field", key.partitionKeyValue().toString());

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -13,7 +13,6 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.MapMessage;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.BirthDate;
@@ -114,7 +113,7 @@ public class UserIdentityService {
         List<UserIssuedCredentialsItem> credentialIssuerItems = dataStore.getItems(userId);
         if (!credentialIssuerItems.isEmpty()) {
             var message =
-                    new MapMessage()
+                    new StringMapMessage()
                             .with("description", "Deleting existing issued VCs")
                             .with(
                                     LogHelper.LogField.NUMBER_OF_VCS.getFieldName(),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use StringMapMessage in place of MapMessage.

### Why did it change

When creating structured logs we were using a raw MapMessage. Since we always use strings for key and values, we can use StringMapMessage and avoid using a raw generic type or dealing with the complex generic type of MapMessage.
