### PR TITLE
PYIC-2419 Add audit event delete

### DIFF
--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -191,6 +191,8 @@ Resources:
                 - 'kms:GenerateDataKey'
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/self/componentId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:

--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -102,6 +102,7 @@ Resources:
           DECRYPTION_KEY: !FindInMap [ DeleteAccountKMSKey, Environment, !Ref Environment]
           IPV_DECRYPTION_KEY: !GetAtt IPVSnsKmsKey.Arn
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Sub user-issued-credentials-v2-${Environment}
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
 
       DeadLetterQueue:
         TargetArn: !GetAtt DeleteAccountLambdaDLQ.Arn
@@ -180,6 +181,16 @@ Resources:
               Fn::ImportValue: !Sub "CoreBackDynamoDBKmsKey-${Environment}"
         - DynamoDBCrudPolicy:
             TableName: !Sub user-issued-credentials-v2-${Environment}
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
+        - Statement:
+            - Sid: kmsAuditEventQueueEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
     Metadata:
       BuildMethod: esbuild
       BuildProperties:

--- a/lambdas/delete-user-data/package-lock.json
+++ b/lambdas/delete-user-data/package-lock.json
@@ -14,6 +14,7 @@
         "@aws-lambda-powertools/commons": "1.5.1",
         "@aws-sdk/client-dynamodb": "3.259.0",
         "@aws-sdk/client-sqs": "3.264.0",
+        "@aws-sdk/client-ssm": "3.266.0",
         "@aws-sdk/lib-dynamodb": "3.259.0",
         "@swc/jest": "0.2.24",
         "@types/aws-lambda": "8.10.109",
@@ -509,6 +510,836 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.266.0.tgz",
+      "integrity": "sha512-sGjFw1JuQw+lwS2FZEcHXSuMl2M357gkKDHTqMHAfaGt3Fe1Tf56sHreBlOPd1uSakK7x4QFIGghoDu6Ox3nVw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.266.0",
+        "@aws-sdk/config-resolver": "3.266.0",
+        "@aws-sdk/credential-provider-node": "3.266.0",
+        "@aws-sdk/fetch-http-handler": "3.266.0",
+        "@aws-sdk/hash-node": "3.266.0",
+        "@aws-sdk/invalid-dependency": "3.266.0",
+        "@aws-sdk/middleware-content-length": "3.266.0",
+        "@aws-sdk/middleware-endpoint": "3.266.0",
+        "@aws-sdk/middleware-host-header": "3.266.0",
+        "@aws-sdk/middleware-logger": "3.266.0",
+        "@aws-sdk/middleware-recursion-detection": "3.266.0",
+        "@aws-sdk/middleware-retry": "3.266.0",
+        "@aws-sdk/middleware-serde": "3.266.0",
+        "@aws-sdk/middleware-signing": "3.266.0",
+        "@aws-sdk/middleware-stack": "3.266.0",
+        "@aws-sdk/middleware-user-agent": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.266.0",
+        "@aws-sdk/node-http-handler": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/smithy-client": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
+        "@aws-sdk/util-defaults-mode-node": "3.266.0",
+        "@aws-sdk/util-endpoints": "3.266.0",
+        "@aws-sdk/util-retry": "3.266.0",
+        "@aws-sdk/util-user-agent-browser": "3.266.0",
+        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "@aws-sdk/util-waiter": "3.266.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.266.0.tgz",
+      "integrity": "sha512-H/ySWWSwJN5coP9c5Ge2pOJYs1YPG5AVemGeKRx3kw5Z7Btd9jSFyYV0qGPd78HG3FopjZqSb4l2puPPp8UdpA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.266.0.tgz",
+      "integrity": "sha512-eK20HlA61ehvCBf62bk29DX0cXPQh2/KMlvuHnjhxDrn4BLMxLCMer8Awz3MIoBbVQKG1h46X2z6/pJra8Fs4w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.266.0",
+        "@aws-sdk/fetch-http-handler": "3.266.0",
+        "@aws-sdk/hash-node": "3.266.0",
+        "@aws-sdk/invalid-dependency": "3.266.0",
+        "@aws-sdk/middleware-content-length": "3.266.0",
+        "@aws-sdk/middleware-endpoint": "3.266.0",
+        "@aws-sdk/middleware-host-header": "3.266.0",
+        "@aws-sdk/middleware-logger": "3.266.0",
+        "@aws-sdk/middleware-recursion-detection": "3.266.0",
+        "@aws-sdk/middleware-retry": "3.266.0",
+        "@aws-sdk/middleware-serde": "3.266.0",
+        "@aws-sdk/middleware-stack": "3.266.0",
+        "@aws-sdk/middleware-user-agent": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.266.0",
+        "@aws-sdk/node-http-handler": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/smithy-client": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
+        "@aws-sdk/util-defaults-mode-node": "3.266.0",
+        "@aws-sdk/util-endpoints": "3.266.0",
+        "@aws-sdk/util-retry": "3.266.0",
+        "@aws-sdk/util-user-agent-browser": "3.266.0",
+        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.266.0.tgz",
+      "integrity": "sha512-kpXr0Vj7IjDZ1ef3GHAe+/eDFp/XpEKfNHCl0r2MB5zTTFYxDm8BlFl7qB1rBJlqzqpPRhy+1J+UAsg84melsw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.266.0",
+        "@aws-sdk/fetch-http-handler": "3.266.0",
+        "@aws-sdk/hash-node": "3.266.0",
+        "@aws-sdk/invalid-dependency": "3.266.0",
+        "@aws-sdk/middleware-content-length": "3.266.0",
+        "@aws-sdk/middleware-endpoint": "3.266.0",
+        "@aws-sdk/middleware-host-header": "3.266.0",
+        "@aws-sdk/middleware-logger": "3.266.0",
+        "@aws-sdk/middleware-recursion-detection": "3.266.0",
+        "@aws-sdk/middleware-retry": "3.266.0",
+        "@aws-sdk/middleware-serde": "3.266.0",
+        "@aws-sdk/middleware-stack": "3.266.0",
+        "@aws-sdk/middleware-user-agent": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.266.0",
+        "@aws-sdk/node-http-handler": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/smithy-client": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
+        "@aws-sdk/util-defaults-mode-node": "3.266.0",
+        "@aws-sdk/util-endpoints": "3.266.0",
+        "@aws-sdk/util-retry": "3.266.0",
+        "@aws-sdk/util-user-agent-browser": "3.266.0",
+        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.266.0.tgz",
+      "integrity": "sha512-ml3cjtIhHP21OwNKAC25ys5nAox0m4E2gPH97Q5s/1aE/hzxqQKkTO6YWp3eW7gwruubNV1GG/w0uHvAUYMjBw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.266.0",
+        "@aws-sdk/credential-provider-node": "3.266.0",
+        "@aws-sdk/fetch-http-handler": "3.266.0",
+        "@aws-sdk/hash-node": "3.266.0",
+        "@aws-sdk/invalid-dependency": "3.266.0",
+        "@aws-sdk/middleware-content-length": "3.266.0",
+        "@aws-sdk/middleware-endpoint": "3.266.0",
+        "@aws-sdk/middleware-host-header": "3.266.0",
+        "@aws-sdk/middleware-logger": "3.266.0",
+        "@aws-sdk/middleware-recursion-detection": "3.266.0",
+        "@aws-sdk/middleware-retry": "3.266.0",
+        "@aws-sdk/middleware-sdk-sts": "3.266.0",
+        "@aws-sdk/middleware-serde": "3.266.0",
+        "@aws-sdk/middleware-signing": "3.266.0",
+        "@aws-sdk/middleware-stack": "3.266.0",
+        "@aws-sdk/middleware-user-agent": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.266.0",
+        "@aws-sdk/node-http-handler": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/smithy-client": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
+        "@aws-sdk/util-defaults-mode-node": "3.266.0",
+        "@aws-sdk/util-endpoints": "3.266.0",
+        "@aws-sdk/util-retry": "3.266.0",
+        "@aws-sdk/util-user-agent-browser": "3.266.0",
+        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.266.0.tgz",
+      "integrity": "sha512-s1DKPIJVcB506mRDGLzRAT3ZFUD/JvglbRoN9/oGUkCHusiOAlOIuTTilSfkjq13Ntq+O/sUIpWhir0R45dBcA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.266.0.tgz",
+      "integrity": "sha512-hh6/mkchzl6KUZBNFBkTB2YKEKPr2nLYS65d5DQnj+O2zXrWzVejS3mGT5iI7FZTcmKEdkxEGM+w8eZNGrdLBQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.266.0.tgz",
+      "integrity": "sha512-UEfzcMtSJsNt9DedP+LDAG3cSLq7XFl/6wJAkDAAeNuDmy5iTCk03sZF21LJ1A31GKviEHpxLquBslOdk1DYGQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.266.0",
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/url-parser": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.266.0.tgz",
+      "integrity": "sha512-zyQo/eCtiPjoDvcsDI4xBojY6qy+o59B4LiVan1byvDQBbdI2VqshaDC4E+VJyCXcIZlYY1cT5NWt2g3wKKOLg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.266.0",
+        "@aws-sdk/credential-provider-imds": "3.266.0",
+        "@aws-sdk/credential-provider-process": "3.266.0",
+        "@aws-sdk/credential-provider-sso": "3.266.0",
+        "@aws-sdk/credential-provider-web-identity": "3.266.0",
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/shared-ini-file-loader": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.266.0.tgz",
+      "integrity": "sha512-x4KtMZFpNuh6jfrKWtOnwkRrVJj4dR7fAWD95xiUtykE4eD7YthTBOQPVtRcroxHNKo80gmcZnJf6ZdvHG0XCw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.266.0",
+        "@aws-sdk/credential-provider-imds": "3.266.0",
+        "@aws-sdk/credential-provider-ini": "3.266.0",
+        "@aws-sdk/credential-provider-process": "3.266.0",
+        "@aws-sdk/credential-provider-sso": "3.266.0",
+        "@aws-sdk/credential-provider-web-identity": "3.266.0",
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/shared-ini-file-loader": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.266.0.tgz",
+      "integrity": "sha512-x9MvMCAVUGr/7c2h6HbpDbEQSkdc2CH7snqdzl3fL6f3Q2HqhIG9rYWi9kAm4WIOIe2AuEIyzpOcGhwu+lyAqQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/shared-ini-file-loader": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.266.0.tgz",
+      "integrity": "sha512-48QjXHmL8etffasJa0ioQxLvFGJrD53cPC8PbiUCcsbhmEg7TEGIRDdir7h+RzEup+9s1kJhdwCsi1k2jkyXMg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.266.0",
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/shared-ini-file-loader": "3.266.0",
+        "@aws-sdk/token-providers": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.266.0.tgz",
+      "integrity": "sha512-EMcH+vt/WyWysHa2vwq2G3n73gRhyJ7fw3sh+3MhBtK5850bpLeSBz3iXvow3VKm8rbkn5IwZ2YdwG2OZgr66w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.266.0.tgz",
+      "integrity": "sha512-qqW5G/AdanNdAtNtDripRvijzgVOhvZ6NLRjVuOwWp3C5WRAAzMdl2lew2Q2swUy4InHwDsNeYjdhn1+hIIjrg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/querystring-builder": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/hash-node": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.266.0.tgz",
+      "integrity": "sha512-E0uXwLU0/lY1itKhS2wsDBaqysAryV/Suk6cXpyJWe13iktRJhMoVaD3SYEJD9jytXohXYgXCRly8tDYnxPwZQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.266.0.tgz",
+      "integrity": "sha512-q3LkPLTd3LXhFnym6jjtlZzhJK9U4WekCyhFYrD+bBlyQGW/wuimpKE0ovGIyxuIZ/oklreYai5u1uH5FzgFlA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.266.0.tgz",
+      "integrity": "sha512-sVsSJ00BBu5ttOOggNp9kRKPopz01g3+z4aZng8nH/ZLpNO0cNVJPqU0SOlwiWuYCQQBXJahMe/SpWLXuPPstA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.266.0.tgz",
+      "integrity": "sha512-xAuLKmCjD8DYNIb9LVfnWG/16nqzoHEW+kxfecxeTaKGXb3eD+LoCbbE2l7pqBFC4uE+8ufrgexBBibHRnhotg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/signature-v4": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.266.0.tgz",
+      "integrity": "sha512-Rz5xkVkr7DW23QiZoXHUhqXIHhtqM364jjmIfmHCXeYsobXqLw9spU8n2DLzcltFqFKLOljzahu3RKjYe5IUSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.266.0.tgz",
+      "integrity": "sha512-JiAvd0kKOmehdn2KBWxd7EobOVg5LCVZUtSKcwNdZiWhcxLw/z4Rn95J+Sk/e0GoHKETIkD5gRLWNNumjGgnvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.266.0.tgz",
+      "integrity": "sha512-kaAQQmeTL0JNPtT6g83FksIwnJfgtRP05a8FAeiLQOdhkxs862HWK7vpFHlEgSrGi49LP27Du+msqTErXcwOMQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.266.0.tgz",
+      "integrity": "sha512-SxfRXOfuuvllgtTSAPX/43+PTb0Xf8BlAoVQDstW+GDC+IfaL4wcmOKS4ClwUdzGEGBb4E+wL8wdEaVej3T3lA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/service-error-classification": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/util-retry": "3.266.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.266.0.tgz",
+      "integrity": "sha512-8yETgfyfFHc1m4v8LEUpxF2kEzc6qokjC6vwPGx2FghmZ9JdhpVWNJZRzpNqecKCl+MpkGfRv07NLvyc9veqww==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.266.0",
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/signature-v4": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.266.0.tgz",
+      "integrity": "sha512-UX7kFB5SmizNBcFIw6qNp/87dldx0VsDIZtTDpbeS05O3vsh7BEfByibOFPS5PlGqWjZt0T+FLcx/9Y4XSrSxA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.266.0.tgz",
+      "integrity": "sha512-PlpngmBB5P9oxEdYZRtCbHiP1ftDk/RIWLY2ewk02xK6lkzY8tlZ8wPGOmshj9C7b3SzPOASJLEbtDS86yXn/Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/signature-v4": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/util-middleware": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.266.0.tgz",
+      "integrity": "sha512-v1BHaHu+o1MUYoozeHRJQBEbnQvFeOnxL8e1/uio19DdWqtOA2wv6eznTfsxXOORER1xZX38EjlcZGWbM41maA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.266.0.tgz",
+      "integrity": "sha512-ofnRkm+iMMl6NatDa0nqGIFRVEtS5lIKntS4htPVsJvI/lqWzlgn75L2YgzYgkpU2o4GWBMvjCjhnnZ3V32BQQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.266.0.tgz",
+      "integrity": "sha512-myK9Dr/QNfijEZQFOFkQJ8NAyZVA8yBiZTA15+EMphap1ciVXRGSpE/8KzF/qEX5wY2WoDZuPUUfmPebC3+jUA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/shared-ini-file-loader": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.266.0.tgz",
+      "integrity": "sha512-JLezkHEDWN7dN/mZEzA0La+iKRZqxOyqjYJNpFNTz4ZiR0XlV5zhihHBkgatE0/hL1xVCV+ljSiyMGP//4DkjQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/querystring-builder": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/property-provider": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.266.0.tgz",
+      "integrity": "sha512-/M0HpUNkAUJF9wEKsWyJ/w2ZXwSwRByZ1IGkDluPoCweDmhbSp2n9WC8S/IyPktGlesEjQbfuLCvgjgiEfGPkg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.266.0.tgz",
+      "integrity": "sha512-bg59CcRVgqKlrwDBdxy3NFmi30P61nUqZlAHaEtdxoj/oVHNaUKMDGl/YEM8O1UB2r0KO4KJdEu5tvAcChYk+A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.266.0.tgz",
+      "integrity": "sha512-dor4slaD1ohUiGZxouK4Nu5LmRwspJg6JhOwKfaUMUR3oJnVnBBv5k/84UHjsmC6mJDWu4fEsfUd8rVg2HpYxA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.266.0.tgz",
+      "integrity": "sha512-XECB7T7xNoFOfyqgitQPwjLDGn4Y9M5pnPVwdKs3UiZGvX0KSBxtWMNRo5Sv4QyIOm0DQYQimER1DiKxbrpvZA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.266.0.tgz",
+      "integrity": "sha512-Yq9NVRkVaVzNsQsWZ6gwkfmyuPM6CBxBeWkjvcE0B4TiD8DDjFZIjGoUrUpGgraCA4W7WHeTwOFghzSK+BcYVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.266.0.tgz",
+      "integrity": "sha512-8S/7I6FjQczulFha2ebpBfUcbg3G/NDp+fByTz9DWqY9EI4VsvCJsScYexSc9t89F0ny9zyyspfESzfzdy2PRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.266.0.tgz",
+      "integrity": "sha512-TvDhA3yVTKLBgHNtKNY31m7O5HRSSQrk0OjVVt6mkEjAuXjSC4TDno+l/kOfpFco+gV1WiFt0cqrLAM6h9CL8A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.266.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.266.0.tgz",
+      "integrity": "sha512-FCv4cIt/uDFe2E24mgnL4PlnQcnkIj1v7H/jS6amRoZAkrDai6DcvnUQJ6TsyRTjKY56K1Xq/ev7vcXe+bcVJA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/token-providers": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.266.0.tgz",
+      "integrity": "sha512-NnWqT03u8STssKnKkGtHUSFDUBgv/VF+h4rwvyY5NKO9FMReN0v90XE/Bb2Oa3pzx6C5AG89kGmAvy+0VRn+Rg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.266.0",
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/shared-ini-file-loader": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.266.0.tgz",
+      "integrity": "sha512-DGOnzUKM9gE1xRyzNKe9S0hOMHT1C1CEuTJ8MgPQjXj5UgndAIItU+9kkfeZTLSbp3rDHeNZ8EP9/oS9kC+q8Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/url-parser": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.266.0.tgz",
+      "integrity": "sha512-KeXkGDNBlNGdrXKu9mKE018GvgtJg5aH3mliXvPnO3jXlhpbgu7G+PJoykAJiw41fcIwWC/lX6JDMkmIgvElwQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.266.0.tgz",
+      "integrity": "sha512-DzjU4TZyrvQBZfwdBBXTH5+SjeHWSrCplOOt6zXKtu8rt5GntVS4Oyx0DTz1JGCAqesicQpZ9jTQ6YKp7EOntw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.266.0.tgz",
+      "integrity": "sha512-hyxPm84YuHPxze7jHnYaLBGVcmdE6V9irlXUe3V/JgYYCnGdwMob+TNwkdWVp4DGW/8b41FxlBDvRZPBKCvTpQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.266.0",
+        "@aws-sdk/credential-provider-imds": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.266.0",
+        "@aws-sdk/property-provider": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.266.0.tgz",
+      "integrity": "sha512-G75mBFyEoO9+fnx2BawcmdnRyBkE2mIyDl560cgxH3HiicmgED71QNQ+qWxxmFx+G4bnZOft+2l9BfIf+i9wcA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.266.0.tgz",
+      "integrity": "sha512-q5dWY20Euh9vCXCuTNbcKXLNhW6dXBHxYAHR+csP2OFNLLB4wiJaeMYr9iwcB0YXcfnpQbXznSF0PLbPPZgCmw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-retry": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.266.0.tgz",
+      "integrity": "sha512-+HcMcJ8y9O3Jsq0I3Zqh9/cqMey3RM4j+M6hzAsFBOwjbBvWV4EfXb5g+NODJzyLxrBIHAesZyyQAiCipvbAlA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.266.0.tgz",
+      "integrity": "sha512-pMJ4C5lzDEVJ0kZoZdV1ww4hn9s15cExaPcRgUqjCwzNxYo9E1Jc6wCC533sYNZF1aSkY9NDLyJmv/lP7FvF4A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.266.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.266.0.tgz",
+      "integrity": "sha512-CNpJsxvEplAP3XLwUmr7iJ428pCH2aFQIFLjXFjcAaB2IbgG1/801hdzdmeBH+1LSYVJ5qd3R+HeaZhxMDo62A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.266.0.tgz",
+      "integrity": "sha512-le+ekM2U/MyQ81e9aZHfhj2XFsHxzmHdlvqFIkrSQ71Wt1/Fkv8DcVUEQy9IbO88sOzVGOsB8T7USU3zAVBGnQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
@@ -7321,6 +8152,698 @@
             "@aws-sdk/node-config-provider": "3.259.0",
             "@aws-sdk/property-provider": "3.257.0",
             "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/client-ssm": {
+      "version": "3.266.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.266.0.tgz",
+      "integrity": "sha512-sGjFw1JuQw+lwS2FZEcHXSuMl2M357gkKDHTqMHAfaGt3Fe1Tf56sHreBlOPd1uSakK7x4QFIGghoDu6Ox3nVw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.266.0",
+        "@aws-sdk/config-resolver": "3.266.0",
+        "@aws-sdk/credential-provider-node": "3.266.0",
+        "@aws-sdk/fetch-http-handler": "3.266.0",
+        "@aws-sdk/hash-node": "3.266.0",
+        "@aws-sdk/invalid-dependency": "3.266.0",
+        "@aws-sdk/middleware-content-length": "3.266.0",
+        "@aws-sdk/middleware-endpoint": "3.266.0",
+        "@aws-sdk/middleware-host-header": "3.266.0",
+        "@aws-sdk/middleware-logger": "3.266.0",
+        "@aws-sdk/middleware-recursion-detection": "3.266.0",
+        "@aws-sdk/middleware-retry": "3.266.0",
+        "@aws-sdk/middleware-serde": "3.266.0",
+        "@aws-sdk/middleware-signing": "3.266.0",
+        "@aws-sdk/middleware-stack": "3.266.0",
+        "@aws-sdk/middleware-user-agent": "3.266.0",
+        "@aws-sdk/node-config-provider": "3.266.0",
+        "@aws-sdk/node-http-handler": "3.266.0",
+        "@aws-sdk/protocol-http": "3.266.0",
+        "@aws-sdk/smithy-client": "3.266.0",
+        "@aws-sdk/types": "3.266.0",
+        "@aws-sdk/url-parser": "3.266.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.266.0",
+        "@aws-sdk/util-defaults-mode-node": "3.266.0",
+        "@aws-sdk/util-endpoints": "3.266.0",
+        "@aws-sdk/util-retry": "3.266.0",
+        "@aws-sdk/util-user-agent-browser": "3.266.0",
+        "@aws-sdk/util-user-agent-node": "3.266.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "@aws-sdk/util-waiter": "3.266.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.266.0.tgz",
+          "integrity": "sha512-H/ySWWSwJN5coP9c5Ge2pOJYs1YPG5AVemGeKRx3kw5Z7Btd9jSFyYV0qGPd78HG3FopjZqSb4l2puPPp8UdpA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.266.0.tgz",
+          "integrity": "sha512-eK20HlA61ehvCBf62bk29DX0cXPQh2/KMlvuHnjhxDrn4BLMxLCMer8Awz3MIoBbVQKG1h46X2z6/pJra8Fs4w==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.266.0",
+            "@aws-sdk/fetch-http-handler": "3.266.0",
+            "@aws-sdk/hash-node": "3.266.0",
+            "@aws-sdk/invalid-dependency": "3.266.0",
+            "@aws-sdk/middleware-content-length": "3.266.0",
+            "@aws-sdk/middleware-endpoint": "3.266.0",
+            "@aws-sdk/middleware-host-header": "3.266.0",
+            "@aws-sdk/middleware-logger": "3.266.0",
+            "@aws-sdk/middleware-recursion-detection": "3.266.0",
+            "@aws-sdk/middleware-retry": "3.266.0",
+            "@aws-sdk/middleware-serde": "3.266.0",
+            "@aws-sdk/middleware-stack": "3.266.0",
+            "@aws-sdk/middleware-user-agent": "3.266.0",
+            "@aws-sdk/node-config-provider": "3.266.0",
+            "@aws-sdk/node-http-handler": "3.266.0",
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/smithy-client": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/url-parser": "3.266.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.266.0",
+            "@aws-sdk/util-defaults-mode-node": "3.266.0",
+            "@aws-sdk/util-endpoints": "3.266.0",
+            "@aws-sdk/util-retry": "3.266.0",
+            "@aws-sdk/util-user-agent-browser": "3.266.0",
+            "@aws-sdk/util-user-agent-node": "3.266.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.266.0.tgz",
+          "integrity": "sha512-kpXr0Vj7IjDZ1ef3GHAe+/eDFp/XpEKfNHCl0r2MB5zTTFYxDm8BlFl7qB1rBJlqzqpPRhy+1J+UAsg84melsw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.266.0",
+            "@aws-sdk/fetch-http-handler": "3.266.0",
+            "@aws-sdk/hash-node": "3.266.0",
+            "@aws-sdk/invalid-dependency": "3.266.0",
+            "@aws-sdk/middleware-content-length": "3.266.0",
+            "@aws-sdk/middleware-endpoint": "3.266.0",
+            "@aws-sdk/middleware-host-header": "3.266.0",
+            "@aws-sdk/middleware-logger": "3.266.0",
+            "@aws-sdk/middleware-recursion-detection": "3.266.0",
+            "@aws-sdk/middleware-retry": "3.266.0",
+            "@aws-sdk/middleware-serde": "3.266.0",
+            "@aws-sdk/middleware-stack": "3.266.0",
+            "@aws-sdk/middleware-user-agent": "3.266.0",
+            "@aws-sdk/node-config-provider": "3.266.0",
+            "@aws-sdk/node-http-handler": "3.266.0",
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/smithy-client": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/url-parser": "3.266.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.266.0",
+            "@aws-sdk/util-defaults-mode-node": "3.266.0",
+            "@aws-sdk/util-endpoints": "3.266.0",
+            "@aws-sdk/util-retry": "3.266.0",
+            "@aws-sdk/util-user-agent-browser": "3.266.0",
+            "@aws-sdk/util-user-agent-node": "3.266.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.266.0.tgz",
+          "integrity": "sha512-ml3cjtIhHP21OwNKAC25ys5nAox0m4E2gPH97Q5s/1aE/hzxqQKkTO6YWp3eW7gwruubNV1GG/w0uHvAUYMjBw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.266.0",
+            "@aws-sdk/credential-provider-node": "3.266.0",
+            "@aws-sdk/fetch-http-handler": "3.266.0",
+            "@aws-sdk/hash-node": "3.266.0",
+            "@aws-sdk/invalid-dependency": "3.266.0",
+            "@aws-sdk/middleware-content-length": "3.266.0",
+            "@aws-sdk/middleware-endpoint": "3.266.0",
+            "@aws-sdk/middleware-host-header": "3.266.0",
+            "@aws-sdk/middleware-logger": "3.266.0",
+            "@aws-sdk/middleware-recursion-detection": "3.266.0",
+            "@aws-sdk/middleware-retry": "3.266.0",
+            "@aws-sdk/middleware-sdk-sts": "3.266.0",
+            "@aws-sdk/middleware-serde": "3.266.0",
+            "@aws-sdk/middleware-signing": "3.266.0",
+            "@aws-sdk/middleware-stack": "3.266.0",
+            "@aws-sdk/middleware-user-agent": "3.266.0",
+            "@aws-sdk/node-config-provider": "3.266.0",
+            "@aws-sdk/node-http-handler": "3.266.0",
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/smithy-client": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/url-parser": "3.266.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.266.0",
+            "@aws-sdk/util-defaults-mode-node": "3.266.0",
+            "@aws-sdk/util-endpoints": "3.266.0",
+            "@aws-sdk/util-retry": "3.266.0",
+            "@aws-sdk/util-user-agent-browser": "3.266.0",
+            "@aws-sdk/util-user-agent-node": "3.266.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.266.0.tgz",
+          "integrity": "sha512-s1DKPIJVcB506mRDGLzRAT3ZFUD/JvglbRoN9/oGUkCHusiOAlOIuTTilSfkjq13Ntq+O/sUIpWhir0R45dBcA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/signature-v4": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.266.0.tgz",
+          "integrity": "sha512-hh6/mkchzl6KUZBNFBkTB2YKEKPr2nLYS65d5DQnj+O2zXrWzVejS3mGT5iI7FZTcmKEdkxEGM+w8eZNGrdLBQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.266.0.tgz",
+          "integrity": "sha512-UEfzcMtSJsNt9DedP+LDAG3cSLq7XFl/6wJAkDAAeNuDmy5iTCk03sZF21LJ1A31GKviEHpxLquBslOdk1DYGQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.266.0",
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/url-parser": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.266.0.tgz",
+          "integrity": "sha512-zyQo/eCtiPjoDvcsDI4xBojY6qy+o59B4LiVan1byvDQBbdI2VqshaDC4E+VJyCXcIZlYY1cT5NWt2g3wKKOLg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.266.0",
+            "@aws-sdk/credential-provider-imds": "3.266.0",
+            "@aws-sdk/credential-provider-process": "3.266.0",
+            "@aws-sdk/credential-provider-sso": "3.266.0",
+            "@aws-sdk/credential-provider-web-identity": "3.266.0",
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/shared-ini-file-loader": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.266.0.tgz",
+          "integrity": "sha512-x4KtMZFpNuh6jfrKWtOnwkRrVJj4dR7fAWD95xiUtykE4eD7YthTBOQPVtRcroxHNKo80gmcZnJf6ZdvHG0XCw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.266.0",
+            "@aws-sdk/credential-provider-imds": "3.266.0",
+            "@aws-sdk/credential-provider-ini": "3.266.0",
+            "@aws-sdk/credential-provider-process": "3.266.0",
+            "@aws-sdk/credential-provider-sso": "3.266.0",
+            "@aws-sdk/credential-provider-web-identity": "3.266.0",
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/shared-ini-file-loader": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.266.0.tgz",
+          "integrity": "sha512-x9MvMCAVUGr/7c2h6HbpDbEQSkdc2CH7snqdzl3fL6f3Q2HqhIG9rYWi9kAm4WIOIe2AuEIyzpOcGhwu+lyAqQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/shared-ini-file-loader": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.266.0.tgz",
+          "integrity": "sha512-48QjXHmL8etffasJa0ioQxLvFGJrD53cPC8PbiUCcsbhmEg7TEGIRDdir7h+RzEup+9s1kJhdwCsi1k2jkyXMg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.266.0",
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/shared-ini-file-loader": "3.266.0",
+            "@aws-sdk/token-providers": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.266.0.tgz",
+          "integrity": "sha512-EMcH+vt/WyWysHa2vwq2G3n73gRhyJ7fw3sh+3MhBtK5850bpLeSBz3iXvow3VKm8rbkn5IwZ2YdwG2OZgr66w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.266.0.tgz",
+          "integrity": "sha512-qqW5G/AdanNdAtNtDripRvijzgVOhvZ6NLRjVuOwWp3C5WRAAzMdl2lew2Q2swUy4InHwDsNeYjdhn1+hIIjrg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/querystring-builder": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.266.0.tgz",
+          "integrity": "sha512-E0uXwLU0/lY1itKhS2wsDBaqysAryV/Suk6cXpyJWe13iktRJhMoVaD3SYEJD9jytXohXYgXCRly8tDYnxPwZQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.266.0.tgz",
+          "integrity": "sha512-q3LkPLTd3LXhFnym6jjtlZzhJK9U4WekCyhFYrD+bBlyQGW/wuimpKE0ovGIyxuIZ/oklreYai5u1uH5FzgFlA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.266.0.tgz",
+          "integrity": "sha512-sVsSJ00BBu5ttOOggNp9kRKPopz01g3+z4aZng8nH/ZLpNO0cNVJPqU0SOlwiWuYCQQBXJahMe/SpWLXuPPstA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.266.0.tgz",
+          "integrity": "sha512-xAuLKmCjD8DYNIb9LVfnWG/16nqzoHEW+kxfecxeTaKGXb3eD+LoCbbE2l7pqBFC4uE+8ufrgexBBibHRnhotg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.266.0",
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/signature-v4": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/url-parser": "3.266.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.266.0.tgz",
+          "integrity": "sha512-Rz5xkVkr7DW23QiZoXHUhqXIHhtqM364jjmIfmHCXeYsobXqLw9spU8n2DLzcltFqFKLOljzahu3RKjYe5IUSw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.266.0.tgz",
+          "integrity": "sha512-JiAvd0kKOmehdn2KBWxd7EobOVg5LCVZUtSKcwNdZiWhcxLw/z4Rn95J+Sk/e0GoHKETIkD5gRLWNNumjGgnvA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.266.0.tgz",
+          "integrity": "sha512-kaAQQmeTL0JNPtT6g83FksIwnJfgtRP05a8FAeiLQOdhkxs862HWK7vpFHlEgSrGi49LP27Du+msqTErXcwOMQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.266.0.tgz",
+          "integrity": "sha512-SxfRXOfuuvllgtTSAPX/43+PTb0Xf8BlAoVQDstW+GDC+IfaL4wcmOKS4ClwUdzGEGBb4E+wL8wdEaVej3T3lA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/service-error-classification": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/util-middleware": "3.266.0",
+            "@aws-sdk/util-retry": "3.266.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.266.0.tgz",
+          "integrity": "sha512-8yETgfyfFHc1m4v8LEUpxF2kEzc6qokjC6vwPGx2FghmZ9JdhpVWNJZRzpNqecKCl+MpkGfRv07NLvyc9veqww==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.266.0",
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/signature-v4": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.266.0.tgz",
+          "integrity": "sha512-UX7kFB5SmizNBcFIw6qNp/87dldx0VsDIZtTDpbeS05O3vsh7BEfByibOFPS5PlGqWjZt0T+FLcx/9Y4XSrSxA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.266.0.tgz",
+          "integrity": "sha512-PlpngmBB5P9oxEdYZRtCbHiP1ftDk/RIWLY2ewk02xK6lkzY8tlZ8wPGOmshj9C7b3SzPOASJLEbtDS86yXn/Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/signature-v4": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/util-middleware": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.266.0.tgz",
+          "integrity": "sha512-v1BHaHu+o1MUYoozeHRJQBEbnQvFeOnxL8e1/uio19DdWqtOA2wv6eznTfsxXOORER1xZX38EjlcZGWbM41maA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.266.0.tgz",
+          "integrity": "sha512-ofnRkm+iMMl6NatDa0nqGIFRVEtS5lIKntS4htPVsJvI/lqWzlgn75L2YgzYgkpU2o4GWBMvjCjhnnZ3V32BQQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.266.0.tgz",
+          "integrity": "sha512-myK9Dr/QNfijEZQFOFkQJ8NAyZVA8yBiZTA15+EMphap1ciVXRGSpE/8KzF/qEX5wY2WoDZuPUUfmPebC3+jUA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/shared-ini-file-loader": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.266.0.tgz",
+          "integrity": "sha512-JLezkHEDWN7dN/mZEzA0La+iKRZqxOyqjYJNpFNTz4ZiR0XlV5zhihHBkgatE0/hL1xVCV+ljSiyMGP//4DkjQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.266.0",
+            "@aws-sdk/protocol-http": "3.266.0",
+            "@aws-sdk/querystring-builder": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.266.0.tgz",
+          "integrity": "sha512-/M0HpUNkAUJF9wEKsWyJ/w2ZXwSwRByZ1IGkDluPoCweDmhbSp2n9WC8S/IyPktGlesEjQbfuLCvgjgiEfGPkg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.266.0.tgz",
+          "integrity": "sha512-bg59CcRVgqKlrwDBdxy3NFmi30P61nUqZlAHaEtdxoj/oVHNaUKMDGl/YEM8O1UB2r0KO4KJdEu5tvAcChYk+A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.266.0.tgz",
+          "integrity": "sha512-dor4slaD1ohUiGZxouK4Nu5LmRwspJg6JhOwKfaUMUR3oJnVnBBv5k/84UHjsmC6mJDWu4fEsfUd8rVg2HpYxA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.266.0.tgz",
+          "integrity": "sha512-XECB7T7xNoFOfyqgitQPwjLDGn4Y9M5pnPVwdKs3UiZGvX0KSBxtWMNRo5Sv4QyIOm0DQYQimER1DiKxbrpvZA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.266.0.tgz",
+          "integrity": "sha512-Yq9NVRkVaVzNsQsWZ6gwkfmyuPM6CBxBeWkjvcE0B4TiD8DDjFZIjGoUrUpGgraCA4W7WHeTwOFghzSK+BcYVA==",
+          "dev": true
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.266.0.tgz",
+          "integrity": "sha512-8S/7I6FjQczulFha2ebpBfUcbg3G/NDp+fByTz9DWqY9EI4VsvCJsScYexSc9t89F0ny9zyyspfESzfzdy2PRw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.266.0.tgz",
+          "integrity": "sha512-TvDhA3yVTKLBgHNtKNY31m7O5HRSSQrk0OjVVt6mkEjAuXjSC4TDno+l/kOfpFco+gV1WiFt0cqrLAM6h9CL8A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.266.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.266.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.266.0.tgz",
+          "integrity": "sha512-FCv4cIt/uDFe2E24mgnL4PlnQcnkIj1v7H/jS6amRoZAkrDai6DcvnUQJ6TsyRTjKY56K1Xq/ev7vcXe+bcVJA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.266.0.tgz",
+          "integrity": "sha512-NnWqT03u8STssKnKkGtHUSFDUBgv/VF+h4rwvyY5NKO9FMReN0v90XE/Bb2Oa3pzx6C5AG89kGmAvy+0VRn+Rg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.266.0",
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/shared-ini-file-loader": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.266.0.tgz",
+          "integrity": "sha512-DGOnzUKM9gE1xRyzNKe9S0hOMHT1C1CEuTJ8MgPQjXj5UgndAIItU+9kkfeZTLSbp3rDHeNZ8EP9/oS9kC+q8Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.266.0.tgz",
+          "integrity": "sha512-KeXkGDNBlNGdrXKu9mKE018GvgtJg5aH3mliXvPnO3jXlhpbgu7G+PJoykAJiw41fcIwWC/lX6JDMkmIgvElwQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.266.0.tgz",
+          "integrity": "sha512-DzjU4TZyrvQBZfwdBBXTH5+SjeHWSrCplOOt6zXKtu8rt5GntVS4Oyx0DTz1JGCAqesicQpZ9jTQ6YKp7EOntw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.266.0.tgz",
+          "integrity": "sha512-hyxPm84YuHPxze7jHnYaLBGVcmdE6V9irlXUe3V/JgYYCnGdwMob+TNwkdWVp4DGW/8b41FxlBDvRZPBKCvTpQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/config-resolver": "3.266.0",
+            "@aws-sdk/credential-provider-imds": "3.266.0",
+            "@aws-sdk/node-config-provider": "3.266.0",
+            "@aws-sdk/property-provider": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.266.0.tgz",
+          "integrity": "sha512-G75mBFyEoO9+fnx2BawcmdnRyBkE2mIyDl560cgxH3HiicmgED71QNQ+qWxxmFx+G4bnZOft+2l9BfIf+i9wcA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.266.0.tgz",
+          "integrity": "sha512-q5dWY20Euh9vCXCuTNbcKXLNhW6dXBHxYAHR+csP2OFNLLB4wiJaeMYr9iwcB0YXcfnpQbXznSF0PLbPPZgCmw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-retry": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.266.0.tgz",
+          "integrity": "sha512-+HcMcJ8y9O3Jsq0I3Zqh9/cqMey3RM4j+M6hzAsFBOwjbBvWV4EfXb5g+NODJzyLxrBIHAesZyyQAiCipvbAlA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/service-error-classification": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.266.0.tgz",
+          "integrity": "sha512-pMJ4C5lzDEVJ0kZoZdV1ww4hn9s15cExaPcRgUqjCwzNxYo9E1Jc6wCC533sYNZF1aSkY9NDLyJmv/lP7FvF4A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.266.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.266.0.tgz",
+          "integrity": "sha512-CNpJsxvEplAP3XLwUmr7iJ428pCH2aFQIFLjXFjcAaB2IbgG1/801hdzdmeBH+1LSYVJ5qd3R+HeaZhxMDo62A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.266.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.266.0.tgz",
+          "integrity": "sha512-le+ekM2U/MyQ81e9aZHfhj2XFsHxzmHdlvqFIkrSQ71Wt1/Fkv8DcVUEQy9IbO88sOzVGOsB8T7USU3zAVBGnQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.266.0",
+            "@aws-sdk/types": "3.266.0",
             "tslib": "^2.3.1"
           }
         },

--- a/lambdas/delete-user-data/package-lock.json
+++ b/lambdas/delete-user-data/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@aws-lambda-powertools/commons": "1.5.1",
         "@aws-sdk/client-dynamodb": "3.259.0",
+        "@aws-sdk/client-sqs": "3.264.0",
         "@aws-sdk/lib-dynamodb": "3.259.0",
         "@swc/jest": "0.2.24",
         "@types/aws-lambda": "8.10.109",
@@ -181,6 +182,333 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.264.0.tgz",
+      "integrity": "sha512-ZVnc6sQYto7rQqFBNWzFT9NWEvEhEF8MRE5hwagyhewhDccHyhbI+O9mN+FaiX4InRmRs6eYW9yLUEuFc9RCQA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.264.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/md5-js": "3.258.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.264.0.tgz",
+      "integrity": "sha512-p+7sYpRcdv9omnnsPhD/vOFuZ1SpfV62ZgistBK/RDsQg2W9SIWQRW1KPt7gOCQ0nwp4efntw4Sle0LjS7ykxg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.264.0.tgz",
+      "integrity": "sha512-82hGEbfsD4lBGIF1q8o82jTNSgBCcBpfFsvA+ltZf0bh4ChIWOi4vVvg8G+zVQN1mm/Rj8vWYO/D0tNF8OSyWw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.264.0.tgz",
+      "integrity": "sha512-sco1jREkDdds4Z3V19Vlu/YpBHSzeEt1KFqOPnbjFw7pSakRNzpyWmLLxOwWjwgGKt6pSF3Aw0ZOMYsAUDc5qQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-sdk-sts": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.264.0.tgz",
+      "integrity": "sha512-UU5NNlfn+Go+5PLBzyTH1YE3r/pgykpE4QYFon87sCnEQnQH9xmlRTW1f1cBSQ9kivbFZd2/C2X3qhB3fe2JfA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.264.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.264.0.tgz",
+      "integrity": "sha512-DPzL7oawcILs5Mduim9Z8SVeJaUpaDRVbUIrBHsMBu+N7Zuqtzr+0ckHc1bEi3iYq2QUCk5pH5vpQaZYkMlbtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.257.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/credential-provider-ini": "3.264.0",
+        "@aws-sdk/credential-provider-process": "3.257.0",
+        "@aws-sdk/credential-provider-sso": "3.264.0",
+        "@aws-sdk/credential-provider-web-identity": "3.257.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.264.0.tgz",
+      "integrity": "sha512-CJuAlqIIJap6LXoqimvEAnYZ7Kb5pTbiS3e+aY+fajO3OPujmQpHuiY8kOmscjwZ4ErJdEskivcTGwXph0dPZQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.264.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/token-providers": "3.264.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.264.0.tgz",
+      "integrity": "sha512-H9JEAug3Oo3IA2wZIplVVF6NtauCIjICXWgbNbA8Im+I2KPe0jWtOdtQv4U+tqHe9T4zIixaCM3gjUBld+FoOA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/signature-v4": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
+      "integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.264.0.tgz",
+      "integrity": "sha512-1N54FCdBJRqrwFWHUoDpGI0rKhI29Or9ZwGjjcBzKzLhz5sEF/DEhuID7h1/KKEkXdQ0+lmXOFGMMrahrMpOow==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.264.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/shared-ini-file-loader": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
+      "integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.261.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
+      "integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-imds": "3.259.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/property-provider": "3.257.0",
+        "@aws-sdk/types": "3.257.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
@@ -635,6 +963,23 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.258.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.258.0.tgz",
+      "integrity": "sha512-aLdZ43sEiT68p7YYPHwKsWU1WDC8Wf8UQfb4pzbvhYNgr5VxN46AtbWTKxLAqK2adKS4FnbyX2i66fINg2dHdw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.257.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
@@ -780,6 +1125,27 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.257.0.tgz",
+      "integrity": "sha512-NXdaAmHmFqNtP78NuyzPmUqCd2rCLLZnYxaU4SKSX+OpBpfwHX2sIBJlvKm7rGFH1txI7Zk3O8UkTxKGZe9W1Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
@@ -6673,6 +7039,299 @@
         }
       }
     },
+    "@aws-sdk/client-sqs": {
+      "version": "3.264.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.264.0.tgz",
+      "integrity": "sha512-ZVnc6sQYto7rQqFBNWzFT9NWEvEhEF8MRE5hwagyhewhDccHyhbI+O9mN+FaiX4InRmRs6eYW9yLUEuFc9RCQA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.264.0",
+        "@aws-sdk/config-resolver": "3.259.0",
+        "@aws-sdk/credential-provider-node": "3.264.0",
+        "@aws-sdk/fetch-http-handler": "3.257.0",
+        "@aws-sdk/hash-node": "3.257.0",
+        "@aws-sdk/invalid-dependency": "3.257.0",
+        "@aws-sdk/md5-js": "3.258.0",
+        "@aws-sdk/middleware-content-length": "3.257.0",
+        "@aws-sdk/middleware-endpoint": "3.264.0",
+        "@aws-sdk/middleware-host-header": "3.257.0",
+        "@aws-sdk/middleware-logger": "3.257.0",
+        "@aws-sdk/middleware-recursion-detection": "3.257.0",
+        "@aws-sdk/middleware-retry": "3.259.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.257.0",
+        "@aws-sdk/middleware-serde": "3.257.0",
+        "@aws-sdk/middleware-signing": "3.257.0",
+        "@aws-sdk/middleware-stack": "3.257.0",
+        "@aws-sdk/middleware-user-agent": "3.257.0",
+        "@aws-sdk/node-config-provider": "3.259.0",
+        "@aws-sdk/node-http-handler": "3.257.0",
+        "@aws-sdk/protocol-http": "3.257.0",
+        "@aws-sdk/smithy-client": "3.261.0",
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/url-parser": "3.257.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+        "@aws-sdk/util-defaults-mode-node": "3.261.0",
+        "@aws-sdk/util-endpoints": "3.257.0",
+        "@aws-sdk/util-retry": "3.257.0",
+        "@aws-sdk/util-user-agent-browser": "3.257.0",
+        "@aws-sdk/util-user-agent-node": "3.259.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.264.0.tgz",
+          "integrity": "sha512-p+7sYpRcdv9omnnsPhD/vOFuZ1SpfV62ZgistBK/RDsQg2W9SIWQRW1KPt7gOCQ0nwp4efntw4Sle0LjS7ykxg==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/fetch-http-handler": "3.257.0",
+            "@aws-sdk/hash-node": "3.257.0",
+            "@aws-sdk/invalid-dependency": "3.257.0",
+            "@aws-sdk/middleware-content-length": "3.257.0",
+            "@aws-sdk/middleware-endpoint": "3.264.0",
+            "@aws-sdk/middleware-host-header": "3.257.0",
+            "@aws-sdk/middleware-logger": "3.257.0",
+            "@aws-sdk/middleware-recursion-detection": "3.257.0",
+            "@aws-sdk/middleware-retry": "3.259.0",
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/middleware-user-agent": "3.257.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/node-http-handler": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/smithy-client": "3.261.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+            "@aws-sdk/util-defaults-mode-node": "3.261.0",
+            "@aws-sdk/util-endpoints": "3.257.0",
+            "@aws-sdk/util-retry": "3.257.0",
+            "@aws-sdk/util-user-agent-browser": "3.257.0",
+            "@aws-sdk/util-user-agent-node": "3.259.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.264.0.tgz",
+          "integrity": "sha512-82hGEbfsD4lBGIF1q8o82jTNSgBCcBpfFsvA+ltZf0bh4ChIWOi4vVvg8G+zVQN1mm/Rj8vWYO/D0tNF8OSyWw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/fetch-http-handler": "3.257.0",
+            "@aws-sdk/hash-node": "3.257.0",
+            "@aws-sdk/invalid-dependency": "3.257.0",
+            "@aws-sdk/middleware-content-length": "3.257.0",
+            "@aws-sdk/middleware-endpoint": "3.264.0",
+            "@aws-sdk/middleware-host-header": "3.257.0",
+            "@aws-sdk/middleware-logger": "3.257.0",
+            "@aws-sdk/middleware-recursion-detection": "3.257.0",
+            "@aws-sdk/middleware-retry": "3.259.0",
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/middleware-user-agent": "3.257.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/node-http-handler": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/smithy-client": "3.261.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+            "@aws-sdk/util-defaults-mode-node": "3.261.0",
+            "@aws-sdk/util-endpoints": "3.257.0",
+            "@aws-sdk/util-retry": "3.257.0",
+            "@aws-sdk/util-user-agent-browser": "3.257.0",
+            "@aws-sdk/util-user-agent-node": "3.259.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.264.0.tgz",
+          "integrity": "sha512-sco1jREkDdds4Z3V19Vlu/YpBHSzeEt1KFqOPnbjFw7pSakRNzpyWmLLxOwWjwgGKt6pSF3Aw0ZOMYsAUDc5qQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/credential-provider-node": "3.264.0",
+            "@aws-sdk/fetch-http-handler": "3.257.0",
+            "@aws-sdk/hash-node": "3.257.0",
+            "@aws-sdk/invalid-dependency": "3.257.0",
+            "@aws-sdk/middleware-content-length": "3.257.0",
+            "@aws-sdk/middleware-endpoint": "3.264.0",
+            "@aws-sdk/middleware-host-header": "3.257.0",
+            "@aws-sdk/middleware-logger": "3.257.0",
+            "@aws-sdk/middleware-recursion-detection": "3.257.0",
+            "@aws-sdk/middleware-retry": "3.259.0",
+            "@aws-sdk/middleware-sdk-sts": "3.257.0",
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/middleware-signing": "3.257.0",
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/middleware-user-agent": "3.257.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/node-http-handler": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/smithy-client": "3.261.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.261.0",
+            "@aws-sdk/util-defaults-mode-node": "3.261.0",
+            "@aws-sdk/util-endpoints": "3.257.0",
+            "@aws-sdk/util-retry": "3.257.0",
+            "@aws-sdk/util-user-agent-browser": "3.257.0",
+            "@aws-sdk/util-user-agent-node": "3.259.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.264.0.tgz",
+          "integrity": "sha512-UU5NNlfn+Go+5PLBzyTH1YE3r/pgykpE4QYFon87sCnEQnQH9xmlRTW1f1cBSQ9kivbFZd2/C2X3qhB3fe2JfA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.257.0",
+            "@aws-sdk/credential-provider-imds": "3.259.0",
+            "@aws-sdk/credential-provider-process": "3.257.0",
+            "@aws-sdk/credential-provider-sso": "3.264.0",
+            "@aws-sdk/credential-provider-web-identity": "3.257.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.264.0.tgz",
+          "integrity": "sha512-DPzL7oawcILs5Mduim9Z8SVeJaUpaDRVbUIrBHsMBu+N7Zuqtzr+0ckHc1bEi3iYq2QUCk5pH5vpQaZYkMlbtw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.257.0",
+            "@aws-sdk/credential-provider-imds": "3.259.0",
+            "@aws-sdk/credential-provider-ini": "3.264.0",
+            "@aws-sdk/credential-provider-process": "3.257.0",
+            "@aws-sdk/credential-provider-sso": "3.264.0",
+            "@aws-sdk/credential-provider-web-identity": "3.257.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.264.0.tgz",
+          "integrity": "sha512-CJuAlqIIJap6LXoqimvEAnYZ7Kb5pTbiS3e+aY+fajO3OPujmQpHuiY8kOmscjwZ4ErJdEskivcTGwXph0dPZQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.264.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/token-providers": "3.264.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.264.0.tgz",
+          "integrity": "sha512-H9JEAug3Oo3IA2wZIplVVF6NtauCIjICXWgbNbA8Im+I2KPe0jWtOdtQv4U+tqHe9T4zIixaCM3gjUBld+FoOA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.257.0",
+            "@aws-sdk/protocol-http": "3.257.0",
+            "@aws-sdk/signature-v4": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "@aws-sdk/url-parser": "3.257.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.261.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
+          "integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.264.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.264.0.tgz",
+          "integrity": "sha512-1N54FCdBJRqrwFWHUoDpGI0rKhI29Or9ZwGjjcBzKzLhz5sEF/DEhuID7h1/KKEkXdQ0+lmXOFGMMrahrMpOow==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.264.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/shared-ini-file-loader": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.261.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
+          "integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.261.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
+          "integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/config-resolver": "3.259.0",
+            "@aws-sdk/credential-provider-imds": "3.259.0",
+            "@aws-sdk/node-config-provider": "3.259.0",
+            "@aws-sdk/property-provider": "3.257.0",
+            "@aws-sdk/types": "3.257.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/client-sso": {
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.259.0.tgz",
@@ -7106,6 +7765,25 @@
         }
       }
     },
+    "@aws-sdk/md5-js": {
+      "version": "3.258.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.258.0.tgz",
+      "integrity": "sha512-aLdZ43sEiT68p7YYPHwKsWU1WDC8Wf8UQfb4pzbvhYNgr5VxN46AtbWTKxLAqK2adKS4FnbyX2i66fINg2dHdw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/middleware-content-length": {
       "version": "3.257.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
@@ -7239,6 +7917,26 @@
         "@aws-sdk/util-retry": "3.257.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.257.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.257.0.tgz",
+      "integrity": "sha512-NXdaAmHmFqNtP78NuyzPmUqCd2rCLLZnYxaU4SKSX+OpBpfwHX2sIBJlvKm7rGFH1txI7Zk3O8UkTxKGZe9W1Q==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.257.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {

--- a/lambdas/delete-user-data/package.json
+++ b/lambdas/delete-user-data/package.json
@@ -13,6 +13,7 @@
     "@aws-lambda-powertools/commons": "1.5.1",
     "@aws-sdk/client-dynamodb": "3.259.0",
     "@aws-sdk/client-sqs": "3.264.0",
+    "@aws-sdk/client-ssm": "3.266.0",
     "@aws-sdk/lib-dynamodb": "3.259.0",
     "@swc/jest": "0.2.24",
     "@types/aws-lambda": "8.10.109",

--- a/lambdas/delete-user-data/package.json
+++ b/lambdas/delete-user-data/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@aws-lambda-powertools/commons": "1.5.1",
     "@aws-sdk/client-dynamodb": "3.259.0",
+    "@aws-sdk/client-sqs": "3.264.0",
     "@aws-sdk/lib-dynamodb": "3.259.0",
     "@swc/jest": "0.2.24",
     "@types/aws-lambda": "8.10.109",

--- a/lambdas/delete-user-data/src/config.ts
+++ b/lambdas/delete-user-data/src/config.ts
@@ -1,5 +1,5 @@
 export const config = {
-  componentId: "ipv-core-delete-user-data",
+  environment: process.env.ENVIRONMENT || "",
   userIssuedCredentialsTableName: process.env.USER_ISSUED_CREDENTIALS_TABLE_NAME || "",
   sqsAuditEventQueueUrl: process.env.SQS_AUDIT_EVENT_QUEUE_URL || "",
 };

--- a/lambdas/delete-user-data/src/config.ts
+++ b/lambdas/delete-user-data/src/config.ts
@@ -1,3 +1,5 @@
 export const config = {
+  componentId: "ipv-core-delete-user-data",
   userIssuedCredentialsTableName: process.env.USER_ISSUED_CREDENTIALS_TABLE_NAME || "",
+  sqsAuditEventQueueUrl: process.env.SQS_AUDIT_EVENT_QUEUE_URL || "",
 };

--- a/lambdas/delete-user-data/src/delete-data.ts
+++ b/lambdas/delete-user-data/src/delete-data.ts
@@ -6,18 +6,21 @@ import { VCItemKey } from "./types";
 
 const ddbDocClient = DynamoDBDocument.from(new DynamoDBClient({ region: "eu-west-2" }));
 
-export const deleteVCs = async (userId: string): Promise<void> => {
+export const deleteVCs = async (userId: string): Promise<number> => {
   const keysToDelete = await getVCItemKeys(userId);
-  if (keysToDelete.length > 0) {
-    const deletePromises = keysToDelete.map((key) =>
-      ddbDocClient.delete({
-        TableName: config.userIssuedCredentialsTableName,
-        Key: key,
-      })
-    );
-    await Promise.all(deletePromises);
-    logger.info("Deleted user's VCs", { userId, count: keysToDelete.length });
+  const deleteCount = keysToDelete.length;
+  if (deleteCount === 0) {
+    return 0;
   }
+  const deletePromises = keysToDelete.map((key) =>
+    ddbDocClient.delete({
+      TableName: config.userIssuedCredentialsTableName,
+      Key: key,
+    })
+  );
+  await Promise.all(deletePromises);
+  logger.info("Deleted user's VCs", { userId, count: deleteCount });
+  return deleteCount;
 };
 
 const getVCItemKeys = async (userId: string): Promise<VCItemKey[]> => {

--- a/lambdas/delete-user-data/src/get-config-param.ts
+++ b/lambdas/delete-user-data/src/get-config-param.ts
@@ -1,0 +1,15 @@
+import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+import { config } from "./config";
+
+const ssmClient = new SSMClient({ region: "eu-west-2" });
+
+export const getConfigParam = async (name: string): Promise<string> => {
+  const command = new GetParameterCommand({
+    Name: `/${config.environment}/${name}`,
+  });
+  const { Parameter } = await ssmClient.send(command);
+  if (!Parameter?.Value) {
+    throw new Error(`Config parameter not found: ${name}`);
+  }
+  return Parameter.Value;
+};

--- a/lambdas/delete-user-data/src/index.ts
+++ b/lambdas/delete-user-data/src/index.ts
@@ -2,12 +2,16 @@ import { Context, SQSEvent } from "aws-lambda";
 import { deleteVCs } from "./delete-data";
 import { logger } from "./logger";
 import { readSNSMessage } from "./read-message";
+import { sendAuditEvent } from "./send-audit-event";
 
 export const handler = async (event: SQSEvent, context: Context): Promise<void> => {
   logger.addContext(context);
   if (!event?.Records?.[0].body) {
     throw new TypeError("no event provided");
   }
-  const message = readSNSMessage(event.Records[0].body);
-  await deleteVCs(message.user_id);
+  const { message, topicARN } = readSNSMessage(event.Records[0].body);
+  const deleteCount = await deleteVCs(message.user_id);
+  if (deleteCount > 0) {
+    await sendAuditEvent("IPV_DELETE_USER_DATA", { user_id: message.user_id }, { source_topic_arn: topicARN });
+  }
 };

--- a/lambdas/delete-user-data/src/read-message.ts
+++ b/lambdas/delete-user-data/src/read-message.ts
@@ -1,11 +1,11 @@
 import { SNSMessage } from "aws-lambda";
 import { Message } from "./types";
 
-export const readSNSMessage = (body: string): Message => {
+export const readSNSMessage = (body: string): { message: Message; topicARN?: string } => {
   const snsBody = JSON.parse(body) as SNSMessage;
   const message = JSON.parse(snsBody.Message);
   validateMessage(message);
-  return message;
+  return { message, topicARN: snsBody.TopicArn };
 };
 
 const validateMessage: (input: unknown) => asserts input is Message = (input) => {

--- a/lambdas/delete-user-data/src/send-audit-event.ts
+++ b/lambdas/delete-user-data/src/send-audit-event.ts
@@ -1,0 +1,32 @@
+import { SQSClient, SendMessageCommandInput, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { config } from "./config";
+import { logger } from "./logger";
+import { AuditEvent, AuditUser } from "./types";
+
+const sqsClient = new SQSClient({ region: "eu-west-2" });
+
+export const sendAuditEvent = async (
+  eventName: string,
+  user: AuditUser,
+  extensions?: Record<string, unknown>
+): Promise<void> => {
+  logger.info("Sending audit event", { event: { name: eventName } });
+
+  const auditEvent: AuditEvent = {
+    timestamp: Math.trunc(Date.now() / 1000),
+    component_id: config.componentId,
+    event_name: eventName,
+    user,
+  };
+  if (extensions) auditEvent.extensions = extensions;
+
+  const input: SendMessageCommandInput = {
+    MessageBody: JSON.stringify(auditEvent),
+    QueueUrl: config.sqsAuditEventQueueUrl,
+  };
+  try {
+    await sqsClient.send(new SendMessageCommand(input));
+  } catch (e) {
+    logger.error("Error sending audit event", e as Error);
+  }
+};

--- a/lambdas/delete-user-data/src/types.ts
+++ b/lambdas/delete-user-data/src/types.ts
@@ -4,3 +4,17 @@ export type VCItemKey = {
   userId: string;
   credentialIssuer: string;
 };
+
+export type AuditUser = {
+  user_id?: string;
+  govuk_signin_journey_id?: string;
+  ip_address?: string;
+};
+
+export type AuditEvent = {
+  timestamp: number; // Epoch seconds
+  component_id: string;
+  event_name: string;
+  user: AuditUser;
+  extensions?: unknown;
+};

--- a/lambdas/delete-user-data/tests/get-config-param.test.ts
+++ b/lambdas/delete-user-data/tests/get-config-param.test.ts
@@ -1,0 +1,19 @@
+import { getConfigParam } from "../src/get-config-param";
+
+const mockSSMSend = jest.fn();
+jest.mock("@aws-sdk/client-ssm", () => ({
+  SSMClient: jest.fn().mockImplementation(() => ({
+    send: (getCommand: any) => mockSSMSend(getCommand),
+  })),
+  GetParameterCommand: jest.fn().mockImplementation((input) => ({ input })),
+}));
+
+describe("GetConfigParam", () => {
+  test("return config parameter value", async () => {
+    mockSSMSend.mockResolvedValue({ Parameter: { Value: "param-value" } });
+
+    const result = await getConfigParam("param/name");
+
+    expect(result).toBe("param-value");
+  });
+});

--- a/lambdas/delete-user-data/tests/index.test.ts
+++ b/lambdas/delete-user-data/tests/index.test.ts
@@ -7,6 +7,10 @@ import { buildMockSQSEvent } from "./mock-sqs-event";
 jest.mock("../src/delete-data");
 const mockDeleteVCs = deleteVCs as jest.Mocked<typeof deleteVCs>;
 
+jest.mock("../src/send-audit-event", () => ({
+  sendAuditEvent: jest.fn(),
+}));
+
 describe("handler", () => {
   const mockContext = ContextExamples.helloworldContext;
   let mockSQSEvent: SQSEvent;

--- a/lambdas/delete-user-data/tests/read-message.test.ts
+++ b/lambdas/delete-user-data/tests/read-message.test.ts
@@ -3,13 +3,14 @@ import { readSNSMessage } from "../src/read-message";
 import { Message } from "../src/types";
 
 describe("readSNSMessage", () => {
+  const mockTopicARN = "arn:aws:sns:EXAMPLE";
   let mockBody: SNSMessage;
   beforeEach(() => {
     mockBody = {
       Signature: "EXAMPLE",
       MessageId: "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
       Type: "Notification",
-      TopicArn: "arn:aws:sns:EXAMPLE",
+      TopicArn: mockTopicARN,
       MessageAttributes: {},
       SignatureVersion: "1",
       Timestamp: "2015-06-03T17:43:27.123Z",
@@ -24,7 +25,13 @@ describe("readSNSMessage", () => {
     const expectedMessage: Message = {
       user_id: "123",
     };
-    expect(readSNSMessage(JSON.stringify(mockBody))).toStrictEqual(expectedMessage);
+    const { message } = readSNSMessage(JSON.stringify(mockBody));
+    expect(message).toStrictEqual(expectedMessage);
+  });
+
+  test("returns the source topic ARN alongside the message", () => {
+    const { topicARN } = readSNSMessage(JSON.stringify(mockBody));
+    expect(topicARN).toBe(mockTopicARN);
   });
 
   test("throws error if no user id in the message", () => {

--- a/lambdas/delete-user-data/tests/send-audit-event.test.ts
+++ b/lambdas/delete-user-data/tests/send-audit-event.test.ts
@@ -1,0 +1,83 @@
+import { config } from "../src/config";
+import { sendAuditEvent } from "../src/send-audit-event";
+import { AuditUser } from "../src/types";
+
+jest.mock("../src/config");
+
+const mockSQSSend = jest.fn();
+jest.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: jest.fn().mockImplementation(() => ({
+    send: (sendCommand: any) => mockSQSSend(sendCommand),
+  })),
+  SendMessageCommand: jest.fn().mockImplementation((input) => ({ input })),
+}));
+
+describe("sendAuditEvent", () => {
+  const now = new Date();
+  const mockQueueUrl = "queue-url.com";
+  const mockComponentId = "component-id";
+  const mockAuditEventName = "IPV_DELETE_USER_DATA";
+  const mockAuditUser: AuditUser = {
+    user_id: "78912",
+  };
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+  });
+
+  beforeEach(() => {
+    config.sqsAuditEventQueueUrl = mockQueueUrl;
+    config.componentId = mockComponentId;
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+
+  test("sends audit event to SQS queue", async () => {
+    const expectedAuditEvent = {
+      timestamp: Math.trunc(Date.now() / 1000),
+      component_id: mockComponentId,
+      event_name: mockAuditEventName,
+      user: mockAuditUser,
+    };
+
+    await sendAuditEvent(mockAuditEventName, mockAuditUser);
+
+    expect(mockSQSSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          MessageBody: JSON.stringify(expectedAuditEvent),
+          QueueUrl: mockQueueUrl,
+        },
+      })
+    );
+  });
+
+  describe("audit extensions property", () => {
+    test("when extensions is passed in AuditEvent should contain extensions", () => {
+      const expectedAuditEvent = {
+        timestamp: Math.trunc(Date.now() / 1000),
+        component_id: mockComponentId,
+        event_name: mockAuditEventName,
+        user: mockAuditUser,
+        extensions: { prop1: "prop1_value" },
+      };
+
+      sendAuditEvent(mockAuditEventName, mockAuditUser, {
+        prop1: "prop1_value",
+      });
+
+      expect(mockSQSSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: {
+            MessageBody: JSON.stringify(expectedAuditEvent),
+            QueueUrl: mockQueueUrl,
+          },
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

### What changed

Send audit event `IPV_DELETE_USER_DATA` when lambda executes successfully and has deleted some data. Include `source-topic-arn` which identifies the SNS topic the message came from.

### Why did it change

So we have audit logs for deleted data

### Issue tracking
- [PYIC-2419](https://govukverify.atlassian.net/browse/PYIC-2419)



[PYIC-2419]: https://govukverify.atlassian.net/browse/PYIC-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ