### PR TITLE
PYIC-2333: Only store oauth error visit on real oauth errors

### DIFF
--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -177,11 +177,6 @@ public class ValidateOAuthCallbackHandler
             LOGGER.warn("Unknown Oauth error code received");
         }
 
-        ipvSessionItem.addVisitedCredentialIssuerDetails(
-                new VisitedCredentialIssuerDetailsDto(
-                        request.getCredentialIssuerId(), false, error));
-        ipvSessionService.updateIpvSession(ipvSessionItem);
-
         boolean attemptRecoveryEnabled =
                 Boolean.parseBoolean(
                         configurationService.getSsmParameter(
@@ -200,6 +195,11 @@ public class ValidateOAuthCallbackHandler
             return StepFunctionHelpers.generatePageOutputMap(
                     "error", HttpStatus.SC_BAD_REQUEST, PYI_ATTEMPT_RECOVERY_PAGE_ID);
         }
+
+        ipvSessionItem.addVisitedCredentialIssuerDetails(
+                new VisitedCredentialIssuerDetailsDto(
+                        request.getCredentialIssuerId(), false, error));
+        ipvSessionService.updateIpvSession(ipvSessionItem);
 
         if (OAuth2Error.ACCESS_DENIED_CODE.equals(error)) {
             LOGGER.info("OAuth access_denied");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Only updated the visited cri list in the users session with details of the oauth error if it was not caused by unexpected user navigation.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
This list is used by the select-cri lambda to decide on the next step in the users journey. If this list contains oauth error details caused by unexpected user navigation then the attempt recovery won't work properly.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2333](https://govukverify.atlassian.net/browse/PYIC-2333)



[PYIC-2333]: https://govukverify.atlassian.net/browse/PYIC-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ