### PR TITLE
PYIC-2386: Update open-api to load certs from new SSM path

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -124,7 +124,7 @@ Resources:
                 Action:
                   - "ssm:GetParametersByPath"
                 Resource:
-                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Environment}/deploy/core/outputs/*'
+                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/deploy/core/outputs/*'
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -54,7 +54,7 @@ paths:
         type: "aws"
         httpMethod: "GET"
         uri:
-          Fn::Sub: 'arn:aws:apigateway:${AWS::Region}:ssm:action/GetParametersByPath&Path=/${Environment}/deploy/core/outputs/'
+          Fn::Sub: 'arn:aws:apigateway:${AWS::Region}:ssm:action/GetParametersByPath&Path=/deploy/core/outputs/'
         credentials:
           Fn::GetAtt: ["JWKSParamRole", "Arn"]
         responses:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update the well_known endpoint to load the JWK ssm params from the new path
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The IPV Core public JWK files were redeployed to a new SSM param path location that didn't include the environment name. This change will make sure we are serving these new params from our well_known endpoint instead of the old ones.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2386](https://govukverify.atlassian.net/browse/PYIC-2386)



[PYIC-2386]: https://govukverify.atlassian.net/browse/PYIC-2386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ