### PR TITLE
PYIC-2564: rename config parameters

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -56,8 +56,7 @@ public class BuildClientOauthResponseHandler
         this.sessionService = new IpvSessionService(configService);
         this.authRequestValidator = new AuthRequestValidator(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
-        this.componentId =
-                configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     public BuildClientOauthResponseHandler(
@@ -69,8 +68,7 @@ public class BuildClientOauthResponseHandler
         this.configService = configService;
         this.authRequestValidator = authRequestValidator;
         this.auditService = auditService;
-        this.componentId =
-                configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -95,8 +95,7 @@ public class BuildCriOauthRequestHandler
         this.ipvSessionService = ipvSessionService;
         this.criOAuthSessionService = criOAuthSessionService;
         this.componentId =
-                credentialIssuerConfigService.getSsmParameter(
-                        ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+                credentialIssuerConfigService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -109,8 +108,7 @@ public class BuildCriOauthRequestHandler
         this.ipvSessionService = new IpvSessionService(credentialIssuerConfigService);
         this.criOAuthSessionService = new CriOAuthSessionService(credentialIssuerConfigService);
         this.componentId =
-                credentialIssuerConfigService.getSsmParameter(
-                        ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+                credentialIssuerConfigService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override
@@ -204,7 +202,7 @@ public class BuildCriOauthRequestHandler
 
         URIBuilder redirectUri =
                 new URIBuilder(credentialIssuerConfig.getAuthorizeUrl())
-                        .addParameter("client_id", credentialIssuerConfig.getIpvClientId())
+                        .addParameter("client_id", credentialIssuerConfig.getClientId())
                         .addParameter("request", jweObject.serialize());
 
         if (credentialIssuerConfig.getId().equals(DCMAW_CRI_ID)
@@ -236,8 +234,7 @@ public class BuildCriOauthRequestHandler
                         userId,
                         govukSigninJourneyId);
 
-        RSAEncrypter rsaEncrypter =
-                new RSAEncrypter(credentialIssuerConfig.getJarEncryptionPublicJwk());
+        RSAEncrypter rsaEncrypter = new RSAEncrypter(credentialIssuerConfig.getEncryptionKey());
         return AuthorizationRequestHelper.createJweObject(rsaEncrypter, signedJWT);
     }
 
@@ -296,7 +293,7 @@ public class BuildCriOauthRequestHandler
 
                     SharedClaims credentialsSharedClaims =
                             mapper.readValue(credentialSubject.toString(), SharedClaims.class);
-                    if (credentialIss.equals(addressCriConfig.getAudienceForClients())) {
+                    if (credentialIss.equals(addressCriConfig.getComponentId())) {
                         hasAddressVc = true;
                         sharedClaimsSet.forEach(sharedClaims -> sharedClaims.setAddress(null));
                     } else if (hasAddressVc) {

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -28,7 +28,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Objects;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 
 public class AuthorizationRequestHelper {
@@ -54,16 +54,16 @@ public class AuthorizationRequestHelper {
         JWTClaimsSet authClaimsSet =
                 new AuthorizationRequest.Builder(
                                 ResponseType.CODE,
-                                new ClientID(credentialIssuerConfig.getIpvClientId()))
-                        .redirectionURI(credentialIssuerConfig.getIpvCoreRedirectUrl())
+                                new ClientID(credentialIssuerConfig.getClientId()))
+                        .redirectionURI(credentialIssuerConfig.getClientCallbackUrl())
                         .state(new State(oauthState))
                         .build()
                         .toJWTClaimsSet();
 
         JWTClaimsSet.Builder claimsSetBuilder =
                 new JWTClaimsSet.Builder(authClaimsSet)
-                        .audience(credentialIssuerConfig.getAudienceForClients())
-                        .issuer(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS))
+                        .audience(credentialIssuerConfig.getComponentId())
+                        .issuer(configService.getSsmParameter(COMPONENT_ID))
                         .issueTime(Date.from(now))
                         .expirationTime(
                                 Date.from(

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -60,7 +60,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_2;
@@ -218,7 +218,7 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CRI_ID))
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
                 .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
@@ -292,7 +292,7 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
                 .thenReturn(dcmawCredentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
                 .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
@@ -420,7 +420,7 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CRI_ID))
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
                 .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
@@ -476,7 +476,7 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CRI_ID))
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
                 .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
@@ -530,7 +530,7 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CRI_ID))
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
                 .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
@@ -603,7 +603,7 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CRI_ID))
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
                 .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
@@ -661,7 +661,7 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CRI_ID))
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
                 .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
@@ -717,7 +717,7 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CRI_ID))
                 .thenReturn(kbvCredentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
                 .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PUBLIC_JWK;
@@ -99,8 +99,8 @@ class AuthorizationRequestHelperTest {
             throws JOSEException, ParseException, HttpResponseExceptionWithErrorBody {
         setupCredentialIssuerConfigMock();
         setupConfigurationServiceMock();
-        when(credentialIssuerConfig.getAudienceForClients()).thenReturn(AUDIENCE);
-        when(credentialIssuerConfig.getIpvCoreRedirectUrl())
+        when(credentialIssuerConfig.getComponentId()).thenReturn(AUDIENCE);
+        when(credentialIssuerConfig.getClientCallbackUrl())
                 .thenReturn(URI.create(TEST_REDIRECT_URI));
 
         SignedJWT result =
@@ -203,12 +203,12 @@ class AuthorizationRequestHelperTest {
     }
 
     private void setupCredentialIssuerConfigMock() {
-        when(credentialIssuerConfig.getIpvClientId()).thenReturn(IPV_CLIENT_ID_VALUE);
+        when(credentialIssuerConfig.getClientId()).thenReturn(IPV_CLIENT_ID_VALUE);
     }
 
     private void setupConfigurationServiceMock() {
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn(IPV_TOKEN_TTL);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
     }
 
     private PrivateKey getEncryptionPrivateKey()

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -136,7 +136,7 @@ public class BuildProvenUserIdentityDetailsHandler
                             item.getCredentialIssuer());
             if (EVIDENCE_CRI_TYPES.contains(item.getCredentialIssuer())
                     && userIdentityService.isVcSuccessful(
-                            currentVcStatuses, credentialIssuerConfig.getAudienceForClients())) {
+                            currentVcStatuses, credentialIssuerConfig.getComponentId())) {
                 JsonNode vcSubjectNode =
                         mapper.readTree(
                                         SignedJWT.parse(item.getCredential())
@@ -182,7 +182,7 @@ public class BuildProvenUserIdentityDetailsHandler
                             item.getCredentialIssuer());
             if (ADDRESS_CRI_TYPES.contains(item.getCredentialIssuer())
                     && userIdentityService.isVcSuccessful(
-                            currentVcStatuses, credentialIssuerConfig.getAudienceForClients())) {
+                            currentVcStatuses, credentialIssuerConfig.getComponentId())) {
                 JsonNode addressNode =
                         mapper.readTree(
                                         SignedJWT.parse(item.getCredential())

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -58,8 +58,7 @@ public class BuildUserIdentityHandler
         this.ipvSessionService = ipvSessionService;
         this.configService = configService;
         this.auditService = auditService;
-        this.componentId =
-                configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -68,8 +67,7 @@ public class BuildUserIdentityHandler
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
-        this.componentId =
-                configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -84,8 +84,7 @@ public class CheckExistingIdentityHandler
         this.gpg45ProfileEvaluator = gpg45ProfileEvaluator;
         this.ciStorageService = ciStorageService;
         this.auditService = auditService;
-        this.componentId =
-                configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -96,7 +95,7 @@ public class CheckExistingIdentityHandler
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService);
         this.ciStorageService = new CiStorageService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
-        componentId = configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override

--- a/lambdas/end-mitigation-journey/src/main/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01Validation.java
+++ b/lambdas/end-mitigation-journey/src/main/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01Validation.java
@@ -47,7 +47,7 @@ public class Mj01Validation {
                         if (signedJWT
                                 .getJWTClaimsSet()
                                 .getIssuer()
-                                .equals(fraudCriConfig.getAudienceForClients())) {
+                                .equals(fraudCriConfig.getComponentId())) {
                             boolean isAfterCiIssueDate =
                                     signedJWT
                                             .getJWTClaimsSet()

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -90,7 +90,7 @@ public class EvaluateGpg45ScoresHandler
         this.auditService = auditService;
 
         addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
-        componentId = configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -103,7 +103,7 @@ public class EvaluateGpg45ScoresHandler
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
 
         addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
-        componentId = configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -73,8 +73,7 @@ public class InitialiseIpvSessionHandler
                 new KmsRsaDecrypter(configService.getSsmParameter(JAR_KMS_ENCRYPTION_KEY_ID));
         this.jarValidator = new JarValidator(kmsRsaDecrypter, configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
-        this.componentId =
-                configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     public InitialiseIpvSessionHandler(
@@ -90,8 +89,7 @@ public class InitialiseIpvSessionHandler
         this.kmsRsaDecrypter = kmsRsaDecrypter;
         this.jarValidator = jarValidator;
         this.auditService = auditService;
-        this.componentId =
-                configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
@@ -28,8 +28,8 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_ISSUER;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY;
 
@@ -137,7 +137,7 @@ public class JarValidator {
     private JWTClaimsSet getValidatedClaimSet(SignedJWT signedJWT, String clientId)
             throws JarValidationException {
 
-        String criAudience = configService.getSsmParameter(AUDIENCE_FOR_CLIENTS);
+        String criAudience = configService.getSsmParameter(COMPONENT_ID);
         String clientIssuer = configService.getSsmParameter(CLIENT_ISSUER, clientId);
 
         DefaultJWTClaimsVerifier<?> verifier =

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
@@ -44,8 +44,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_ISSUER;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
@@ -115,7 +115,7 @@ class JarValidatorTest {
                     ParseException {
         when(configService.getSsmParameter(eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(audienceClaim);
         when(configService.getSsmParameter(eq(CLIENT_ISSUER), anyString())).thenReturn(issuerClaim);
         when(configService.getSsmParameter(MAX_ALLOWED_AUTH_CLIENT_TTL)).thenReturn("1500");
         when(configService.getClientRedirectUrls(anyString()))
@@ -253,7 +253,7 @@ class JarValidatorTest {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         when(configService.getSsmParameter(eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(audienceClaim);
         when(configService.getSsmParameter(eq(CLIENT_ISSUER), anyString())).thenReturn(issuerClaim);
         when(configService.getClientRedirectUrls(anyString()))
                 .thenReturn(Collections.singletonList(redirectUriClaim));
@@ -299,7 +299,7 @@ class JarValidatorTest {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         when(configService.getSsmParameter(eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(audienceClaim);
         when(configService.getSsmParameter(eq(CLIENT_ISSUER), anyString())).thenReturn(issuerClaim);
         when(configService.getClientRedirectUrls(anyString()))
                 .thenReturn(Collections.singletonList(redirectUriClaim));
@@ -347,7 +347,7 @@ class JarValidatorTest {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         when(configService.getSsmParameter(eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(audienceClaim);
         when(configService.getSsmParameter(eq(CLIENT_ISSUER), anyString())).thenReturn(issuerClaim);
         when(configService.getClientRedirectUrls(anyString()))
                 .thenReturn(Collections.singletonList(redirectUriClaim));
@@ -395,7 +395,7 @@ class JarValidatorTest {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         when(configService.getSsmParameter(eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(audienceClaim);
         when(configService.getSsmParameter(eq(CLIENT_ISSUER), anyString())).thenReturn(issuerClaim);
         when(configService.getClientRedirectUrls(anyString()))
                 .thenReturn(Collections.singletonList(redirectUriClaim));
@@ -443,7 +443,7 @@ class JarValidatorTest {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         when(configService.getSsmParameter(eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(audienceClaim);
         when(configService.getSsmParameter(eq(CLIENT_ISSUER), anyString())).thenReturn(issuerClaim);
         when(configService.getClientRedirectUrls(anyString()))
                 .thenReturn(Collections.singletonList(redirectUriClaim));
@@ -489,7 +489,7 @@ class JarValidatorTest {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         when(configService.getSsmParameter(eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(audienceClaim);
         when(configService.getSsmParameter(eq(CLIENT_ISSUER), anyString())).thenReturn(issuerClaim);
         when(configService.getClientRedirectUrls(anyString()))
                 .thenReturn(Collections.singletonList(redirectUriClaim));
@@ -535,7 +535,7 @@ class JarValidatorTest {
             throws NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
         when(configService.getSsmParameter(eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(EC_PUBLIC_JWK);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audienceClaim);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(audienceClaim);
         when(configService.getSsmParameter(eq(CLIENT_ISSUER), anyString())).thenReturn(issuerClaim);
         when(configService.getSsmParameter(MAX_ALLOWED_AUTH_CLIENT_TTL)).thenReturn("1500");
         when(configService.getClientRedirectUrls(anyString()))

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidator.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidator.java
@@ -23,7 +23,7 @@ import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.Set;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
 
 public class TokenRequestValidator {
@@ -89,7 +89,7 @@ public class TokenRequestValidator {
 
         return new ClientAuthenticationVerifier<>(
                 new ConfigurationServicePublicKeySelector(configService),
-                Set.of(new Audience(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS))));
+                Set.of(new Audience(configService.getSsmParameter(COMPONENT_ID))));
     }
 
     private void logWarningJtiHasAlreadyBeenUsed(ClientAuthJwtIdItem clientAuthJwtIdItem) {

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidatorTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidatorTest.java
@@ -44,7 +44,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY;
 
@@ -62,7 +62,7 @@ class TokenRequestValidatorTest {
 
     @BeforeEach
     void setUp() {
-        when(mockConfigService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(audience);
+        when(mockConfigService.getSsmParameter(COMPONENT_ID)).thenReturn(audience);
         validator = new TokenRequestValidator(mockConfigService, mockClientAuthJwtIdService);
     }
 

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -126,8 +126,7 @@ public class RetrieveCriCredentialHandler
                             ipvSessionItem.getIpvSessionId(),
                             clientSessionDetailsDto.getGovukSigninJourneyId(),
                             ipAddress);
-            this.componentId =
-                    configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+            this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
 
             CredentialIssuerConfig credentialIssuerConfig =
                     configService.getCredentialIssuerActiveConnectionConfig(credentialIssuerId);

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/validation/VerifiableCredentialJwtValidator.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/validation/VerifiableCredentialJwtValidator.java
@@ -54,8 +54,7 @@ public class VerifiableCredentialJwtValidator {
         }
 
         try {
-            ECDSAVerifier verifier =
-                    new ECDSAVerifier(credentialIssuerConfig.getVcVerifyingPublicJwk());
+            ECDSAVerifier verifier = new ECDSAVerifier(credentialIssuerConfig.getSigningKey());
             if (!concatSignatureVerifiableCredential.verify(verifier)) {
                 LOGGER.error("Verifiable credential signature not valid");
                 throw new CredentialIssuerException(
@@ -97,7 +96,7 @@ public class VerifiableCredentialJwtValidator {
         DefaultJWTClaimsVerifier<SimpleSecurityContext> verifier =
                 new DefaultJWTClaimsVerifier<>(
                         new JWTClaimsSet.Builder()
-                                .issuer(credentialIssuerConfig.getAudienceForClients())
+                                .issuer(credentialIssuerConfig.getComponentId())
                                 .subject(userId)
                                 .build(),
                         new HashSet<>(Arrays.asList(JWTClaimNames.NOT_BEFORE, VC_CLAIM_NAME)));

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATORS;
@@ -171,7 +171,7 @@ class RetrieveCriCredentialHandlerTest {
     void shouldUpdateSessionWithDetailsOfVisitedCri() throws ParseException {
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(testPassportIssuer);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(testComponentId);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
         when(credentialIssuerService.getVerifiableCredential(
                         testBearerAccessToken, testPassportIssuer, testApiKey))
@@ -334,7 +334,7 @@ class RetrieveCriCredentialHandlerTest {
                 .thenReturn(testPassportIssuer);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_JOURNEY_ID))
                 .thenReturn(addressConfig);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(testComponentId);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -373,7 +373,7 @@ class RetrieveCriCredentialHandlerTest {
     private void mockServiceCallsAndSessionItem() {
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(testPassportIssuer);
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(testComponentId);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(ipvSessionItem.getClientSessionDetails()).thenReturn(testClientSessionDetailsDto);

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -110,8 +110,7 @@ public class RetrieveCriOauthAccessTokenHandler
                             ipvSessionId,
                             clientSessionDetailsDto.getGovukSigninJourneyId(),
                             ipAddress);
-            String componentId =
-                    configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+            String componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
 
             auditService.sendAuditEvent(
                     new AuditEvent(

--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 
 @ExtendWith(MockitoExtension.class)
@@ -204,7 +204,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(passportIssuer);
 
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(testComponentId);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
 
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
 
@@ -294,7 +294,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(passportIssuer);
 
-        when(configService.getSsmParameter(AUDIENCE_FOR_CLIENTS)).thenReturn(testComponentId);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
 
         doThrow(new SqsException("Test sqs error"))
                 .when(auditService)

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -262,7 +262,7 @@ public class SelectCriHandler
 
         CredentialIssuerConfig criConfig =
                 configService.getCredentialIssuerActiveConnectionConfig(criId);
-        Optional<VcStatusDto> vc = getVc(currentVcStatuses, criConfig.getAudienceForClients());
+        Optional<VcStatusDto> vc = getVc(currentVcStatuses, criConfig.getComponentId());
 
         if (vc.isEmpty()) {
             if (userHasNotVisited(visitedCredentialIssuers, criId)) {
@@ -329,7 +329,7 @@ public class SelectCriHandler
         CredentialIssuerConfig passportConfig =
                 configService.getCredentialIssuerActiveConnectionConfig(passportCriId);
         Optional<VcStatusDto> passportVc =
-                getVc(currentVcStatuses, passportConfig.getAudienceForClients());
+                getVc(currentVcStatuses, passportConfig.getComponentId());
         return passportVc.isPresent();
     }
 
@@ -337,7 +337,7 @@ public class SelectCriHandler
         CredentialIssuerConfig drivingLicenceConfig =
                 configService.getCredentialIssuerActiveConnectionConfig(drivingLicenceCriId);
         Optional<VcStatusDto> drivingLicenceVc =
-                getVc(currentVcStatuses, drivingLicenceConfig.getAudienceForClients());
+                getVc(currentVcStatuses, drivingLicenceConfig.getComponentId());
         return drivingLicenceVc.isPresent();
     }
 

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -81,8 +81,7 @@ public class ValidateOAuthCallbackHandler
         this.configService = configService;
         this.ipvSessionService = ipvSessionService;
         this.auditService = auditService;
-        this.componentId =
-                this.configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = this.configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
         this.passportCriId = configService.getSsmParameter(PASSPORT_CRI_ID);
         this.drivingLicenceCriId = configService.getSsmParameter(DRIVING_LICENCE_CRI_ID);
         this.criOAuthSessionService = criOAuthSessionService;
@@ -93,8 +92,7 @@ public class ValidateOAuthCallbackHandler
         this.configService = new ConfigService();
         this.ipvSessionService = new IpvSessionService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
-        this.componentId =
-                this.configService.getSsmParameter(ConfigurationVariable.AUDIENCE_FOR_CLIENTS);
+        this.componentId = this.configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
         this.passportCriId = configService.getSsmParameter(PASSPORT_CRI_ID);
         this.drivingLicenceCriId = configService.getSsmParameter(DRIVING_LICENCE_CRI_ID);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.AUDIENCE_FOR_CLIENTS;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DRIVING_LICENCE_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PASSPORT_CRI_ID;
 
@@ -74,8 +74,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
     @BeforeEach
     void setUpBeforeEach() throws URISyntaxException {
-        when(mockConfigService.getSsmParameter(AUDIENCE_FOR_CLIENTS))
-                .thenReturn("audience.for.clients");
+        when(mockConfigService.getSsmParameter(COMPONENT_ID)).thenReturn("audience.for.clients");
         when(mockConfigService.getSsmParameter(PASSPORT_CRI_ID)).thenReturn(CRI_PASSPORT);
         when(mockConfigService.getSsmParameter(DRIVING_LICENCE_CRI_ID))
                 .thenReturn(CRI_DRIVING_LICENCE);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -2,10 +2,10 @@ package uk.gov.di.ipv.core.library.config;
 
 public enum ConfigurationVariable {
     ADDRESS_CRI_ID("/%s/core/self/journey/addressCriId"),
-    AUDIENCE_FOR_CLIENTS("/%s/core/self/audienceForClients"),
     BACKEND_SESSION_TIMEOUT("/%s/core/self/backendSessionTimeout"),
     BACKEND_SESSION_TTL("/%s/core/self/backendSessionTtl"),
     CLIENT_ISSUER("/%s/core/clients/%s/issuer"),
+    COMPONENT_ID("/%s/core/self/componentId"),
     CORE_FRONT_CALLBACK_URL("/%s/core/self/coreFrontCallbackUrl"),
     CORE_VTM_CLAIM("/%s/core/self/coreVtmClaim"),
     DRIVING_LICENCE_CRI_ID("/%s/core/self/journey/drivingLicenceId"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -80,7 +80,7 @@ public class Gpg45ProfileEvaluator {
             String lastCiIssuer =
                     contraIndicatorItems.get(contraIndicatorItems.size() - 1).getIss();
             String kbvIssuer =
-                    configService.getAudienceForClients(configService.getSsmParameter(KBV_CRI_ID));
+                    configService.getComponentId(configService.getSsmParameter(KBV_CRI_ID));
 
             return Optional.of(
                     lastCiIssuer.equals(kbvIssuer)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -19,11 +19,11 @@ public class CredentialIssuerConfig {
     private URI tokenUrl;
     private URI credentialUrl;
     private URI authorizeUrl;
-    private String ipvClientId;
-    private String vcVerifyingPublicJwk;
-    private String jarEncryptionPublicJwk;
-    private String audienceForClients;
-    private URI ipvCoreRedirectUrl;
+    private String clientId;
+    private String signingKey;
+    private String encryptionKey;
+    private String componentId;
+    private URI clientCallbackUrl;
 
     public CredentialIssuerConfig() {}
 
@@ -34,21 +34,21 @@ public class CredentialIssuerConfig {
             URI tokenUrl,
             URI credentialUrl,
             URI authorizeUrl,
-            String ipvClientId,
-            String vcVerifyingPublicJwk,
-            String jarEncryptionPublicJwk,
-            String audienceForClients,
-            URI ipvCoreRedirectUrl) {
+            String clientId,
+            String signingKey,
+            String encryptionKey,
+            String componentId,
+            URI clientCallbackUrl) {
         this.id = id;
         this.name = name;
         this.tokenUrl = tokenUrl;
         this.credentialUrl = credentialUrl;
         this.authorizeUrl = authorizeUrl;
-        this.ipvClientId = ipvClientId;
-        this.vcVerifyingPublicJwk = vcVerifyingPublicJwk;
-        this.jarEncryptionPublicJwk = jarEncryptionPublicJwk;
-        this.audienceForClients = audienceForClients;
-        this.ipvCoreRedirectUrl = ipvCoreRedirectUrl;
+        this.clientId = clientId;
+        this.signingKey = signingKey;
+        this.encryptionKey = encryptionKey;
+        this.componentId = componentId;
+        this.clientCallbackUrl = clientCallbackUrl;
     }
 
     public String getId() {
@@ -71,34 +71,34 @@ public class CredentialIssuerConfig {
         return authorizeUrl;
     }
 
-    public String getIpvClientId() {
-        return ipvClientId;
+    public String getClientId() {
+        return clientId;
     }
 
-    @JsonGetter("vcVerifyingPublicJwk")
-    public String getVcVerifyingPublicKeyString() {
-        return vcVerifyingPublicJwk;
+    @JsonGetter("signingKey")
+    public String getSigningKeyString() {
+        return signingKey;
     }
 
-    public ECKey getVcVerifyingPublicJwk() throws ParseException {
-        return ECKey.parse(vcVerifyingPublicJwk);
+    public ECKey getSigningKey() throws ParseException {
+        return ECKey.parse(signingKey);
     }
 
-    @JsonGetter("jarEncryptionPublicJwk")
-    public String getJarEncryptionPublicJwkString() {
-        return jarEncryptionPublicJwk;
+    @JsonGetter("encryptionKey")
+    public String getEncryptionKeyString() {
+        return encryptionKey;
     }
 
-    public RSAKey getJarEncryptionPublicJwk() throws ParseException {
-        return RSAKey.parse(jarEncryptionPublicJwk);
+    public RSAKey getEncryptionKey() throws ParseException {
+        return RSAKey.parse(encryptionKey);
     }
 
-    public String getAudienceForClients() {
-        return audienceForClients;
+    public String getComponentId() {
+        return componentId;
     }
 
-    public URI getIpvCoreRedirectUrl() {
-        return ipvCoreRedirectUrl;
+    public URI getClientCallbackUrl() {
+        return clientCallbackUrl;
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -197,11 +197,11 @@ public class ConfigService {
                         credentialIssuerId));
     }
 
-    public String getAudienceForClients(String credentialIssuerId) {
+    public String getComponentId(String credentialIssuerId) {
         String activeConnection = getActiveConnection(credentialIssuerId);
         return getSsmParameter(
                 String.format(
-                        "%s/%s/connections/%s/audienceForClients",
+                        "%s/%s/connections/%s/componentId",
                         getEnvironmentVariable(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX),
                         credentialIssuerId,
                         activeConnection));

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -177,11 +177,10 @@ public class UserIdentityService {
             List<VcStoreItem> vcStoreItems, List<VcStatusDto> currentVcStatuses)
             throws HttpResponseExceptionWithErrorBody {
         for (VcStoreItem item : vcStoreItems) {
-            String audienceForClients =
-                    configService.getAudienceForClients(item.getCredentialIssuer());
+            String componentId = configService.getComponentId(item.getCredentialIssuer());
 
             if (EVIDENCE_CRI_TYPES.contains(item.getCredentialIssuer())
-                    && isVcSuccessful(currentVcStatuses, audienceForClients)) {
+                    && isVcSuccessful(currentVcStatuses, componentId)) {
                 try {
                     JsonNode nameNode =
                             objectMapper
@@ -283,10 +282,9 @@ public class UserIdentityService {
             List<VcStoreItem> vcStoreItems, List<VcStatusDto> currentVcStatuses)
             throws HttpResponseExceptionWithErrorBody {
         for (VcStoreItem item : vcStoreItems) {
-            String audienceForClients =
-                    configService.getAudienceForClients(item.getCredentialIssuer());
+            String componentId = configService.getComponentId(item.getCredentialIssuer());
             if (PASSPORT_CRI_TYPES.contains(item.getCredentialIssuer())
-                    && isVcSuccessful(currentVcStatuses, audienceForClients)) {
+                    && isVcSuccessful(currentVcStatuses, componentId)) {
                 JsonNode passportNode;
                 try {
                     passportNode =
@@ -326,10 +324,9 @@ public class UserIdentityService {
             List<VcStoreItem> vcStoreItems, List<VcStatusDto> currentVcStatuses)
             throws HttpResponseExceptionWithErrorBody {
         for (VcStoreItem item : vcStoreItems) {
-            String audienceForClients =
-                    configService.getAudienceForClients(item.getCredentialIssuer());
+            String componentId = configService.getComponentId(item.getCredentialIssuer());
             if (DRIVING_PERMIT_CRI_TYPES.contains(item.getCredentialIssuer())
-                    && isVcSuccessful(currentVcStatuses, audienceForClients)) {
+                    && isVcSuccessful(currentVcStatuses, componentId)) {
                 JsonNode drivingPermitNode;
                 try {
                     drivingPermitNode =

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -136,7 +136,7 @@ class Gpg45ProfileEvaluatorTest {
         when(mockConfigService.getContraIndicatorScoresMap()).thenReturn(ciScoresMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
         when(mockConfigService.getSsmParameter(KBV_CRI_ID)).thenReturn("kbv");
-        when(mockConfigService.getAudienceForClients("kbv")).thenReturn("kbvIssuer");
+        when(mockConfigService.getComponentId("kbv")).thenReturn("kbvIssuer");
 
         assertEquals(
                 Optional.of(JOURNEY_RESPONSE_PYI_KBV_FAIL),

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -122,7 +122,7 @@ class ConfigServiceTest {
                         TEST_TOKEN_URL,
                         "credentialUrl",
                         TEST_CREDENTIAL_URL,
-                        "jarEncryptionPublicJwk",
+                        "encryptionKey",
                         RSA_ENCRYPTION_PUBLIC_JWK);
         when(ssmProvider.get("/dev/core/credentialIssuers/passportCri/activeConnection"))
                 .thenReturn("stub");
@@ -148,7 +148,7 @@ class ConfigServiceTest {
 
         assertEquals(expected.getTokenUrl(), result.getTokenUrl());
         assertEquals(expected.getCredentialUrl(), result.getCredentialUrl());
-        assertEquals("RSA", result.getJarEncryptionPublicJwk().getKeyType().toString());
+        assertEquals("RSA", result.getEncryptionKey().getKeyType().toString());
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -75,7 +75,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -116,7 +116,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -139,7 +139,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -189,7 +189,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
@@ -224,7 +224,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
@@ -257,7 +257,7 @@ class UserIdentityServiceTest {
                 List.of(new VcStatusDto("test-issuer", true), new VcStatusDto("test-issuer", true));
 
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -306,7 +306,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -358,7 +358,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         UserIdentity userIdentity =
                 userIdentityService.generateUserIdentity(
@@ -397,7 +397,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         HttpResponseExceptionWithErrorBody thrownException =
                 assertThrows(
@@ -429,7 +429,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         HttpResponseExceptionWithErrorBody thrownException =
                 assertThrows(
@@ -617,7 +617,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("dcmaw")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("dcmaw")).thenReturn("test-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -669,7 +669,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -698,11 +698,11 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("dcmaw")).thenReturn("dcmaw-issuer");
-        when(mockConfigService.getAudienceForClients("ukPassport")).thenReturn("test-issuer");
-        when(mockConfigService.getAudienceForClients("fraud")).thenReturn("test-issuer");
-        when(mockConfigService.getAudienceForClients("address")).thenReturn("test-issuer");
-        when(mockConfigService.getAudienceForClients("kbv")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("dcmaw")).thenReturn("dcmaw-issuer");
+        when(mockConfigService.getComponentId("ukPassport")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("fraud")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("address")).thenReturn("test-issuer");
+        when(mockConfigService.getComponentId("kbv")).thenReturn("test-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -728,7 +728,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients("dcmaw")).thenReturn("dcmaw-issuer");
+        when(mockConfigService.getComponentId("dcmaw")).thenReturn("dcmaw-issuer");
 
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
@@ -751,7 +751,7 @@ class UserIdentityServiceTest {
 
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
-        when(mockConfigService.getAudienceForClients(anyString())).thenReturn("dcmaw-issuer");
+        when(mockConfigService.getComponentId(anyString())).thenReturn("dcmaw-issuer");
 
         HttpResponseExceptionWithErrorBody thrownException =
                 assertThrows(

--- a/libs/credential-issuer-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerService.java
+++ b/libs/credential-issuer-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerService.java
@@ -84,9 +84,9 @@ public class CredentialIssuerService {
             OffsetDateTime dateTime = OffsetDateTime.now();
             ClientAuthClaims clientAuthClaims =
                     new ClientAuthClaims(
-                            config.getIpvClientId(),
-                            config.getIpvClientId(),
-                            config.getAudienceForClients(),
+                            config.getClientId(),
+                            config.getClientId(),
+                            config.getComponentId(),
                             dateTime.plusSeconds(
                                             Long.parseLong(
                                                     configService.getSsmParameter(
@@ -98,7 +98,7 @@ public class CredentialIssuerService {
 
             ClientAuthentication clientAuthentication = new PrivateKeyJWT(signedClientJwt);
 
-            URI redirectionUri = config.getIpvCoreRedirectUrl();
+            URI redirectionUri = config.getClientCallbackUrl();
 
             TokenRequest tokenRequest =
                     new TokenRequest(

--- a/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
+++ b/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
@@ -48,7 +48,7 @@ public class VcHelper {
         JSONArray evidenceArray = (JSONArray) vcClaim.get(VC_EVIDENCE);
         if (evidenceArray == null) {
             String vcIss = vc.getJWTClaimsSet().getIssuer();
-            if (vcIss.equals(addressCriConfig.getAudienceForClients())) {
+            if (vcIss.equals(addressCriConfig.getComponentId())) {
                 return true;
             }
             LOGGER.warn("Unexpected missing evidence on VC from issuer: {}", vcIss);

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -160,7 +160,7 @@ paths:
       description: Called when the frontend begins the CRI journey.
       responses:
         200:
-          description: "Returns the id, ipvClientId and authorizationUrl for a CRI."
+          description: "Returns the id, clientId and authorizationUrl for a CRI."
           content:
             application/json:
               schema:


### PR DESCRIPTION
Reverts alphagov/di-ipv-core-back#736

We have found the cause of the issue being the verification_params in common-infra which has ben rectified 
This can now be merged in again 