### PR TITLE
[PYIC-2622] Update journey step handler to show timeout page

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -38,6 +38,7 @@ public class ProcessJourneyStepHandler
         implements RequestHandler<Map<String, String>, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String PYIC_TECHNICAL_ERROR_PAGE_ID = "pyi-technical";
+    private static final String PYIC_TIMEOUT_UNRECOVERABLE_ID = "pyi-timeout-unrecoverable";
     private static final String CORE_SESSION_TIMEOUT_STATE = "CORE_SESSION_TIMEOUT";
 
     private final IpvSessionService ipvSessionService;
@@ -106,7 +107,7 @@ public class ProcessJourneyStepHandler
         String currentUserState = ipvSessionItem.getUserState();
         if (sessionIsNewlyExpired(ipvSessionItem)) {
             updateUserSessionForTimeout(currentUserState, ipvSessionItem);
-            return new PageResponse(PYIC_TECHNICAL_ERROR_PAGE_ID).value(configService);
+            return new PageResponse(PYIC_TIMEOUT_UNRECOVERABLE_ID).value(configService);
         }
 
         try {

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -636,7 +636,8 @@ class ProcessJourneyStepHandlerTest {
                 OAuth2Error.ACCESS_DENIED.getDescription(),
                 capturedIpvSessionItem.getErrorDescription());
 
-        assertEquals(ProcessJourneyStepPages.PYI_UNRECOVERABLE_TIMEOUT_ERROR_PAGE, output.get("page"));
+        assertEquals(
+                ProcessJourneyStepPages.PYI_UNRECOVERABLE_TIMEOUT_ERROR_PAGE, output.get("page"));
     }
 
     @ParameterizedTest

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -636,7 +636,7 @@ class ProcessJourneyStepHandlerTest {
                 OAuth2Error.ACCESS_DENIED.getDescription(),
                 capturedIpvSessionItem.getErrorDescription());
 
-        assertEquals(ProcessJourneyStepPages.PYI_TECHNICAL_ERROR_PAGE, output.get("page"));
+        assertEquals(ProcessJourneyStepPages.PYI_UNRECOVERABLE_TIMEOUT_ERROR_PAGE, output.get("page"));
     }
 
     @ParameterizedTest

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/utils/ProcessJourneyStepPages.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/utils/ProcessJourneyStepPages.java
@@ -6,4 +6,5 @@ public class ProcessJourneyStepPages {
     public static final String PRE_KBV_TRANSITION_PAGE = "page-pre-kbv-transition";
     public static final String PYI_NO_MATCH_PAGE = "pyi-no-match";
     public static final String PYI_TECHNICAL_ERROR_PAGE = "pyi-technical";
+    public static final String PYI_UNRECOVERABLE_TIMEOUT_ERROR_PAGE = "pyi-timeout-unrecoverable";
 }


### PR DESCRIPTION
Updates the ProcessJourneyStepHandler lambda to redirect to the new unrecoverable timeout page instead of the default error page

## Proposed changes

### What changed

- Use `PYIC_TIMEOUT_UNRECOVERABLE_ID` to determine page name
- Updates `executeJourneyEvent` to return new timeout page when sessions are newly expired

### Why did it change

- Required for new timeout page to display to users

### Issue tracking

- [PYIC-2622](https://govukverify.atlassian.net/browse/PYIC-2622)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2622]: https://govukverify.atlassian.net/browse/PYIC-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ