### PR TITLE
PYIC-2495: Update State machine so that the SELECT_CRI state can accept ukPassport, ukDrivingLicence, and passportAndDrivingLicence events.

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -155,35 +155,49 @@ SELECT_CRI:
   events:
     stubUkPassport:
       type: basic
-      name: next
+      name: stubUkPassport
       targetState: PASSPORT_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-passport-doc-check
+    stubUkDrivingLicence:
+      type: basic
+      name: stubUkDrivingLicence
+      targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-driving-licence-doc-check
+    stubUkPassportAndDrivingLicence:
+      type: basic
+      name: stubUkPassportAndDrivingLicence
+      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-passport-and-driving-licence-doc-check
     stubAddress:
       type: basic
-      name: address
+      name: stubAddress
       targetState: CRI_ADDRESS
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubAddress
     stubFraud:
       type: basic
-      name: fraud
+      name: stubFraud
       targetState: CRI_FRAUD
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubFraud
     stubKbv:
       type: basic
-      name: kbv
+      name: stubKbv
       targetState: PRE_KBV_TRANSITION_PAGE
       response:
         type: page
         pageId: page-pre-kbv-transition
     stubDcmaw:
       type: basic
-      name: dcmaw
+      name: stubDcmaw
       targetState: CRI_DCMAW
       response:
         type: journey
@@ -241,6 +255,12 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+CRI_UK_DRIVING_LICENCE:
+  name: CRI_UK_DRIVING_LICENCE
+  parent: CRI_STATE
+CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
+  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+  parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -261,6 +281,42 @@ PASSPORT_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -160,9 +160,9 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-passport-doc-check
-    stubUkDrivingLicence:
+    stubDrivingLicence:
       type: basic
-      name: stubUkDrivingLicence
+      name: stubDrivingLicence
       targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
       response:
         type: page
@@ -170,10 +170,10 @@ SELECT_CRI:
     stubUkPassportAndDrivingLicence:
       type: basic
       name: stubUkPassportAndDrivingLicence
-      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
-        pageId: page-passport-and-driving-licence-doc-check
+        pageId: page-multiple-doc-check
     stubAddress:
       type: basic
       name: stubAddress
@@ -255,11 +255,8 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
-CRI_UK_DRIVING_LICENCE:
-  name: CRI_UK_DRIVING_LICENCE
-  parent: CRI_STATE
-CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
-  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+CRI_DRIVING_LICENCE:
+  name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
@@ -295,10 +292,10 @@ DRIVING_LICENCE_DOC_CHECK_PAGE:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_DRIVING_LICENCE
+      targetState: CRI_DRIVING_LICENCE
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/stubDrivingLicence
     end:
       type: basic
       name: end
@@ -306,17 +303,24 @@ DRIVING_LICENCE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
-  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+MULTIPLE_DOC_CHECK_PAGE:
+  name: MULTIPLE_DOC_CHECK_PAGE
   parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    drivingLicence:
+      type: basic
+      name: next
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubDrivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -148,35 +148,49 @@ SELECT_CRI:
   events:
     stubUkPassport:
       type: basic
-      name: next
+      name: stubUkPassport
       targetState: PASSPORT_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-passport-doc-check
+    stubUkDrivingLicence:
+      type: basic
+      name: stubUkDrivingLicence
+      targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-driving-licence-doc-check
+    stubUkPassportAndDrivingLicence:
+      type: basic
+      name: stubUkPassportAndDrivingLicence
+      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-passport-and-driving-licence-doc-check
     stubAddress:
       type: basic
-      name: address
+      name: stubAddress
       targetState: CRI_ADDRESS
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubAddress
     stubFraud:
       type: basic
-      name: fraud
+      name: stubFraud
       targetState: CRI_FRAUD
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubFraud
     stubKbv:
       type: basic
-      name: kbv
+      name: stubKbv
       targetState: PRE_KBV_TRANSITION_PAGE
       response:
         type: page
         pageId: page-pre-kbv-transition
     stubDcmaw:
       type: basic
-      name: dcmaw
+      name: stubDcmaw
       targetState: CRI_DCMAW
       response:
         type: journey
@@ -234,6 +248,12 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+CRI_UK_DRIVING_LICENCE:
+  name: CRI_UK_DRIVING_LICENCE
+  parent: CRI_STATE
+CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
+  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+  parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -254,6 +274,42 @@ PASSPORT_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -153,9 +153,9 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-passport-doc-check
-    stubUkDrivingLicence:
+    stubDrivingLicence:
       type: basic
-      name: stubUkDrivingLicence
+      name: stubDrivingLicence
       targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
       response:
         type: page
@@ -163,10 +163,10 @@ SELECT_CRI:
     stubUkPassportAndDrivingLicence:
       type: basic
       name: stubUkPassportAndDrivingLicence
-      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
-        pageId: page-passport-and-driving-licence-doc-check
+        pageId: page-multiple-doc-check
     stubAddress:
       type: basic
       name: stubAddress
@@ -248,11 +248,8 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
-CRI_UK_DRIVING_LICENCE:
-  name: CRI_UK_DRIVING_LICENCE
-  parent: CRI_STATE
-CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
-  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+CRI_DRIVING_LICENCE:
+  name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
@@ -288,10 +285,10 @@ DRIVING_LICENCE_DOC_CHECK_PAGE:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_DRIVING_LICENCE
+      targetState: CRI_DRIVING_LICENCE
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/stubDrivingLicence
     end:
       type: basic
       name: end
@@ -299,17 +296,24 @@ DRIVING_LICENCE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
-  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+MULTIPLE_DOC_CHECK_PAGE:
+  name: MULTIPLE_DOC_CHECK_PAGE
   parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    drivingLicence:
+      type: basic
+      name: next
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubDrivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -148,7 +148,7 @@ SELECT_CRI:
   events:
     ukPassport:
       type: basic
-      name: next
+      name: ukPassport
       targetState: PASSPORT_DOC_CHECK_PAGE
       response:
         type: page
@@ -160,6 +160,34 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-passport-doc-check
+    ukDrivingLicence:
+      type: basic
+      name: ukDrivingLicence
+      targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-driving-licence-doc-check
+    stubUkDrivingLicence:
+      type: basic
+      name: stubUkDrivingLicence
+      targetState: STUB_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-driving-licence-doc-check
+    ukPassportAndDrivingLicence:
+      type: basic
+      name: ukPassportAndDrivingLicence
+      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-passport-and-driving-licence-doc-check
+    stubUkPassportAndDrivingLicence:
+      type: basic
+      name: stubUkPassportAndDrivingLicence
+      targetState: STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-passport-and-driving-licence-doc-check
     address:
       type: basic
       name: address
@@ -167,7 +195,7 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/address
-    stubddress:
+    stubAddress:
       type: basic
       name: stubAddress
       targetState: CRI_ADDRESS
@@ -269,6 +297,12 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+CRI_UK_DRIVING_LICENCE:
+  name: CRI_UK_DRIVING_LICENCE
+  parent: CRI_STATE
+CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
+  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+  parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -307,6 +341,78 @@ STUB_PASSPORT_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+STUB_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: STUB_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubUkDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassportAndDrivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -160,16 +160,16 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-passport-doc-check
-    ukDrivingLicence:
+    drivingLicence:
       type: basic
-      name: ukDrivingLicence
+      name: drivingLicence
       targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    stubUkDrivingLicence:
+    stubDrivingLicence:
       type: basic
-      name: stubUkDrivingLicence
+      name: stubDrivingLicence
       targetState: STUB_DRIVING_LICENCE_DOC_CHECK_PAGE
       response:
         type: page
@@ -177,17 +177,17 @@ SELECT_CRI:
     ukPassportAndDrivingLicence:
       type: basic
       name: ukPassportAndDrivingLicence
-      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
-        pageId: page-passport-and-driving-licence-doc-check
+        pageId: page-multiple-doc-check
     stubUkPassportAndDrivingLicence:
       type: basic
       name: stubUkPassportAndDrivingLicence
-      targetState: STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      targetState: STUB_MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
-        pageId: page-passport-and-driving-licence-doc-check
+        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address
@@ -297,11 +297,8 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
-CRI_UK_DRIVING_LICENCE:
-  name: CRI_UK_DRIVING_LICENCE
-  parent: CRI_STATE
-CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
-  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+CRI_DRIVING_LICENCE:
+  name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
@@ -355,10 +352,10 @@ DRIVING_LICENCE_DOC_CHECK_PAGE:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_DRIVING_LICENCE
+      targetState: CRI_DRIVING_LICENCE
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
     end:
       type: basic
       name: end
@@ -373,10 +370,10 @@ STUB_DRIVING_LICENCE_DOC_CHECK_PAGE:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_DRIVING_LICENCE
+      targetState: CRI_DRIVING_LICENCE
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubUkDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/stubDrivingLicence
     end:
       type: basic
       name: end
@@ -384,17 +381,24 @@ STUB_DRIVING_LICENCE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
-  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+MULTIPLE_DOC_CHECK_PAGE:
+  name: MULTIPLE_DOC_CHECK_PAGE
   parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: next
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
     end:
       type: basic
       name: end
@@ -402,17 +406,24 @@ PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
-  name: STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+STUB_MULTIPLE_DOC_CHECK_PAGE:
+  name: STUB_MULTIPLE_DOC_CHECK_PAGE
   parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubUkPassportAndDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    drivingLicence:
+      type: basic
+      name: next
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubDrivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -153,6 +153,20 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-passport-doc-check
+    ukDrivingLicence:
+      type: basic
+      name: ukDrivingLicence
+      targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-driving-licence-doc-check
+    ukPassportAndDrivingLicence:
+      type: basic
+      name: ukPassportAndDrivingLicence
+      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-passport-and-driving-licence-doc-check
     address:
       type: basic
       name: address
@@ -234,6 +248,12 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+CRI_UK_DRIVING_LICENCE:
+  name: CRI_UK_DRIVING_LICENCE
+  parent: CRI_STATE
+CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
+  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+  parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -254,6 +274,42 @@ PASSPORT_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -153,9 +153,9 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-passport-doc-check
-    ukDrivingLicence:
+    drivingLicence:
       type: basic
-      name: ukDrivingLicence
+      name: drivingLicence
       targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
       response:
         type: page
@@ -163,10 +163,10 @@ SELECT_CRI:
     ukPassportAndDrivingLicence:
       type: basic
       name: ukPassportAndDrivingLicence
-      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
-        pageId: page-passport-and-driving-licence-doc-check
+        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address
@@ -248,11 +248,8 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
-CRI_UK_DRIVING_LICENCE:
-  name: CRI_UK_DRIVING_LICENCE
-  parent: CRI_STATE
-CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
-  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+CRI_DRIVING_LICENCE:
+  name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
@@ -288,10 +285,10 @@ DRIVING_LICENCE_DOC_CHECK_PAGE:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_DRIVING_LICENCE
+      targetState: CRI_DRIVING_LICENCE
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
     end:
       type: basic
       name: end
@@ -299,17 +296,24 @@ DRIVING_LICENCE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
-  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+MULTIPLE_DOC_CHECK_PAGE:
+  name: MULTIPLE_DOC_CHECK_PAGE
   parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: next
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -160,16 +160,16 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-passport-doc-check
-    ukDrivingLicence:
+    drivingLicence:
       type: basic
-      name: ukDrivingLicence
+      name: drivingLicence
       targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    stubUkDrivingLicence:
+    stubDrivingLicence:
       type: basic
-      name: stubUkDrivingLicence
+      name: stubDrivingLicence
       targetState: STUB_DRIVING_LICENCE_DOC_CHECK_PAGE
       response:
         type: page
@@ -177,17 +177,17 @@ SELECT_CRI:
     ukPassportAndDrivingLicence:
       type: basic
       name: ukPassportAndDrivingLicence
-      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
-        pageId: page-passport-and-driving-licence-doc-check
+        pageId: page-multiple-doc-check
     stubUkPassportAndDrivingLicence:
       type: basic
       name: stubUkPassportAndDrivingLicence
-      targetState: STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      targetState: STUB_MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
-        pageId: page-passport-and-driving-licence-doc-check
+        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address
@@ -297,11 +297,8 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
-CRI_UK_DRIVING_LICENCE:
-  name: CRI_UK_DRIVING_LICENCE
-  parent: CRI_STATE
-CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
-  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+CRI_DRIVING_LICENCE:
+  name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
@@ -355,10 +352,10 @@ DRIVING_LICENCE_DOC_CHECK_PAGE:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_DRIVING_LICENCE
+      targetState: CRI_DRIVING_LICENCE
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
     end:
       type: basic
       name: end
@@ -373,10 +370,10 @@ STUB_DRIVING_LICENCE_DOC_CHECK_PAGE:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_DRIVING_LICENCE
+      targetState: CRI_DRIVING_LICENCE
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubUkDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/stubDrivingLicence
     end:
       type: basic
       name: end
@@ -384,17 +381,24 @@ STUB_DRIVING_LICENCE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
-  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+MULTIPLE_DOC_CHECK_PAGE:
+  name: MULTIPLE_DOC_CHECK_PAGE
   parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: next
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
     end:
       type: basic
       name: end
@@ -402,17 +406,24 @@ PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
-  name: STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+STUB_MULTIPLE_DOC_CHECK_PAGE:
+  name: STUB_MULTIPLE_DOC_CHECK_PAGE
   parent: ATTEMPT_RECOVERY_STATE
   events:
     next:
       type: basic
       name: next
-      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      targetState: CRI_UK_PASSPORT
       response:
         type: journey
-        journeyStepId: /journey/cri/build-oauth-request/stubUkPassportAndDrivingLicence
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    drivingLicence:
+      type: basic
+      name: next
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubDrivingLicence
     end:
       type: basic
       name: end

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -160,6 +160,34 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-passport-doc-check
+    ukDrivingLicence:
+      type: basic
+      name: ukDrivingLicence
+      targetState: DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-driving-licence-doc-check
+    stubUkDrivingLicence:
+      type: basic
+      name: stubUkDrivingLicence
+      targetState: STUB_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-driving-licence-doc-check
+    ukPassportAndDrivingLicence:
+      type: basic
+      name: ukPassportAndDrivingLicence
+      targetState: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-passport-and-driving-licence-doc-check
+    stubUkPassportAndDrivingLicence:
+      type: basic
+      name: stubUkPassportAndDrivingLicence
+      targetState: STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-passport-and-driving-licence-doc-check
     address:
       type: basic
       name: address
@@ -167,7 +195,7 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/address
-    stubddress:
+    stubAddress:
       type: basic
       name: stubAddress
       targetState: CRI_ADDRESS
@@ -269,6 +297,12 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+CRI_UK_DRIVING_LICENCE:
+  name: CRI_UK_DRIVING_LICENCE
+  parent: CRI_STATE
+CRI_UK_PASSPORT_AND_DRIVING_LICENCE:
+  name: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+  parent: CRI_STATE
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
@@ -307,6 +341,78 @@ STUB_PASSPORT_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/stubUkPassport
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+STUB_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: STUB_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubUkDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassportAndDrivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE:
+  name: STUB_PASSPORT_AND_DRIVING_LICENCE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT_AND_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/stubUkPassportAndDrivingLicence
     end:
       type: basic
       name: end


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update State machine so that the SELECT_CRI state can accept ukPassport, ukDrivingLicence, and passportAndDrivingLicence events.

<!-- Describe the changes in detail - the "what"-->

### Why did it change


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2495](https://govukverify.atlassian.net/browse/PYIC-2495)


[PYIC-2495]: https://govukverify.atlassian.net/browse/PYIC-2495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ