### PR TITLE
set the TTL to false for the VCs table

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2168,7 +2168,7 @@ Resources:
           KeyType: "RANGE"
       TimeToLiveSpecification:
         AttributeName: "ttl"
-        Enabled: true
+        Enabled: false
       SSESpecification:
         SSEEnabled: true
         SSEType: KMS


### PR DESCRIPTION
This will disable the ttl from the dynamo DB table which stores the VCs this afternoon - we still have CRIs which are coming through with the expirationTime attribute set but I understand this is as expected and we will implement logic in config/code to expire the VCs as appropriate.
As requested by @erino and Katie Reed