### PR TITLE
PYIC-2616: remove journey cri from select cri handle

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -53,6 +53,7 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.*;
 
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 
@@ -255,11 +256,9 @@ public class BuildCriOauthRequestHandler
     private SharedClaimsResponse getSharedAttributes(
             String userId, List<VcStatusDto> currentVcStatuses, String criId)
             throws HttpResponseExceptionWithErrorBody {
-        String addressCriId =
-                credentialIssuerConfigService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID);
         CredentialIssuerConfig addressCriConfig =
                 credentialIssuerConfigService.getCredentialIssuerActiveConnectionConfig(
-                        addressCriId);
+                        ADDRESS_CRI_ID);
 
         List<String> credentials = userIdentityService.getUserIssuedCredentials(userId);
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -24,7 +24,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
-import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.credentialissuer.CredentialIssuerConfigService;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -62,6 +61,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.DCMAW_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.KBV_CRI_ID;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_2;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_3;
@@ -77,9 +79,6 @@ import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.v
 class BuildCriOauthRequestHandlerTest {
 
     private static final String CRI_ID = "PassportIssuer";
-    private static final String DCMAW_CRI_ID = "dcmaw";
-    private static final String ADDRESS_CRI_ID = "address";
-    private static final String KBV_CRI_ID = "kbv";
     private static final String CRI_NAME = "any";
     private static final String CRI_TOKEN_URL = "http://www.example.com";
     private static final String CRI_CREDENTIAL_URL = "http://www.example.com/credential";
@@ -219,8 +218,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
@@ -293,8 +290,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(dcmawCredentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
@@ -421,8 +416,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
@@ -477,8 +470,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
@@ -531,8 +522,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
@@ -604,8 +593,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
@@ -662,8 +649,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
@@ -718,8 +703,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(kbvCredentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn(ADDRESS_CRI_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -18,7 +18,6 @@ import uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain.NameAndDateOfBir
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain.ProvenUserIdentityDetails;
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.exceptions.ProvenUserIdentityDetailsException;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -42,6 +41,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.core.library.service.UserIdentityService.ADDRESS_CRI_TYPES;
@@ -215,10 +215,8 @@ public class BuildProvenUserIdentityDetailsHandler
 
         for (VcStoreItem item : credentials) {
             SignedJWT signedJWT = SignedJWT.parse(item.getCredential());
-            String addressCriId =
-                    configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID);
             CredentialIssuerConfig addressCriConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(addressCriId);
+                    configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID);
             boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, addressCriConfig);
 
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain.ProvenUserIdentityDetails;
-import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
@@ -69,8 +68,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     void shouldReceive200ResponseCodeProvenUserIdentityDetails() throws Exception {
         when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockConfigService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn("address");
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
@@ -132,8 +129,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
             throws Exception {
         when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockConfigService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn("address");
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
@@ -203,8 +198,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                     throws Exception {
         when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockConfigService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn("address");
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
@@ -267,8 +260,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     @Test
     void shouldReceive400ResponseCodeWhenEvidenceVcIsMissing() throws Exception {
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockConfigService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn("address");
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
                         new CredentialIssuerConfig(
@@ -316,8 +307,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     void shouldReceive400ResponseCodeWhenAddressVcIsMissing() throws Exception {
         when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockConfigService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn("address");
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
@@ -408,8 +397,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     void shouldReceive400ResponseCodeWhenEvidenceVcIsNotSuccessful() throws Exception {
         when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockConfigService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn("address");
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(clientSessionDetailsDto);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -48,7 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE_TXN;
@@ -240,12 +240,10 @@ public class CheckExistingIdentityHandler
     private List<VcStatusDto> generateVcSuccessStatuses(List<SignedJWT> credentials)
             throws ParseException {
         List<VcStatusDto> vcStatuses = new ArrayList<>();
-        String addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
-
         for (SignedJWT signedJWT : credentials) {
 
             CredentialIssuerConfig addressCriConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(addressCriId);
+                    configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID);
             boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, addressCriConfig);
 
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -17,7 +17,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
-import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
@@ -150,8 +149,6 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
-        when(configService.getSsmParameter(ConfigurationVariable.ADDRESS_CRI_ID))
-                .thenReturn("address");
         when(configService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(addressConfig);
 

--- a/lambdas/end-mitigation-journey/src/main/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01Validation.java
+++ b/lambdas/end-mitigation-journey/src/main/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01Validation.java
@@ -7,7 +7,6 @@ import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
@@ -19,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.FRAUD_CRI_ID;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 
@@ -33,9 +33,8 @@ public class Mj01Validation {
             List<String> credentials,
             ContraIndicatorItem contraIndicatorItem,
             ConfigService configService) {
-        String fraudCriId = configService.getSsmParameter(ConfigurationVariable.FRAUD_CRI_ID);
         CredentialIssuerConfig fraudCriConfig =
-                configService.getCredentialIssuerActiveConnectionConfig(fraudCriId);
+                configService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI_ID);
 
         List<String> mitigatingVcList = new ArrayList<>();
 

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -50,8 +50,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE_TXN;
@@ -72,7 +72,6 @@ public class EvaluateGpg45ScoresHandler
     private final CiStorageService ciStorageService;
     private final ConfigService configService;
     private final AuditService auditService;
-    private final String addressCriId;
     private final String componentId;
 
     public EvaluateGpg45ScoresHandler(
@@ -89,7 +88,6 @@ public class EvaluateGpg45ScoresHandler
         this.configService = configService;
         this.auditService = auditService;
 
-        addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
         componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
@@ -102,7 +100,6 @@ public class EvaluateGpg45ScoresHandler
         this.ciStorageService = new CiStorageService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
 
-        addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
         componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
@@ -307,7 +304,7 @@ public class EvaluateGpg45ScoresHandler
         for (SignedJWT signedJWT : credentials) {
 
             CredentialIssuerConfig addressCriConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(addressCriId);
+                    configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID);
             boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, addressCriConfig);
 
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -45,7 +45,7 @@ import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 
 public class RetrieveCriCredentialHandler
@@ -151,9 +151,8 @@ public class RetrieveCriCredentialHandler
             for (SignedJWT vc : verifiableCredentials) {
                 verifiableCredentialJwtValidator.validate(vc, credentialIssuerConfig, userId);
 
-                String addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
                 CredentialIssuerConfig addressCriConfig =
-                        configService.getCredentialIssuerActiveConnectionConfig(addressCriId);
+                        configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID);
                 boolean isSuccessful = VcHelper.isSuccessfulVc(vc, addressCriConfig);
 
                 sendIpvVcReceivedAuditEvent(auditEventUser, vc, isSuccessful);

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -53,8 +53,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATORS;
@@ -64,7 +64,6 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_VC_1;
 class RetrieveCriCredentialHandlerTest {
     private static final String ACCESS_TOKEN = "Bearer dGVzdAo=";
     private static final String CREDENTIAL_ISSUER_ID = "PassportIssuer";
-    private static final String ADDRESS_CRI_JOURNEY_ID = "address";
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_STATE = "test-state";
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
@@ -305,8 +304,7 @@ class RetrieveCriCredentialHandlerTest {
         when(credentialIssuerService.getVerifiableCredential(
                         testBearerAccessToken, testPassportIssuer, testApiKey))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)));
-        when(configService.getSsmParameter(ADDRESS_CRI_ID)).thenReturn(ADDRESS_CRI_JOURNEY_ID);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_JOURNEY_ID))
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressConfig);
         mockServiceCallsAndSessionItem();
 
@@ -337,10 +335,9 @@ class RetrieveCriCredentialHandlerTest {
         when(credentialIssuerService.getVerifiableCredential(
                         testBearerAccessToken, testPassportIssuer, testApiKey))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)));
-        when(configService.getSsmParameter(ADDRESS_CRI_ID)).thenReturn(ADDRESS_CRI_JOURNEY_ID);
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(testPassportIssuer);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_JOURNEY_ID))
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
                 .thenReturn(addressConfig);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -30,15 +30,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ALLOWED_USER_IDS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ENABLED;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_SHOULD_SEND_ALL_USERS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DRIVING_LICENCE_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.FRAUD_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.KBV_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PASSPORT_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.DCMAW_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.DRIVING_LICENCE_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.FRAUD_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.KBV_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.PASSPORT_CRI_ID;
 
 public class SelectCriHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -54,36 +54,16 @@ public class SelectCriHandler
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
-    private final String passportCriId;
-    private final String fraudCriId;
-    private final String kbvCriId;
-    private final String addressCriId;
-    private final String dcmawCriId;
-    private final String drivingLicenceCriId;
 
     public SelectCriHandler(ConfigService configService, IpvSessionService ipvSessionService) {
         this.configService = configService;
         this.ipvSessionService = ipvSessionService;
-
-        passportCriId = configService.getSsmParameter(PASSPORT_CRI_ID);
-        fraudCriId = configService.getSsmParameter(FRAUD_CRI_ID);
-        kbvCriId = configService.getSsmParameter(KBV_CRI_ID);
-        addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
-        dcmawCriId = configService.getSsmParameter(DCMAW_CRI_ID);
-        drivingLicenceCriId = configService.getSsmParameter(DRIVING_LICENCE_CRI_ID);
     }
 
     @ExcludeFromGeneratedCoverageReport
     public SelectCriHandler() {
         this.configService = new ConfigService();
         this.ipvSessionService = new IpvSessionService(configService);
-
-        passportCriId = configService.getSsmParameter(PASSPORT_CRI_ID);
-        fraudCriId = configService.getSsmParameter(FRAUD_CRI_ID);
-        kbvCriId = configService.getSsmParameter(KBV_CRI_ID);
-        addressCriId = configService.getSsmParameter(ADDRESS_CRI_ID);
-        dcmawCriId = configService.getSsmParameter(DCMAW_CRI_ID);
-        drivingLicenceCriId = configService.getSsmParameter(DRIVING_LICENCE_CRI_ID);
     }
 
     @Override
@@ -141,18 +121,18 @@ public class SelectCriHandler
                 getCriResponse(
                         visitedCredentialIssuers,
                         currentVcStatuses,
-                        passportCriId,
-                        passportCriId,
+                        PASSPORT_CRI_ID,
+                        PASSPORT_CRI_ID,
                         userId);
         Optional<JourneyResponse> drivingLicenceResponse =
                 getCriResponse(
                         visitedCredentialIssuers,
                         currentVcStatuses,
-                        drivingLicenceCriId,
-                        drivingLicenceCriId,
+                        DRIVING_LICENCE_CRI_ID,
+                        DRIVING_LICENCE_CRI_ID,
                         userId);
         if (passportResponse.isPresent() && drivingLicenceResponse.isPresent()) {
-            if (userHasVisited(visitedCredentialIssuers, drivingLicenceCriId)) {
+            if (userHasVisited(visitedCredentialIssuers, DRIVING_LICENCE_CRI_ID)) {
                 return drivingLicenceResponse.get();
             }
             return passportResponse.get();
@@ -162,8 +142,8 @@ public class SelectCriHandler
                 getCriResponse(
                         visitedCredentialIssuers,
                         currentVcStatuses,
-                        addressCriId,
-                        addressCriId,
+                        ADDRESS_CRI_ID,
+                        ADDRESS_CRI_ID,
                         userId);
         if (addressResponse.isPresent()) {
             return addressResponse.get();
@@ -173,8 +153,8 @@ public class SelectCriHandler
                 getCriResponse(
                         visitedCredentialIssuers,
                         currentVcStatuses,
-                        fraudCriId,
-                        fraudCriId,
+                        FRAUD_CRI_ID,
+                        FRAUD_CRI_ID,
                         userId);
         if (fraudResponse.isPresent()) {
             return fraudResponse.get();
@@ -182,7 +162,11 @@ public class SelectCriHandler
 
         Optional<JourneyResponse> kbvResponse =
                 getCriResponse(
-                        visitedCredentialIssuers, currentVcStatuses, kbvCriId, kbvCriId, userId);
+                        visitedCredentialIssuers,
+                        currentVcStatuses,
+                        KBV_CRI_ID,
+                        KBV_CRI_ID,
+                        userId);
         if (kbvResponse.isPresent()) {
             return kbvResponse.get();
         }
@@ -200,8 +184,8 @@ public class SelectCriHandler
                 getCriResponse(
                         visitedCredentialIssuers,
                         currentVcStatuses,
-                        dcmawCriId,
-                        dcmawCriId,
+                        DCMAW_CRI_ID,
+                        DCMAW_CRI_ID,
                         userId);
         if (dcmawResponse.isPresent()) {
             return dcmawResponse.get();
@@ -211,7 +195,7 @@ public class SelectCriHandler
                 getCriResponse(
                         visitedCredentialIssuers,
                         currentVcStatuses,
-                        addressCriId,
+                        ADDRESS_CRI_ID,
                         DCMAW_SUCCESS_PAGE,
                         userId);
         if (addressResponse.isPresent()) {
@@ -222,8 +206,8 @@ public class SelectCriHandler
                 getCriResponse(
                         visitedCredentialIssuers,
                         currentVcStatuses,
-                        fraudCriId,
-                        fraudCriId,
+                        FRAUD_CRI_ID,
+                        FRAUD_CRI_ID,
                         userId);
         if (fraudResponse.isPresent()) {
             return fraudResponse.get();
@@ -266,7 +250,7 @@ public class SelectCriHandler
 
         if (vc.isEmpty()) {
             if (userHasNotVisited(visitedCredentialIssuers, criId)) {
-                if (criId.equals(dcmawCriId)
+                if (criId.equals(DCMAW_CRI_ID)
                         && (hasPassportVc(currentVcStatuses)
                                 || hasDrivingLicenceVc(currentVcStatuses))) {
                     LOGGER.info(
@@ -276,7 +260,8 @@ public class SelectCriHandler
                                     visitedCredentialIssuers, currentVcStatuses, userId));
                 }
 
-                if (criId.equals(passportCriId) && configService.isEnabled(drivingLicenceCriId)) {
+                if (criId.equals(PASSPORT_CRI_ID)
+                        && configService.isEnabled(DRIVING_LICENCE_CRI_ID)) {
                     return getMultipleDocCheckPage();
                 }
 
@@ -291,7 +276,7 @@ public class SelectCriHandler
             LOGGER.info(message);
 
             return Optional.of(
-                    criId.equals(dcmawCriId)
+                    criId.equals(DCMAW_CRI_ID)
                             ? getNextWebJourneyCri(
                                     visitedCredentialIssuers, currentVcStatuses, userId)
                             : getJourneyPyiNoMatchResponse());
@@ -306,11 +291,11 @@ public class SelectCriHandler
                             .with("criId", criId);
             LOGGER.info(message);
 
-            if (criId.equals(dcmawCriId)) {
+            if (criId.equals(DCMAW_CRI_ID)) {
                 LOGGER.info("Reverting app user to the web journey");
                 return Optional.of(
                         getNextWebJourneyCri(visitedCredentialIssuers, currentVcStatuses, userId));
-            } else if (criId.equals(kbvCriId)) {
+            } else if (criId.equals(KBV_CRI_ID)) {
                 return Optional.of(getJourneyKbvFailResponse());
             }
             return Optional.of(getJourneyPyiNoMatchResponse());
@@ -319,7 +304,7 @@ public class SelectCriHandler
     }
 
     private Optional<JourneyResponse> getMultipleDocCheckPage() {
-        if (configService.getActiveConnection(drivingLicenceCriId).equals("stub")) {
+        if (configService.getActiveConnection(DRIVING_LICENCE_CRI_ID).equals("stub")) {
             return Optional.of(getJourneyResponse(STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
         }
         return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
@@ -327,7 +312,7 @@ public class SelectCriHandler
 
     private boolean hasPassportVc(List<VcStatusDto> currentVcStatuses) {
         CredentialIssuerConfig passportConfig =
-                configService.getCredentialIssuerActiveConnectionConfig(passportCriId);
+                configService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID);
         Optional<VcStatusDto> passportVc =
                 getVc(currentVcStatuses, passportConfig.getComponentId());
         return passportVc.isPresent();
@@ -335,7 +320,7 @@ public class SelectCriHandler
 
     private boolean hasDrivingLicenceVc(List<VcStatusDto> currentVcStatuses) {
         CredentialIssuerConfig drivingLicenceConfig =
-                configService.getCredentialIssuerActiveConnectionConfig(drivingLicenceCriId);
+                configService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID);
         Optional<VcStatusDto> drivingLicenceVc =
                 getVc(currentVcStatuses, drivingLicenceConfig.getComponentId());
         return drivingLicenceVc.isPresent();

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -28,26 +28,20 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ALLOWED_USER_IDS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ENABLED;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_SHOULD_SEND_ALL_USERS;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DRIVING_LICENCE_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.FRAUD_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.KBV_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PASSPORT_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.ADDRESS_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.DCMAW_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.DRIVING_LICENCE_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.FRAUD_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.KBV_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.PASSPORT_CRI_ID;
 
 @ExtendWith(MockitoExtension.class)
 class SelectCriHandlerTest {
 
     private static final String TEST_SESSION_ID = "the-session-id";
-    private static final String CRI_PASSPORT = "ukPassport";
-    private static final String CRI_DRIVING_LICENCE = "drivingLicence";
-    private static final String CRI_FRAUD = "fraud";
-    private static final String CRI_KBV = "kbv";
-    private static final String CRI_ADDRESS = "address";
-    private static final String CRI_DCMAW = "dcmaw";
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -61,8 +55,6 @@ class SelectCriHandlerTest {
 
     @BeforeEach
     void setUp() {
-        mockConfigurationServiceMethodCalls();
-
         underTest = new SelectCriHandler(mockConfigService, mockIpvSessionService);
     }
 
@@ -71,8 +63,8 @@ class SelectCriHandlerTest {
             throws JsonProcessingException, URISyntaxException {
         mockIpvSessionService();
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-dcmaw-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
@@ -94,8 +86,8 @@ class SelectCriHandlerTest {
             throws JsonProcessingException, URISyntaxException {
         mockIpvSessionService();
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-dcmaw-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
@@ -118,17 +110,18 @@ class SelectCriHandlerTest {
 
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-passport-iss", true)));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
-                List.of(new VisitedCredentialIssuerDetailsDto(CRI_PASSPORT, true, null));
+                List.of(new VisitedCredentialIssuerDetailsDto(PASSPORT_CRI_ID, true, null));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
@@ -150,17 +143,18 @@ class SelectCriHandlerTest {
 
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-passport-iss", true)));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
-                List.of(new VisitedCredentialIssuerDetailsDto(CRI_DRIVING_LICENCE, true, null));
+                List.of(new VisitedCredentialIssuerDetailsDto(DRIVING_LICENCE_CRI_ID, true, null));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
@@ -182,15 +176,17 @@ class SelectCriHandlerTest {
 
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(
-                        new VisitedCredentialIssuerDetailsDto(CRI_PASSPORT, true, null),
-                        new VisitedCredentialIssuerDetailsDto(CRI_ADDRESS, false, "access_denied"));
+                        new VisitedCredentialIssuerDetailsDto(PASSPORT_CRI_ID, true, null),
+                        new VisitedCredentialIssuerDetailsDto(
+                                ADDRESS_CRI_ID, false, "access_denied"));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
@@ -211,14 +207,15 @@ class SelectCriHandlerTest {
 
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI_ID))
+                .thenReturn(createCriConfig(FRAUD_CRI_ID, "test-fraud-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
                         List.of(
@@ -227,8 +224,8 @@ class SelectCriHandlerTest {
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(
-                        new VisitedCredentialIssuerDetailsDto(CRI_PASSPORT, true, null),
-                        new VisitedCredentialIssuerDetailsDto(CRI_ADDRESS, true, null));
+                        new VisitedCredentialIssuerDetailsDto(PASSPORT_CRI_ID, true, null),
+                        new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI_ID, true, null));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
@@ -249,16 +246,17 @@ class SelectCriHandlerTest {
 
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_KBV))
-                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI_ID))
+                .thenReturn(createCriConfig(FRAUD_CRI_ID, "test-fraud-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(KBV_CRI_ID))
+                .thenReturn(createCriConfig(KBV_CRI_ID, "test-kbv-iss", true));
 
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
@@ -269,9 +267,9 @@ class SelectCriHandlerTest {
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(
-                        new VisitedCredentialIssuerDetailsDto(CRI_PASSPORT, true, null),
-                        new VisitedCredentialIssuerDetailsDto(CRI_ADDRESS, true, null),
-                        new VisitedCredentialIssuerDetailsDto(CRI_FRAUD, true, null));
+                        new VisitedCredentialIssuerDetailsDto(PASSPORT_CRI_ID, true, null),
+                        new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI_ID, true, null),
+                        new VisitedCredentialIssuerDetailsDto(FRAUD_CRI_ID, true, null));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
@@ -293,16 +291,17 @@ class SelectCriHandlerTest {
 
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_KBV))
-                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI_ID))
+                .thenReturn(createCriConfig(FRAUD_CRI_ID, "test-fraud-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(KBV_CRI_ID))
+                .thenReturn(createCriConfig(KBV_CRI_ID, "test-kbv-iss", true));
 
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
@@ -314,10 +313,10 @@ class SelectCriHandlerTest {
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
                 List.of(
-                        new VisitedCredentialIssuerDetailsDto(CRI_PASSPORT, true, null),
-                        new VisitedCredentialIssuerDetailsDto(CRI_ADDRESS, true, null),
-                        new VisitedCredentialIssuerDetailsDto(CRI_FRAUD, true, null),
-                        new VisitedCredentialIssuerDetailsDto(CRI_KBV, true, null));
+                        new VisitedCredentialIssuerDetailsDto(PASSPORT_CRI_ID, true, null),
+                        new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI_ID, true, null),
+                        new VisitedCredentialIssuerDetailsDto(FRAUD_CRI_ID, true, null),
+                        new VisitedCredentialIssuerDetailsDto(KBV_CRI_ID, true, null));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
@@ -340,12 +339,13 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
@@ -366,10 +366,10 @@ class SelectCriHandlerTest {
         mockIpvSessionService();
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-dcmaw-iss", true)));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -395,12 +395,12 @@ class SelectCriHandlerTest {
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI_ID))
+                .thenReturn(createCriConfig(FRAUD_CRI_ID, "test-fraud-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
                         List.of(
@@ -410,8 +410,8 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
-                                new VisitedCredentialIssuerDetailsDto(CRI_DCMAW, true, null),
-                                new VisitedCredentialIssuerDetailsDto(CRI_ADDRESS, true, null)));
+                                new VisitedCredentialIssuerDetailsDto(DCMAW_CRI_ID, true, null),
+                                new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI_ID, true, null)));
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
@@ -433,14 +433,15 @@ class SelectCriHandlerTest {
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-passport-iss", true)));
 
@@ -467,10 +468,10 @@ class SelectCriHandlerTest {
 
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI_ID))
+                .thenReturn(createCriConfig(FRAUD_CRI_ID, "test-fraud-iss", true));
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
                         List.of(
@@ -479,9 +480,9 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
-                                new VisitedCredentialIssuerDetailsDto(CRI_DCMAW, true, null),
-                                new VisitedCredentialIssuerDetailsDto(CRI_ADDRESS, true, null),
-                                new VisitedCredentialIssuerDetailsDto(CRI_FRAUD, true, null)));
+                                new VisitedCredentialIssuerDetailsDto(DCMAW_CRI_ID, true, null),
+                                new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI_ID, true, null),
+                                new VisitedCredentialIssuerDetailsDto(FRAUD_CRI_ID, true, null)));
 
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(
@@ -493,12 +494,12 @@ class SelectCriHandlerTest {
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI_ID))
+                .thenReturn(createCriConfig(FRAUD_CRI_ID, "test-fraud-iss", true));
 
         APIGatewayProxyRequestEvent input = createRequestEvent();
 
@@ -516,10 +517,10 @@ class SelectCriHandlerTest {
         mockIpvSessionService();
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(List.of(new VisitedCredentialIssuerDetailsDto("dcmaw", true, null)));
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
@@ -544,10 +545,10 @@ class SelectCriHandlerTest {
         mockIpvSessionService();
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
@@ -576,10 +577,10 @@ class SelectCriHandlerTest {
         mockIpvSessionService();
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
@@ -608,10 +609,11 @@ class SelectCriHandlerTest {
         mockIpvSessionService();
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
@@ -636,16 +638,17 @@ class SelectCriHandlerTest {
         mockIpvSessionService();
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_ADDRESS))
-                .thenReturn(createCriConfig(CRI_ADDRESS, "test-address-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_FRAUD))
-                .thenReturn(createCriConfig(CRI_FRAUD, "test-fraud-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_KBV))
-                .thenReturn(createCriConfig(CRI_KBV, "test-kbv-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI_ID))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ID, "test-address-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI_ID))
+                .thenReturn(createCriConfig(FRAUD_CRI_ID, "test-fraud-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(KBV_CRI_ID))
+                .thenReturn(createCriConfig(KBV_CRI_ID, "test-kbv-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(
                         List.of(
@@ -680,8 +683,8 @@ class SelectCriHandlerTest {
         mockIpvSessionService();
 
         when(mockClientSessionDetailsDto.getUserId()).thenReturn("test-user-id");
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
         when(mockIpvSessionItem.getCurrentVcStatuses()).thenReturn(null);
@@ -709,12 +712,13 @@ class SelectCriHandlerTest {
         String userId = "test-user-id";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
@@ -741,12 +745,13 @@ class SelectCriHandlerTest {
         String userId = APP_JOURNEY_USER_ID_PREFIX + "some-uuid";
         when(mockClientSessionDetailsDto.getUserId()).thenReturn(userId);
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
@@ -774,8 +779,8 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("false");
@@ -806,12 +811,13 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DCMAW))
-                .thenReturn(createCriConfig(CRI_DCMAW, "test-dcmaw-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_PASSPORT))
-                .thenReturn(createCriConfig(CRI_PASSPORT, "test-passport-iss", true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CRI_DRIVING_LICENCE))
-                .thenReturn(createCriConfig(CRI_DRIVING_LICENCE, "test-driving-licence-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI_ID))
+                .thenReturn(createCriConfig(DCMAW_CRI_ID, "test-dcmaw-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI_ID))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ID, "test-passport-iss", true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI_ID))
+                .thenReturn(
+                        createCriConfig(DRIVING_LICENCE_CRI_ID, "test-driving-licence-iss", true));
 
         when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("true");
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS))
@@ -831,17 +837,6 @@ class SelectCriHandlerTest {
 
         when(mockIpvSessionItem.getClientSessionDetails()).thenReturn(mockClientSessionDetailsDto);
         when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(mockIpvSessionItem);
-    }
-
-    private void mockConfigurationServiceMethodCalls() {
-        when(mockConfigService.getSsmParameter(PASSPORT_CRI_ID)).thenReturn(CRI_PASSPORT);
-        when(mockConfigService.getSsmParameter(FRAUD_CRI_ID)).thenReturn(CRI_FRAUD);
-        when(mockConfigService.getSsmParameter(KBV_CRI_ID)).thenReturn(CRI_KBV);
-        when(mockConfigService.getSsmParameter(ADDRESS_CRI_ID)).thenReturn(CRI_ADDRESS);
-        when(mockConfigService.getSsmParameter(DRIVING_LICENCE_CRI_ID))
-                .thenReturn("drivingLicence");
-        when(mockConfigService.getSsmParameter(DCMAW_CRI_ID)).thenReturn(CRI_DCMAW);
-        when(mockConfigService.getSsmParameter(DCMAW_ENABLED)).thenReturn("false");
     }
 
     private APIGatewayProxyRequestEvent createRequestEvent() {

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -37,8 +37,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DRIVING_LICENCE_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PASSPORT_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.DRIVING_LICENCE_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.PASSPORT_CRI_ID;
 
 public class ValidateOAuthCallbackHandler
         implements RequestHandler<CriCallbackRequest, Map<String, Object>> {
@@ -68,8 +68,6 @@ public class ValidateOAuthCallbackHandler
     private final IpvSessionService ipvSessionService;
     private final AuditService auditService;
     private final String componentId;
-    private final String passportCriId;
-    private final String drivingLicenceCriId;
     private final CriOAuthSessionService criOAuthSessionService;
 
     public ValidateOAuthCallbackHandler(
@@ -81,8 +79,6 @@ public class ValidateOAuthCallbackHandler
         this.ipvSessionService = ipvSessionService;
         this.auditService = auditService;
         this.componentId = this.configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
-        this.passportCriId = configService.getSsmParameter(PASSPORT_CRI_ID);
-        this.drivingLicenceCriId = configService.getSsmParameter(DRIVING_LICENCE_CRI_ID);
         this.criOAuthSessionService = criOAuthSessionService;
     }
 
@@ -92,8 +88,6 @@ public class ValidateOAuthCallbackHandler
         this.ipvSessionService = new IpvSessionService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
         this.componentId = this.configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
-        this.passportCriId = configService.getSsmParameter(PASSPORT_CRI_ID);
-        this.drivingLicenceCriId = configService.getSsmParameter(DRIVING_LICENCE_CRI_ID);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);
     }
 
@@ -211,8 +205,8 @@ public class ValidateOAuthCallbackHandler
         LogHelper.logOauthError("OAuth error received from CRI", error, errorDescription);
 
         if (OAuth2Error.ACCESS_DENIED_CODE.equals(error)) {
-            if (configService.isEnabled(passportCriId)
-                    && configService.isEnabled(drivingLicenceCriId)) {
+            if (configService.isEnabled(PASSPORT_CRI_ID)
+                    && configService.isEnabled(DRIVING_LICENCE_CRI_ID)) {
                 return JOURNEY_ACCESS_DENIED_MULTI;
             }
             return JOURNEY_ACCESS_DENIED;

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -38,8 +38,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DRIVING_LICENCE_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PASSPORT_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.DRIVING_LICENCE_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.PASSPORT_CRI_ID;
 
 @ExtendWith(MockitoExtension.class)
 class ValidateOAuthCallbackHandlerHandlerTest {
@@ -59,8 +59,6 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     private static final String STATUS_CODE = "statusCode";
     private static final String TYPE = "type";
     private static final String PAGE = "page";
-    private static final String CRI_PASSPORT = "ukPassport";
-    private static final String CRI_DRIVING_LICENCE = "drivingLicence";
     private static CredentialIssuerConfig credentialIssuerConfig;
     private static IpvSessionItem ipvSessionItem;
     @Mock private Context context;
@@ -74,9 +72,6 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     @BeforeEach
     void setUpBeforeEach() throws URISyntaxException {
         when(mockConfigService.getSsmParameter(COMPONENT_ID)).thenReturn("audience.for.clients");
-        when(mockConfigService.getSsmParameter(PASSPORT_CRI_ID)).thenReturn(CRI_PASSPORT);
-        when(mockConfigService.getSsmParameter(DRIVING_LICENCE_CRI_ID))
-                .thenReturn(CRI_DRIVING_LICENCE);
 
         credentialIssuerConfig = createCriConfig("criId", "cri.iss.com");
 
@@ -307,9 +302,9 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockCriOAuthSessionService.getCriOauthSessionItem(any()))
                 .thenReturn(criOAuthSessionItem);
-        when(mockConfigService.isEnabled(CRI_PASSPORT)).thenReturn(true);
+        when(mockConfigService.isEnabled(PASSPORT_CRI_ID)).thenReturn(true);
 
-        when(mockConfigService.isEnabled(CRI_DRIVING_LICENCE)).thenReturn(false);
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI_ID)).thenReturn(false);
         Map<String, Object> output =
                 underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
 
@@ -327,9 +322,9 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockCriOAuthSessionService.getCriOauthSessionItem(any()))
                 .thenReturn(criOAuthSessionItem);
-        when(mockConfigService.isEnabled(CRI_PASSPORT)).thenReturn(true);
+        when(mockConfigService.isEnabled(PASSPORT_CRI_ID)).thenReturn(true);
 
-        when(mockConfigService.isEnabled(CRI_DRIVING_LICENCE)).thenReturn(true);
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI_ID)).thenReturn(true);
 
         Map<String, Object> output =
                 underTest.handleRequest(criCallbackRequestWithAccessDenied, context);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -1,21 +1,15 @@
 package uk.gov.di.ipv.core.library.config;
 
 public enum ConfigurationVariable {
-    ADDRESS_CRI_ID("/%s/core/self/journey/addressCriId"),
     BACKEND_SESSION_TIMEOUT("/%s/core/self/backendSessionTimeout"),
     BACKEND_SESSION_TTL("/%s/core/self/backendSessionTtl"),
     CLIENT_ISSUER("/%s/core/clients/%s/issuer"),
     COMPONENT_ID("/%s/core/self/componentId"),
     CORE_FRONT_CALLBACK_URL("/%s/core/self/coreFrontCallbackUrl"),
     CORE_VTM_CLAIM("/%s/core/self/coreVtmClaim"),
-    DRIVING_LICENCE_CRI_ID("/%s/core/self/journey/drivingLicenceId"),
-    FRAUD_CRI_ID("/%s/core/self/journey/fraudCriId"),
-    KBV_CRI_ID("/%s/core/self/journey/kbvCriId"),
-    DCMAW_CRI_ID("/%s/core/self/journey/dcmawCriId"),
     JAR_KMS_ENCRYPTION_KEY_ID("/%s/core/self/jarKmsEncryptionKeyId"),
     JWT_TTL_SECONDS("/%s/core/self/jwtTtlSeconds"),
     MAX_ALLOWED_AUTH_CLIENT_TTL("/%s/core/self/maxAllowedAuthClientTtl"),
-    PASSPORT_CRI_ID("/%s/core/self/journey/passportCriId"),
     DCMAW_ENABLED("/%s/core/credentialIssuers/dcmaw/enabled"),
     DCMAW_SHOULD_SEND_ALL_USERS("/%s/core/self/journey/dcmawShouldSendAllUsers"),
     DCMAW_ALLOWED_USER_IDS("/%s/core/self/journey/dcmawAllowedUserIds"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriIdConstants.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriIdConstants.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.core.library.domain;
+
+public class CriIdConstants {
+    public static final String PASSPORT_CRI_ID = "ukPassport";
+    public static final String DRIVING_LICENCE_CRI_ID = "drivingLicence";
+    public static final String FRAUD_CRI_ID = "fraud";
+    public static final String KBV_CRI_ID = "kbv";
+    public static final String ADDRESS_CRI_ID = "address";
+    public static final String DCMAW_CRI_ID = "dcmaw";
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriIdConstants.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriIdConstants.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
 public class CriIdConstants {
     public static final String PASSPORT_CRI_ID = "ukPassport";
     public static final String DRIVING_LICENCE_CRI_ID = "drivingLicence";

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.KBV_CRI_ID;
+import static uk.gov.di.ipv.core.library.domain.CriIdConstants.KBV_CRI_ID;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 
@@ -79,8 +79,7 @@ public class Gpg45ProfileEvaluator {
             Collections.sort(contraIndicatorItems);
             String lastCiIssuer =
                     contraIndicatorItems.get(contraIndicatorItems.size() - 1).getIss();
-            String kbvIssuer =
-                    configService.getComponentId(configService.getSsmParameter(KBV_CRI_ID));
+            String kbvIssuer = configService.getComponentId(KBV_CRI_ID);
 
             return Optional.of(
                     lastCiIssuer.equals(kbvIssuer)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -142,11 +142,7 @@ public class ConfigService {
 
     public CredentialIssuerConfig getCredentialIssuerActiveConnectionConfig(
             String credentialIssuerId) {
-
-        LOGGER.info(credentialIssuerId);
-        LOGGER.info(getEnvironmentVariable(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX));
         String activeConnection = getActiveConnection(credentialIssuerId);
-        LOGGER.info(activeConnection);
 
         Map<String, String> result =
                 getSsmParameters(
@@ -233,7 +229,6 @@ public class ConfigService {
     }
 
     public boolean isEnabled(String credentialIssuerId) {
-        LOGGER.info(credentialIssuerId);
         String enabled =
                 getSsmParameter(
                         String.format(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -11,9 +11,6 @@ import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
-import uk.gov.di.ipv.core.library.dto.ClientSessionDetailsDto;
-import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
-import uk.gov.di.ipv.core.library.service.CiStorageService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.util.Collections;
@@ -25,10 +22,8 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.KBV_CRI_ID;
 
 @ExtendWith(MockitoExtension.class)
 class Gpg45ProfileEvaluatorTest {
@@ -40,10 +35,7 @@ class Gpg45ProfileEvaluatorTest {
     private static final String JOURNEY_PYI_KBV_FAIL = "/journey/pyi-kbv-fail";
     private static final JourneyResponse JOURNEY_RESPONSE_PYI_KBV_FAIL =
             new JourneyResponse(JOURNEY_PYI_KBV_FAIL);
-
-    @Mock CiStorageService mockCiStorageService;
     @Mock ConfigService mockConfigService;
-    @Mock ClientSessionDetailsDto mockClientSessionDetails;
     @InjectMocks Gpg45ProfileEvaluator evaluator;
 
     private final String M1A_PASSPORT_VC =
@@ -135,7 +127,6 @@ class Gpg45ProfileEvaluatorTest {
                 "X99", new ContraIndicatorScore("X99", 3, -2, null, Collections.emptyList()));
         when(mockConfigService.getContraIndicatorScoresMap()).thenReturn(ciScoresMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
-        when(mockConfigService.getSsmParameter(KBV_CRI_ID)).thenReturn("kbv");
         when(mockConfigService.getComponentId("kbv")).thenReturn("kbvIssuer");
 
         assertEquals(
@@ -173,9 +164,6 @@ class Gpg45ProfileEvaluatorTest {
                 "X99", new ContraIndicatorScore("X99", 3, -2, null, Collections.emptyList()));
         when(mockConfigService.getContraIndicatorScoresMap()).thenReturn(ciScoresMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
-
-        CredentialIssuerConfig kbvConfig = mock(CredentialIssuerConfig.class);
-        when(mockConfigService.getSsmParameter(KBV_CRI_ID)).thenReturn("kbv");
 
         assertEquals(
                 Optional.of(JOURNEY_RESPONSE_PYI_NO_MATCH),

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -41,16 +41,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ADDRESS_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TIMEOUT;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_ISSUER;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_FRONT_CALLBACK_URL;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.FRAUD_CRI_ID;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.KBV_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PASSPORT_CRI_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 
@@ -238,38 +234,6 @@ class ConfigServiceTest {
         String coreVtmClaim = "aCoreVtmClaim";
         when(ssmProvider.get("/test/core/self/coreVtmClaim")).thenReturn(coreVtmClaim);
         assertEquals(coreVtmClaim, configService.getSsmParameter(CORE_VTM_CLAIM));
-    }
-
-    @Test
-    void shouldReturnPassportCriId() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String passportCriId = "ukPassport";
-        when(ssmProvider.get("/test/core/self/journey/passportCriId")).thenReturn(passportCriId);
-        assertEquals(passportCriId, configService.getSsmParameter(PASSPORT_CRI_ID));
-    }
-
-    @Test
-    void shouldReturnAddressCriId() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String addressCriId = "address";
-        when(ssmProvider.get("/test/core/self/journey/addressCriId")).thenReturn(addressCriId);
-        assertEquals(addressCriId, configService.getSsmParameter(ADDRESS_CRI_ID));
-    }
-
-    @Test
-    void shouldReturnFraudCriId() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String fraudCriId = "fraud";
-        when(ssmProvider.get("/test/core/self/journey/fraudCriId")).thenReturn(fraudCriId);
-        assertEquals(fraudCriId, configService.getSsmParameter(FRAUD_CRI_ID));
-    }
-
-    @Test
-    void shouldReturnKbvCriId() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String kbvCriId = "kbv";
-        when(ssmProvider.get("/test/core/self/journey/kbvCriId")).thenReturn(kbvCriId);
-        assertEquals(kbvCriId, configService.getSsmParameter(KBV_CRI_ID));
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Remove unwanted fetching journey cri Id. Use default cri id.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2616](https://govukverify.atlassian.net/browse/PYIC-2616)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2616]: https://govukverify.atlassian.net/browse/PYIC-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ