### PR TITLE
BAU Improve mitigation journey logging

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -152,6 +152,8 @@ public class EvaluateGpg45ScoresHandler
 
             if (mitigationJourneyResponse.isPresent()) {
                 journeyResponse = mitigationJourneyResponse.get();
+                message.with("message", "Returning mitigation journey response")
+                        .with("mitigationJourneyResponse", journeyResponse.toString());
             } else {
                 Optional<JourneyResponse> contraIndicatorErrorJourneyResponse =
                         gpg45ProfileEvaluator.getJourneyResponseForStoredCis(ciItems);
@@ -160,6 +162,11 @@ public class EvaluateGpg45ScoresHandler
                             checkForMatchingGpg45Profile(
                                     message, ipvSessionItem, credentials, ipAddress);
                 } else {
+                    message.with("message", "Returning CI error response")
+                            .with(
+                                    "errorJourneyResponse",
+                                    contraIndicatorErrorJourneyResponse.get().toString());
+                    LOGGER.info(message);
                     return ApiGatewayResponseGenerator.proxyJsonResponse(
                             HttpStatus.SC_OK, contraIndicatorErrorJourneyResponse.get());
                 }


### PR DESCRIPTION
## Proposed changes

### What changed

With mitigation journeys enabled we've been getting a stray empty log from the EvaluateGpg45ScoresHandler due to the mapMessage not being set. This sets the message for the mitigation journey scenario and adds a log for the CI error response scenario which was also missing.

### Why did it change

Noticed this stray empty log which I thought was the result of something else breaking - tracked it down to this.
