### PR TITLE
BAU: Set vot value to P2 on a successful reuse journey

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2067,7 +2067,7 @@ Resources:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBReadPolicy:
+        - DynamoDBCrudPolicy:
             TableName: !Ref SessionsTable
         - DynamoDBCrudPolicy:
             TableName: !Ref UserIssuedCredentialsV2Table

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -39,6 +39,7 @@ public class CheckExistingIdentityHandler
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
     public static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
     public static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
+    private static final String VOT_P2 = "P2";
     private static final Logger LOGGER = LogManager.getLogger();
     private final ConfigurationService configurationService;
     private final UserIdentityService userIdentityService;
@@ -112,6 +113,10 @@ public class CheckExistingIdentityHandler
                                             "Matched profile and within CI threshold so returning reuse journey")
                                     .with("profile", matchedProfile.get().getLabel());
                     LOGGER.info(message);
+
+                    ipvSessionItem.setVot(VOT_P2);
+                    ipvSessionService.updateIpvSession(ipvSessionItem);
+
                     return ApiGatewayResponseGenerator.proxyJsonResponse(
                             HttpStatus.SC_OK, JOURNEY_REUSE);
                 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Set the vot value in the users session to be P2 if the check-existing-identity lambda matches with a gpg45 profile.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This value will be loaded from the users session when we build the final identity and will be returned to orchestration.
<!-- Describe the reason these changes were made - the "why" -->

