### PR TITLE
PYIC-2476: Set up enabled field for cris

### DIFF
--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -121,6 +121,7 @@ class BuildCriOauthRequestHandlerTest {
                 new CredentialIssuerConfig(
                         CRI_ID,
                         CRI_NAME,
+                        true,
                         new URI(CRI_TOKEN_URL),
                         new URI(CRI_CREDENTIAL_URL),
                         new URI(CRI_AUTHORIZE_URL),
@@ -134,6 +135,7 @@ class BuildCriOauthRequestHandlerTest {
                 new CredentialIssuerConfig(
                         ADDRESS_CRI_ID,
                         CRI_NAME,
+                        true,
                         new URI(CRI_TOKEN_URL),
                         new URI(CRI_CREDENTIAL_URL),
                         new URI(CRI_AUTHORIZE_URL),
@@ -147,6 +149,7 @@ class BuildCriOauthRequestHandlerTest {
                 new CredentialIssuerConfig(
                         DCMAW_CRI_ID,
                         CRI_NAME,
+                        true,
                         new URI(CRI_TOKEN_URL),
                         new URI(CRI_CREDENTIAL_URL),
                         new URI(CRI_AUTHORIZE_URL),

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -89,6 +89,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -103,6 +104,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -155,6 +157,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -169,6 +172,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -226,6 +230,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -240,6 +245,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -274,6 +280,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -334,6 +341,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -348,6 +356,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -362,6 +371,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -376,6 +386,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -431,6 +442,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -445,6 +457,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -459,6 +472,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -473,6 +487,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -89,6 +89,7 @@ class CheckExistingIdentityHandlerTest {
                     new CredentialIssuerConfig(
                             "address",
                             "address",
+                            true,
                             new URI("http://example.com/token"),
                             new URI("http://example.com/credential"),
                             new URI("http://example.com/authorize"),

--- a/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandlerTest.java
+++ b/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandlerTest.java
@@ -620,6 +620,7 @@ class EndMitigationJourneyHandlerTest {
         return new CredentialIssuerConfig(
                 "fraud",
                 "fraud",
+                true,
                 URI.create("http://example.com/token"),
                 URI.create("http://example.com/credential"),
                 URI.create("http://example.com/authorize"),

--- a/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01ValidationTest.java
+++ b/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01ValidationTest.java
@@ -205,6 +205,7 @@ class Mj01ValidationTest {
         return new CredentialIssuerConfig(
                 "fraud",
                 "fraud",
+                true,
                 URI.create("http://example.com/token"),
                 URI.create("http://example.com/credential"),
                 URI.create("http://example.com/authorize"),

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -96,6 +96,7 @@ class EvaluateGpg45ScoreHandlerTest {
                     new CredentialIssuerConfig(
                             "address",
                             "address",
+                            true,
                             new URI("http://example.com/token"),
                             new URI("http://example.com/credential"),
                             new URI("http://example.com/authorize"),

--- a/lambdas/get-credential-issuer-config/src/test/java/uk/gov/di/ipv/core/getcredentialisserconfig/GetCredentialIssuerConfigHandlerTest.java
+++ b/lambdas/get-credential-issuer-config/src/test/java/uk/gov/di/ipv/core/getcredentialisserconfig/GetCredentialIssuerConfigHandlerTest.java
@@ -34,6 +34,7 @@ class GetCredentialIssuerConfigHandlerTest {
                     new CredentialIssuerConfig(
                             "test1",
                             "Any",
+                            true,
                             URI.create("test1TokenUrl"),
                             URI.create("test1credentialUrl"),
                             URI.create("test1AuthorizeUrl"),
@@ -45,6 +46,7 @@ class GetCredentialIssuerConfigHandlerTest {
                     new CredentialIssuerConfig(
                             "test2",
                             "Any",
+                            true,
                             URI.create("test2TokenUrl"),
                             URI.create("test2credentialUrl"),
                             URI.create("test2AuthorizeUrl"),

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -98,6 +98,7 @@ class RetrieveCriCredentialHandlerTest {
                     new CredentialIssuerConfig(
                             "address",
                             "address",
+                            true,
                             new URI("http://example.com/token"),
                             new URI("http://example.com/credential"),
                             new URI("http://example.com/authorize"),
@@ -117,6 +118,7 @@ class RetrieveCriCredentialHandlerTest {
                 new CredentialIssuerConfig(
                         CREDENTIAL_ISSUER_ID,
                         "any",
+                        true,
                         new URI("https://www.example.com"),
                         new URI("https://www.example.com/credential"),
                         new URI("https://www.example.com/authorize"),

--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -76,6 +76,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                 new CredentialIssuerConfig(
                         CREDENTIAL_ISSUER_ID,
                         "any",
+                        true,
                         new URI("http://www.example.com"),
                         new URI("http://www.example.com/credential"),
                         new URI("http://www.example.com/authorize"),

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -748,6 +748,7 @@ class SelectCriHandlerTest {
         return new CredentialIssuerConfig(
                 criId,
                 criId,
+                true,
                 new URI("http://example.com/token"),
                 new URI("http://example.com/credential"),
                 new URI("http://example.com/authorize"),

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -71,6 +71,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 new CredentialIssuerConfig(
                         TEST_SESSION_ID,
                         "any",
+                        true,
                         new URI("http://www.example.com"),
                         new URI("http://www.example.com/credential"),
                         new URI("http://www.example.com/authorize"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -15,7 +15,7 @@ public enum ConfigurationVariable {
     JWT_TTL_SECONDS("/%s/core/self/jwtTtlSeconds"),
     MAX_ALLOWED_AUTH_CLIENT_TTL("/%s/core/self/maxAllowedAuthClientTtl"),
     PASSPORT_CRI_ID("/%s/core/self/journey/passportCriId"),
-    DCMAW_ENABLED("/%s/core/self/journey/dcmawEnabled"),
+    DCMAW_ENABLED("/%s/core/credentialIssuers/dcmaw/enabled"),
     DCMAW_SHOULD_SEND_ALL_USERS("/%s/core/self/journey/dcmawShouldSendAllUsers"),
     DCMAW_ALLOWED_USER_IDS("/%s/core/self/journey/dcmawAllowedUserIds"),
     AUTH_CODE_EXPIRY_SECONDS("/%s/core/self/authCodeExpirySeconds"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -16,6 +16,7 @@ public class CredentialIssuerConfig {
 
     private String id;
     private String name;
+    private Boolean enabled;
     private URI tokenUrl;
     private URI credentialUrl;
     private URI authorizeUrl;
@@ -31,6 +32,7 @@ public class CredentialIssuerConfig {
     public CredentialIssuerConfig(
             String id,
             String name,
+            Boolean enabled,
             URI tokenUrl,
             URI credentialUrl,
             URI authorizeUrl,
@@ -41,6 +43,7 @@ public class CredentialIssuerConfig {
             URI ipvCoreRedirectUrl) {
         this.id = id;
         this.name = name;
+        this.enabled = enabled;
         this.tokenUrl = tokenUrl;
         this.credentialUrl = credentialUrl;
         this.authorizeUrl = authorizeUrl;
@@ -53,6 +56,10 @@ public class CredentialIssuerConfig {
 
     public String getId() {
         return id;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
     }
 
     public URI getTokenUrl() {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/VcHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/VcHelperTest.java
@@ -29,6 +29,7 @@ class VcHelperTest {
                     new CredentialIssuerConfig(
                             "address",
                             "address",
+                            true,
                             new URI("http://example.com/token"),
                             new URI("http://example.com/credential"),
                             new URI("http://example.com/authorize"),

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigurationServiceTest.java
@@ -133,6 +133,7 @@ class ConfigurationServiceTest {
                 new CredentialIssuerConfig(
                         "passportCri",
                         "",
+                        true,
                         URI.create(TEST_TOKEN_URL),
                         URI.create(TEST_CREDENTIAL_URL),
                         URI.create(TEST_CREDENTIAL_URL),

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -78,6 +78,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -130,6 +131,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -164,6 +166,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -225,6 +228,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -271,6 +275,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -314,6 +319,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -374,6 +380,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -438,6 +445,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -488,6 +496,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -531,6 +540,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -685,6 +695,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -748,6 +759,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -788,6 +800,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -801,6 +814,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -814,6 +828,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -827,6 +842,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -840,6 +856,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -877,6 +894,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -911,6 +929,7 @@ class UserIdentityServiceTest {
                         new CredentialIssuerConfig(
                                 "test-cri",
                                 "test cri",
+                                true,
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),

--- a/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerServiceTest.java
+++ b/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerServiceTest.java
@@ -380,6 +380,7 @@ class CredentialIssuerServiceTest {
         return new CredentialIssuerConfig(
                 "StubPassport",
                 "any",
+                true,
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"),
                 URI.create(
                         "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/credentials/issue"),


### PR DESCRIPTION
## Proposed changes

### What changed

Added new `enabled` field to the credential issuer config 
The new field has been added in the common-infra config: https://github.com/alphagov/di-ipv-core-common-infra/pull/231

### Why did it change

This gives us the ability to switch between different CRI's

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2476](https://govukverify.atlassian.net/browse/PYIC-2476)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-2476]: https://govukverify.atlassian.net/browse/PYIC-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ