### PR TITLE
PYIC-2588 Return no-match page for driving licence on VC failure

### DIFF
--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -152,6 +152,9 @@ public class SelectCriHandler
                         drivingLicenceCriId,
                         userId);
         if (passportResponse.isPresent() && drivingLicenceResponse.isPresent()) {
+            if (userHasVisited(visitedCredentialIssuers, drivingLicenceCriId)) {
+                return drivingLicenceResponse.get();
+            }
             return passportResponse.get();
         }
 
@@ -350,6 +353,11 @@ public class SelectCriHandler
     private boolean userHasNotVisited(
             List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuers, String criId) {
         return visitedCredentialIssuers.stream().noneMatch(cri -> cri.getCriId().equals(criId));
+    }
+
+    private boolean userHasVisited(
+            List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuers, String criId) {
+        return visitedCredentialIssuers.stream().anyMatch(cri -> cri.getCriId().equals(criId));
     }
 
     private boolean shouldSendUserToApp(String userId) {

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -603,6 +603,34 @@ class SelectCriHandlerTest {
     }
 
     @Test
+    void shouldReturnPyiNoMatchErrorJourneyResponseIfUserHasAPreviouslyFailedVisitToDrivingLicence()
+            throws JsonProcessingException, URISyntaxException {
+        mockIpvSessionService();
+
+        when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
+        when(mockConfigService.getCredentialIssuer(CRI_PASSPORT))
+                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuer(CRI_DRIVING_LICENCE))
+                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(
+                        List.of(
+                                new VisitedCredentialIssuerDetailsDto(
+                                        "drivingLicence", true, null)));
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(List.of(new VcStatusDto("test-driving-licence-iss", false)));
+
+        APIGatewayProxyRequestEvent input = createRequestEvent();
+
+        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+
+        Map<String, String> responseBody = getResponseBodyAsMap(response);
+
+        assertEquals("/journey/pyi-no-match", responseBody.get("journey"));
+        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+    }
+
+    @Test
     void shouldReturnKbvThinFileErrorJourneyResponseIfUserHasAPreviouslyFailedVisitKbvWithoutCis()
             throws JsonProcessingException, URISyntaxException {
         mockIpvSessionService();


### PR DESCRIPTION
## Proposed changes

### What changed

Make sure we are returning no-match when driving licence issues a fail VC. Do this by checking if they've come back from driving licence and if so returning the driving licence response (rather than defaulting to the passport response as before).

### Why did it change

So it behaves the same way as a passport VC failure - before we were routing back to the multi doc check page.

### Issue tracking
- [PYIC-2588](https://govukverify.atlassian.net/browse/PYIC-2588)



[PYIC-2588]: https://govukverify.atlassian.net/browse/PYIC-2588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ