### PR TITLE
PYIC-2379: Handle temporarily_unavailable oauth errors

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -43,6 +43,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: ATTEMPT_RECOVERY_STATE
@@ -290,6 +297,13 @@ CRI_DCMAW:
     access-denied:
       type: basic
       name: access-denied
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
       targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -36,6 +36,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: ATTEMPT_RECOVERY_STATE
@@ -283,6 +290,13 @@ CRI_DCMAW:
     access-denied:
       type: basic
       name: access-denied
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
       targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -36,6 +36,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: ATTEMPT_RECOVERY_STATE
@@ -347,6 +354,13 @@ CRI_DCMAW:
     access-denied:
       type: basic
       name: access-denied
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
       targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -36,6 +36,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: ATTEMPT_RECOVERY_STATE
@@ -283,6 +290,13 @@ CRI_DCMAW:
     access-denied:
       type: basic
       name: access-denied
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
       targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -36,6 +36,13 @@ CRI_STATE:
       response:
         type: page
         pageId: pyi-no-match
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
 END_JOURNEY:
   name: END_JOURNEY
   parent: ATTEMPT_RECOVERY_STATE
@@ -347,6 +354,13 @@ CRI_DCMAW:
     access-denied:
       type: basic
       name: access-denied
+      targetState: EVALUATE_GPG45_SCORES
+      response:
+        type: journey
+        journeyStepId: /journey/evaluate-gpg45-scores
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
       targetState: EVALUATE_GPG45_SCORES
       response:
         type: journey

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -45,6 +45,8 @@ public class ValidateOAuthCallbackHandler
             Map.of(JOURNEY, "/journey/cri/access-token");
     private static final Map<String, Object> JOURNEY_ACCESS_DENIED =
             Map.of(JOURNEY, "/journey/access-denied");
+    private static final Map<String, Object> JOURNEY_TEMPORARILY_UNAVAILABLE =
+            Map.of(JOURNEY, "/journey/temporarily-unavailable");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
     private static final List<String> ALLOWED_OAUTH_ERROR_CODES =
             Arrays.asList(
@@ -185,11 +187,13 @@ public class ValidateOAuthCallbackHandler
                         request.getCredentialIssuerId(), false, error));
         ipvSessionService.updateIpvSession(ipvSessionItem);
 
+        LogHelper.logOauthError("OAuth error received from CRI", error, errorDescription);
+
         if (OAuth2Error.ACCESS_DENIED_CODE.equals(error)) {
-            LOGGER.info("OAuth access_denied");
             return JOURNEY_ACCESS_DENIED;
+        } else if (OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE.equals(error)) {
+            return JOURNEY_TEMPORARILY_UNAVAILABLE;
         } else {
-            LogHelper.logOauthError("OAuth error received from CRI", error, errorDescription);
             return JOURNEY_ERROR;
         }
     }

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -277,6 +277,21 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     }
 
     @Test
+    void shouldReceiveTemporarilyUnavailableJourneyResponseWhenOauthErrorTemporarilyUnavailable() {
+        CredentialIssuerRequestDto credentialIssuerRequestWithAccessDenied =
+                validCredentialIssuerRequestDto();
+        credentialIssuerRequestWithAccessDenied.setError(OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE);
+        credentialIssuerRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+
+        Map<String, Object> output =
+                underTest.handleRequest(credentialIssuerRequestWithAccessDenied, context);
+
+        assertEquals("/journey/temporarily-unavailable", output.get("journey"));
+    }
+
+    @Test
     void shouldReceiveJourneyErrorJourneyResponseWhenAnyOtherOauthError() {
         CredentialIssuerRequestDto credentialIssuerRequestWithOtherError =
                 validCredentialIssuerRequestDto();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the validate-oauth-callback lambda to be able to specifically handle the `temporarily_unavailable` oauth error and return a new journey response.

Also updated the journey state machine to be able to accept the temporarily-unavailable event and for now handle it in the same way as the access-denied event.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
DCMAW (and potentially other CRI's in the future) will use this oauth error when there is an outage and things like this. So we need the statemachine to be able to specifically handle these events in case they need to be handled in different ways.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2379](https://govukverify.atlassian.net/browse/PYIC-2379)



[PYIC-2379]: https://govukverify.atlassian.net/browse/PYIC-2379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ