### PR TITLE
PYIC-2513 Check validity of VCs in store using VC_VALID_DURATION

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -121,6 +121,7 @@ public class CheckExistingIdentityHandler
                     new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
 
             userIdentityService.deleteVcStoreItemsIfAnyExpired(userId);
+            userIdentityService.deleteVcStoreItemsIfAnyInvalid(userId);
 
             List<SignedJWT> credentials =
                     gpg45ProfileEvaluator.parseCredentials(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -24,7 +24,8 @@ public enum ConfigurationVariable {
     CI_SCORING_CONFIG("/%s/core/self/ci-scoring-config"),
     CI_SCORING_THRESHOLD("/%s/core/self/ciScoringThreshold"),
     CI_MITIGATION_JOURNEYS_ENABLED("/%s/core/self/journey/ciMitigationsEnabled"),
-    VC_TTL("/%s/core/self/vcTtl");
+    VC_TTL("/%s/core/self/vcTtl"),
+    VC_VALID_DURATION("/%s/core/self/vcValidDuration");
 
     private final String value;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -119,10 +119,11 @@ public class UserIdentityService {
                                         configService.getSsmParameter(BACKEND_SESSION_TIMEOUT)));
         Duration vcValidDuration = Duration.parse(configService.getSsmParameter(VC_VALID_DURATION));
         List<String> credentials = getUserIssuedCredentials(userId);
-        credentials.removeIf(credential -> isVcValid(credential, vcValidDuration, nowPlusSessionTimeout));
+        credentials.removeIf(
+                credential -> isVcValid(credential, vcValidDuration, nowPlusSessionTimeout));
         if (!credentials.isEmpty()) {
-                LOGGER.info("Found invalid VCs within session timeout");
-                deleteVcStoreItems(userId);
+            LOGGER.info("Found invalid VCs within session timeout");
+            deleteVcStoreItems(userId);
         }
     }
 
@@ -391,18 +392,20 @@ public class UserIdentityService {
                         "audienceForClients"));
     }
 
-    private boolean isVcValid(String credential, Duration vcValidDuration, Instant nowPlusSessionTimeout) {
+    private boolean isVcValid(
+            String credential, Duration vcValidDuration, Instant nowPlusSessionTimeout) {
         boolean isValid = true;
         try {
-                SignedJWT credentialJWT = SignedJWT.parse(credential);
-                isValid = credentialJWT
+            SignedJWT credentialJWT = SignedJWT.parse(credential);
+            isValid =
+                    credentialJWT
                             .getJWTClaimsSet()
                             .getNotBeforeTime()
                             .toInstant()
                             .plus(vcValidDuration)
                             .isAfter(nowPlusSessionTimeout);
         } catch (ParseException e) {
-                LOGGER.warn("Failed to parse VC");
+            LOGGER.warn("Failed to parse VC");
         }
         return isValid;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -395,11 +395,12 @@ public class UserIdentityService {
         boolean isValid = true;
         try {
                 SignedJWT credentialJWT = SignedJWT.parse(credential);
-                Instant nbf = credentialJWT.getJWTClaimsSet()
-                                        .getNotBeforeTime()
-                                        .toInstant();
-                Instant nbfplus = nbf.plus(vcValidDuration);
-                isValid = nbfplus.isAfter(nowPlusSessionTimeout);
+                isValid = credentialJWT
+                            .getJWTClaimsSet()
+                            .getNotBeforeTime()
+                            .toInstant()
+                            .plus(vcValidDuration)
+                            .isAfter(nowPlusSessionTimeout);
         } catch (ParseException e) {
                 LOGGER.warn("Failed to parse VC");
         }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
@@ -590,8 +589,7 @@ class UserIdentityServiceTest {
         String signedVc = signedJwt.serialize();
 
         List<VcStoreItem> vcStoreItems =
-                List.of(
-                        createVcStoreItem("a-users-id", "ukPassport", signedVc, Instant.now()));
+                List.of(createVcStoreItem("a-users-id", "ukPassport", signedVc, Instant.now()));
         when(mockDataStore.getItems("a-users-id")).thenReturn(vcStoreItems);
 
         userIdentityService.deleteVcStoreItemsIfAnyInvalid("a-users-id");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Checks added in UserIdentityService to support deletion of VCs if no longer in `VC_VALID_DURATION`
- Adds `VC_VALID_DURATION` to ConfigurationVariables (imported from parameters provided by https://github.com/alphagov/di-ipv-config/pull/1143 / https://github.com/alphagov/di-ipv-core-common-infra/pull/271

### Why did it change

- Required to check VCs if valid on date of issue

### Issue tracking

- Main ticket [PYIC-2489](https://govukverify.atlassian.net/browse/PYIC-2489)
- Sub task [PYIC-2513](https://govukverify.atlassian.net/browse/PYIC-2513)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2489]: https://govukverify.atlassian.net/browse/PYIC-2489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-2513]: https://govukverify.atlassian.net/browse/PYIC-2513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ