### PR TITLE
BAU Remove unused httpStatusCode and update pageId->page

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/ErrorResponse.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/ErrorResponse.java
@@ -14,21 +14,13 @@ public class ErrorResponse implements JourneyStepResponse {
 
     private static final String ERROR = "error";
     private String pageId;
-    private String httpStatusCode;
+    private String statusCode;
 
     public Map<String, Object> value(ConfigurationService configurationService) {
         return value(pageId);
     }
 
     public Map<String, Object> value(String id) {
-        return Map.of(
-                "type",
-                ERROR,
-                "pageId",
-                id,
-                "httpStatusCode",
-                httpStatusCode,
-                "statusCode",
-                Integer.parseInt(httpStatusCode));
+        return Map.of("type", ERROR, "page", id, "statusCode", Integer.parseInt(statusCode));
     }
 }

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -70,8 +70,7 @@ class ProcessJourneyStepHandlerTest {
     private static final String JOURNEY = "journey";
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
-    public static final String HTTP_STATUS_CODE_500 = "500";
-    public static final String HTTP_STATUS_CODE = "httpStatusCode";
+    public static final int HTTP_STATUS_CODE_500 = 500;
     @Mock private Context mockContext;
     @Mock private IpvSessionService mockIpvSessionService;
     @Mock private ConfigurationService mockConfigurationService;
@@ -277,8 +276,8 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(ERROR, output.get("type"));
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("pageId"));
-        assertEquals(HTTP_STATUS_CODE_500, output.get(HTTP_STATUS_CODE));
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("page"));
+        assertEquals(HTTP_STATUS_CODE_500, output.get(STATUS_CODE));
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, output.get(STATUS_CODE));
     }
 
@@ -332,8 +331,8 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(ERROR, output.get("type"));
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("pageId"));
-        assertEquals(HTTP_STATUS_CODE_500, output.get(HTTP_STATUS_CODE));
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("page"));
+        assertEquals(HTTP_STATUS_CODE_500, output.get(STATUS_CODE));
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, output.get(STATUS_CODE));
     }
 
@@ -425,8 +424,8 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(ERROR, output.get("type"));
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("pageId"));
-        assertEquals(HTTP_STATUS_CODE_500, output.get(HTTP_STATUS_CODE));
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("page"));
+        assertEquals(HTTP_STATUS_CODE_500, output.get(STATUS_CODE));
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, output.get(STATUS_CODE));
     }
 
@@ -480,8 +479,8 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(ERROR, output.get("type"));
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("pageId"));
-        assertEquals(HTTP_STATUS_CODE_500, output.get(HTTP_STATUS_CODE));
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("page"));
+        assertEquals(HTTP_STATUS_CODE_500, output.get(STATUS_CODE));
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, output.get(STATUS_CODE));
     }
 
@@ -553,8 +552,8 @@ class ProcessJourneyStepHandlerTest {
         assertEquals(CRI_ERROR_STATE, sessionArgumentCaptor.getValue().getUserState());
 
         assertEquals(ERROR, output.get("type"));
-        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("pageId"));
-        assertEquals(HTTP_STATUS_CODE_500, output.get(HTTP_STATUS_CODE));
+        assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("page"));
+        assertEquals(HTTP_STATUS_CODE_500, output.get(STATUS_CODE));
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, output.get(STATUS_CODE));
     }
 
@@ -643,7 +642,7 @@ class ProcessJourneyStepHandlerTest {
 
         assertEquals(ERROR, output.get("type"));
         assertEquals(PYI_TECHNICAL_ERROR_PAGE, output.get("pageId"));
-        assertEquals(HTTP_STATUS_CODE_500, output.get(HTTP_STATUS_CODE));
+        assertEquals(HTTP_STATUS_CODE_500, output.get(STATUS_CODE));
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, output.get(STATUS_CODE));
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Remove unused httpStatusCode and update pageId->page.

### Why did it change

Follow up to PYIC-2302. We don't need the `httpStatusCode` in the new state machine error response as we can just use `statusCode` instead. Also update the `pageId` property to `page` in line with the other state machine responses.

### Issue tracking
- [PYIC-2302](https://govukverify.atlassian.net/browse/PYIC-2302)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed


[PYIC-2302]: https://govukverify.atlassian.net/browse/PYIC-2302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ