### PR TITLE
PYIC-2488 Route access token step directly to retrieve credential step

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -15,16 +15,22 @@
         "ipAddress.$": "$.ipAddress",
         "journey.$": "$.lambdaResult.journey"
       },
+      "Catch": [
+        {
+          "ErrorEquals": ["uk.gov.di.ipv.core.library.exceptions.JourneyError"],
+          "ResultPath": "$.error",
+          "Next": "ProcessJourneyStep-JourneyError"
+        }
+      ],
       "ResultPath": "$.lambdaResult",
-      "Next": "RouteJourneyResponse"
+      "Next": "RetrieveCriCredential"
     },
     "RetrieveCriCredential": {
       "Type": "Task",
       "Resource": "${RetrieveCriCredentialFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
-        "ipAddress.$": "$.ipAddress",
-        "journey.$": "$.lambdaResult.journey"
+        "ipAddress.$": "$.ipAddress"
       },
       "ResultPath": "$.lambdaResult",
       "Next": "RouteJourneyResponse"
@@ -39,6 +45,17 @@
       },
       "ResultPath": "$.lambdaResult",
       "Next": "RouteJourneyResponse"
+    },
+    "ProcessJourneyStep-JourneyError": {
+      "Type": "Task",
+      "Resource": "${IPVProcessJourneyStepFunctionArn}",
+      "Parameters": {
+        "ipvSessionId.$": "$.ipvSessionId",
+        "ipAddress.$": "$.ipAddress",
+        "journey": "journey/error"
+      },
+      "ResultPath": "$.lambdaResult",
+      "Next": "ReturnToFrontend"
     },
     "ReturnToFrontend": {
       "Type": "Succeed",
@@ -78,11 +95,6 @@
           "Variable": "$.lambdaResult.journey",
           "StringEquals": "/journey/cri/access-token",
           "Next": "RetrieveCriOauthAccessToken"
-        },
-        {
-          "Variable": "$.lambdaResult.journey",
-          "StringEquals": "/journey/cri/credential",
-          "Next": "RetrieveCriCredential"
         }
       ],
       "Default": "ReturnToFrontend"

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -22,7 +21,9 @@ import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
+import uk.gov.di.ipv.core.library.exceptions.BadRequestError;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.exceptions.JourneyError;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -37,10 +38,6 @@ import java.util.Map;
 public class RetrieveCriOauthAccessTokenHandler
         implements RequestHandler<Map<String, String>, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final String JOURNEY = "journey";
-    private static final Map<String, Object> JOURNEY_CREDENTIAL =
-            Map.of(JOURNEY, "/journey/cri/credential");
-    private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
     private final CredentialIssuerService credentialIssuerService;
     private final ConfigurationService configurationService;
     private final AuditService auditService;
@@ -72,7 +69,8 @@ public class RetrieveCriOauthAccessTokenHandler
     @Override
     @Tracing
     @Logging(clearState = true)
-    public Map<String, Object> handleRequest(Map<String, String> input, Context context) {
+    public Map<String, Object> handleRequest(Map<String, String> input, Context context)
+            throws JourneyError {
         LogHelper.attachComponentIdToLogs();
         IpvSessionItem ipvSessionItem = null;
         String credentialIssuerId = null;
@@ -128,7 +126,7 @@ public class RetrieveCriOauthAccessTokenHandler
                             .with("criId", credentialIssuerId);
             LOGGER.info(message);
 
-            return JOURNEY_CREDENTIAL;
+            return Map.of("result", "success");
         } catch (CredentialIssuerException e) {
             if (ipvSessionItem != null) {
                 setVisitedCredentials(
@@ -136,7 +134,7 @@ public class RetrieveCriOauthAccessTokenHandler
                 ipvSessionService.updateIpvSession(ipvSessionItem);
             }
 
-            return JOURNEY_ERROR;
+            throw new JourneyError();
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue because: {}", e.getMessage());
 
@@ -144,15 +142,14 @@ public class RetrieveCriOauthAccessTokenHandler
                     ipvSessionItem, credentialIssuerId, false, OAuth2Error.SERVER_ERROR_CODE);
             ipvSessionService.updateIpvSession(ipvSessionItem);
 
-            return JOURNEY_ERROR;
+            throw new JourneyError();
         } catch (HttpResponseExceptionWithErrorBody e) {
             ErrorResponse errorResponse = e.getErrorResponse();
             LogHelper.logOauthError(
                     "Error in credential issuer return lambda",
                     errorResponse.getCode(),
                     errorResponse.getMessage());
-            return StepFunctionHelpers.generateErrorOutputMap(
-                    HttpStatus.SC_BAD_REQUEST, errorResponse);
+            throw new BadRequestError();
         }
     }
 

--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerSessionDetailsDto;
+import uk.gov.di.ipv.core.library.exceptions.JourneyError;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -34,6 +35,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -101,7 +103,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
     }
 
     @Test
-    void shouldReceiveJourneyResponseOnSuccessfulRequest() throws SqsException {
+    void shouldReceiveSuccessResponseOnSuccessfulRequest() throws SqsException {
         Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
 
         JSONObject testCredential = new JSONObject();
@@ -121,11 +123,11 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         assertEquals(
                 AuditEventTypes.IPV_CRI_ACCESS_TOKEN_EXCHANGED, auditEvents.get(0).getEventName());
 
-        assertEquals("/journey/cri/credential", output.get("journey"));
+        assertEquals("success", output.get("result"));
     }
 
     @Test
-    void shouldReceiveErrorJourneyResponseIfCredentialIssuerServiceThrowsException() {
+    void shouldThrowJourneyErrorIfCredentialIssuerServiceThrowsException() {
         Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
 
         when(credentialIssuerService.exchangeCodeForToken(
@@ -143,9 +145,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         when(ipvSessionItem.getCredentialIssuerSessionDetails())
                 .thenReturn(credentialIssuerSessionDetailsDto);
 
-        Map<String, Object> output = handler.handleRequest(input, context);
-
-        assertEquals("/journey/error", output.get("journey"));
+        assertThrows(JourneyError.class, () -> handler.handleRequest(input, context));
     }
 
     @Test
@@ -192,7 +192,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
     }
 
     @Test
-    void shouldReceiveErrorJourneyResponseIfSqsExceptionIsThrown() throws SqsException {
+    void shouldThrowJourneyErrorIfSqsExceptionIsThrown() throws SqsException {
         Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
 
         JSONObject testCredential = new JSONObject();
@@ -208,9 +208,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                 .when(auditService)
                 .sendAuditEvent(any(AuditEvent.class));
 
-        Map<String, Object> output = handler.handleRequest(input, context);
-
-        assertEquals("/journey/error", output.get("journey"));
+        assertThrows(JourneyError.class, () -> handler.handleRequest(input, context));
     }
 
     @Test
@@ -237,7 +235,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         ipvSessionItem.setCredentialIssuerSessionDetails(credentialIssuerSessionDetailsDto);
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        handler.handleRequest(input, context);
+        assertThrows(JourneyError.class, () -> handler.handleRequest(input, context));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -280,7 +278,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         ipvSessionItem.setCredentialIssuerSessionDetails(credentialIssuerSessionDetailsDto);
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        handler.handleRequest(input, context);
+        assertThrows(JourneyError.class, () -> handler.handleRequest(input, context));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/BadRequestError.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/BadRequestError.java
@@ -1,0 +1,6 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class BadRequestError extends RuntimeException {}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/JourneyError.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/JourneyError.java
@@ -1,0 +1,6 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class JourneyError extends RuntimeException {}


### PR DESCRIPTION
## Proposed changes

### What changed

In the CRI return step function, route RetrieveCriOauthAccessToken directly to RetrieveCriCredential rather than via RouteJourneyResponse. Handle exception cases with error catchers.

### Why did it change

As a first step towards simplifying the step function and eventually removing the RouteJourneyResponse and ProcessJourneyStep handling.

### Issue tracking
- [PYIC-2488](https://govukverify.atlassian.net/browse/PYIC-2488)


[PYIC-2488]: https://govukverify.atlassian.net/browse/PYIC-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ