### PR TITLE
Remove checkDetails from verification and fraud evidence type checks

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
@@ -92,9 +92,7 @@ public class CredentialEvidenceItem {
                 && identityFraudScore == null
                 && strengthScore == null
                 && validityScore == null
-                && verificationScore == null
-                && checkDetails == null
-                && failedCheckDetails == null;
+                && verificationScore == null;
     }
 
     private boolean isIdentityFraud() {
@@ -102,9 +100,7 @@ public class CredentialEvidenceItem {
                 && activityHistoryScore == null
                 && strengthScore == null
                 && validityScore == null
-                && verificationScore == null
-                && checkDetails == null
-                && failedCheckDetails == null;
+                && verificationScore == null;
     }
 
     private boolean isEvidence() {
@@ -122,9 +118,7 @@ public class CredentialEvidenceItem {
                 && activityHistoryScore == null
                 && identityFraudScore == null
                 && strengthScore == null
-                && validityScore == null
-                && checkDetails == null
-                && failedCheckDetails == null;
+                && validityScore == null;
     }
 
     private boolean isDcmaw() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Removed the checkDetails check for fraud & verification evidence types
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The KBV Cri now returns checkDetails on the VC evidence block. Fraud CRI are also planning to add this.
<!-- Describe the reason these changes were made - the "why" -->

