### PR TITLE
PYIC-2248 Tidy up - remove old addressDetails field

### DIFF
--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -104,7 +104,6 @@ public class BuildProvenUserIdentityDetailsHandler
             provenUserIdentityDetailsBuilder.setDateOfBirth(nameAndDateOfBirth.getDateOfBirth());
 
             List<Address> addresses = getProvenIdentityAddresses(credentials, currentVcStatuses);
-            provenUserIdentityDetailsBuilder.setAddressDetails(addresses.get(0));
             provenUserIdentityDetailsBuilder.setAddresses(addresses);
 
             LOGGER.info("Successfully retrieved proven identity response");

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/ProvenUserIdentityDetails.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/ProvenUserIdentityDetails.java
@@ -9,16 +9,13 @@ import java.util.List;
 public class ProvenUserIdentityDetails {
     private String name;
     private String dateOfBirth;
-    private Address addressDetails;
     private List<Address> addresses;
 
     public ProvenUserIdentityDetails() {}
 
-    public ProvenUserIdentityDetails(
-            String name, String dateOfBirth, Address addressDetails, List<Address> addresses) {
+    public ProvenUserIdentityDetails(String name, String dateOfBirth, List<Address> addresses) {
         this.name = name;
         this.dateOfBirth = dateOfBirth;
-        this.addressDetails = addressDetails;
         this.addresses = addresses;
     }
 
@@ -30,10 +27,6 @@ public class ProvenUserIdentityDetails {
         return dateOfBirth;
     }
 
-    public Address getAddressDetails() {
-        return addressDetails;
-    }
-
     public List<Address> getAddresses() {
         return addresses;
     }
@@ -41,16 +34,10 @@ public class ProvenUserIdentityDetails {
     public static class Builder {
         private String name;
         private String dateOfBirth;
-        private Address addressDetails;
         private List<Address> addresses;
 
         public Builder setDateOfBirth(String dateOfBirth) {
             this.dateOfBirth = dateOfBirth;
-            return this;
-        }
-
-        public Builder setAddressDetails(Address addressDetails) {
-            this.addressDetails = addressDetails;
             return this;
         }
 
@@ -65,7 +52,7 @@ public class ProvenUserIdentityDetails {
         }
 
         public ProvenUserIdentityDetails build() {
-            return new ProvenUserIdentityDetails(name, dateOfBirth, addressDetails, addresses);
+            return new ProvenUserIdentityDetails(name, dateOfBirth, addresses);
         }
     }
 }

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -124,7 +124,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         assertEquals(200, response.getStatusCode());
         assertEquals("KENNETH DECERQUEIRA", provenUserIdentityDetails.getName());
         assertEquals("1959-08-23", provenUserIdentityDetails.getDateOfBirth());
-        assertEquals("BA2 5AA", provenUserIdentityDetails.getAddressDetails().getPostalCode());
         assertEquals("BA2 5AA", provenUserIdentityDetails.getAddresses().get(0).getPostalCode());
     }
 
@@ -192,7 +191,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         assertEquals(200, response.getStatusCode());
         assertEquals("KENNETH DECERQUEIRA", provenUserIdentityDetails.getName());
         assertEquals("1959-08-23", provenUserIdentityDetails.getDateOfBirth());
-        assertEquals("CA14 5PH", provenUserIdentityDetails.getAddressDetails().getPostalCode());
         assertEquals(3, addresses.size());
         assertEquals("CA14 5PH", addresses.get(0).getPostalCode());
         assertEquals("TE5 7ER", addresses.get(1).getPostalCode());
@@ -263,7 +261,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         assertEquals(200, response.getStatusCode());
         assertEquals("KENNETH DECERQUEIRA", provenUserIdentityDetails.getName());
         assertEquals("1959-08-23", provenUserIdentityDetails.getDateOfBirth());
-        assertEquals("BA2 5AA", provenUserIdentityDetails.getAddressDetails().getPostalCode());
         assertEquals("BA2 5AA", provenUserIdentityDetails.getAddresses().get(0).getPostalCode());
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Remove unused `addressDetails` field

### Why did it change

`addressDetails` was kept so we could merge the backend changes adding the new `addresses` field without breaking the frontend - once the frontend changes are merged we can remove this

### Issue tracking
- [PYIC-2248](https://govukverify.atlassian.net/browse/PYIC-2248)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed
