### PR TITLE
`CredentialIssuerService.persistUserCredentials()` to check based for…

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/VcStoreItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/VcStoreItem.java
@@ -1,6 +1,9 @@
 package uk.gov.di.ipv.core.library.persistence.item;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
@@ -11,6 +14,9 @@ import java.time.Instant;
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class VcStoreItem implements DynamodbItem {
 
     private String userId;

--- a/libs/credential-issuer-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerService.java
+++ b/libs/credential-issuer-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerService.java
@@ -41,9 +41,9 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
-import java.util.Date;
 
 public class CredentialIssuerService {
 
@@ -208,7 +208,7 @@ public class CredentialIssuerService {
 
     public void persistUserCredentials(
             SignedJWT credential, String credentialIssuerId, String userId) {
-        try{
+        try {
             VcStoreItem vcStoreItem = createVcStoreItem(credential, credentialIssuerId, userId);
             dataStore.create(vcStoreItem, ConfigurationVariable.VC_TTL);
         } catch (Exception e) {
@@ -218,16 +218,19 @@ public class CredentialIssuerService {
         }
     }
 
-    private VcStoreItem createVcStoreItem(SignedJWT credential, String credentialIssuerId, String userId) throws java.text.ParseException {
-        VcStoreItem vcStoreItem = VcStoreItem.builder()
-                .userId(userId)
-                .credentialIssuer(credentialIssuerId)
-                .dateCreated(Instant.now())
-                .credential(credential.serialize())
-                .build();
+    private VcStoreItem createVcStoreItem(
+            SignedJWT credential, String credentialIssuerId, String userId)
+            throws java.text.ParseException {
+        VcStoreItem vcStoreItem =
+                VcStoreItem.builder()
+                        .userId(userId)
+                        .credentialIssuer(credentialIssuerId)
+                        .dateCreated(Instant.now())
+                        .credential(credential.serialize())
+                        .build();
 
         Date expirationTime = credential.getJWTClaimsSet().getExpirationTime();
-        if (expirationTime != null){
+        if (expirationTime != null) {
             vcStoreItem.setExpirationTime(expirationTime.toInstant());
         }
         return vcStoreItem;

--- a/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerServiceTest.java
+++ b/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerServiceTest.java
@@ -35,8 +35,8 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
 import java.util.Base64;
-import java.util.List;
 import java.util.Date;
+import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -47,8 +47,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -223,24 +223,25 @@ class CredentialIssuerServiceTest {
         assertEquals(Instant.parse("2022-05-20T12:50:54Z"), vcStoreItem.getExpirationTime());
         assertEquals(SIGNED_VC_1, vcStoreItem.getCredential());
     }
+
     @Test
     void expectedSuccessWithoutExpWhenSaveCredentials() throws Exception {
         String credentialIssuerId = "cred_issuer_id_1";
         String userId = "user-id-1";
 
-        SignedJWT signedJwt = new SignedJWT(
-                new JWSHeader.Builder(JWSAlgorithm.ES256).build(),
-                new JWTClaimsSet.Builder()
-                        .subject("testSubject")
-                        .issuer(credentialIssuerId)
-                        .build());
+        SignedJWT signedJwt =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).build(),
+                        new JWTClaimsSet.Builder()
+                                .subject("testSubject")
+                                .issuer(credentialIssuerId)
+                                .build());
         signedJwt.sign(new ECDSASigner(getPrivateKey()));
 
         ArgumentCaptor<VcStoreItem> userIssuedCredentialsItemCaptor =
                 ArgumentCaptor.forClass(VcStoreItem.class);
 
-        credentialIssuerService.persistUserCredentials(
-                signedJwt, credentialIssuerId, userId);
+        credentialIssuerService.persistUserCredentials(signedJwt, credentialIssuerId, userId);
 
         verify(mockDataStore).create(userIssuedCredentialsItemCaptor.capture(), eq(VC_TTL));
         VcStoreItem vcStoreItem = userIssuedCredentialsItemCaptor.getValue();
@@ -273,15 +274,14 @@ class CredentialIssuerServiceTest {
     }
 
     @Test
-    void expectedExceptionWithoutAnySignerWhenSaveCredentialsForIllegalStateException(){
+    void expectedExceptionWithoutAnySignerWhenSaveCredentialsForIllegalStateException() {
         String credentialIssuerId = "cred_issuer_id_1";
         String userId = "user-id-1";
 
-        SignedJWT signedJwt = new SignedJWT(
-                new JWSHeader.Builder(JWSAlgorithm.ES256).build(),
-                new JWTClaimsSet.Builder()
-                        .expirationTime(new Date())
-                        .build());
+        SignedJWT signedJwt =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.ES256).build(),
+                        new JWTClaimsSet.Builder().expirationTime(new Date()).build());
 
         CredentialIssuerException thrown =
                 assertThrows(


### PR DESCRIPTION
… `exp` null value.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

   CRIs will stop including exp in the VC JWT. We made some code changes so that our code that saves credential to db is not affected by this situation.

### Why did it change

- If JWT comes without 'exp' value. We will get the NullPointerException and not adding the credential to db. We fixed that in these code changes. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2547](https://govukverify.atlassian.net/browse/PYIC-2547)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2547]: https://govukverify.atlassian.net/browse/PYIC-2547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ