### PR TITLE
BAU: Rename CredentialIssuerRequestDto to CriCallbackRequest

### DIFF
--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -86,13 +86,13 @@ public class ValidateOAuthCallbackHandler
     @Override
     @Tracing
     @Logging(clearState = true)
-    public Map<String, Object> handleRequest(CriCallbackRequest request, Context context) {
+    public Map<String, Object> handleRequest(CriCallbackRequest callbackRequest, Context context) {
         LogHelper.attachComponentIdToLogs();
 
         IpvSessionItem ipvSessionItem = null;
 
         try {
-            String ipvSessionId = request.getIpvSessionId();
+            String ipvSessionId = callbackRequest.getIpvSessionId();
             if (ipvSessionId == null) {
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
@@ -100,23 +100,23 @@ public class ValidateOAuthCallbackHandler
             LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
 
             ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
-            if (request.getError() != null) {
-                return sendOauthErrorJourneyResponse(ipvSessionItem, request);
+            if (callbackRequest.getError() != null) {
+                return sendOauthErrorJourneyResponse(ipvSessionItem, callbackRequest);
             }
 
-            validate(request);
+            validate(callbackRequest);
 
-            sendAuditEvent(ipvSessionItem, null, request.getIpAddress());
+            sendAuditEvent(ipvSessionItem, null, callbackRequest.getIpAddress());
 
             setIpvSessionCRIAuthorizationCode(
-                    ipvSessionItem, new AuthorizationCode(request.getAuthorizationCode()));
+                    ipvSessionItem, new AuthorizationCode(callbackRequest.getAuthorizationCode()));
 
             ipvSessionService.updateIpvSession(ipvSessionItem);
 
             var mapMessage =
                     new StringMapMessage()
                             .with("message", "Successfully validated oauth callback")
-                            .with("criId", request.getCredentialIssuerId());
+                            .with("criId", callbackRequest.getCredentialIssuerId());
             LOGGER.info(mapMessage);
 
             return JOURNEY_ACCESS_TOKEN;
@@ -150,16 +150,16 @@ public class ValidateOAuthCallbackHandler
 
     @Tracing
     private Map<String, Object> sendOauthErrorJourneyResponse(
-            IpvSessionItem ipvSessionItem, CriCallbackRequest request) throws SqsException {
-        String error = request.getError();
-        String errorDescription = request.getErrorDescription();
+            IpvSessionItem ipvSessionItem, CriCallbackRequest callbackRequest) throws SqsException {
+        String error = callbackRequest.getError();
+        String errorDescription = callbackRequest.getErrorDescription();
 
         AuditExtensionErrorParams extensions =
                 new AuditExtensionErrorParams.Builder()
                         .setErrorCode(error)
                         .setErrorDescription(errorDescription)
                         .build();
-        sendAuditEvent(ipvSessionItem, extensions, request.getIpAddress());
+        sendAuditEvent(ipvSessionItem, extensions, callbackRequest.getIpAddress());
 
         if (!ALLOWED_OAUTH_ERROR_CODES.contains(error)) {
             LOGGER.warn("Unknown Oauth error code received");
@@ -169,10 +169,10 @@ public class ValidateOAuthCallbackHandler
                 || !ipvSessionItem
                         .getCredentialIssuerSessionDetails()
                         .getCriId()
-                        .equals(request.getCredentialIssuerId())) {
+                        .equals(callbackRequest.getCredentialIssuerId())) {
             var message =
                     new StringMapMessage()
-                            .with("criId", request.getCredentialIssuerId())
+                            .with("criId", callbackRequest.getCredentialIssuerId())
                             .with("message", "Oauth error from unexpected CRI");
             LOGGER.warn(message);
             return StepFunctionHelpers.generatePageOutputMap(
@@ -181,7 +181,7 @@ public class ValidateOAuthCallbackHandler
 
         ipvSessionItem.addVisitedCredentialIssuerDetails(
                 new VisitedCredentialIssuerDetailsDto(
-                        request.getCredentialIssuerId(), false, error));
+                        callbackRequest.getCredentialIssuerId(), false, error));
         ipvSessionService.updateIpvSession(ipvSessionItem);
 
         LogHelper.logOauthError("OAuth error received from CRI", error, errorDescription);
@@ -196,36 +196,37 @@ public class ValidateOAuthCallbackHandler
     }
 
     @Tracing
-    private void validate(CriCallbackRequest request) throws HttpResponseExceptionWithErrorBody {
+    private void validate(CriCallbackRequest callbackRequest)
+            throws HttpResponseExceptionWithErrorBody {
 
-        if (StringUtils.isBlank(request.getAuthorizationCode())) {
+        if (StringUtils.isBlank(callbackRequest.getAuthorizationCode())) {
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_AUTHORIZATION_CODE);
         }
 
-        if (StringUtils.isBlank(request.getCredentialIssuerId())) {
+        if (StringUtils.isBlank(callbackRequest.getCredentialIssuerId())) {
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
         }
-        LogHelper.attachCriIdToLogs(request.getCredentialIssuerId());
+        LogHelper.attachCriIdToLogs(callbackRequest.getCredentialIssuerId());
 
-        if (StringUtils.isBlank(request.getIpvSessionId())) {
+        if (StringUtils.isBlank(callbackRequest.getIpvSessionId())) {
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
         }
 
-        if (StringUtils.isBlank(request.getState())) {
+        if (StringUtils.isBlank(callbackRequest.getState())) {
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_OAUTH_STATE);
         }
 
-        String persistedOauthState = getPersistedOauthState(request);
-        if (!request.getState().equals(persistedOauthState)) {
+        String persistedOauthState = getPersistedOauthState(callbackRequest);
+        if (!callbackRequest.getState().equals(persistedOauthState)) {
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_OAUTH_STATE);
         }
 
-        if (getCredentialIssuerConfig(request) == null) {
+        if (getCredentialIssuerConfig(callbackRequest) == null) {
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
         }
@@ -241,10 +242,10 @@ public class ValidateOAuthCallbackHandler
     }
 
     @Tracing
-    private String getPersistedOauthState(CriCallbackRequest request) {
+    private String getPersistedOauthState(CriCallbackRequest callbackRequest) {
         CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails =
                 ipvSessionService
-                        .getIpvSession(request.getIpvSessionId())
+                        .getIpvSession(callbackRequest.getIpvSessionId())
                         .getCredentialIssuerSessionDetails();
         if (credentialIssuerSessionDetails != null) {
             return credentialIssuerSessionDetails.getState();
@@ -253,8 +254,8 @@ public class ValidateOAuthCallbackHandler
     }
 
     @Tracing
-    private CredentialIssuerConfig getCredentialIssuerConfig(CriCallbackRequest request) {
-        return configService.getCredentialIssuer(request.getCredentialIssuerId());
+    private CredentialIssuerConfig getCredentialIssuerConfig(CriCallbackRequest callbackRequest) {
+        return configService.getCredentialIssuer(callbackRequest.getCredentialIssuerId());
     }
 
     @Tracing

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -30,14 +30,14 @@ import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
-import uk.gov.di.ipv.core.validateoauthcallback.dto.CredentialIssuerRequestDto;
+import uk.gov.di.ipv.core.validateoauthcallback.dto.CriCallbackRequest;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 public class ValidateOAuthCallbackHandler
-        implements RequestHandler<CredentialIssuerRequestDto, Map<String, Object>> {
+        implements RequestHandler<CriCallbackRequest, Map<String, Object>> {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String JOURNEY = "journey";
@@ -86,7 +86,7 @@ public class ValidateOAuthCallbackHandler
     @Override
     @Tracing
     @Logging(clearState = true)
-    public Map<String, Object> handleRequest(CredentialIssuerRequestDto request, Context context) {
+    public Map<String, Object> handleRequest(CriCallbackRequest request, Context context) {
         LogHelper.attachComponentIdToLogs();
 
         IpvSessionItem ipvSessionItem = null;
@@ -150,7 +150,7 @@ public class ValidateOAuthCallbackHandler
 
     @Tracing
     private Map<String, Object> sendOauthErrorJourneyResponse(
-            IpvSessionItem ipvSessionItem, CredentialIssuerRequestDto request) throws SqsException {
+            IpvSessionItem ipvSessionItem, CriCallbackRequest request) throws SqsException {
         String error = request.getError();
         String errorDescription = request.getErrorDescription();
 
@@ -196,8 +196,7 @@ public class ValidateOAuthCallbackHandler
     }
 
     @Tracing
-    private void validate(CredentialIssuerRequestDto request)
-            throws HttpResponseExceptionWithErrorBody {
+    private void validate(CriCallbackRequest request) throws HttpResponseExceptionWithErrorBody {
 
         if (StringUtils.isBlank(request.getAuthorizationCode())) {
             throw new HttpResponseExceptionWithErrorBody(
@@ -242,7 +241,7 @@ public class ValidateOAuthCallbackHandler
     }
 
     @Tracing
-    private String getPersistedOauthState(CredentialIssuerRequestDto request) {
+    private String getPersistedOauthState(CriCallbackRequest request) {
         CredentialIssuerSessionDetailsDto credentialIssuerSessionDetails =
                 ipvSessionService
                         .getIpvSession(request.getIpvSessionId())
@@ -254,7 +253,7 @@ public class ValidateOAuthCallbackHandler
     }
 
     @Tracing
-    private CredentialIssuerConfig getCredentialIssuerConfig(CredentialIssuerRequestDto request) {
+    private CredentialIssuerConfig getCredentialIssuerConfig(CriCallbackRequest request) {
         return configService.getCredentialIssuer(request.getCredentialIssuerId());
     }
 

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/dto/CriCallbackRequest.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/dto/CriCallbackRequest.java
@@ -9,7 +9,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public class CredentialIssuerRequestDto {
+public class CriCallbackRequest {
     private String authorizationCode;
     private String credentialIssuerId;
     private String ipvSessionId;

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -129,12 +129,11 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfAuthorizationCodeNotPresent() {
-        CriCallbackRequest credentialIssuerRequestWithoutAuthCode =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithoutAuthCode.setAuthorizationCode(null);
+        CriCallbackRequest criCallbackRequestWithoutAuthCode = validCredentialIssuerRequestDto();
+        criCallbackRequestWithoutAuthCode.setAuthorizationCode(null);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithoutAuthCode, context);
+                underTest.handleRequest(criCallbackRequestWithoutAuthCode, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
         assertEquals(ErrorResponse.MISSING_AUTHORIZATION_CODE.getCode(), output.get(CODE));
@@ -143,11 +142,11 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotPresent() {
-        CriCallbackRequest credentialIssuerRequestWithoutCriId = validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithoutCriId.setCredentialIssuerId(null);
+        CriCallbackRequest criCallbackRequestWithoutCriId = validCredentialIssuerRequestDto();
+        criCallbackRequestWithoutCriId.setCredentialIssuerId(null);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithoutCriId, context);
+                underTest.handleRequest(criCallbackRequestWithoutCriId, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
         assertEquals(ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID.getCode(), output.get(CODE));
@@ -156,14 +155,13 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotInPermittedSet() {
-        CriCallbackRequest credentialIssuerRequestWithInvalidCriId =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithInvalidCriId.setCredentialIssuerId("an invalid id");
+        CriCallbackRequest criCallbackRequestWithInvalidCriId = validCredentialIssuerRequestDto();
+        criCallbackRequestWithInvalidCriId.setCredentialIssuerId("an invalid id");
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithInvalidCriId, context);
+                underTest.handleRequest(criCallbackRequestWithInvalidCriId, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
         assertEquals(ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID.getCode(), output.get(CODE));
@@ -172,12 +170,11 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfSessionIdNotPresent() {
-        CriCallbackRequest credentialIssuerRequestWithoutSessionId =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithoutSessionId.setIpvSessionId(null);
+        CriCallbackRequest criCallbackRequestWithoutSessionId = validCredentialIssuerRequestDto();
+        criCallbackRequestWithoutSessionId.setIpvSessionId(null);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithoutSessionId, context);
+                underTest.handleRequest(criCallbackRequestWithoutSessionId, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
         assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), output.get(CODE));
@@ -186,11 +183,11 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfOAuthStateNotPresentInRequest() {
-        CriCallbackRequest credentialIssuerRequestWithoutState = validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithoutState.setState(null);
+        CriCallbackRequest criCallbackRequestWithoutState = validCredentialIssuerRequestDto();
+        criCallbackRequestWithoutState.setState(null);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithoutState, context);
+                underTest.handleRequest(criCallbackRequestWithoutState, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
         assertEquals(ErrorResponse.MISSING_OAUTH_STATE.getCode(), output.get(CODE));
@@ -199,13 +196,13 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseWithAttemptRecoveryPageIfOAuthStateNotPresentInSession() {
-        CriCallbackRequest credentialIssuerRequest = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequest = validCredentialIssuerRequestDto();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setCredentialIssuerSessionDetails(null);
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        Map<String, Object> output = underTest.handleRequest(credentialIssuerRequest, context);
+        Map<String, Object> output = underTest.handleRequest(criCallbackRequest, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
         assertEquals("pyi-attempt-recovery", output.get(PAGE));
@@ -214,14 +211,13 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseWithAttemptRecoveryPageIfOAuthStateNotValid() {
-        CriCallbackRequest credentialIssuerRequestWithInvalidState =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithInvalidState.setState("not-correct-state");
+        CriCallbackRequest criCallbackRequestWithInvalidState = validCredentialIssuerRequestDto();
+        criCallbackRequestWithInvalidState.setState("not-correct-state");
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithInvalidState, context);
+                underTest.handleRequest(criCallbackRequestWithInvalidState, context);
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
         assertEquals("pyi-attempt-recovery", output.get(PAGE));
@@ -262,61 +258,57 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceiveAccessDeniedJourneyResponseWhenOauthErrorAccessDenied() {
-        CriCallbackRequest credentialIssuerRequestWithAccessDenied =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
-        credentialIssuerRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
+        CriCallbackRequest criCallbackRequestWithAccessDenied = validCredentialIssuerRequestDto();
+        criCallbackRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
+        criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithAccessDenied, context);
+                underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
 
         assertEquals("/journey/access-denied", output.get("journey"));
     }
 
     @Test
     void shouldReceiveTemporarilyUnavailableJourneyResponseWhenOauthErrorTemporarilyUnavailable() {
-        CriCallbackRequest credentialIssuerRequestWithAccessDenied =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithAccessDenied.setError(OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE);
-        credentialIssuerRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
+        CriCallbackRequest criCallbackRequestWithAccessDenied = validCredentialIssuerRequestDto();
+        criCallbackRequestWithAccessDenied.setError(OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE);
+        criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithAccessDenied, context);
+                underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
 
         assertEquals("/journey/temporarily-unavailable", output.get("journey"));
     }
 
     @Test
     void shouldReceiveJourneyErrorJourneyResponseWhenAnyOtherOauthError() {
-        CriCallbackRequest credentialIssuerRequestWithOtherError =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
-        credentialIssuerRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
+        CriCallbackRequest criCallbackRequestWithOtherError = validCredentialIssuerRequestDto();
+        criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
+        criCallbackRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithOtherError, context);
+                underTest.handleRequest(criCallbackRequestWithOtherError, context);
 
         assertEquals("/journey/error", output.get("journey"));
     }
 
     @Test
     void shouldAttemptRecoveryErrorResponseWhenOauthSessionIsNull() {
-        CriCallbackRequest credentialIssuerRequestWithOtherError =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
-        credentialIssuerRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
+        CriCallbackRequest criCallbackRequestWithOtherError = validCredentialIssuerRequestDto();
+        criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
+        criCallbackRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
         ipvSessionItem.setCredentialIssuerSessionDetails(null);
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithOtherError, context);
+                underTest.handleRequest(criCallbackRequestWithOtherError, context);
 
         assertEquals("error", output.get("type"));
         assertEquals("pyi-attempt-recovery", output.get("page"));
@@ -325,10 +317,9 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldAttemptRecoveryErrorResponseWhenOauthSessionIsForDifferentCri() {
-        CriCallbackRequest credentialIssuerRequestWithOtherError =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
-        credentialIssuerRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
+        CriCallbackRequest criCallbackRequestWithOtherError = validCredentialIssuerRequestDto();
+        criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
+        criCallbackRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
         CredentialIssuerSessionDetailsDto credentialIssuerSessionDetailsDto =
                 new CredentialIssuerSessionDetailsDto();
@@ -337,7 +328,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithOtherError, context);
+                underTest.handleRequest(criCallbackRequestWithOtherError, context);
 
         assertEquals("error", output.get("type"));
         assertEquals("pyi-attempt-recovery", output.get("page"));
@@ -346,10 +337,9 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldNotUpdateSessionOnAttemptRecoveryError() {
-        CriCallbackRequest credentialIssuerRequestWithOtherError =
-                validCredentialIssuerRequestDto();
-        credentialIssuerRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
-        credentialIssuerRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
+        CriCallbackRequest criCallbackRequestWithOtherError = validCredentialIssuerRequestDto();
+        criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
+        criCallbackRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
         CredentialIssuerSessionDetailsDto credentialIssuerSessionDetailsDto =
                 new CredentialIssuerSessionDetailsDto();
@@ -363,7 +353,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 .updateIpvSession(ipvSessionItemArgumentCaptor.capture());
 
         Map<String, Object> output =
-                underTest.handleRequest(credentialIssuerRequestWithOtherError, context);
+                underTest.handleRequest(criCallbackRequestWithOtherError, context);
 
         assertEquals("error", output.get("type"));
         assertEquals("pyi-attempt-recovery", output.get("page"));

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -104,8 +104,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        Map<String, Object> output =
-                underTest.handleRequest(validCredentialIssuerRequestDto(), context);
+        Map<String, Object> output = underTest.handleRequest(validCriCallbackRequest(), context);
 
         ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
         verify(mockAuditService, times(1)).sendAuditEvent(auditEventCaptor.capture());
@@ -129,7 +128,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfAuthorizationCodeNotPresent() {
-        CriCallbackRequest criCallbackRequestWithoutAuthCode = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithoutAuthCode = validCriCallbackRequest();
         criCallbackRequestWithoutAuthCode.setAuthorizationCode(null);
 
         Map<String, Object> output =
@@ -142,7 +141,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotPresent() {
-        CriCallbackRequest criCallbackRequestWithoutCriId = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithoutCriId = validCriCallbackRequest();
         criCallbackRequestWithoutCriId.setCredentialIssuerId(null);
 
         Map<String, Object> output =
@@ -155,7 +154,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotInPermittedSet() {
-        CriCallbackRequest criCallbackRequestWithInvalidCriId = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithInvalidCriId = validCriCallbackRequest();
         criCallbackRequestWithInvalidCriId.setCredentialIssuerId("an invalid id");
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -170,7 +169,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfSessionIdNotPresent() {
-        CriCallbackRequest criCallbackRequestWithoutSessionId = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithoutSessionId = validCriCallbackRequest();
         criCallbackRequestWithoutSessionId.setIpvSessionId(null);
 
         Map<String, Object> output =
@@ -183,7 +182,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfOAuthStateNotPresentInRequest() {
-        CriCallbackRequest criCallbackRequestWithoutState = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithoutState = validCriCallbackRequest();
         criCallbackRequestWithoutState.setState(null);
 
         Map<String, Object> output =
@@ -196,7 +195,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseWithAttemptRecoveryPageIfOAuthStateNotPresentInSession() {
-        CriCallbackRequest criCallbackRequest = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequest = validCriCallbackRequest();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setCredentialIssuerSessionDetails(null);
@@ -211,7 +210,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseWithAttemptRecoveryPageIfOAuthStateNotValid() {
-        CriCallbackRequest criCallbackRequestWithInvalidState = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithInvalidState = validCriCallbackRequest();
         criCallbackRequestWithInvalidState.setState("not-correct-state");
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -236,7 +235,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
 
-        underTest.handleRequest(validCredentialIssuerRequestDto(), context);
+        underTest.handleRequest(validCriCallbackRequest(), context);
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -258,7 +257,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceiveAccessDeniedJourneyResponseWhenOauthErrorAccessDenied() {
-        CriCallbackRequest criCallbackRequestWithAccessDenied = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithAccessDenied = validCriCallbackRequest();
         criCallbackRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
         criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
@@ -272,7 +271,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceiveTemporarilyUnavailableJourneyResponseWhenOauthErrorTemporarilyUnavailable() {
-        CriCallbackRequest criCallbackRequestWithAccessDenied = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithAccessDenied = validCriCallbackRequest();
         criCallbackRequestWithAccessDenied.setError(OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE);
         criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
@@ -286,7 +285,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceiveJourneyErrorJourneyResponseWhenAnyOtherOauthError() {
-        CriCallbackRequest criCallbackRequestWithOtherError = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithOtherError = validCriCallbackRequest();
         criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
         criCallbackRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
@@ -300,7 +299,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldAttemptRecoveryErrorResponseWhenOauthSessionIsNull() {
-        CriCallbackRequest criCallbackRequestWithOtherError = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithOtherError = validCriCallbackRequest();
         criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
         criCallbackRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
@@ -317,7 +316,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldAttemptRecoveryErrorResponseWhenOauthSessionIsForDifferentCri() {
-        CriCallbackRequest criCallbackRequestWithOtherError = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithOtherError = validCriCallbackRequest();
         criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
         criCallbackRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
@@ -337,7 +336,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldNotUpdateSessionOnAttemptRecoveryError() {
-        CriCallbackRequest criCallbackRequestWithOtherError = validCredentialIssuerRequestDto();
+        CriCallbackRequest criCallbackRequestWithOtherError = validCriCallbackRequest();
         criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
         criCallbackRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
 
@@ -360,7 +359,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         assertEquals(400, output.get("statusCode"));
     }
 
-    private CriCallbackRequest validCredentialIssuerRequestDto() {
+    private CriCallbackRequest validCriCallbackRequest() {
         return new CriCallbackRequest(
                 TEST_AUTHORIZATION_CODE,
                 TEST_CREDENTIAL_ISSUER_ID,

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -23,7 +23,7 @@ import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.validateoauthcallback.ValidateOAuthCallbackHandler;
-import uk.gov.di.ipv.core.validateoauthcallback.dto.CredentialIssuerRequestDto;
+import uk.gov.di.ipv.core.validateoauthcallback.dto.CriCallbackRequest;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -129,7 +129,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfAuthorizationCodeNotPresent() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithoutAuthCode =
+        CriCallbackRequest credentialIssuerRequestWithoutAuthCode =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithoutAuthCode.setAuthorizationCode(null);
 
@@ -143,8 +143,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotPresent() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithoutCriId =
-                validCredentialIssuerRequestDto();
+        CriCallbackRequest credentialIssuerRequestWithoutCriId = validCredentialIssuerRequestDto();
         credentialIssuerRequestWithoutCriId.setCredentialIssuerId(null);
 
         Map<String, Object> output =
@@ -157,7 +156,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfCredentialIssuerNotInPermittedSet() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithInvalidCriId =
+        CriCallbackRequest credentialIssuerRequestWithInvalidCriId =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithInvalidCriId.setCredentialIssuerId("an invalid id");
 
@@ -173,7 +172,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfSessionIdNotPresent() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithoutSessionId =
+        CriCallbackRequest credentialIssuerRequestWithoutSessionId =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithoutSessionId.setIpvSessionId(null);
 
@@ -187,8 +186,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeIfOAuthStateNotPresentInRequest() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithoutState =
-                validCredentialIssuerRequestDto();
+        CriCallbackRequest credentialIssuerRequestWithoutState = validCredentialIssuerRequestDto();
         credentialIssuerRequestWithoutState.setState(null);
 
         Map<String, Object> output =
@@ -201,7 +199,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseWithAttemptRecoveryPageIfOAuthStateNotPresentInSession() {
-        CredentialIssuerRequestDto credentialIssuerRequest = validCredentialIssuerRequestDto();
+        CriCallbackRequest credentialIssuerRequest = validCredentialIssuerRequestDto();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setCredentialIssuerSessionDetails(null);
@@ -216,7 +214,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceive400ResponseWithAttemptRecoveryPageIfOAuthStateNotValid() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithInvalidState =
+        CriCallbackRequest credentialIssuerRequestWithInvalidState =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithInvalidState.setState("not-correct-state");
 
@@ -264,7 +262,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceiveAccessDeniedJourneyResponseWhenOauthErrorAccessDenied() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithAccessDenied =
+        CriCallbackRequest credentialIssuerRequestWithAccessDenied =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
         credentialIssuerRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
@@ -279,7 +277,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceiveTemporarilyUnavailableJourneyResponseWhenOauthErrorTemporarilyUnavailable() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithAccessDenied =
+        CriCallbackRequest credentialIssuerRequestWithAccessDenied =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithAccessDenied.setError(OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE);
         credentialIssuerRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
@@ -294,7 +292,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldReceiveJourneyErrorJourneyResponseWhenAnyOtherOauthError() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithOtherError =
+        CriCallbackRequest credentialIssuerRequestWithOtherError =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
         credentialIssuerRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
@@ -309,7 +307,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldAttemptRecoveryErrorResponseWhenOauthSessionIsNull() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithOtherError =
+        CriCallbackRequest credentialIssuerRequestWithOtherError =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
         credentialIssuerRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
@@ -327,7 +325,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldAttemptRecoveryErrorResponseWhenOauthSessionIsForDifferentCri() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithOtherError =
+        CriCallbackRequest credentialIssuerRequestWithOtherError =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
         credentialIssuerRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
@@ -348,7 +346,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @Test
     void shouldNotUpdateSessionOnAttemptRecoveryError() {
-        CredentialIssuerRequestDto credentialIssuerRequestWithOtherError =
+        CriCallbackRequest credentialIssuerRequestWithOtherError =
                 validCredentialIssuerRequestDto();
         credentialIssuerRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
         credentialIssuerRequestWithOtherError.setErrorDescription(TEST_ERROR_DESCRIPTION);
@@ -372,8 +370,8 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         assertEquals(400, output.get("statusCode"));
     }
 
-    private CredentialIssuerRequestDto validCredentialIssuerRequestDto() {
-        return new CredentialIssuerRequestDto(
+    private CriCallbackRequest validCredentialIssuerRequestDto() {
+        return new CriCallbackRequest(
                 TEST_AUTHORIZATION_CODE,
                 TEST_CREDENTIAL_ISSUER_ID,
                 TEST_SESSION_ID,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Rename `CredentialIssuerRequestDto` to `CriCallbackRequest`

<!-- Describe the changes in detail - the "what"-->

### Why did it change

This object represents the data we receive in the OAuth callback from the Credential Issuer. Since we also make requests to Credential Issuers this rename is helpful in scoping the data to the callback.

Also rename variables and methods to better reflect this change.
