### PR TITLE
PYIC-2221 Implement check-existing-identity lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2022,6 +2022,17 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub check-existing-identity-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
+          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
+          CI_STORAGE_GET_LAMBDA_ARN: !Sub
+            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
+            - contra_indicator_storage_account_id: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - ciStorageAccountId
+              env: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - environment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2053,8 +2064,30 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
-        - DynamoDBReadPolicy:
+        - DynamoDBCrudPolicy:
             TableName: !Ref UserIssuedCredentialsV2Table
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/*
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
+        - Statement:
+            - Sid: invokeGetCiFunction
+              Effect: Allow
+              Action:
+                - 'lambda:InvokeFunction'
+              Resource:
+                - !Sub
+                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
+                  - contra_indicator_storage_account_id: !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - ciStorageAccountId
+                    env: !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - environment
       Events:
         IPVCorePrivateAPI:
           Type: Api

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -13,18 +13,30 @@ dependencies {
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			project(":lib")
 
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
 			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+	testImplementation "com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"org.junit.jupiter:junit-jupiter:5.8.2",
+			"org.mockito:mockito-junit-jupiter:4.2.0",
+			project(":lib").sourceSets.test.output
 }
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_11
 	targetCompatibility = JavaVersion.VERSION_11
+}
+
+task buildZip(type: Zip) {
+	from compileJava
+	from processResources
+	destinationDirectory = file("$rootDir/dist")
+	into("lib") {
+		from configurations.runtimeClasspath
+	}
 }
 
 test {

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -4,19 +4,146 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
+import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.service.CiStorageService;
+import uk.gov.di.ipv.core.library.service.ConfigurationService;
+import uk.gov.di.ipv.core.library.service.IpvSessionService;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.Optional;
 
 public class CheckExistingIdentityHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    public static final List<Gpg45Profile> ACCEPTED_PROFILES =
+            List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
+    public static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
+    public static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final ConfigurationService configurationService;
+    private final UserIdentityService userIdentityService;
+    private final IpvSessionService ipvSessionService;
+    private final Gpg45ProfileEvaluator gpg45ProfileEvaluator;
+    private final CiStorageService ciStorageService;
+
+    public CheckExistingIdentityHandler(
+            ConfigurationService configurationService,
+            UserIdentityService userIdentityService,
+            IpvSessionService ipvSessionService,
+            Gpg45ProfileEvaluator gpg45ProfileEvaluator,
+            CiStorageService ciStorageService) {
+        this.configurationService = configurationService;
+        this.userIdentityService = userIdentityService;
+        this.ipvSessionService = ipvSessionService;
+        this.gpg45ProfileEvaluator = gpg45ProfileEvaluator;
+        this.ciStorageService = ciStorageService;
+    }
 
     @ExcludeFromGeneratedCoverageReport
-    public CheckExistingIdentityHandler() {}
+    public CheckExistingIdentityHandler() {
+        this.configurationService = new ConfigurationService();
+        this.userIdentityService = new UserIdentityService(configurationService);
+        this.ipvSessionService = new IpvSessionService(configurationService);
+        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configurationService);
+        this.ciStorageService = new CiStorageService(configurationService);
+    }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, "Hello world");
+            APIGatewayProxyRequestEvent event, Context context) {
+        LogHelper.attachComponentIdToLogs();
+
+        try {
+            String ipvSessionId = RequestHelper.getIpvSessionId(event);
+            String ipAddress = RequestHelper.getIpAddress(event);
+            IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
+            ClientSessionDetailsDto clientSessionDetailsDto =
+                    ipvSessionItem.getClientSessionDetails();
+            String userId = clientSessionDetailsDto.getUserId();
+
+            String govukSigninJourneyId = clientSessionDetailsDto.getGovukSigninJourneyId();
+            LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
+
+            userIdentityService.deleteUserIssuedCredentialsIfAnyExpired(userId);
+
+            List<SignedJWT> credentials =
+                    gpg45ProfileEvaluator.parseCredentials(
+                            userIdentityService.getUserIssuedCredentials(userId));
+
+            List<ContraIndicatorItem> ciItems;
+            ciItems =
+                    ciStorageService.getCIs(
+                            clientSessionDetailsDto.getUserId(),
+                            clientSessionDetailsDto.getGovukSigninJourneyId(),
+                            ipAddress);
+
+            Optional<JourneyResponse> contraIndicatorErrorJourneyResponse =
+                    gpg45ProfileEvaluator.getJourneyResponseForStoredCis(ciItems);
+            if (contraIndicatorErrorJourneyResponse.isEmpty()) {
+                Gpg45Scores gpg45Scores = gpg45ProfileEvaluator.buildScore(credentials);
+                Optional<Gpg45Profile> matchedProfile =
+                        gpg45ProfileEvaluator.getFirstMatchingProfile(
+                                gpg45Scores, ACCEPTED_PROFILES);
+                if (matchedProfile.isPresent()) {
+                    var message =
+                            new StringMapMessage()
+                                    .with(
+                                            "message",
+                                            "Matched profile and within CI threshold so returning reuse journey")
+                                    .with("profile", matchedProfile.get().getLabel());
+                    LOGGER.info(message);
+                    return ApiGatewayResponseGenerator.proxyJsonResponse(
+                            HttpStatus.SC_OK, JOURNEY_REUSE);
+                }
+            }
+
+            var message =
+                    new StringMapMessage()
+                            .with(
+                                    "message",
+                                    "Failed to match profile so clearing VCs and returning next");
+            LOGGER.info(message);
+
+            userIdentityService.deleteUserIssuedCredentials(userId);
+
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, JOURNEY_NEXT);
+        } catch (HttpResponseExceptionWithErrorBody e) {
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    e.getResponseCode(), e.getErrorBody());
+        } catch (ParseException e) {
+            LOGGER.error("Unable to parse existing credentials", e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
+        } catch (CiRetrievalException e) {
+            LOGGER.error("Error when fetching CIs from storage system", e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_GET_STORED_CIS);
+        } catch (UnknownEvidenceTypeException e) {
+            LOGGER.error("Unable to determine type of credential", e);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE);
+        }
     }
 }

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1,0 +1,265 @@
+package uk.gov.di.ipv.core.checkexistingidentity;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
+import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
+import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
+import uk.gov.di.ipv.core.library.dto.ContraIndicatorMitigationDetailsDto;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.service.CiStorageService;
+import uk.gov.di.ipv.core.library.service.IpvSessionService;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler.ACCEPTED_PROFILES;
+import static uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler.JOURNEY_NEXT;
+import static uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler.JOURNEY_REUSE;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_ADDRESS_VC;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_VC;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1B_DCMAW_VC;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
+
+@ExtendWith(MockitoExtension.class)
+class CheckExistingIdentityHandlerTest {
+    private static final String TEST_SESSION_ID = "test-session-id";
+    private static final String TEST_USER_ID = "test-user-id";
+    private static final String TEST_JOURNEY_ID = "test-journey-id";
+    private static final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+    public static final List<String> CREDENTIALS =
+            List.of(
+                    M1A_PASSPORT_VC,
+                    M1A_ADDRESS_VC,
+                    M1A_FRAUD_VC,
+                    M1A_VERIFICATION_VC,
+                    M1B_DCMAW_VC);
+    public static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
+    public static CredentialIssuerConfig addressConfig = null;
+    private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
+
+    static {
+        try {
+            addressConfig =
+                    new CredentialIssuerConfig(
+                            "address",
+                            "address",
+                            new URI("http://example.com/token"),
+                            new URI("http://example.com/credential"),
+                            new URI("http://example.com/authorize"),
+                            "ipv-core",
+                            "test-jwk",
+                            "test-encryption-jwk",
+                            "test-audience",
+                            new URI("http://example.com/redirect"));
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock private Context context;
+    @Mock private UserIdentityService userIdentityService;
+    @Mock private IpvSessionService ipvSessionService;
+    @Mock private Gpg45ProfileEvaluator gpg45ProfileEvaluator;
+    @Mock private CiStorageService ciStorageService;
+    @InjectMocks private CheckExistingIdentityHandler checkExistingIdentityHandler;
+
+    private final Gson gson = new Gson();
+
+    private IpvSessionItem ipvSessionItem;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        event.setHeaders(
+                Map.of(
+                        IPV_SESSION_ID_HEADER,
+                        TEST_SESSION_ID,
+                        IP_ADDRESS_HEADER,
+                        TEST_CLIENT_SOURCE_IP));
+        for (String cred : CREDENTIALS) {
+            PARSED_CREDENTIALS.add(SignedJWT.parse(cred));
+        }
+    }
+
+    @BeforeEach
+    void setUpEach() {
+        ipvSessionItem = new IpvSessionItem();
+        ClientSessionDetailsDto clientSessionDetailsDto = new ClientSessionDetailsDto();
+        clientSessionDetailsDto.setUserId(TEST_USER_ID);
+        clientSessionDetailsDto.setGovukSigninJourneyId(TEST_JOURNEY_ID);
+        ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
+        ipvSessionItem.setIpvSessionId(TEST_SESSION_ID);
+        ipvSessionItem.setContraIndicatorMitigationDetails(
+                List.of(new ContraIndicatorMitigationDetailsDto("A01")));
+    }
+
+    @Test
+    void shouldReturnJourneyReuseResponseIfScoresSatisfyM1AGpg45Profile() throws Exception {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
+                .thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.of(Gpg45Profile.M1A));
+
+        var response = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_REUSE, journeyResponse);
+        verify(userIdentityService, never()).deleteUserIssuedCredentials(TEST_USER_ID);
+    }
+
+    @Test
+    void shouldReturnJourneyReuseResponseIfScoresSatisfyM1BGpg45Profile() {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
+                .thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.of(Gpg45Profile.M1B));
+
+        var response = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_REUSE, journeyResponse);
+        verify(userIdentityService, never()).deleteUserIssuedCredentials(TEST_USER_ID);
+    }
+
+    @Test
+    void shouldReturnJourneyNextResponseIfScoresDoNotSatisfyM1AGpg45Profile() {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
+                .thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.empty());
+
+        var response = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(JOURNEY_NEXT, journeyResponse);
+        verify(userIdentityService).deleteUserIssuedCredentials(TEST_USER_ID);
+    }
+
+    @Test
+    void shouldReturnJourneyNextResponseIfVcsFailCiScoreCheck() {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
+                .thenReturn(Optional.of(new JourneyResponse("/journey/pyi-no-match")));
+
+        var response = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals("/journey/next", journeyResponse.getJourney());
+        verify(userIdentityService).deleteUserIssuedCredentials(TEST_USER_ID);
+    }
+
+    @Test
+    void shouldReturn400IfSessionIdNotInHeader() {
+        APIGatewayProxyRequestEvent eventWithoutHeaders = new APIGatewayProxyRequestEvent();
+
+        var response = checkExistingIdentityHandler.handleRequest(eventWithoutHeaders, context);
+        var error = gson.fromJson(response.getBody(), Map.class);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), error.get("error_description"));
+    }
+
+    @Test
+    void shouldReturn500IfFailedToParseCredentials() throws Exception {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(gpg45ProfileEvaluator.buildScore(any())).thenThrow(new ParseException("Whoops", 0));
+
+        var response = checkExistingIdentityHandler.handleRequest(event, context);
+        Map<String, Object> responseMap =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getCode(),
+                responseMap.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(),
+                responseMap.get("message"));
+        verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
+    }
+
+    @Test
+    void shouldReturn500IfCredentialOfUnknownType() throws Exception {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(gpg45ProfileEvaluator.buildScore(any())).thenThrow(new UnknownEvidenceTypeException());
+
+        var response = checkExistingIdentityHandler.handleRequest(event, context);
+        Map<String, Object> responseMap =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getCode(),
+                responseMap.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getMessage(),
+                responseMap.get("message"));
+        verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
+    }
+
+    @Test
+    void shouldReturn500IfFailedToRetrieveCisFromStorageSystem() throws Exception {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(ciStorageService.getCIs(anyString(), anyString(), anyString()))
+                .thenThrow(CiRetrievalException.class);
+
+        var response = checkExistingIdentityHandler.handleRequest(event, context);
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        Map<String, Object> responseMap =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_TO_GET_STORED_CIS.getCode(), responseMap.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_GET_STORED_CIS.getMessage(), responseMap.get("message"));
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed

Implement lambda to check a user's existing identity. If they have VCs that match a profile within the CI score threshold, return the journey 'reuse' response. Otherwise clear all of the user's VCs and return journey next to continue the journey

### Why did it change

We want to redirect users to a new 'reuse' journey if they've already proven their identity, so we'll route them via this new lambda on session initialisation

### Issue tracking
- [PYIC-2221](https://govukverify.atlassian.net/browse/PYIC-2221)

