### PR TITLE
Remove check for activityHistory for dcmaw evidence types:

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
@@ -130,7 +130,6 @@ public class CredentialEvidenceItem {
     private boolean isDcmaw() {
         return strengthScore != null
                 && validityScore != null
-                && activityHistoryScore != null
                 && identityFraudScore == null
                 && verificationScore == null
                 && (checkDetails != null || failedCheckDetails != null);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Remove check for the activityHistory score value when determining if an evidence type is of DCMAW or not.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
DCMAW VC can now have this value missing for a passport VC, so the check is no longer valid.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2226](https://govukverify.atlassian.net/browse/PYIC-2226)

