### PR TITLE
PYIC-2300: Add attempt-recovery event to all states

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -1,7 +1,18 @@
 #parent states
+ATTEMPT_RECOVERY_STATE:
+  name: ATTEMPT_RECOVERY_STATE
+  parent: null
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recover
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 CRI_STATE:
   name: CRI_STATE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -33,7 +44,7 @@ CRI_STATE:
         pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -44,7 +55,7 @@ END_JOURNEY:
         journeyStepId: /journey/build-client-oauth-response
 MITIGATION_JOURNEY:
   name: MITIGATION_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -57,7 +68,7 @@ MITIGATION_JOURNEY:
 #child states
 INITIAL_IPV_JOURNEY:
   name: INIT
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -68,7 +79,7 @@ INITIAL_IPV_JOURNEY:
         pageId: page-ipv-identity-start
 IPV_IDENTITY_START_PAGE:
   name: IPV_IDENTITY_START_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -79,7 +90,7 @@ IPV_IDENTITY_START_PAGE:
         journeyStepId: /journey/check-existing-identity
 CHECK_EXISTING_IDENTITY:
   name: CHECK_EXISTING_IDENTITY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -100,7 +111,7 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -132,7 +143,7 @@ EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 SELECT_CRI:
   name: SELECT_CRI
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     stubUkPassport:
       type: basic
@@ -232,7 +243,7 @@ CRI_KBV:
   parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -250,7 +261,7 @@ PASSPORT_DOC_CHECK_PAGE:
         journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -261,7 +272,7 @@ PRE_KBV_TRANSITION_PAGE:
         journeyStepId: /journey/cri/build-oauth-request/stubKbv
 POST_DCMAW_SUCCESS_PAGE:
   name: POST_DCMAW_SUCCESS_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -331,7 +342,7 @@ DEBUG_PAGE:
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -363,7 +374,7 @@ DEBUG_EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 DEBUG_PYI_NO_MATCH:
   name: DEBUG_PYI_NO_MATCH
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -374,7 +385,7 @@ DEBUG_PYI_NO_MATCH:
         pageId: page-ipv-debug
 DEBUG_PYI_KBV_FAIL:
   name: DEBUG_PYI_KBV_FAIL
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -1,7 +1,18 @@
 #parent states
+ATTEMPT_RECOVERY_STATE:
+  name: ATTEMPT_RECOVERY_STATE
+  parent: null
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recover
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 CRI_STATE:
   name: CRI_STATE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -26,7 +37,7 @@ CRI_STATE:
         pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -37,7 +48,7 @@ END_JOURNEY:
         journeyStepId: /journey/build-client-oauth-response
 MITIGATION_JOURNEY:
   name: MITIGATION_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -50,7 +61,7 @@ MITIGATION_JOURNEY:
 #child states
 INITIAL_IPV_JOURNEY:
   name: INIT
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -61,7 +72,7 @@ INITIAL_IPV_JOURNEY:
         pageId: page-ipv-identity-start
 IPV_IDENTITY_START_PAGE:
   name: IPV_IDENTITY_START_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -72,7 +83,7 @@ IPV_IDENTITY_START_PAGE:
         journeyStepId: /journey/check-existing-identity
 CHECK_EXISTING_IDENTITY:
   name: CHECK_EXISTING_IDENTITY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -93,7 +104,7 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -125,7 +136,7 @@ EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 SELECT_CRI:
   name: SELECT_CRI
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     stubUkPassport:
       type: basic
@@ -225,7 +236,7 @@ CRI_KBV:
   parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -243,7 +254,7 @@ PASSPORT_DOC_CHECK_PAGE:
         journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -254,7 +265,7 @@ PRE_KBV_TRANSITION_PAGE:
         journeyStepId: /journey/cri/build-oauth-request/stubKbv
 POST_DCMAW_SUCCESS_PAGE:
   name: POST_DCMAW_SUCCESS_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -324,7 +335,7 @@ DEBUG_PAGE:
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -356,7 +367,7 @@ DEBUG_EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 DEBUG_PYI_NO_MATCH:
   name: DEBUG_PYI_NO_MATCH
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -367,7 +378,7 @@ DEBUG_PYI_NO_MATCH:
         pageId: page-ipv-debug
 DEBUG_PYI_KBV_FAIL:
   name: DEBUG_PYI_KBV_FAIL
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -1,7 +1,18 @@
 #parent states
+ATTEMPT_RECOVERY_STATE:
+  name: ATTEMPT_RECOVERY_STATE
+  parent: null
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recover
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 CRI_STATE:
   name: CRI_STATE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -26,7 +37,7 @@ CRI_STATE:
         pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -37,7 +48,7 @@ END_JOURNEY:
         journeyStepId: /journey/build-client-oauth-response
 MITIGATION_JOURNEY:
   name: MITIGATION_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -50,7 +61,7 @@ MITIGATION_JOURNEY:
 #child states
 INITIAL_IPV_JOURNEY:
   name: INIT
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -61,7 +72,7 @@ INITIAL_IPV_JOURNEY:
         pageId: page-ipv-identity-start
 IPV_IDENTITY_START_PAGE:
   name: IPV_IDENTITY_START_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -72,7 +83,7 @@ IPV_IDENTITY_START_PAGE:
         journeyStepId: /journey/check-existing-identity
 CHECK_EXISTING_IDENTITY:
   name: CHECK_EXISTING_IDENTITY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -93,7 +104,7 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -125,7 +136,7 @@ EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 SELECT_CRI:
   name: SELECT_CRI
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     ukPassport:
       type: basic
@@ -260,7 +271,7 @@ CRI_KBV:
   parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -278,7 +289,7 @@ PASSPORT_DOC_CHECK_PAGE:
         journeyStepId: /journey/build-client-oauth-response
 STUB_PASSPORT_DOC_CHECK_PAGE:
   name: STUB_PASSPORT_DOC_CHECK_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -296,7 +307,7 @@ STUB_PASSPORT_DOC_CHECK_PAGE:
         journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -307,7 +318,7 @@ PRE_KBV_TRANSITION_PAGE:
         journeyStepId: /journey/cri/build-oauth-request/kbv
 PRE_STUB_KBV_TRANSITION_PAGE:
   name: PRE_STUB_KBV_TRANSITION_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -318,7 +329,7 @@ PRE_STUB_KBV_TRANSITION_PAGE:
         journeyStepId: /journey/cri/build-oauth-request/stubKbv
 POST_DCMAW_SUCCESS_PAGE:
   name: POST_DCMAW_SUCCESS_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -388,7 +399,7 @@ DEBUG_PAGE:
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -420,7 +431,7 @@ DEBUG_EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 DEBUG_PYI_NO_MATCH:
   name: DEBUG_PYI_NO_MATCH
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -431,7 +442,7 @@ DEBUG_PYI_NO_MATCH:
         pageId: page-ipv-debug
 DEBUG_PYI_KBV_FAIL:
   name: DEBUG_PYI_KBV_FAIL
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -1,7 +1,18 @@
 #parent states
+ATTEMPT_RECOVERY_STATE:
+  name: ATTEMPT_RECOVERY_STATE
+  parent: null
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recover
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 CRI_STATE:
   name: CRI_STATE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -26,7 +37,7 @@ CRI_STATE:
         pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -37,7 +48,7 @@ END_JOURNEY:
         journeyStepId: /journey/build-client-oauth-response
 MITIGATION_JOURNEY:
   name: MITIGATION_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -50,7 +61,7 @@ MITIGATION_JOURNEY:
 #child states
 INITIAL_IPV_JOURNEY:
   name: INIT
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -61,7 +72,7 @@ INITIAL_IPV_JOURNEY:
         pageId: page-ipv-identity-start
 IPV_IDENTITY_START_PAGE:
   name: IPV_IDENTITY_START_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -72,7 +83,7 @@ IPV_IDENTITY_START_PAGE:
         journeyStepId: /journey/check-existing-identity
 CHECK_EXISTING_IDENTITY:
   name: CHECK_EXISTING_IDENTITY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -93,7 +104,7 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -125,7 +136,7 @@ EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 SELECT_CRI:
   name: SELECT_CRI
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     ukPassport:
       type: basic
@@ -225,7 +236,7 @@ CRI_KBV:
   parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -243,7 +254,7 @@ PASSPORT_DOC_CHECK_PAGE:
         journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -254,7 +265,7 @@ PRE_KBV_TRANSITION_PAGE:
         journeyStepId: /journey/cri/build-oauth-request/kbv
 POST_DCMAW_SUCCESS_PAGE:
   name: POST_DCMAW_SUCCESS_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -324,7 +335,7 @@ DEBUG_PAGE:
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -356,7 +367,7 @@ DEBUG_EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 DEBUG_PYI_NO_MATCH:
   name: DEBUG_PYI_NO_MATCH
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -367,7 +378,7 @@ DEBUG_PYI_NO_MATCH:
         pageId: page-ipv-debug
 DEBUG_PYI_KBV_FAIL:
   name: DEBUG_PYI_KBV_FAIL
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -1,7 +1,18 @@
 #parent states
+ATTEMPT_RECOVERY_STATE:
+  name: ATTEMPT_RECOVERY_STATE
+  parent: null
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recover
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
 CRI_STATE:
   name: CRI_STATE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -26,7 +37,7 @@ CRI_STATE:
         pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -37,7 +48,7 @@ END_JOURNEY:
         journeyStepId: /journey/build-client-oauth-response
 MITIGATION_JOURNEY:
   name: MITIGATION_JOURNEY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -50,7 +61,7 @@ MITIGATION_JOURNEY:
 #child states
 INITIAL_IPV_JOURNEY:
   name: INIT
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -61,7 +72,7 @@ INITIAL_IPV_JOURNEY:
         pageId: page-ipv-identity-start
 IPV_IDENTITY_START_PAGE:
   name: IPV_IDENTITY_START_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -72,7 +83,7 @@ IPV_IDENTITY_START_PAGE:
         journeyStepId: /journey/check-existing-identity
 CHECK_EXISTING_IDENTITY:
   name: CHECK_EXISTING_IDENTITY
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -93,7 +104,7 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -125,7 +136,7 @@ EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 SELECT_CRI:
   name: SELECT_CRI
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     ukPassport:
       type: basic
@@ -260,7 +271,7 @@ CRI_KBV:
   parent: CRI_STATE
 PASSPORT_DOC_CHECK_PAGE:
   name: PASSPORT_DOC_CHECK_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -278,7 +289,7 @@ PASSPORT_DOC_CHECK_PAGE:
         journeyStepId: /journey/build-client-oauth-response
 STUB_PASSPORT_DOC_CHECK_PAGE:
   name: STUB_PASSPORT_DOC_CHECK_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -296,7 +307,7 @@ STUB_PASSPORT_DOC_CHECK_PAGE:
         journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -307,7 +318,7 @@ PRE_KBV_TRANSITION_PAGE:
         journeyStepId: /journey/cri/build-oauth-request/kbv
 PRE_STUB_KBV_TRANSITION_PAGE:
   name: PRE_STUB_KBV_TRANSITION_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -318,7 +329,7 @@ PRE_STUB_KBV_TRANSITION_PAGE:
         journeyStepId: /journey/cri/build-oauth-request/stubKbv
 POST_DCMAW_SUCCESS_PAGE:
   name: POST_DCMAW_SUCCESS_PAGE
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -388,7 +399,7 @@ DEBUG_PAGE:
 
 DEBUG_EVALUATE_GPG45_SCORES:
   name: DEBUG_EVALUATE_GPG45_SCORES
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -420,7 +431,7 @@ DEBUG_EVALUATE_GPG45_SCORES:
         pageId: pyi-kbv-fail
 DEBUG_PYI_NO_MATCH:
   name: DEBUG_PYI_NO_MATCH
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
@@ -431,7 +442,7 @@ DEBUG_PYI_NO_MATCH:
         pageId: page-ipv-debug
 DEBUG_PYI_KBV_FAIL:
   name: DEBUG_PYI_KBV_FAIL
-  parent: null
+  parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add new ATTEMPT_RECOVERY_STATE to the state machine.

Update all other states to use this as a parent in order to inherit the attempt-recovery event which sends users to the evaluategpg45Scores lambda.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This event could be used potentially from any point within the system so we want all states to be able to handle this event.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2300](https://govukverify.atlassian.net/browse/PYIC-2300)



[PYIC-2300]: https://govukverify.atlassian.net/browse/PYIC-2300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ