### PR TITLE
PYIC-2573 Create DynamoDB table to store Client OAuth session

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2185,6 +2185,26 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
 
+  ClientOAuthSessionsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
+      TableName: !Sub "client-oauth-sessions-${Environment}"
+      BillingMode: "PAY_PER_REQUEST"
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: true
+      SSESpecification:
+        SSEEnabled: true
+        SSEType: KMS
+        KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
+
   ClientAuthJwtIdsTable:
     Type: AWS::DynamoDB::Table
     # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.


### PR DESCRIPTION
## Proposed changes

### What changed

Add DynamoDB table definition to deploy template, with hash key `id` which will be a unique id generated by IPV core to represent the client oauth session

### Why did it change

To begin the work to separate the client oauth session from the sessions table and retrieve them even if session id is missing

### Issue tracking
- [PYIC-2573](https://govukverify.atlassian.net/browse/PYIC-2573)



[PYIC-2573]: https://govukverify.atlassian.net/browse/PYIC-2573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ