### PR TITLE
PYIC-2422 Return user to multi-doc-page on access-denied

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -255,9 +255,25 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_DRIVING_LICENCE:
   name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -248,9 +248,25 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_DRIVING_LICENCE:
   name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -297,9 +297,25 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_DRIVING_LICENCE:
   name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -248,9 +248,25 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_DRIVING_LICENCE:
   name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -297,9 +297,25 @@ SELECT_CRI:
 CRI_UK_PASSPORT:
   name: CRI_UK_PASSPORT
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_DRIVING_LICENCE:
   name: CRI_DRIVING_LICENCE
   parent: CRI_STATE
+  events:
+    access-denied-multi-doc:
+      type: basic
+      name: access-denied-multi-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE


### PR DESCRIPTION
## Proposed changes

### What changed

On an access denied error from passport or driving licence CRI (and when a user cancels out of a CRI) return them back to the multiple doc selection page - if both CRIs are enabled. Otherwise go to pyi-no-match as before.

### Why did it change

The user has the option of using their passport or driving licence instead in this scenario.

### Issue tracking
- [PYIC-2422](https://govukverify.atlassian.net/browse/PYIC-2422)



[PYIC-2422]: https://govukverify.atlassian.net/browse/PYIC-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ