### PR TITLE
BAU Set up logger and log not throw when no VCs found

### DIFF
--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -138,7 +138,7 @@ Resources:
                   "lambda:VpcIds":
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
-            KeyId: !ImportValue DynamoDBKmsKey
+            KeyId: !ImportValue CoreBackDynamoDBKmsKey
         - DynamoDBCrudPolicy:
             TableName: !Sub user-issued-credentials-v2-${Environment}
     Metadata:
@@ -156,7 +156,7 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/delete-user-data-${Environment}"
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+      KmsKeyId: !ImportValue CoreBackLoggingKmsKey
 
   DeleteUserDataFunctionSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter

--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -156,7 +156,7 @@ Resources:
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/delete-user-data-${Environment}"
-      KmsKeyId: !ImportValue CoreBackLoggingKmsKey
+      KmsKeyId: !ImportValue CoreBackLoggingKmsKeyArn
 
   DeleteUserDataFunctionSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter

--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -28,7 +28,11 @@ Conditions:
       - !Equals [ !Ref Environment, "staging" ]
       - !Equals [ !Ref Environment, "integration" ]
       - !Equals [ !Ref Environment, "production" ]
-#  IsNotDevelopment: !Not [ !Condition IsBuild ]
+  IsNotDevelopment: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -146,6 +150,21 @@ Resources:
         Sourcemap: true  # Required to preserve error stack traces to TS source
         EntryPoints:
           - src/index.ts
+
+  DeleteUserDataFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/delete-user-data-${Environment}"
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  DeleteUserDataFunctionSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref DeleteUserDataFunctionLogGroup
 
 ##SNS Subscription
 #  DeleteAccountSNSSubscription:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2349,8 +2349,8 @@ Outputs:
     Value: !Ref DynamoDBKmsKey
     Export:
       Name: CoreBackDynamoDBKmsKey
-  CoreBackLoggingKmsKey:
+  CoreBackLoggingKmsKeyArn:
     Description: Core Back Logging KMS Key Export
     Value: !GetAtt LoggingKmsKey.Arn
     Export:
-      Name: CoreBackLoggingKmsKey
+      Name: CoreBackLoggingKmsKeyArn

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2344,3 +2344,13 @@ Outputs:
     Value: !Ref DynamoDBKmsKey
     Export:
       Name: DynamoDBKmsKey
+  CoreBackDynamoDBKmsKey:
+    Description: Core Back DynamoDB KMS Key Export
+    Value: !Ref DynamoDBKmsKey
+    Export:
+      Name: CoreBackDynamoDBKmsKey
+  CoreBackLoggingKmsKey:
+    Description: Core Back Logging KMS Key Export
+    Value: !GetAtt LoggingKmsKey.Arn
+    Export:
+      Name: CoreBackLoggingKmsKey

--- a/lambdas/delete-user-data/package-lock.json
+++ b/lambdas/delete-user-data/package-lock.json
@@ -7,12 +7,13 @@
     "": {
       "name": "delete-user-data",
       "version": "1.0.0",
+      "dependencies": {
+        "@aws-lambda-powertools/logger": "1.5.1"
+      },
       "devDependencies": {
-<<<<<<< HEAD
-=======
+        "@aws-lambda-powertools/commons": "1.5.1",
         "@aws-sdk/client-dynamodb": "3.259.0",
         "@aws-sdk/lib-dynamodb": "3.259.0",
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
         "@swc/jest": "0.2.24",
         "@types/aws-lambda": "8.10.109",
         "@types/jest": "29.2.6",
@@ -95,6 +96,20 @@
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-lambda-powertools/commons": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.5.1.tgz",
+      "integrity": "sha512-qp13/WksB6M/liEHgV3301qmI/aeQKmrYk1iODB+rrkVWeKW4AJqBMuWQ26gIlbD8t82EtuUNPUFle1a2qwjIg=="
+    },
+    "node_modules/@aws-lambda-powertools/logger": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.5.1.tgz",
+      "integrity": "sha512-dXvw7c4Z0DUEY62zEWsQ4DQZ3yf+JsEAqojQH+kw+rXVv0cjnIEbM4ZKONPG2jcPS5IMzO6gmCbu/PKB1PYgyA==",
+      "dependencies": {
+        "@aws-lambda-powertools/commons": "^1.5.1",
+        "lodash.merge": "^4.6.2"
       }
     },
     "node_modules/@aws-sdk/abort-controller": {
@@ -3429,15 +3444,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-<<<<<<< HEAD
-=======
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "dev": true
     },
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5364,8 +5376,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -5461,8 +5472,6 @@
         "node": "*"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
@@ -5472,7 +5481,6 @@
         "obliterator": "^1.6.1"
       }
     },
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5524,15 +5532,12 @@
         "node": ">=8"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "dev": true
     },
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6362,8 +6367,6 @@
         "punycode": "^2.1.0"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -6373,7 +6376,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -6583,6 +6585,20 @@
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
+      }
+    },
+    "@aws-lambda-powertools/commons": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.5.1.tgz",
+      "integrity": "sha512-qp13/WksB6M/liEHgV3301qmI/aeQKmrYk1iODB+rrkVWeKW4AJqBMuWQ26gIlbD8t82EtuUNPUFle1a2qwjIg=="
+    },
+    "@aws-lambda-powertools/logger": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.5.1.tgz",
+      "integrity": "sha512-dXvw7c4Z0DUEY62zEWsQ4DQZ3yf+JsEAqojQH+kw+rXVv0cjnIEbM4ZKONPG2jcPS5IMzO6gmCbu/PKB1PYgyA==",
+      "requires": {
+        "@aws-lambda-powertools/commons": "^1.5.1",
+        "lodash.merge": "^4.6.2"
       }
     },
     "@aws-sdk/abort-controller": {
@@ -9341,15 +9357,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-<<<<<<< HEAD
-=======
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "dev": true
     },
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -10767,8 +10780,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -10842,8 +10854,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-<<<<<<< HEAD
-=======
     "mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
@@ -10853,7 +10863,6 @@
         "obliterator": "^1.6.1"
       }
     },
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10899,15 +10908,12 @@
         "path-key": "^3.0.0"
       }
     },
-<<<<<<< HEAD
-=======
     "obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "dev": true
     },
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11474,15 +11480,12 @@
         "punycode": "^2.1.0"
       }
     },
-<<<<<<< HEAD
-=======
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
->>>>>>> b5864663 (PYIC-2327 Update lambda to delete data from VCs table)
     "v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",

--- a/lambdas/delete-user-data/package.json
+++ b/lambdas/delete-user-data/package.json
@@ -10,6 +10,7 @@
     "local-invoke": "sam local invoke DeleteUserDataFunction -e sample-sns-event.json"
   },
   "devDependencies": {
+    "@aws-lambda-powertools/commons": "1.5.1",
     "@aws-sdk/client-dynamodb": "3.259.0",
     "@aws-sdk/lib-dynamodb": "3.259.0",
     "@swc/jest": "0.2.24",
@@ -30,5 +31,8 @@
     "transform": {
       "^.+\\.ts?$": "@swc/jest"
     }
+  },
+  "dependencies": {
+    "@aws-lambda-powertools/logger": "1.5.1"
   }
 }

--- a/lambdas/delete-user-data/src/delete-data.ts
+++ b/lambdas/delete-user-data/src/delete-data.ts
@@ -1,19 +1,23 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 import { config } from "./config";
+import { logger } from "./logger";
 import { VCItemKey } from "./types";
 
 const ddbDocClient = DynamoDBDocument.from(new DynamoDBClient({ region: "eu-west-2" }));
 
 export const deleteVCs = async (userId: string): Promise<void> => {
   const keysToDelete = await getVCItemKeys(userId);
-  const deletePromises = keysToDelete.map((key) =>
-    ddbDocClient.delete({
-      TableName: config.userIssuedCredentialsTableName,
-      Key: key,
-    })
-  );
-  await Promise.all(deletePromises);
+  if (keysToDelete.length > 0) {
+    const deletePromises = keysToDelete.map((key) =>
+      ddbDocClient.delete({
+        TableName: config.userIssuedCredentialsTableName,
+        Key: key,
+      })
+    );
+    await Promise.all(deletePromises);
+    logger.info("Deleted user's VCs", { userId, count: keysToDelete.length });
+  }
 };
 
 const getVCItemKeys = async (userId: string): Promise<VCItemKey[]> => {
@@ -26,7 +30,9 @@ const getVCItemKeys = async (userId: string): Promise<VCItemKey[]> => {
     },
   });
   if (!itemKeys || itemKeys.length === 0) {
-    throw new Error("failed to find any VCs for user: " + userId);
+    logger.info("No VCs found for user", { userId });
+    return [];
   }
+  logger.info("Found user's VCs", { userId, count: itemKeys.length });
   return itemKeys as VCItemKey[];
 };

--- a/lambdas/delete-user-data/src/index.ts
+++ b/lambdas/delete-user-data/src/index.ts
@@ -1,8 +1,10 @@
-import { SQSEvent } from "aws-lambda";
+import { Context, SQSEvent } from "aws-lambda";
 import { deleteVCs } from "./delete-data";
+import { logger } from "./logger";
 import { readSNSMessage } from "./read-message";
 
-export const handler = async (event: SQSEvent): Promise<void> => {
+export const handler = async (event: SQSEvent, context: Context): Promise<void> => {
+  logger.addContext(context);
   if (!event?.Records?.[0].body) {
     throw new TypeError("no event provided");
   }

--- a/lambdas/delete-user-data/src/logger.ts
+++ b/lambdas/delete-user-data/src/logger.ts
@@ -1,0 +1,3 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+
+export const logger = new Logger({ serviceName: "ipv-core-delete-user-data" });

--- a/lambdas/delete-user-data/tests/delete-data.test.ts
+++ b/lambdas/delete-user-data/tests/delete-data.test.ts
@@ -46,11 +46,4 @@ describe("deleteVCs", () => {
       Key: vcItem2,
     });
   });
-
-  test("throws error if no VC records found for given user", async () => {
-    mockQuery.mockResolvedValue({ Items: [] });
-
-    await expect(deleteVCs("unknown-user")).rejects.toThrow("failed to find any VCs for user: unknown-user");
-    expect(mockDelete).not.toHaveBeenCalled();
-  });
 });

--- a/lambdas/delete-user-data/tests/index.test.ts
+++ b/lambdas/delete-user-data/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { SQSEvent } from "aws-lambda";
+import { ContextExamples } from "@aws-lambda-powertools/commons";
 import { handler } from "../src";
 import { deleteVCs } from "../src/delete-data";
 import { buildMockSQSEvent } from "./mock-sqs-event";
@@ -7,19 +8,20 @@ jest.mock("../src/delete-data");
 const mockDeleteVCs = deleteVCs as jest.Mocked<typeof deleteVCs>;
 
 describe("handler", () => {
+  const mockContext = ContextExamples.helloworldContext;
   let mockSQSEvent: SQSEvent;
   beforeEach(() => {
     mockSQSEvent = buildMockSQSEvent();
   });
 
   test("deletes VCs for user id in incoming SNS message", async () => {
-    await handler(mockSQSEvent);
+    await handler(mockSQSEvent, mockContext);
 
     expect(mockDeleteVCs).toHaveBeenCalledWith("123");
   });
 
   test("throws error if no event found", async () => {
     mockSQSEvent = { something: "else" } as any;
-    await expect(handler(mockSQSEvent)).rejects.toThrow(TypeError);
+    await expect(handler(mockSQSEvent, mockContext)).rejects.toThrow(TypeError);
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Set up logger and add info logs with context. Also in the case when no VCs are found for the given user id, log rather than throwing an error - because this is expected behaviour for users who haven't been through IPV

### Why did it change

So we can do structured logging from this lambda, and not throw errors for expected behaviour
