### PR TITLE
BAU Add global mock for aws logger

### DIFF
--- a/lambdas/delete-user-data/package.json
+++ b/lambdas/delete-user-data/package.json
@@ -32,7 +32,10 @@
   "jest": {
     "transform": {
       "^.+\\.ts?$": "@swc/jest"
-    }
+    },
+    "setupFilesAfterEnv": [
+      "<rootDir>/setup-jest.js"
+    ]
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "1.5.1"

--- a/lambdas/delete-user-data/setup-jest.js
+++ b/lambdas/delete-user-data/setup-jest.js
@@ -1,0 +1,4 @@
+/* eslint-disable no-undef */
+
+// Set global Jest mocks here
+jest.mock("@aws-lambda-powertools/logger");


### PR DESCRIPTION
## Proposed changes

### What changed

Add a setup-jest file to globally mock the `@aws-lambda-powertools/logger` package

### Why did it change

So we don't get noisy logs in the test output
