### PR TITLE
PYIC-2621 Change made to store clientOAuthSessionId with ipvSession.

### DIFF
--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -63,6 +63,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
 class InitialiseIpvSessionHandlerTest {
 
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
+    public static final String CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     @Mock private Context mockContext;
 
     @Mock private IpvSessionService mockIpvSessionService;
@@ -116,11 +117,12 @@ class InitialiseIpvSessionHandlerTest {
 
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setClientOAuthSessionId(CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setClientSessionDetails(clientSessionDetailsDto);
 
         clientOAuthSessionItem = new ClientOAuthSessionItem();
-        clientOAuthSessionItem.setClientOAuthSessionId(SecureTokenHelper.generate());
+        clientOAuthSessionItem.setClientOAuthSessionId(CLIENT_OAUTH_SESSION_ID);
         clientOAuthSessionItem.setResponseType("test-type");
         clientOAuthSessionItem.setClientId("test-client");
         clientOAuthSessionItem.setRedirectUri("http://example.com");
@@ -132,8 +134,9 @@ class InitialiseIpvSessionHandlerTest {
     @Test
     void shouldReturnIpvSessionIdWhenProvidedValidRequest()
             throws JsonProcessingException, JarValidationException, ParseException, SqsException {
-        when(mockIpvSessionService.generateIpvSession(any(), any())).thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any()))
+        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
+                .thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
                 .thenReturn(clientOAuthSessionItem);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
@@ -258,9 +261,10 @@ class InitialiseIpvSessionHandlerTest {
     @Test
     void shouldReturnIpvSessionIdWhenRecoverableErrorFound()
             throws JsonProcessingException, JarValidationException, ParseException {
-        when(mockIpvSessionService.generateIpvSession(any(), any())).thenReturn(ipvSessionItem);
+        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
+                .thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.generateErrorClientSessionDetails(
-                        any(), any(), any(), any()))
+                        any(), any(), any(), any(), any()))
                 .thenReturn(clientOAuthSessionItem);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenThrow(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -22,6 +22,7 @@ import java.util.List;
 @Data
 public class IpvSessionItem implements DynamodbItem {
     private String ipvSessionId;
+    private String clientOAuthSessionId;
     private String userState;
     private String creationDateTime;
     private ClientSessionDetailsDto clientSessionDetails;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 
@@ -39,10 +38,11 @@ public class ClientOAuthSessionDetailsService {
     }
 
     public ClientOAuthSessionItem generateClientSessionDetails(
-            JWTClaimsSet claimsSet, String clientId) throws ParseException {
+            String clientOauthSessionId, JWTClaimsSet claimsSet, String clientId)
+            throws ParseException {
         ClientOAuthSessionItem clientOAuthSessionItem = new ClientOAuthSessionItem();
 
-        clientOAuthSessionItem.setClientOAuthSessionId(SecureTokenHelper.generate());
+        clientOAuthSessionItem.setClientOAuthSessionId(clientOauthSessionId);
         clientOAuthSessionItem.setResponseType(claimsSet.getStringClaim("response_type"));
         clientOAuthSessionItem.setClientId(clientId);
         clientOAuthSessionItem.setRedirectUri(claimsSet.getStringClaim("redirect_uri"));
@@ -57,9 +57,13 @@ public class ClientOAuthSessionDetailsService {
     }
 
     public ClientOAuthSessionItem generateErrorClientSessionDetails(
-            String redirectUri, String clientId, String state, String govukSigninJourneyId) {
+            String clientOAuthSessionId,
+            String redirectUri,
+            String clientId,
+            String state,
+            String govukSigninJourneyId) {
         ClientOAuthSessionItem clientOAuthSessionErrorItem = new ClientOAuthSessionItem();
-        clientOAuthSessionErrorItem.setClientOAuthSessionId(SecureTokenHelper.generate());
+        clientOAuthSessionErrorItem.setClientOAuthSessionId(clientOAuthSessionId);
         clientOAuthSessionErrorItem.setResponseType(null);
         clientOAuthSessionErrorItem.setClientId(clientId);
         clientOAuthSessionErrorItem.setRedirectUri(redirectUri);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -98,11 +98,13 @@ public class IpvSessionService {
     }
 
     public IpvSessionItem generateIpvSession(
-            ClientSessionDetailsDto clientSessionDetailsDto, ErrorObject errorObject) {
+            ClientSessionDetailsDto clientSessionDetailsDto,
+            String clientOAuthSessionId,
+            ErrorObject errorObject) {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
-
+        ipvSessionItem.setClientOAuthSessionId(clientOAuthSessionId);
         LogHelper.attachIpvSessionIdToLogs(ipvSessionItem.getIpvSessionId());
 
         ipvSessionItem.setCreationDateTime(Instant.now().toString());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
@@ -64,6 +64,7 @@ class ClientOAuthSessionDetailsServiceTest {
 
     @Test
     void shouldCreateClientOAuthSessionItem() throws ParseException {
+        String clientOAuthSessionId = SecureTokenHelper.generate();
         JWTClaimsSet testClaimSet =
                 new JWTClaimsSet.Builder()
                         .claim("response_type", "test-type")
@@ -74,15 +75,13 @@ class ClientOAuthSessionDetailsServiceTest {
                         .build();
         ClientOAuthSessionItem clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.generateClientSessionDetails(
-                        testClaimSet, "test-client");
+                        clientOAuthSessionId, testClaimSet, "test-client");
 
         ArgumentCaptor<ClientOAuthSessionItem> clientOAuthSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(ClientOAuthSessionItem.class);
         verify(mockDataStore)
                 .create(clientOAuthSessionItemArgumentCaptor.capture(), eq(BACKEND_SESSION_TTL));
-        assertEquals(
-                clientOAuthSessionItem.getClientOAuthSessionId(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getClientOAuthSessionId());
+        assertEquals(clientOAuthSessionId, clientOAuthSessionItem.getClientOAuthSessionId());
         assertEquals(
                 clientOAuthSessionItem.getClientId(),
                 clientOAuthSessionItemArgumentCaptor.getValue().getClientId());
@@ -105,18 +104,21 @@ class ClientOAuthSessionDetailsServiceTest {
 
     @Test
     void shouldCreateSessionItemWithErrorObject() {
+        String clientOAuthSessionId = SecureTokenHelper.generate();
         ClientOAuthSessionItem clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.generateErrorClientSessionDetails(
-                        "http://example.com", "test-client", "test-state", "test-journey-id");
+                        clientOAuthSessionId,
+                        "http://example.com",
+                        "test-client",
+                        "test-state",
+                        "test-journey-id");
 
         ArgumentCaptor<ClientOAuthSessionItem> clientOAuthSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(ClientOAuthSessionItem.class);
         verify(mockDataStore)
                 .create(clientOAuthSessionItemArgumentCaptor.capture(), eq(BACKEND_SESSION_TTL));
         assertNotNull(clientOAuthSessionItemArgumentCaptor.getValue().getClientOAuthSessionId());
-        assertEquals(
-                clientOAuthSessionItem.getClientOAuthSessionId(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getClientOAuthSessionId());
+        assertEquals(clientOAuthSessionId, clientOAuthSessionItem.getClientOAuthSessionId());
         assertEquals(
                 clientOAuthSessionItem.getClientId(),
                 clientOAuthSessionItemArgumentCaptor.getValue().getClientId());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -122,6 +122,7 @@ class IpvSessionServiceTest {
                                 "test-user-id",
                                 "test-journey-id",
                                 false),
+                        null,
                         null);
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
@@ -150,6 +151,7 @@ class IpvSessionServiceTest {
                                 "test-user-id",
                                 "test-journey-id",
                                 true),
+                        null,
                         null);
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
@@ -180,6 +182,7 @@ class IpvSessionServiceTest {
                                 "test-user-id",
                                 "test-journey-id",
                                 false),
+                        null,
                         testErrorObject);
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Store clientOAuthSessionId with ipvSession.
### What changed
Update InitialiseIpvSessionHandler to store clientOAuthSessionId with ipvSession.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2621](https://govukverify.atlassian.net/browse/PYIC-2621)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2621]: https://govukverify.atlassian.net/browse/PYIC-2621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ