### PR TITLE
PYIC-2299 Return error response type on invalid oauth state

### DIFF
--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -55,6 +55,8 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     private static final String CODE = "code";
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
+    private static final String TYPE = "type";
+    private static final String PAGE = "page";
     private static CredentialIssuerConfig credentialIssuerConfig;
     private static IpvSessionItem ipvSessionItem;
     @Mock private Context context;
@@ -197,7 +199,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     }
 
     @Test
-    void shouldReceive400ResponseCodeIfOAuthStateNotPresentInSession() {
+    void shouldReceive400ResponseWithPageIdIfOAuthStateNotPresentInSession() {
         CredentialIssuerRequestDto credentialIssuerRequest = validCredentialIssuerRequestDto();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -207,12 +209,12 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         Map<String, Object> output = underTest.handleRequest(credentialIssuerRequest, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
-        assertEquals(ErrorResponse.INVALID_OAUTH_STATE.getCode(), output.get(CODE));
-        assertEquals(ErrorResponse.INVALID_OAUTH_STATE.getMessage(), output.get(MESSAGE));
+        assertEquals("pyi-technical-unrecoverable", output.get(PAGE));
+        assertEquals("error", output.get(TYPE));
     }
 
     @Test
-    void shouldReceive400ResponseCodeIfOAuthStateNotValid() {
+    void shouldReceive400ResponseWithPageIdIfOAuthStateNotValid() {
         CredentialIssuerRequestDto credentialIssuerRequestWithInvalidState =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithInvalidState.setState("not-correct-state");
@@ -223,8 +225,8 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 underTest.handleRequest(credentialIssuerRequestWithInvalidState, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
-        assertEquals(ErrorResponse.INVALID_OAUTH_STATE.getCode(), output.get(CODE));
-        assertEquals(ErrorResponse.INVALID_OAUTH_STATE.getMessage(), output.get(MESSAGE));
+        assertEquals("pyi-technical-unrecoverable", output.get(PAGE));
+        assertEquals("error", output.get(TYPE));
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
@@ -15,6 +15,8 @@ public class StepFunctionHelpers {
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
     private static final String IP_ADDRESS = "ipAddress";
+    private static final String TYPE = "type";
+    private static final String PAGE = "page";
 
     private StepFunctionHelpers() {
         throw new IllegalStateException("Utility class");
@@ -57,6 +59,15 @@ public class StepFunctionHelpers {
         output.put(STATUS_CODE, statusCode);
         output.put(MESSAGE, errorResponse.getMessage());
         output.put(CODE, errorResponse.getCode());
+        return output;
+    }
+
+    public static Map<String, Object> generatePageOutputMap(
+            String type, int statusCode, String pageId) {
+        Map<String, Object> output = new HashMap<>();
+        output.put(TYPE, type);
+        output.put(STATUS_CODE, statusCode);
+        output.put(PAGE, pageId);
         return output;
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
@@ -15,6 +15,8 @@ class StepFunctionHelpersTest {
     private static final String CODE = "code";
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
+    private static final String TYPE = "type";
+    private static final String PAGE = "page";
 
     @Test
     void getIpvSessionIdShouldReturnIpvSessionId() throws Exception {
@@ -73,5 +75,17 @@ class StepFunctionHelpersTest {
                 expected,
                 StepFunctionHelpers.generateErrorOutputMap(
                         400, ErrorResponse.CREDENTIAL_SUBJECT_MISSING));
+    }
+
+    @Test
+    void generatePageOutputMapShouldGenerateAPageOutputMap() {
+        Map<String, Object> expected =
+                Map.of(
+                        TYPE, "error",
+                        STATUS_CODE, 400,
+                        PAGE, "some-page");
+
+        assertEquals(
+                expected, StepFunctionHelpers.generatePageOutputMap("error", 400, "some-page"));
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Update the validate-oauth-callback lambda to return an error response type if the oauth state doesn't match or if the oauth state has already been closed. The error response contains the page id which core-front should render. For now this is the `pyi-technical-unrecoverable` page, which is how core-front currently handles this error.

### Why did it change

Eventually we want to be able to tell core-front to go to the new attempt recovery error page in certain error scenarios like this. This PR just lays the groundwork for this while we stage things out.

### Issue tracking
- [PYIC-2299](https://govukverify.atlassian.net/browse/PYIC-2299)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed


[PYIC-2299]: https://govukverify.atlassian.net/browse/PYIC-2299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ