### PR TITLE
PYIC-2540 Update user-identity lambda to handle driving licence VC

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -46,11 +46,20 @@ public class UserIdentityService {
     public static final String STUB_UK_PASSPORT = "stubUkPassport";
     public static final String DCMAW = "dcmaw";
     public static final String STUB_DCMAW = "stubDcmaw";
+    public static final String DRIVING_LICENCE = "drivingLicence";
+    public static final String STUB_DRIVING_LICENCE = "stubDrivingLicence";
     private static final List<String> PASSPORT_CRI_TYPES =
             List.of(UK_PASSPORT, STUB_UK_PASSPORT, DCMAW, STUB_DCMAW);
-    private static final List<String> DRIVING_PERMIT_CRI_TYPES = List.of(DCMAW, STUB_DCMAW);
+    private static final List<String> DRIVING_PERMIT_CRI_TYPES =
+            List.of(DCMAW, STUB_DCMAW, DRIVING_LICENCE, STUB_DRIVING_LICENCE);
     public static final List<String> EVIDENCE_CRI_TYPES =
-            List.of(UK_PASSPORT, STUB_UK_PASSPORT, DCMAW, STUB_DCMAW);
+            List.of(
+                    UK_PASSPORT,
+                    STUB_UK_PASSPORT,
+                    DCMAW,
+                    STUB_DCMAW,
+                    DRIVING_LICENCE,
+                    STUB_DRIVING_LICENCE);
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String PASSPORT_PROPERTY_NAME = "passport";

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -363,8 +363,7 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void generateUserIdentityShouldSetAddressClaimOnUserIdentity()
-            throws Exception, HttpResponseExceptionWithErrorBody {
+    void generateUserIdentityShouldSetAddressClaimOnUserIdentity() throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem("user-id-1", "ukPassport", SIGNED_VC_1, Instant.now()),


### PR DESCRIPTION
## Proposed changes

### What changed

Add the driving licence CRI ids to the evidence and driving permit types

### Why did it change

So that the CoreIdentity and DrivingPermit claims are correctly generated for driving licence VCs

### Issue tracking
- [PYIC-2540](https://govukverify.atlassian.net/browse/PYIC-2540)


[PYIC-2540]: https://govukverify.atlassian.net/browse/PYIC-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ