### PR TITLE
PYIC-2298 Clear oauth session on process journey step

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -12,6 +12,7 @@ import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
@@ -121,6 +122,10 @@ public class ProcessJourneyStepHandler
                     journeyStep,
                     ipvSessionItem);
 
+            clearOauthSessionIfExists(ipvSessionItem);
+
+            ipvSessionService.updateIpvSession(ipvSessionItem);
+
             return stateMachineResult.getJourneyStepResponse().value(configurationService);
         } catch (UnknownStateException e) {
             LOGGER.warn("Unknown journey state: {}", ipvSessionItem.getUserState());
@@ -140,7 +145,6 @@ public class ProcessJourneyStepHandler
             String journeyStep,
             IpvSessionItem ipvSessionItem) {
         ipvSessionItem.setUserState(updatedStateValue);
-        ipvSessionService.updateIpvSession(ipvSessionItem);
         var message =
                 new StringMapMessage()
                         .with("journeyEngine", "State transition")
@@ -148,6 +152,15 @@ public class ProcessJourneyStepHandler
                         .with("from", oldState)
                         .with("to", updatedStateValue);
         LOGGER.info(message);
+    }
+
+    @Tracing
+    private void clearOauthSessionIfExists(IpvSessionItem ipvSessionItem) {
+        CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails =
+                ipvSessionItem.getCredentialIssuerSessionDetails();
+        if (credentialIssuerSessionDetails != null) {
+            ipvSessionItem.setCredentialIssuerSessionDetails(null);
+        }
     }
 
     @Tracing

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -193,7 +193,7 @@ public class ValidateOAuthCallbackHandler
         }
 
         String persistedOauthState = getPersistedOauthState(request);
-        if (!request.getState().equals(persistedOauthState)) {
+        if (persistedOauthState == null || !request.getState().equals(persistedOauthState)) {
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_OAUTH_STATE);
         }
@@ -215,10 +215,14 @@ public class ValidateOAuthCallbackHandler
 
     @Tracing
     private String getPersistedOauthState(CredentialIssuerRequestDto request) {
-        return ipvSessionService
-                .getIpvSession(request.getIpvSessionId())
-                .getCredentialIssuerSessionDetails()
-                .getState();
+        CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails =
+                ipvSessionService
+                        .getIpvSession(request.getIpvSessionId())
+                        .getCredentialIssuerSessionDetails();
+        if (credentialIssuerSessionDetails != null) {
+            return credentialIssuerSessionDetails.getState();
+        }
+        return null;
     }
 
     @Tracing

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -8,6 +8,7 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -111,6 +112,12 @@ public class ValidateOAuthCallbackHandler
                     ipvSessionItem, new AuthorizationCode(request.getAuthorizationCode()));
 
             ipvSessionService.updateIpvSession(ipvSessionItem);
+
+            var mapMessage =
+                    new StringMapMessage()
+                            .with("message", "Successfully validated oauth callback")
+                            .with("criId", request.getCredentialIssuerId());
+            LOGGER.info(mapMessage);
 
             return JOURNEY_ACCESS_TOKEN;
         } catch (HttpResponseExceptionWithErrorBody e) {

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -183,7 +183,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     }
 
     @Test
-    void shouldReceive400ResponseCodeIfOAuthStateNotPresent() {
+    void shouldReceive400ResponseCodeIfOAuthStateNotPresentInRequest() {
         CredentialIssuerRequestDto credentialIssuerRequestWithoutState =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithoutState.setState(null);
@@ -194,6 +194,21 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
         assertEquals(ErrorResponse.MISSING_OAUTH_STATE.getCode(), output.get(CODE));
         assertEquals(ErrorResponse.MISSING_OAUTH_STATE.getMessage(), output.get(MESSAGE));
+    }
+
+    @Test
+    void shouldReceive400ResponseCodeIfOAuthStateNotPresentInSession() {
+        CredentialIssuerRequestDto credentialIssuerRequest = validCredentialIssuerRequestDto();
+
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        ipvSessionItem.setCredentialIssuerSessionDetails(null);
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        Map<String, Object> output = underTest.handleRequest(credentialIssuerRequest, context);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
+        assertEquals(ErrorResponse.INVALID_OAUTH_STATE.getCode(), output.get(CODE));
+        assertEquals(ErrorResponse.INVALID_OAUTH_STATE.getMessage(), output.get(MESSAGE));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Update process-journey-step to clear the oauth session on any state change. Also add a new check in validate-oauth-callback as the oauth session may now be null.

### Why did it change

We need to make sure that we are managing the state of OAuth connections with CRIs in a more robust way. We should track this “OAuth Session” so that after a user has returned form a CRI we close the session, so that it is no longer valid. In particular this fixes a 'bug' spotted where you can go back from the pre-kbv page to fraud CRI and get a new fraud VC issued.

### Issue tracking
- [PYIC-2298](https://govukverify.atlassian.net/browse/PYIC-2298)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed



[PYIC-2298]: https://govukverify.atlassian.net/browse/PYIC-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ