### PR TITLE
BAU Remove unused step function mapping template for x-www-form-urlencoded requests

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -84,13 +84,6 @@ paths:
                 "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\"#foreach($key in $inputRoot.keySet()), \"$key\": \"$inputRoot.get($key)\"#end}",
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CriReturnStepFunction.Name}"
               }
-          application/x-www-form-urlencoded:
-            Fn::Sub: |
-              #set($bodyParts = $util.urlDecode($input.path('$')).split('&'))
-              {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\"#foreach( $token in $bodyParts )#set( $keyVal = $token.split('=') ), \"$keyVal[0]\": \"$keyVal[1]\"#end}",
-                "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CriReturnStepFunction.Name}"
-              }
         responses:
           default:
             statusCode: 200


### PR DESCRIPTION
## Proposed changes

### What changed

Remove step function mapping template for x-www-form-urlencoded requests

### Why did it change

The frontend now always sends an application/json request to `/journey/cri/callback` so we don't need the mapping for x-www-form-urlencoded requests for the input fed to the step function
