### PR TITLE
Fix DynamoDBKmsKey export name

### DIFF
--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -174,7 +174,8 @@ Resources:
                   "lambda:VpcIds":
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
-            KeyId: !ImportValue CoreBackDynamoDBKmsKey
+            KeyId:
+              Fn::ImportValue: !Sub "CoreBackDynamoDBKmsKey-${Environment}"
         - DynamoDBCrudPolicy:
             TableName: !Sub user-issued-credentials-v2-${Environment}
     Metadata:
@@ -204,7 +205,8 @@ Resources:
                       - Fn::Split:
                           - "/"
                           - Ref: AWS::StackId
-      KmsKeyId: !ImportValue CoreBackLoggingKmsKeyArn
+      KmsKeyId:
+        Fn::ImportValue: !Sub "CoreBackLoggingKmsKeyArn-${Environment}"
 
   DeleteUserDataFunctionSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2343,7 +2343,7 @@ Outputs:
     Description: Core Back DynamoDB KMS Key Export
     Value: !Ref DynamoDBKmsKey
     Export:
-      Name: DynamoDBKmsKey
+      Name: !Sub "DynamoDBKmsKey-${Environment}"
   CoreBackDynamoDBKmsKey:
     Description: Core Back DynamoDB KMS Key Export
     Value: !Ref DynamoDBKmsKey

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2339,18 +2339,13 @@ Outputs:
     Export:
       Name: !Sub "IPVCoreExternalAPIGatewayID-${Environment}"
     Value: !Ref IPVCoreExternalAPI
-  DynamoDBKmsKey:
-    Description: Core Back DynamoDB KMS Key Export
-    Value: !Ref DynamoDBKmsKey
-    Export:
-      Name: !Sub "DynamoDBKmsKey-${Environment}"
   CoreBackDynamoDBKmsKey:
     Description: Core Back DynamoDB KMS Key Export
     Value: !Ref DynamoDBKmsKey
     Export:
-      Name: CoreBackDynamoDBKmsKey
+      Name: !Sub "CoreBackDynamoDBKmsKey-${Environment}"
   CoreBackLoggingKmsKeyArn:
     Description: Core Back Logging KMS Key Export
     Value: !GetAtt LoggingKmsKey.Arn
     Export:
-      Name: CoreBackLoggingKmsKeyArn
+      Name: !Sub "CoreBackLoggingKmsKeyArn-${Environment}"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2343,9 +2343,19 @@ Outputs:
     Description: Core Back DynamoDB KMS Key Export
     Value: !Ref DynamoDBKmsKey
     Export:
-      Name: !Sub "CoreBackDynamoDBKmsKey-${Environment}"
+      Name: CoreBackDynamoDBKmsKey
   CoreBackLoggingKmsKeyArn:
     Description: Core Back Logging KMS Key Export
+    Value: !GetAtt LoggingKmsKey.Arn
+    Export:
+      Name: CoreBackLoggingKmsKeyArn
+  IPVCoreDynamoDBKmsKey:
+    Description: Core Back DynamoDB KMS Key Export with Environment
+    Value: !Ref DynamoDBKmsKey
+    Export:
+      Name: !Sub "CoreBackDynamoDBKmsKey-${Environment}"
+  IPVCoreLoggingKmsKey:
+    Description: Core Back Logging KMS Key Export with Environment
     Value: !GetAtt LoggingKmsKey.Arn
     Export:
       Name: !Sub "CoreBackLoggingKmsKeyArn-${Environment}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Remove DynamoDBKmsKey now no longer used
Add env suffix to names for CoreBackDynamoDBKmsKey and CoreBackLoggingKmsKeyArn to fix conflicts deploying to dev
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Was previously getting an error when deploying changes to dev envs in cloudformation.

`Export with name DynamoDBKmsKey is already exported by stack core-back-dev-jithinj`

We can't have the same output name in all the different stacks within the dev account.


