### PR TITLE
PYIC-2392 Read SNS notification to extract user id

### DIFF
--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -69,9 +69,10 @@ Resources:
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
+        UseNpmCi: true
         Minify: true
-        Target: "es2022"
-        Sourcemap: true
+        Target: "node18"
+        Sourcemap: true  # Required to preserve error stack traces to TS source
         EntryPoints:
           - src/index.ts
 

--- a/lambdas/delete-user-data/.eslintrc
+++ b/lambdas/delete-user-data/.eslintrc
@@ -19,6 +19,7 @@
       "plugins": ["jest"],
       "extends": ["plugin:jest/recommended", "plugin:jest/style"],
       "rules": {
+        "@typescript-eslint/no-explicit-any": "off",
         "jest/consistent-test-it": ["error", { "fn": "test" }],
         "jest/prefer-hooks-in-order": ["error"],
         "jest/prefer-hooks-on-top": ["error"],

--- a/lambdas/delete-user-data/README.md
+++ b/lambdas/delete-user-data/README.md
@@ -22,16 +22,18 @@ This uses `esbuild-jest` to transpile and run the tests on the fly. Note it will
 
 In VSCode you can use an extension such as "Jest Runner" to run and debug individual tests within the IDE.
 
-### Build and deploy
+### Build and invoke locally
 
-Build and deploy with AWS SAM CLI:
+Build via AWS SAM CLI:
 
-```sam build```
+```npm run build```
 
-Deploy TBC.
+Invoke the function locally with the sample SNS event:
 
-### Run locally
+```npm run local-invoke``
 
-After building with SAM, invoke the function locally:
+### Deploy
 
-```sam local invoke DeleteUserDataFunction```
+To build and deploy to the build env, run the script from the `deploy-delete-user-data` directory where the template lives:
+
+```aws-vault exec <core-build-profile> -- sh ./deploy.sh```

--- a/lambdas/delete-user-data/package.json
+++ b/lambdas/delete-user-data/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "test": "jest"
+    "test": "jest --verbose",
+    "build": "sam build -t ../../deploy-delete-user-data/template.yaml",
+    "local-invoke": "sam local invoke DeleteUserDataFunction -e sample-sns-event.json"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.109",

--- a/lambdas/delete-user-data/sample-sns-event.json
+++ b/lambdas/delete-user-data/sample-sns-event.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:EXAMPLE",
+      "EventSource": "aws:sns",
+      "Sns": {
+        "Signature": "EXAMPLE",
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "Type": "Notification",
+        "TopicArn": "arn:aws:sns:EXAMPLE",
+        "MessageAttributes": {},
+        "SignatureVersion": "1",
+        "Timestamp": "2015-06-03T17:43:27.123Z",
+        "SigningCertUrl": "EXAMPLE",
+        "Message": "{ \"user_id\": \"123\" }",
+        "UnsubscribeUrl": "EXAMPLE",
+        "Subject": "TestInvoke"
+      }
+    }
+  ]
+}

--- a/lambdas/delete-user-data/src/index.test.ts
+++ b/lambdas/delete-user-data/src/index.test.ts
@@ -1,5 +1,0 @@
-describe("Handler test", () => {
-  test("something", () => {
-    expect(1 + 1).toBe(2);
-  });
-});

--- a/lambdas/delete-user-data/src/index.ts
+++ b/lambdas/delete-user-data/src/index.ts
@@ -1,6 +1,10 @@
-import { APIGatewayEvent } from "aws-lambda";
+import { SNSEvent } from "aws-lambda";
+import { readMessage } from "./read-message";
 
-export const handler = async (event: APIGatewayEvent): Promise<void> => {
-  console.log("Hello world!");
-  console.log(`Event: ${JSON.stringify(event, null, 2)}`);
+export const handler = async (event: SNSEvent): Promise<void> => {
+  if (!event?.Records?.[0].Sns) {
+    throw new TypeError("no SNS event provided");
+  }
+  const message = readMessage(event);
+  console.log("User id requiring account deletion:", message.user_id);
 };

--- a/lambdas/delete-user-data/src/read-message.ts
+++ b/lambdas/delete-user-data/src/read-message.ts
@@ -1,0 +1,17 @@
+import { SNSEvent } from "aws-lambda";
+import { Message } from "./types";
+
+export const readMessage = (event: SNSEvent): Message => {
+  const message: unknown = JSON.parse(event.Records[0].Sns.Message);
+  validateMessage(message);
+  return message;
+};
+
+const validateMessage: (input: unknown) => asserts input is Message = (input) => {
+  if (input === null || typeof input !== "object" || !("user_id" in input)) {
+    throw new TypeError("message must be an object containing user_id");
+  }
+  if (typeof input.user_id !== "string") {
+    throw new TypeError("user_id in message object must be a string");
+  }
+};

--- a/lambdas/delete-user-data/src/types.ts
+++ b/lambdas/delete-user-data/src/types.ts
@@ -1,0 +1,1 @@
+export type Message = { user_id: string };

--- a/lambdas/delete-user-data/tests/index.test.ts
+++ b/lambdas/delete-user-data/tests/index.test.ts
@@ -1,0 +1,19 @@
+import { SNSEvent } from "aws-lambda";
+import { handler } from "../src";
+import { buildMockSnsEvent } from "./mock-sns-event";
+
+describe("handler", () => {
+  let mockSnsEvent: SNSEvent;
+  beforeEach(() => {
+    mockSnsEvent = buildMockSnsEvent();
+  });
+
+  test("reads an incoming SNS notification", async () => {
+    await expect(handler(mockSnsEvent)).resolves.toBeUndefined();
+  });
+
+  test("throws error if not an SNS notification", async () => {
+    mockSnsEvent = { body: { user_id: "123" } } as any;
+    await expect(handler(mockSnsEvent)).rejects.toThrow(TypeError);
+  });
+});

--- a/lambdas/delete-user-data/tests/mock-sns-event.ts
+++ b/lambdas/delete-user-data/tests/mock-sns-event.ts
@@ -1,0 +1,24 @@
+import { SNSEvent } from "aws-lambda";
+
+export const buildMockSnsEvent = (): SNSEvent => ({
+  Records: [
+    {
+      EventVersion: "1.0",
+      EventSubscriptionArn: "arn:aws:sns:EXAMPLE",
+      EventSource: "aws:sns",
+      Sns: {
+        Signature: "EXAMPLE",
+        MessageId: "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        Type: "Notification",
+        TopicArn: "arn:aws:sns:EXAMPLE",
+        MessageAttributes: {},
+        SignatureVersion: "1",
+        Timestamp: "2015-06-03T17:43:27.123Z",
+        SigningCertUrl: "EXAMPLE",
+        Message: '{ "user_id": "123" }',
+        UnsubscribeUrl: "EXAMPLE",
+        Subject: "TestInvoke",
+      },
+    },
+  ],
+});

--- a/lambdas/delete-user-data/tests/read-message.test.ts
+++ b/lambdas/delete-user-data/tests/read-message.test.ts
@@ -1,0 +1,28 @@
+import { SNSEvent } from "aws-lambda";
+import { buildMockSnsEvent } from "./mock-sns-event";
+import { readMessage } from "../src/read-message";
+import { Message } from "../src/types";
+
+describe("readMessage", () => {
+  let mockEvent: SNSEvent;
+  beforeEach(() => {
+    mockEvent = buildMockSnsEvent();
+  });
+
+  test("parses and validates message from SNS event", () => {
+    const expectedMessage: Message = {
+      user_id: "123",
+    };
+    expect(readMessage(mockEvent)).toStrictEqual(expectedMessage);
+  });
+
+  test("throws error if no user id in the message", () => {
+    mockEvent.Records[0].Sns.Message = '{ "not_user_id": "foo" }';
+    expect(() => readMessage(mockEvent)).toThrow(TypeError);
+  });
+
+  test("throws error if user id is not a string", () => {
+    mockEvent.Records[0].Sns.Message = '{ "user_id": 123 }';
+    expect(() => readMessage(mockEvent)).toThrow(TypeError);
+  });
+});

--- a/lambdas/delete-user-data/tsconfig.json
+++ b/lambdas/delete-user-data/tsconfig.json
@@ -12,5 +12,5 @@
     "moduleResolution": "node",
     "sourceMap": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Parses and validates the incoming SNS event

### Why did it change

As a start so we can get the user id ready for account deletion (just logging it for now)

### Issue tracking
- [PYIC-2392](https://govukverify.atlassian.net/browse/PYIC-2392)


[PYIC-2392]: https://govukverify.atlassian.net/browse/PYIC-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ