### PR TITLE
PYIC-2312 Update validate-oauth-callback to return attempt-recovery page based on feature flag

### DIFF
--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -36,6 +36,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ATTEMPT_RECOVERY_ENABLED;
+
 public class ValidateOAuthCallbackHandler
         implements RequestHandler<CredentialIssuerRequestDto, Map<String, Object>> {
 
@@ -57,6 +59,7 @@ public class ValidateOAuthCallbackHandler
                     OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE);
     private static final String PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE_ID =
             "pyi-technical-unrecoverable";
+    private static final String PYI_ATTEMPT_RECOVERY_PAGE_ID = "pyi-attempt-recovery";
     private final ConfigurationService configurationService;
     private final IpvSessionService ipvSessionService;
     private final AuditService auditService;
@@ -130,10 +133,15 @@ public class ValidateOAuthCallbackHandler
                     errorResponse.getMessage());
 
             if (errorResponse == ErrorResponse.INVALID_OAUTH_STATE) {
+                boolean attemptRecoveryEnabled =
+                        Boolean.parseBoolean(
+                                configurationService.getSsmParameter(ATTEMPT_RECOVERY_ENABLED));
                 return StepFunctionHelpers.generatePageOutputMap(
                         "error",
                         HttpStatus.SC_BAD_REQUEST,
-                        PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE_ID);
+                        attemptRecoveryEnabled
+                                ? PYI_ATTEMPT_RECOVERY_PAGE_ID
+                                : PYI_TECHNICAL_UNRECOVERABLE_ERROR_PAGE_ID);
             }
 
             return StepFunctionHelpers.generateErrorOutputMap(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -23,7 +23,8 @@ public enum ConfigurationVariable {
     CI_SCORING_CONFIG("/%s/core/self/ci-scoring-config"),
     CI_SCORING_THRESHOLD("/%s/core/self/ciScoringThreshold"),
     CI_MITIGATION_JOURNEYS_ENABLED("/%s/core/self/journey/ciMitigationsEnabled"),
-    VC_TTL("/%s/core/self/vcTtl");
+    VC_TTL("/%s/core/self/vcTtl"),
+    ATTEMPT_RECOVERY_ENABLED("/%s/core/self/journey/attemptRecoveryEnabled");
 
     private final String value;
 


### PR DESCRIPTION
## Proposed changes

### What changed

Return the new 'pyi-attempt-recovery' page id on invalid oauth state, only if the feature flag is enabled.

### Why did it change

To stage out the change we're putting it behind a feature flag for testing. We will switch on in higher environments once the new page is production ready.

### Issue tracking
- [PYIC-2312](https://govukverify.atlassian.net/browse/PYIC-2312)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed



[PYIC-2312]: https://govukverify.atlassian.net/browse/PYIC-2312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ