### PR TITLE
BAU: Fix null pointer exception

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -233,11 +233,13 @@ public class Gpg45ProfileEvaluator {
                         dcmawEvidenceItem.getValidityScore(),
                         dcmawEvidenceItem.getCi()));
 
-        gpg45CredentialItems.add(
-                new CredentialEvidenceItem(
-                        CredentialEvidenceItem.EvidenceType.ACTIVITY,
-                        dcmawEvidenceItem.getActivityHistoryScore(),
-                        Collections.emptyList()));
+        if (dcmawEvidenceItem.getActivityHistoryScore() != null) {
+            gpg45CredentialItems.add(
+                    new CredentialEvidenceItem(
+                            CredentialEvidenceItem.EvidenceType.ACTIVITY,
+                            dcmawEvidenceItem.getActivityHistoryScore(),
+                            Collections.emptyList()));
+        }
 
         int dcmawVerificationScore;
         List<DcmawCheckMethod> checkDetails = dcmawEvidenceItem.getCheckDetails();


### PR DESCRIPTION

## Proposed changes

### What changed

 Add a null pointer check when converting dcmaw evidence into GPG45 evidence types when there is no activity history.


<!-- Describe the changes in detail - the "what"-->

### Why did it change

We were failing with a null pointer exception when processing DCMAW VCs with no activity history.
