### PR TITLE
PYIC-2246 Use Powertools SecretsProvider

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
@@ -116,7 +116,6 @@ public class CiStorageService {
 
         String jsonResponse = new String(result.getPayload().array(), StandardCharsets.UTF_8);
         GetCiResponse response = gson.fromJson(jsonResponse, GetCiResponse.class);
-
         return response.getContraIndicators();
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Switch to use the SecretsProvider from powertools-parameters rather than using SecretsManager directly

### Why did it change

SecretsProvider is a wrapper around SecretsManager and enables built in caching

### Issue tracking
- [PYIC-2246](https://govukverify.atlassian.net/browse/PYIC-2246)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

