### PR TITLE
PYIC-2579 Update lambdas to use new table.

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -120,6 +120,8 @@ public class ProcessJourneyStepHandler
                     journeyStep,
                     ipvSessionItem);
 
+            clearOauthSessionIfExists(ipvSessionItem);
+
             ipvSessionService.updateIpvSession(ipvSessionItem);
 
             return stateMachineResult.getJourneyStepResponse().value(configService);
@@ -148,6 +150,13 @@ public class ProcessJourneyStepHandler
                         .with("from", oldState)
                         .with("to", updatedStateValue);
         LOGGER.info(message);
+    }
+
+    @Tracing
+    private void clearOauthSessionIfExists(IpvSessionItem ipvSessionItem) {
+        if (ipvSessionItem.getCriOAuthSessionId() != null) {
+            ipvSessionItem.setCriOAuthSessionId(null);
+        }
     }
 
     @Tracing

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandlerTest.java
@@ -26,7 +26,7 @@ import java.time.Instant;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -691,7 +691,7 @@ class ProcessJourneyStepHandlerTest {
         ArgumentCaptor<IpvSessionItem> sessionArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
         verify(mockIpvSessionService).updateIpvSession(sessionArgumentCaptor.capture());
-        assertNotNull(sessionArgumentCaptor.getValue().getCriOAuthSessionId());
+        assertNull(sessionArgumentCaptor.getValue().getCriOAuthSessionId());
     }
 
     private void mockIpvSessionItemAndTimeout(String validateOauthCallback, String environment) {

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -115,9 +115,11 @@ public class ValidateOAuthCallbackHandler
             LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
 
             ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
-            criOAuthSessionItem =
-                    criOAuthSessionService.getCriOauthSessionItem(
-                            ipvSessionItem.getCriOAuthSessionId());
+            if (ipvSessionItem.getCriOAuthSessionId() != null) {
+                criOAuthSessionItem =
+                        criOAuthSessionService.getCriOauthSessionItem(
+                                ipvSessionItem.getCriOAuthSessionId());
+            }
 
             if (callbackRequest.getError() != null) {
                 return sendOauthErrorJourneyResponse(
@@ -188,8 +190,7 @@ public class ValidateOAuthCallbackHandler
             LOGGER.warn("Unknown Oauth error code received");
         }
 
-        if (ipvSessionItem.getCriOAuthSessionId() == null
-                || criOAuthSessionItem == null
+        if (criOAuthSessionItem == null
                 || !criOAuthSessionItem
                         .getCriId()
                         .equals(callbackRequest.getCredentialIssuerId())) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Update lambda to use newly created tables for cri and client session details.

### What changed
Changes made in ValidateOAuthCallbackHandler to use new table for criOAuthSession details.
Changes made in ProcessJourneyStepHandler to use new table for clientOAuthSession details.

Fix issue with back btn press on kbv transition page.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2579](https://govukverify.atlassian.net/browse/PYIC-2579)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2579]: https://govukverify.atlassian.net/browse/PYIC-2579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ