### PR TITLE
BAU Fix deploy template

### DIFF
--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -104,7 +104,7 @@ Resources:
           IPV_DECRYPTION_KEY: !GetAtt IPVSnsKmsKey.Arn
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Sub user-issued-credentials-v2-${Environment}
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          LOCAL_DYNAMODB_ENDPOINT:
+          LOCAL_DYNAMODB_ENDPOINT: http://host.docker.internal:8000
 
       DeadLetterQueue:
         TargetArn: !GetAtt DeleteAccountLambdaDLQ.Arn


### PR DESCRIPTION
The template doesn't like the env var being empty. But we need to define it otherwise it can't be overridden in local-env.json.
