### PR TITLE
PYIC-2451 Script to bulk push messages to SNS topic

### DIFF
--- a/lambdas/delete-user-data/package-lock.json
+++ b/lambdas/delete-user-data/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@aws-lambda-powertools/commons": "1.5.1",
         "@aws-sdk/client-dynamodb": "3.259.0",
+        "@aws-sdk/client-sns": "3.272.0",
         "@aws-sdk/client-sqs": "3.264.0",
         "@aws-sdk/client-ssm": "3.266.0",
         "@aws-sdk/lib-dynamodb": "3.259.0",
@@ -183,6 +184,821 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.272.0.tgz",
+      "integrity": "sha512-A3iyszg+ujAnwhS/X6UCR+jpSahYdvIsmzVzB6G9jC91V0JyA0mfQi1Oy7/f1/522iod8EhqeSEtU8wygOi7oQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.272.0",
+        "@aws-sdk/config-resolver": "3.272.0",
+        "@aws-sdk/credential-provider-node": "3.272.0",
+        "@aws-sdk/fetch-http-handler": "3.272.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.272.0",
+        "@aws-sdk/middleware-endpoint": "3.272.0",
+        "@aws-sdk/middleware-host-header": "3.272.0",
+        "@aws-sdk/middleware-logger": "3.272.0",
+        "@aws-sdk/middleware-recursion-detection": "3.272.0",
+        "@aws-sdk/middleware-retry": "3.272.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.272.0",
+        "@aws-sdk/node-config-provider": "3.272.0",
+        "@aws-sdk/node-http-handler": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/smithy-client": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+        "@aws-sdk/util-defaults-mode-node": "3.272.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.272.0",
+        "@aws-sdk/util-user-agent-node": "3.272.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
+      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.272.0.tgz",
+      "integrity": "sha512-xn9a0IGONwQIARmngThoRhF1lLGjHAD67sUaShgIMaIMc6ipVYN6alWG1VuUpoUQ6iiwMEt0CHdfCyLyUV/fTA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.272.0",
+        "@aws-sdk/fetch-http-handler": "3.272.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.272.0",
+        "@aws-sdk/middleware-endpoint": "3.272.0",
+        "@aws-sdk/middleware-host-header": "3.272.0",
+        "@aws-sdk/middleware-logger": "3.272.0",
+        "@aws-sdk/middleware-recursion-detection": "3.272.0",
+        "@aws-sdk/middleware-retry": "3.272.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.272.0",
+        "@aws-sdk/node-config-provider": "3.272.0",
+        "@aws-sdk/node-http-handler": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/smithy-client": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+        "@aws-sdk/util-defaults-mode-node": "3.272.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.272.0",
+        "@aws-sdk/util-user-agent-node": "3.272.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.272.0.tgz",
+      "integrity": "sha512-ECcXu3xoa1yggnGKMTh29eWNHiF/wC6r5Uqbla22eOOosyh0+Z6lkJ3JUSLOUKCkBXA4Cs/tJL9UDFBrKbSlvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.272.0",
+        "@aws-sdk/fetch-http-handler": "3.272.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.272.0",
+        "@aws-sdk/middleware-endpoint": "3.272.0",
+        "@aws-sdk/middleware-host-header": "3.272.0",
+        "@aws-sdk/middleware-logger": "3.272.0",
+        "@aws-sdk/middleware-recursion-detection": "3.272.0",
+        "@aws-sdk/middleware-retry": "3.272.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.272.0",
+        "@aws-sdk/node-config-provider": "3.272.0",
+        "@aws-sdk/node-http-handler": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/smithy-client": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+        "@aws-sdk/util-defaults-mode-node": "3.272.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.272.0",
+        "@aws-sdk/util-user-agent-node": "3.272.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sts": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.272.0.tgz",
+      "integrity": "sha512-kigxCxURp3WupufGaL/LABMb7UQfzAQkKcj9royizL3ItJ0vw5kW/JFrPje5IW1mfLgdPF7PI9ShOjE0fCLTqA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.272.0",
+        "@aws-sdk/credential-provider-node": "3.272.0",
+        "@aws-sdk/fetch-http-handler": "3.272.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.272.0",
+        "@aws-sdk/middleware-endpoint": "3.272.0",
+        "@aws-sdk/middleware-host-header": "3.272.0",
+        "@aws-sdk/middleware-logger": "3.272.0",
+        "@aws-sdk/middleware-recursion-detection": "3.272.0",
+        "@aws-sdk/middleware-retry": "3.272.0",
+        "@aws-sdk/middleware-sdk-sts": "3.272.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.272.0",
+        "@aws-sdk/node-config-provider": "3.272.0",
+        "@aws-sdk/node-http-handler": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/smithy-client": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+        "@aws-sdk/util-defaults-mode-node": "3.272.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.272.0",
+        "@aws-sdk/util-user-agent-node": "3.272.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
+      "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
+      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
+      "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.272.0.tgz",
+      "integrity": "sha512-iE3CDzK5NcupHYjfYjBdY1JCy8NLEoRUsboEjG0i0gy3S3jVpDeVHX1dLVcL/slBFj6GiM7SoNV/UfKnJf3Gaw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.272.0",
+        "@aws-sdk/credential-provider-process": "3.272.0",
+        "@aws-sdk/credential-provider-sso": "3.272.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.272.0.tgz",
+      "integrity": "sha512-FI8uvwM1IxiRSvbkdKv8DZG5vxU3ezaseTaB1fHWTxEUFb0pWIoHX9oeOKer9Fj31SOZTCNAaYFURbSRuZlm/w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.272.0",
+        "@aws-sdk/credential-provider-ini": "3.272.0",
+        "@aws-sdk/credential-provider-process": "3.272.0",
+        "@aws-sdk/credential-provider-sso": "3.272.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
+      "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.272.0.tgz",
+      "integrity": "sha512-hwYaulyiU/7chKKFecxCeo0ls6Dxs7h+5EtoYcJJGvfpvCncyOZF35t00OAsCd3Wo7HkhhgfpGdb6dmvCNQAZQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.272.0",
+        "@aws-sdk/token-providers": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
+      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
+      "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/hash-node": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
+      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
+      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
+      "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
+      "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/signature-v4": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.272.0.tgz",
+      "integrity": "sha512-Q8K7bMMFZnioUXpxn57HIt4p+I63XaNAawMLIZ5B4F2piyukbQeM9q2XVKMGwqLvijHR8CyP5nHrtKqVuINogQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
+      "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
+      "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
+      "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
+      "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/signature-v4": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
+      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
+      "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/signature-v4": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
+      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
+      "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
+      "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
+      "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/property-provider": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
+      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
+      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
+      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
+      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
+      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
+      "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
+      "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.272.0.tgz",
+      "integrity": "sha512-pvdleJ3kaRvyRw2pIZnqL85ZlWBOZrPKmR9I69GCvlyrfdjRBhbSjIEZ+sdhZudw0vdHxq25AGoLUXhofVLf5Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/token-providers": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.272.0.tgz",
+      "integrity": "sha512-0GISJ4IKN2rXvbSddB775VjBGSKhYIGQnAdMqbvxi9LB6pSvVxcH9aIL28G0spiuL+dy3yGQZ8RlJPAyP9JW9A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/types": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
+      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/url-parser": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
+      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.272.0.tgz",
+      "integrity": "sha512-W8ZVJSZRuUBg8l0JEZzUc+9fKlthVp/cdE+pFeF8ArhZelOLCiaeCrMaZAeJusaFzIpa6cmOYQAjtSMVyrwRtg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.272.0.tgz",
+      "integrity": "sha512-U0NTcbMw6KFk7uz/avBmfxQSTREEiX6JDMH68oN/3ux4AICd2I4jHyxnloSWGuiER1FxZf1dEJ8ZTwy8Ibl21Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.272.0",
+        "@aws-sdk/node-config-provider": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
+      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
+      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-retry": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
+      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
+      "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
+      "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
@@ -3308,6 +4124,32 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -4106,6 +4948,38 @@
         "@swc/core": "*"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.109",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.109.tgz",
@@ -4449,6 +5323,17 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4528,6 +5413,14 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4852,6 +5745,14 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4911,6 +5812,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -6611,6 +7523,14 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -7462,6 +8382,51 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -7572,6 +8537,14 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -7702,6 +8675,17 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -7862,6 +8846,686 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/client-sns": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.272.0.tgz",
+      "integrity": "sha512-A3iyszg+ujAnwhS/X6UCR+jpSahYdvIsmzVzB6G9jC91V0JyA0mfQi1Oy7/f1/522iod8EhqeSEtU8wygOi7oQ==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.272.0",
+        "@aws-sdk/config-resolver": "3.272.0",
+        "@aws-sdk/credential-provider-node": "3.272.0",
+        "@aws-sdk/fetch-http-handler": "3.272.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.272.0",
+        "@aws-sdk/middleware-endpoint": "3.272.0",
+        "@aws-sdk/middleware-host-header": "3.272.0",
+        "@aws-sdk/middleware-logger": "3.272.0",
+        "@aws-sdk/middleware-recursion-detection": "3.272.0",
+        "@aws-sdk/middleware-retry": "3.272.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.272.0",
+        "@aws-sdk/node-config-provider": "3.272.0",
+        "@aws-sdk/node-http-handler": "3.272.0",
+        "@aws-sdk/protocol-http": "3.272.0",
+        "@aws-sdk/smithy-client": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+        "@aws-sdk/util-defaults-mode-node": "3.272.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.272.0",
+        "@aws-sdk/util-user-agent-node": "3.272.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
+          "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.272.0.tgz",
+          "integrity": "sha512-xn9a0IGONwQIARmngThoRhF1lLGjHAD67sUaShgIMaIMc6ipVYN6alWG1VuUpoUQ6iiwMEt0CHdfCyLyUV/fTA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.272.0",
+            "@aws-sdk/fetch-http-handler": "3.272.0",
+            "@aws-sdk/hash-node": "3.272.0",
+            "@aws-sdk/invalid-dependency": "3.272.0",
+            "@aws-sdk/middleware-content-length": "3.272.0",
+            "@aws-sdk/middleware-endpoint": "3.272.0",
+            "@aws-sdk/middleware-host-header": "3.272.0",
+            "@aws-sdk/middleware-logger": "3.272.0",
+            "@aws-sdk/middleware-recursion-detection": "3.272.0",
+            "@aws-sdk/middleware-retry": "3.272.0",
+            "@aws-sdk/middleware-serde": "3.272.0",
+            "@aws-sdk/middleware-stack": "3.272.0",
+            "@aws-sdk/middleware-user-agent": "3.272.0",
+            "@aws-sdk/node-config-provider": "3.272.0",
+            "@aws-sdk/node-http-handler": "3.272.0",
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/smithy-client": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/url-parser": "3.272.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+            "@aws-sdk/util-defaults-mode-node": "3.272.0",
+            "@aws-sdk/util-endpoints": "3.272.0",
+            "@aws-sdk/util-retry": "3.272.0",
+            "@aws-sdk/util-user-agent-browser": "3.272.0",
+            "@aws-sdk/util-user-agent-node": "3.272.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.272.0.tgz",
+          "integrity": "sha512-ECcXu3xoa1yggnGKMTh29eWNHiF/wC6r5Uqbla22eOOosyh0+Z6lkJ3JUSLOUKCkBXA4Cs/tJL9UDFBrKbSlvA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.272.0",
+            "@aws-sdk/fetch-http-handler": "3.272.0",
+            "@aws-sdk/hash-node": "3.272.0",
+            "@aws-sdk/invalid-dependency": "3.272.0",
+            "@aws-sdk/middleware-content-length": "3.272.0",
+            "@aws-sdk/middleware-endpoint": "3.272.0",
+            "@aws-sdk/middleware-host-header": "3.272.0",
+            "@aws-sdk/middleware-logger": "3.272.0",
+            "@aws-sdk/middleware-recursion-detection": "3.272.0",
+            "@aws-sdk/middleware-retry": "3.272.0",
+            "@aws-sdk/middleware-serde": "3.272.0",
+            "@aws-sdk/middleware-stack": "3.272.0",
+            "@aws-sdk/middleware-user-agent": "3.272.0",
+            "@aws-sdk/node-config-provider": "3.272.0",
+            "@aws-sdk/node-http-handler": "3.272.0",
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/smithy-client": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/url-parser": "3.272.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+            "@aws-sdk/util-defaults-mode-node": "3.272.0",
+            "@aws-sdk/util-endpoints": "3.272.0",
+            "@aws-sdk/util-retry": "3.272.0",
+            "@aws-sdk/util-user-agent-browser": "3.272.0",
+            "@aws-sdk/util-user-agent-node": "3.272.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.272.0.tgz",
+          "integrity": "sha512-kigxCxURp3WupufGaL/LABMb7UQfzAQkKcj9royizL3ItJ0vw5kW/JFrPje5IW1mfLgdPF7PI9ShOjE0fCLTqA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.272.0",
+            "@aws-sdk/credential-provider-node": "3.272.0",
+            "@aws-sdk/fetch-http-handler": "3.272.0",
+            "@aws-sdk/hash-node": "3.272.0",
+            "@aws-sdk/invalid-dependency": "3.272.0",
+            "@aws-sdk/middleware-content-length": "3.272.0",
+            "@aws-sdk/middleware-endpoint": "3.272.0",
+            "@aws-sdk/middleware-host-header": "3.272.0",
+            "@aws-sdk/middleware-logger": "3.272.0",
+            "@aws-sdk/middleware-recursion-detection": "3.272.0",
+            "@aws-sdk/middleware-retry": "3.272.0",
+            "@aws-sdk/middleware-sdk-sts": "3.272.0",
+            "@aws-sdk/middleware-serde": "3.272.0",
+            "@aws-sdk/middleware-signing": "3.272.0",
+            "@aws-sdk/middleware-stack": "3.272.0",
+            "@aws-sdk/middleware-user-agent": "3.272.0",
+            "@aws-sdk/node-config-provider": "3.272.0",
+            "@aws-sdk/node-http-handler": "3.272.0",
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/smithy-client": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/url-parser": "3.272.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.272.0",
+            "@aws-sdk/util-defaults-mode-node": "3.272.0",
+            "@aws-sdk/util-endpoints": "3.272.0",
+            "@aws-sdk/util-retry": "3.272.0",
+            "@aws-sdk/util-user-agent-browser": "3.272.0",
+            "@aws-sdk/util-user-agent-node": "3.272.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
+          "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/signature-v4": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
+          "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
+          "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.272.0",
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/url-parser": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.272.0.tgz",
+          "integrity": "sha512-iE3CDzK5NcupHYjfYjBdY1JCy8NLEoRUsboEjG0i0gy3S3jVpDeVHX1dLVcL/slBFj6GiM7SoNV/UfKnJf3Gaw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.272.0",
+            "@aws-sdk/credential-provider-imds": "3.272.0",
+            "@aws-sdk/credential-provider-process": "3.272.0",
+            "@aws-sdk/credential-provider-sso": "3.272.0",
+            "@aws-sdk/credential-provider-web-identity": "3.272.0",
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/shared-ini-file-loader": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.272.0.tgz",
+          "integrity": "sha512-FI8uvwM1IxiRSvbkdKv8DZG5vxU3ezaseTaB1fHWTxEUFb0pWIoHX9oeOKer9Fj31SOZTCNAaYFURbSRuZlm/w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.272.0",
+            "@aws-sdk/credential-provider-imds": "3.272.0",
+            "@aws-sdk/credential-provider-ini": "3.272.0",
+            "@aws-sdk/credential-provider-process": "3.272.0",
+            "@aws-sdk/credential-provider-sso": "3.272.0",
+            "@aws-sdk/credential-provider-web-identity": "3.272.0",
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/shared-ini-file-loader": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
+          "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/shared-ini-file-loader": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.272.0.tgz",
+          "integrity": "sha512-hwYaulyiU/7chKKFecxCeo0ls6Dxs7h+5EtoYcJJGvfpvCncyOZF35t00OAsCd3Wo7HkhhgfpGdb6dmvCNQAZQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.272.0",
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/shared-ini-file-loader": "3.272.0",
+            "@aws-sdk/token-providers": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
+          "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
+          "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/querystring-builder": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
+          "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
+          "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
+          "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
+          "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.272.0",
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/signature-v4": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/url-parser": "3.272.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.272.0.tgz",
+          "integrity": "sha512-Q8K7bMMFZnioUXpxn57HIt4p+I63XaNAawMLIZ5B4F2piyukbQeM9q2XVKMGwqLvijHR8CyP5nHrtKqVuINogQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
+          "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
+          "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
+          "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/service-error-classification": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-middleware": "3.272.0",
+            "@aws-sdk/util-retry": "3.272.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
+          "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.272.0",
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/signature-v4": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
+          "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
+          "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/signature-v4": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-middleware": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
+          "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
+          "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
+          "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/shared-ini-file-loader": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
+          "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.272.0",
+            "@aws-sdk/protocol-http": "3.272.0",
+            "@aws-sdk/querystring-builder": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
+          "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
+          "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
+          "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
+          "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
+          "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
+          "dev": true
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
+          "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
+          "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.272.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.272.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.272.0.tgz",
+          "integrity": "sha512-pvdleJ3kaRvyRw2pIZnqL85ZlWBOZrPKmR9I69GCvlyrfdjRBhbSjIEZ+sdhZudw0vdHxq25AGoLUXhofVLf5Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.272.0.tgz",
+          "integrity": "sha512-0GISJ4IKN2rXvbSddB775VjBGSKhYIGQnAdMqbvxi9LB6pSvVxcH9aIL28G0spiuL+dy3yGQZ8RlJPAyP9JW9A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.272.0",
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/shared-ini-file-loader": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
+          "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
+          "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.272.0.tgz",
+          "integrity": "sha512-W8ZVJSZRuUBg8l0JEZzUc+9fKlthVp/cdE+pFeF8ArhZelOLCiaeCrMaZAeJusaFzIpa6cmOYQAjtSMVyrwRtg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.272.0.tgz",
+          "integrity": "sha512-U0NTcbMw6KFk7uz/avBmfxQSTREEiX6JDMH68oN/3ux4AICd2I4jHyxnloSWGuiER1FxZf1dEJ8ZTwy8Ibl21Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/config-resolver": "3.272.0",
+            "@aws-sdk/credential-provider-imds": "3.272.0",
+            "@aws-sdk/node-config-provider": "3.272.0",
+            "@aws-sdk/property-provider": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
+          "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
+          "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-retry": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
+          "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/service-error-classification": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
+          "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.272.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.272.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
+          "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.272.0",
+            "@aws-sdk/types": "3.272.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "tslib": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
@@ -10617,6 +12281,31 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -11190,6 +12879,38 @@
         "jsonc-parser": "^3.2.0"
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "@types/aws-lambda": {
       "version": "8.10.109",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.109.tgz",
@@ -11436,6 +13157,14 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -11489,6 +13218,14 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -11726,6 +13463,14 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -11769,6 +13514,14 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "diff-sequences": {
       "version": "29.3.1",
@@ -13029,6 +14782,14 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -13640,6 +15401,29 @@
         "is-number": "^7.0.0"
       }
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -13706,6 +15490,14 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "v8-to-istanbul": {
       "version": "9.0.1",
@@ -13809,6 +15601,14 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/lambdas/delete-user-data/package.json
+++ b/lambdas/delete-user-data/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@aws-lambda-powertools/commons": "1.5.1",
     "@aws-sdk/client-dynamodb": "3.259.0",
+    "@aws-sdk/client-sns": "3.272.0",
     "@aws-sdk/client-sqs": "3.264.0",
     "@aws-sdk/client-ssm": "3.266.0",
     "@aws-sdk/lib-dynamodb": "3.259.0",

--- a/lambdas/delete-user-data/scripts/bulk-push-to-sns.mjs
+++ b/lambdas/delete-user-data/scripts/bulk-push-to-sns.mjs
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef, no-console */
+
+/**
+ * Script to push delete messages to SNS topic given a list of user ids.
+ * Run with node (>16.x) and appropriate permissions for the env you're targeting.
+ * Pass the ARN of the SNS topic as the first argument to the script, and the filename of
+ * the list of user ids (csv file with one per line) as the second argument:
+ * aws-vault exec <profile> -- node bulk-push-to-sns.mjs <topic-arn> <filename>
+ */
+
+import { createInterface } from "readline";
+import { createReadStream } from "fs";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+
+const REGION = "eu-west-2";
+const snsClient = new SNSClient({ region: REGION });
+
+const topicArn = process.argv[2];
+const filename = process.argv[3];
+
+const rl = createInterface({
+  input: createReadStream(filename),
+  crlfDelay: Infinity,
+});
+
+for await (const line of rl) {
+  const userId = line.trim();
+  if (!userId) continue;
+  try {
+    const data = await snsClient.send(
+      new PublishCommand({
+        Message: JSON.stringify({ user_id: userId }),
+        TopicArn: topicArn,
+      })
+    );
+    console.log(`Successfully pushed message for user id: ${userId}`, {
+      messageId: data.MessageId,
+    });
+  } catch (error) {
+    console.error(`Error pushing message for user id: ${userId}`, error);
+  }
+}


### PR DESCRIPTION
## Proposed changes

### What changed

Added node script for bulk pushing SNS messages from a csv of user ids

### Why did it change

We need to clean up any leftover user data IPV core is storing to date - we can give this script a list of user ids for accounts users have requested be deleted. Checking the script in will help if we have to do similar in future.

### Issue tracking
- [PYIC-2451](https://govukverify.atlassian.net/browse/PYIC-2451)


[PYIC-2451]: https://govukverify.atlassian.net/browse/PYIC-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ