### PR TITLE
PYIC-2355: Update statemachine select-cri fail event to return new error response

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -207,8 +207,9 @@ SELECT_CRI:
       name: fail
       targetState: SELECT_CRI_ERROR
       response:
-        type: page
+        type: error
         pageId: pyi-technical
+        statusCode: 500
     pyi-no-match:
       type: basic
       name: pyi-no-match

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -200,8 +200,9 @@ SELECT_CRI:
       name: fail
       targetState: SELECT_CRI_ERROR
       response:
-        type: page
+        type: error
         pageId: pyi-technical
+        statusCode: 500
     pyi-no-match:
       type: basic
       name: pyi-no-match

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/utils/ProcessJourneyStepEvents.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/utils/ProcessJourneyStepEvents.java
@@ -1,0 +1,12 @@
+package uk.gov.di.ipv.core.processjourneystep.utils;
+
+public class ProcessJourneyStepEvents {
+    public static final String ACCESS_DENIED = "access-denied";
+    public static final String ERROR = "error";
+    public static final String INVALID_STEP = "invalid-step";
+    public static final String JOURNEY_CHECK_EXISTING_IDENTITY = "/journey/check-existing-identity";
+    public static final String JOURNEY_EVALUATE_GPG_45_SCORES = "/journey/evaluate-gpg45-scores";
+    public static final String JOURNEY_NEXT = "/journey/next";
+    public static final String JOURNEY_REUSE = "/journey/reuse";
+    public static final String FAIL = "fail";
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/utils/ProcessJourneyStepPages.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/utils/ProcessJourneyStepPages.java
@@ -1,0 +1,9 @@
+package uk.gov.di.ipv.core.processjourneystep.utils;
+
+public class ProcessJourneyStepPages {
+    public static final String IPV_IDENTITY_REUSE_PAGE = "page-ipv-reuse";
+    public static final String IPV_IDENTITY_START_PAGE = "page-ipv-identity-start";
+    public static final String PRE_KBV_TRANSITION_PAGE = "page-pre-kbv-transition";
+    public static final String PYI_NO_MATCH_PAGE = "pyi-no-match";
+    public static final String PYI_TECHNICAL_ERROR_PAGE = "pyi-technical";
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/utils/ProcessJourneyStepStates.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/utils/ProcessJourneyStepStates.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.core.processjourneystep.utils;
+
+public class ProcessJourneyStepStates {
+    public static final String CHECK_EXISTING_IDENTITY_STATE = "CHECK_EXISTING_IDENTITY";
+    public static final String CORE_SESSION_TIMEOUT_STATE = "CORE_SESSION_TIMEOUT";
+    public static final String CRI_ADDRESS_STATE = "CRI_ADDRESS";
+    public static final String CRI_DCMAW_STATE = "CRI_DCMAW";
+    public static final String CRI_ERROR_STATE = "CRI_ERROR";
+    public static final String CRI_FRAUD_STATE = "CRI_FRAUD";
+    public static final String CRI_KBV_STATE = "CRI_KBV";
+    public static final String CRI_UK_PASSPORT_STATE = "CRI_UK_PASSPORT";
+    public static final String DEBUG_EVALUATE_GPG45_SCORES = "DEBUG_EVALUATE_GPG45_SCORES";
+    public static final String DEBUG_PAGE_STATE = "DEBUG_PAGE";
+    public static final String END_STATE = "END";
+    public static final String EVALUATE_GPG45_SCORES = "EVALUATE_GPG45_SCORES";
+    public static final String INITIAL_IPV_JOURNEY_STATE = "INITIAL_IPV_JOURNEY";
+    public static final String IPV_IDENTITY_REUSE_PAGE_STATE = "IPV_IDENTITY_REUSE_PAGE";
+    public static final String IPV_IDENTITY_START_PAGE_STATE = "IPV_IDENTITY_START_PAGE";
+    public static final String IPV_SUCCESS_PAGE_STATE = "IPV_SUCCESS_PAGE";
+    public static final String PRE_KBV_TRANSITION_PAGE_STATE = "PRE_KBV_TRANSITION_PAGE";
+    public static final String PYI_NO_MATCH_STATE = "PYI_NO_MATCH";
+    public static final String SELECT_CRI_STATE = "SELECT_CRI";
+    public static final String SELECT_CRI_ERROR_STATE = "SELECT_CRI_ERROR";
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Update statemachine select-cri fail event to return new error response

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2355](https://govukverify.atlassian.net/browse/PYIC-2355)


[PYIC-2355]: https://govukverify.atlassian.net/browse/PYIC-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ