### PR TITLE
PYIC-2496: Update select-cri lambda to direct user to PassportAndDrivingLicence Doc Check page if DrivingLicence CRI is enabled.

### DIFF
--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -49,6 +49,8 @@ public class SelectCriHandler
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
     private static final String UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
             "ukPassportAndDrivingLicence";
+    private static final String STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
+            "stubUkPassportAndDrivingLicence";
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
@@ -263,7 +265,7 @@ public class SelectCriHandler
                 CredentialIssuerConfig ukDrivingLicenseCriConfig =
                         configService.getCredentialIssuer(drivingLicenceCriId);
                 if (criId.equals(passportCriId) && ukDrivingLicenseCriConfig.getEnabled()) {
-                    return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
+                    return getMultipleDocCheckPage();
                 }
 
                 return Optional.of(getJourneyResponse(journeyId));
@@ -302,6 +304,13 @@ public class SelectCriHandler
             return Optional.of(getJourneyPyiNoMatchResponse());
         }
         return Optional.empty();
+    }
+
+    private Optional<JourneyResponse> getMultipleDocCheckPage() {
+        if (drivingLicenceCriId.startsWith("stub")) {
+            return Optional.of(getJourneyResponse(STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
+        }
+        return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
     }
 
     private boolean hasPassportVc(List<VcStatusDto> currentVcStatuses) {

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -35,6 +35,7 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ALLO
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ENABLED;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_SHOULD_SEND_ALL_USERS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DRIVING_LICENCE_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.FRAUD_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.KBV_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PASSPORT_CRI_ID;
@@ -46,6 +47,8 @@ public class SelectCriHandler
     private static final String JOURNEY_FAIL = "/journey/fail";
     private static final String DCMAW_SUCCESS_PAGE = "dcmaw-success";
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
+    public static final String CRI_UK_DRIVING_LICENCE = "ukDrivingLicence";
+    public static final String CRI_UK_PASSPORT_AND_DRIVING_LICENCE = "ukPassportAndDrivingLicence";
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
@@ -54,6 +57,7 @@ public class SelectCriHandler
     private final String kbvCriId;
     private final String addressCriId;
     private final String dcmawCriId;
+    private final String drivingLicenceCriId;
 
     public SelectCriHandler(ConfigService configService, IpvSessionService ipvSessionService) {
         this.configService = configService;
@@ -64,6 +68,7 @@ public class SelectCriHandler
         kbvCriId = configService.getSsmParameter(KBV_CRI_ID);
         addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
         dcmawCriId = configService.getSsmParameter(DCMAW_CRI_ID);
+        drivingLicenceCriId = configService.getSsmParameter(DRIVING_LICENCE_CRI_ID);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -76,6 +81,7 @@ public class SelectCriHandler
         kbvCriId = configService.getSsmParameter(KBV_CRI_ID);
         addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
         dcmawCriId = configService.getSsmParameter(DCMAW_CRI_ID);
+        drivingLicenceCriId = configService.getSsmParameter(DRIVING_LICENCE_CRI_ID);
     }
 
     @Override
@@ -253,6 +259,13 @@ public class SelectCriHandler
                             getNextWebJourneyCri(
                                     visitedCredentialIssuers, currentVcStatuses, userId));
                 }
+
+                CredentialIssuerConfig ukDrivingLicenseCriConfig =
+                        configService.getCredentialIssuer(drivingLicenceCriId);
+                if (criId.equals(passportCriId) && ukDrivingLicenseCriConfig.getEnabled()) {
+                    return Optional.of(getJourneyResponse(CRI_UK_PASSPORT_AND_DRIVING_LICENCE));
+                }
+
                 return Optional.of(getJourneyResponse(journeyId));
             }
             var message =

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -47,8 +47,8 @@ public class SelectCriHandler
     private static final String JOURNEY_FAIL = "/journey/fail";
     private static final String DCMAW_SUCCESS_PAGE = "dcmaw-success";
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
-    public static final String CRI_UK_DRIVING_LICENCE = "ukDrivingLicence";
-    public static final String CRI_UK_PASSPORT_AND_DRIVING_LICENCE = "ukPassportAndDrivingLicence";
+    private static final String UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
+            "ukPassportAndDrivingLicence";
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
@@ -263,7 +263,7 @@ public class SelectCriHandler
                 CredentialIssuerConfig ukDrivingLicenseCriConfig =
                         configService.getCredentialIssuer(drivingLicenceCriId);
                 if (criId.equals(passportCriId) && ukDrivingLicenseCriConfig.getEnabled()) {
-                    return Optional.of(getJourneyResponse(CRI_UK_PASSPORT_AND_DRIVING_LICENCE));
+                    return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
                 }
 
                 return Optional.of(getJourneyResponse(journeyId));

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -33,6 +33,7 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ALLO
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ENABLED;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_SHOULD_SEND_ALL_USERS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DRIVING_LICENCE_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.FRAUD_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.KBV_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PASSPORT_CRI_ID;
@@ -70,9 +71,12 @@ class SelectCriHandlerTest {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-dcmaw-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
+
+        when(mockConfigService.getCredentialIssuer("ukDrivingLicence"))
+                .thenReturn(createCriConfig("ukDrivingLicence", "ukDrivingLicence", false));
 
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
@@ -85,6 +89,28 @@ class SelectCriHandlerTest {
     }
 
     @Test
+    void shouldReturnPassportAndDrivingLicenceCriJourneyResponseWhenDrivingLicenceCriEnabled()
+            throws JsonProcessingException, URISyntaxException {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-dcmaw-iss", true));
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(Collections.emptyList());
+        when(mockConfigService.getCredentialIssuer("ukDrivingLicence"))
+                .thenReturn(createCriConfig("ukDrivingLicence", "ukDrivingLicence", true));
+
+        APIGatewayProxyRequestEvent input = createRequestEvent();
+
+        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+
+        Map<String, String> responseBody = getResponseBodyAsMap(response);
+
+        assertEquals("/journey/ukPassportAndDrivingLicence", responseBody.get("journey"));
+        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+    }
+
+    @Test
     void shouldReturnAddressCriJourneyResponse()
             throws JsonProcessingException, URISyntaxException {
         mockIpvSessionService();
@@ -92,9 +118,9 @@ class SelectCriHandlerTest {
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-passport-iss", true)));
 
@@ -122,7 +148,7 @@ class SelectCriHandlerTest {
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(
@@ -149,11 +175,11 @@ class SelectCriHandlerTest {
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
+                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
                         List.of(
@@ -185,13 +211,13 @@ class SelectCriHandlerTest {
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
+                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_KBV))
-                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss"));
+                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss", true));
 
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
@@ -227,13 +253,13 @@ class SelectCriHandlerTest {
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
+                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_KBV))
-                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss"));
+                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss", true));
 
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
@@ -272,9 +298,9 @@ class SelectCriHandlerTest {
                 .thenReturn(Collections.emptyList());
 
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
@@ -296,9 +322,9 @@ class SelectCriHandlerTest {
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-dcmaw-iss", true)));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -325,11 +351,11 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
 
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
+                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
                         List.of(
@@ -363,11 +389,11 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
 
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-passport-iss", true)));
 
@@ -395,9 +421,9 @@ class SelectCriHandlerTest {
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
+                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
                         List.of(
@@ -421,11 +447,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
+                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
 
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
@@ -444,13 +470,16 @@ class SelectCriHandlerTest {
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(List.of(new VisitedCredentialIssuerDetailsDto("dcmaw", true, null)));
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
+
+        when(mockConfigService.getCredentialIssuer("ukDrivingLicence"))
+                .thenReturn(createCriConfig("ukDrivingLicence", "ukDrivingLicence", false));
 
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
@@ -469,9 +498,9 @@ class SelectCriHandlerTest {
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
@@ -480,6 +509,9 @@ class SelectCriHandlerTest {
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
+
+        when(mockConfigService.getCredentialIssuer("ukDrivingLicence"))
+                .thenReturn(createCriConfig("ukDrivingLicence", "ukDrivingLicence", false));
 
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
@@ -498,9 +530,9 @@ class SelectCriHandlerTest {
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
@@ -530,13 +562,13 @@ class SelectCriHandlerTest {
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss"));
+                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss"));
+                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_KBV))
-                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss"));
+                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
@@ -572,12 +604,15 @@ class SelectCriHandlerTest {
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
         when(mockIpvSessionItem.getCurrentVcStatuses()).thenReturn(null);
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("false");
+
+        when(mockConfigService.getCredentialIssuer("ukDrivingLicence"))
+                .thenReturn(createCriConfig("ukDrivingLicence", "ukDrivingLicence", false));
 
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
@@ -598,9 +633,9 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
 
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
@@ -628,9 +663,9 @@ class SelectCriHandlerTest {
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
 
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
@@ -659,12 +694,15 @@ class SelectCriHandlerTest {
                 .thenReturn(Collections.emptyList());
 
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("false");
         when(mockConfigService.getSsmParameter(DCMAW_ALLOWED_USER_IDS))
                 .thenReturn("test-user-id,test-user-id-2,test-user-id-3");
+
+        when(mockConfigService.getCredentialIssuer("ukDrivingLicence"))
+                .thenReturn(createCriConfig("ukDrivingLicence", "ukDrivingLicence", false));
 
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
@@ -688,9 +726,9 @@ class SelectCriHandlerTest {
                 .thenReturn(Collections.emptyList());
 
         when(mockConfigService.getCredentialIssuer(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss"));
+                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
         when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss"));
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS))
@@ -717,6 +755,8 @@ class SelectCriHandlerTest {
         when(mockConfigService.getSsmParameter(FRAUD_CRI_ID)).thenReturn(CRI_FRAUD);
         when(mockConfigService.getSsmParameter(KBV_CRI_ID)).thenReturn(CRI_KBV);
         when(mockConfigService.getSsmParameter(ADDRESS_CRI_ID)).thenReturn(CRI_ADDRESS);
+        when(mockConfigService.getSsmParameter(DRIVING_LICENCE_CRI_ID))
+                .thenReturn("ukDrivingLicence");
         when(mockConfigService.getSsmParameter(DCMAW_CRI_ID)).thenReturn(CRI_DCMAW);
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("false");
     }
@@ -732,12 +772,12 @@ class SelectCriHandlerTest {
         return objectMapper.readValue(response.getBody(), Map.class);
     }
 
-    private CredentialIssuerConfig createCriConfig(String criId, String criIss)
+    private CredentialIssuerConfig createCriConfig(String criId, String criIss, boolean enabled)
             throws URISyntaxException {
         return new CredentialIssuerConfig(
                 criId,
                 criId,
-                true,
+                enabled,
                 new URI("http://example.com/token"),
                 new URI("http://example.com/credential"),
                 new URI("http://example.com/authorize"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -8,6 +8,7 @@ public enum ConfigurationVariable {
     CLIENT_ISSUER("/%s/core/clients/%s/issuer"),
     CORE_FRONT_CALLBACK_URL("/%s/core/self/coreFrontCallbackUrl"),
     CORE_VTM_CLAIM("/%s/core/self/coreVtmClaim"),
+    DRIVING_LICENCE_CRI_ID("/%s/core/self/journey/drivingLicenceId"),
     FRAUD_CRI_ID("/%s/core/self/journey/fraudCriId"),
     KBV_CRI_ID("/%s/core/self/journey/kbvCriId"),
     DCMAW_CRI_ID("/%s/core/self/journey/dcmawCriId"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -16,7 +16,7 @@ public class CredentialIssuerConfig {
 
     private String id;
     private String name;
-    private Boolean enabled;
+    private boolean enabled;
     private URI tokenUrl;
     private URI credentialUrl;
     private URI authorizeUrl;
@@ -58,7 +58,7 @@ public class CredentialIssuerConfig {
         return id;
     }
 
-    public Boolean getEnabled() {
+    public boolean getEnabled() {
         return enabled;
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update `select-cri` lambda to direct user to PassportAndDrivingLicence Doc Check page if DrivingLicence CRI is enabled.

Added logic to check to see if the Driving Licence CRI is enabled and return the `ukPassportAndDrivingLicence` Doc Check page instead of the `ukPassport` Doc Check page.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2496](https://govukverify.atlassian.net/browse/PYIC-2496)



[PYIC-2496]: https://govukverify.atlassian.net/browse/PYIC-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ