### PR TITLE
PYIC-2474 remove unwanted fields id, name from config class

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -163,11 +163,11 @@ public class BuildCriOauthRequestHandler
                             currentVcStatuses,
                             criId);
 
-            CriResponse criResponse = getCriResponse(credentialIssuerConfig, jweObject);
+            CriResponse criResponse = getCriResponse(credentialIssuerConfig, jweObject, criId);
 
-            persistOauthState(ipvSessionItem, credentialIssuerConfig.getId(), oauthState);
+            persistOauthState(ipvSessionItem, criId, oauthState);
 
-            persistCriOauthState(oauthState, credentialIssuerConfig.getId());
+            persistCriOauthState(oauthState, criId);
 
             AuditEventUser auditEventUser =
                     new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
@@ -204,7 +204,7 @@ public class BuildCriOauthRequestHandler
     }
 
     private CriResponse getCriResponse(
-            CredentialIssuerConfig credentialIssuerConfig, JWEObject jweObject)
+            CredentialIssuerConfig credentialIssuerConfig, JWEObject jweObject, String criId)
             throws URISyntaxException {
 
         URIBuilder redirectUri =
@@ -212,12 +212,11 @@ public class BuildCriOauthRequestHandler
                         .addParameter("client_id", credentialIssuerConfig.getClientId())
                         .addParameter("request", jweObject.serialize());
 
-        if (credentialIssuerConfig.getId().equals(DCMAW_CRI_ID)) {
+        if (criId.equals(DCMAW_CRI_ID)) {
             redirectUri.addParameter("response_type", "code");
         }
 
-        return new CriResponse(
-                new CriDetails(credentialIssuerConfig.getId(), redirectUri.build().toString()));
+        return new CriResponse(new CriDetails(criId, redirectUri.build().toString()));
     }
 
     private JWEObject signEncryptJar(

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -65,7 +65,6 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.KBV_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_2;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_3;
@@ -135,8 +134,6 @@ class BuildCriOauthRequestHandlerTest {
                         mockClientOAuthSessionDetailsService);
         credentialIssuerConfig =
                 new CredentialIssuerConfig(
-                        CRI_ID,
-                        CRI_NAME,
                         new URI(CRI_TOKEN_URL),
                         new URI(CRI_CREDENTIAL_URL),
                         new URI(CRI_AUTHORIZE_URL),
@@ -148,8 +145,6 @@ class BuildCriOauthRequestHandlerTest {
 
         addressCredentialIssuerConfig =
                 new CredentialIssuerConfig(
-                        ADDRESS_CRI,
-                        CRI_NAME,
                         new URI(CRI_TOKEN_URL),
                         new URI(CRI_CREDENTIAL_URL),
                         new URI(CRI_AUTHORIZE_URL),
@@ -161,8 +156,6 @@ class BuildCriOauthRequestHandlerTest {
 
         dcmawCredentialIssuerConfig =
                 new CredentialIssuerConfig(
-                        DCMAW_CRI,
-                        CRI_NAME,
                         new URI(CRI_TOKEN_URL),
                         new URI(CRI_CREDENTIAL_URL),
                         new URI(CRI_AUTHORIZE_URL),
@@ -174,8 +167,6 @@ class BuildCriOauthRequestHandlerTest {
 
         kbvCredentialIssuerConfig =
                 new CredentialIssuerConfig(
-                        KBV_CRI,
-                        CRI_NAME,
                         new URI(CRI_TOKEN_URL),
                         new URI(CRI_CREDENTIAL_URL),
                         new URI(CRI_AUTHORIZE_URL),

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -99,8 +99,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -113,8 +111,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -167,8 +163,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -181,8 +175,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -240,8 +232,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -254,8 +244,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -289,8 +277,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -349,8 +335,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -363,8 +347,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -377,8 +359,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("fraud"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -391,8 +371,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("kbv"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -446,8 +424,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -460,8 +436,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -474,8 +448,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("fraud"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),
@@ -488,8 +460,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("kbv"))
                 .thenReturn(
                         new CredentialIssuerConfig(
-                                "test-cri",
-                                "test cri",
                                 URI.create("https://example.com/token"),
                                 URI.create("https://example.com/credential"),
                                 URI.create("https://example.com/authorize"),

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -89,8 +89,6 @@ class CheckExistingIdentityHandlerTest {
         try {
             addressConfig =
                     new CredentialIssuerConfig(
-                            "address",
-                            "address",
                             new URI("http://example.com/token"),
                             new URI("http://example.com/credential"),
                             new URI("http://example.com/authorize"),

--- a/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandlerTest.java
+++ b/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandlerTest.java
@@ -656,8 +656,6 @@ class EndMitigationJourneyHandlerTest {
 
     private CredentialIssuerConfig getTestFraudCriConfig() {
         return new CredentialIssuerConfig(
-                "fraud",
-                "fraud",
                 URI.create("http://example.com/token"),
                 URI.create("http://example.com/credential"),
                 URI.create("http://example.com/authorize"),

--- a/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01ValidationTest.java
+++ b/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01ValidationTest.java
@@ -198,8 +198,6 @@ class Mj01ValidationTest {
 
     private CredentialIssuerConfig getTestFraudCriConfig() {
         return new CredentialIssuerConfig(
-                "fraud",
-                "fraud",
                 URI.create("http://example.com/token"),
                 URI.create("http://example.com/credential"),
                 URI.create("http://example.com/authorize"),

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -97,8 +97,6 @@ class EvaluateGpg45ScoreHandlerTest {
         try {
             addressConfig =
                     new CredentialIssuerConfig(
-                            "address",
-                            "address",
                             new URI("http://example.com/token"),
                             new URI("http://example.com/credential"),
                             new URI("http://example.com/authorize"),

--- a/lambdas/get-credential-issuer-config/src/test/java/uk/gov/di/ipv/core/getcredentialisserconfig/GetCredentialIssuerConfigHandlerTest.java
+++ b/lambdas/get-credential-issuer-config/src/test/java/uk/gov/di/ipv/core/getcredentialisserconfig/GetCredentialIssuerConfigHandlerTest.java
@@ -32,8 +32,6 @@ class GetCredentialIssuerConfigHandlerTest {
     private final List<CredentialIssuerConfig> credentialIssuerConfigList =
             List.of(
                     new CredentialIssuerConfig(
-                            "test1",
-                            "Any",
                             URI.create("test1TokenUrl"),
                             URI.create("test1credentialUrl"),
                             URI.create("test1AuthorizeUrl"),
@@ -43,8 +41,6 @@ class GetCredentialIssuerConfigHandlerTest {
                             "test-audience",
                             URI.create("testRedirectUrl")),
                     new CredentialIssuerConfig(
-                            "test2",
-                            "Any",
                             URI.create("test2TokenUrl"),
                             URI.create("test2credentialUrl"),
                             URI.create("test2AuthorizeUrl"),

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -141,13 +141,14 @@ public class RetrieveCriCredentialHandler
             CredentialIssuerConfig credentialIssuerConfig =
                     configService.getCredentialIssuerActiveConnectionConfig(credentialIssuerId);
 
-            String apiKey = configService.getCriPrivateApiKey(credentialIssuerConfig.getId());
+            String apiKey = configService.getCriPrivateApiKey(credentialIssuerId);
 
             List<SignedJWT> verifiableCredentials =
                     credentialIssuerService.getVerifiableCredential(
                             BearerAccessToken.parse(criOAuthSessionItem.getAccessToken()),
                             credentialIssuerConfig,
-                            apiKey);
+                            apiKey,
+                            credentialIssuerId);
 
             for (SignedJWT vc : verifiableCredentials) {
                 verifiableCredentialJwtValidator.validate(vc, credentialIssuerConfig, userId);

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -98,8 +98,6 @@ class RetrieveCriCredentialHandlerTest {
         try {
             addressConfig =
                     new CredentialIssuerConfig(
-                            "address",
-                            "address",
                             new URI("http://example.com/token"),
                             new URI("http://example.com/credential"),
                             new URI("http://example.com/authorize"),
@@ -117,8 +115,6 @@ class RetrieveCriCredentialHandlerTest {
     static void setUp() throws URISyntaxException, com.nimbusds.oauth2.sdk.ParseException {
         testPassportIssuer =
                 new CredentialIssuerConfig(
-                        CREDENTIAL_ISSUER_ID,
-                        "any",
                         new URI("https://www.example.com"),
                         new URI("https://www.example.com/credential"),
                         new URI("https://www.example.com/authorize"),
@@ -144,7 +140,10 @@ class RetrieveCriCredentialHandlerTest {
     void shouldReturnJourneyResponseOnSuccessfulRequest() throws Exception {
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(credentialIssuerService.getVerifiableCredential(
-                        testBearerAccessToken, testPassportIssuer, testApiKey))
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
 
         mockServiceCallsAndSessionItem();
@@ -170,7 +169,10 @@ class RetrieveCriCredentialHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
         when(credentialIssuerService.getVerifiableCredential(
-                        testBearerAccessToken, testPassportIssuer, testApiKey))
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -211,7 +213,8 @@ class RetrieveCriCredentialHandlerTest {
     void shouldReturnErrorJourneyResponseIfCredentialIssuerServiceGetCredentialThrows() {
         mockServiceCallsAndSessionItem();
 
-        when(credentialIssuerService.getVerifiableCredential(any(), any(), anyString()))
+        when(credentialIssuerService.getVerifiableCredential(
+                        any(), any(), anyString(), anyString()))
                 .thenThrow(
                         new CredentialIssuerException(
                                 HTTPResponse.SC_SERVER_ERROR,
@@ -226,7 +229,10 @@ class RetrieveCriCredentialHandlerTest {
     void shouldReturnErrorJourneyResponseIfSqsExceptionIsThrown() throws Exception {
         mockServiceCallsAndSessionItem();
         when(credentialIssuerService.getVerifiableCredential(
-                        testBearerAccessToken, testPassportIssuer, testApiKey))
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
 
         doThrow(new SqsException("Test sqs error"))
@@ -241,7 +247,10 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldReturnErrorJourneyIfVCFailsValidation() throws Exception {
         when(credentialIssuerService.getVerifiableCredential(
-                        testBearerAccessToken, testPassportIssuer, testApiKey))
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
 
         mockServiceCallsAndSessionItem();
@@ -262,7 +271,10 @@ class RetrieveCriCredentialHandlerTest {
     void shouldSendIpvVcReceivedAuditEvent() throws Exception {
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(credentialIssuerService.getVerifiableCredential(
-                        testBearerAccessToken, testPassportIssuer, testApiKey))
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_CONTRA_INDICATORS)));
         mockServiceCallsAndSessionItem();
 
@@ -292,7 +304,10 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldSendIpvVcReceivedAuditEventWhenVcEvidenceIsMissing() throws Exception {
         when(credentialIssuerService.getVerifiableCredential(
-                        testBearerAccessToken, testPassportIssuer, testApiKey))
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)));
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressConfig);
@@ -323,7 +338,10 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldNotStoreVcIfFailedToSubmitItToTheCiStorageSystem() throws Exception {
         when(credentialIssuerService.getVerifiableCredential(
-                        testBearerAccessToken, testPassportIssuer, testApiKey))
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)));
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(testPassportIssuer);

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -103,11 +103,11 @@ public class RetrieveCriOauthAccessTokenHandler
             CredentialIssuerConfig credentialIssuerConfig =
                     getCredentialIssuerConfig(credentialIssuerId);
 
-            String apiKey = configService.getCriPrivateApiKey(credentialIssuerConfig.getId());
+            String apiKey = configService.getCriPrivateApiKey(credentialIssuerId);
 
             BearerAccessToken accessToken =
                     credentialIssuerService.exchangeCodeForToken(
-                            authorizationCode, credentialIssuerConfig, apiKey);
+                            authorizationCode, credentialIssuerConfig, apiKey, credentialIssuerId);
 
             AuditEventUser auditEventUser =
                     new AuditEventUser(

--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -80,8 +80,6 @@ class RetrieveCriOauthAccessTokenHandlerTest {
 
         passportIssuer =
                 new CredentialIssuerConfig(
-                        CREDENTIAL_ISSUER_ID,
-                        "any",
                         new URI("http://www.example.com"),
                         new URI("http://www.example.com/credential"),
                         new URI("http://www.example.com/authorize"),
@@ -108,7 +106,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         testCredential.appendField("foo", "bar");
 
         when(credentialIssuerService.exchangeCodeForToken(
-                        TEST_AUTH_CODE, passportIssuer, testApiKey))
+                        TEST_AUTH_CODE, passportIssuer, testApiKey, CREDENTIAL_ISSUER_ID))
                 .thenReturn(new BearerAccessToken());
 
         mockServiceCallsAndSessionItem();
@@ -139,7 +137,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
 
         when(credentialIssuerService.exchangeCodeForToken(
-                        TEST_AUTH_CODE, passportIssuer, testApiKey))
+                        TEST_AUTH_CODE, passportIssuer, testApiKey, CREDENTIAL_ISSUER_ID))
                 .thenThrow(
                         new CredentialIssuerException(
                                 HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
@@ -161,7 +159,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         BearerAccessToken accessToken = mock(BearerAccessToken.class);
 
         when(credentialIssuerService.exchangeCodeForToken(
-                        TEST_AUTH_CODE, passportIssuer, testApiKey))
+                        TEST_AUTH_CODE, passportIssuer, testApiKey, CREDENTIAL_ISSUER_ID))
                 .thenReturn(accessToken);
 
         mockServiceCallsAndSessionItem();
@@ -235,7 +233,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
 
         when(credentialIssuerService.exchangeCodeForToken(
-                        TEST_AUTH_CODE, passportIssuer, testApiKey))
+                        TEST_AUTH_CODE, passportIssuer, testApiKey, CREDENTIAL_ISSUER_ID))
                 .thenThrow(
                         new CredentialIssuerException(
                                 HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -809,8 +809,6 @@ class SelectCriHandlerTest {
     private CredentialIssuerConfig createCriConfig(String criId, String criIss, boolean enabled)
             throws URISyntaxException {
         return new CredentialIssuerConfig(
-                criId,
-                criId,
                 new URI("http://example.com/token"),
                 new URI("http://example.com/credential"),
                 new URI("http://example.com/authorize"),
@@ -822,15 +820,13 @@ class SelectCriHandlerTest {
     }
 
     private ClientOAuthSessionItem getClientOAuthSessionItem() {
-        ClientOAuthSessionItem clientOAuthSessionItem =
-                ClientOAuthSessionItem.builder()
-                        .clientOAuthSessionId(SecureTokenHelper.generate())
-                        .responseType("code")
-                        .state("test-state")
-                        .redirectUri("https://example.com/redirect")
-                        .govukSigninJourneyId("test-journey-id")
-                        .userId("test-user-id")
-                        .build();
-        return clientOAuthSessionItem;
+        return ClientOAuthSessionItem.builder()
+                .clientOAuthSessionId(SecureTokenHelper.generate())
+                .responseType("code")
+                .state("test-state")
+                .redirectUri("https://example.com/redirect")
+                .govukSigninJourneyId("test-journey-id")
+                .userId("test-user-id")
+                .build();
     }
 }

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -78,7 +78,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     void setUpBeforeEach() throws URISyntaxException {
         when(mockConfigService.getSsmParameter(COMPONENT_ID)).thenReturn("audience.for.clients");
 
-        credentialIssuerConfig = createCriConfig("criId", "cri.iss.com");
+        credentialIssuerConfig = createCriConfig("cri.iss.com");
 
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setCriOAuthSessionId(TEST_OAUTH_STATE);
@@ -519,11 +519,8 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 TEST_IP_ADDRESS);
     }
 
-    private CredentialIssuerConfig createCriConfig(String criId, String criIss)
-            throws URISyntaxException {
+    private CredentialIssuerConfig createCriConfig(String criIss) throws URISyntaxException {
         return new CredentialIssuerConfig(
-                criId,
-                criId,
                 new URI("http://example.com/token"),
                 new URI("http://example.com/credential"),
                 new URI("http://example.com/authorize"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -8,14 +8,10 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 
 import java.net.URI;
 import java.text.ParseException;
-import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ExcludeFromGeneratedCoverageReport
 public class CredentialIssuerConfig {
-
-    private String id;
-    private String name;
     private URI tokenUrl;
     private URI credentialUrl;
     private URI authorizeUrl;
@@ -29,8 +25,6 @@ public class CredentialIssuerConfig {
 
     @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public CredentialIssuerConfig(
-            String id,
-            String name,
             URI tokenUrl,
             URI credentialUrl,
             URI authorizeUrl,
@@ -39,8 +33,6 @@ public class CredentialIssuerConfig {
             String encryptionKey,
             String componentId,
             URI clientCallbackUrl) {
-        this.id = id;
-        this.name = name;
         this.tokenUrl = tokenUrl;
         this.credentialUrl = credentialUrl;
         this.authorizeUrl = authorizeUrl;
@@ -51,20 +43,12 @@ public class CredentialIssuerConfig {
         this.clientCallbackUrl = clientCallbackUrl;
     }
 
-    public String getId() {
-        return id;
-    }
-
     public URI getTokenUrl() {
         return tokenUrl;
     }
 
     public URI getCredentialUrl() {
         return credentialUrl;
-    }
-
-    public String getName() {
-        return name;
     }
 
     public URI getAuthorizeUrl() {
@@ -102,11 +86,6 @@ public class CredentialIssuerConfig {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -115,12 +94,6 @@ public class CredentialIssuerConfig {
             return false;
         }
         CredentialIssuerConfig that = (CredentialIssuerConfig) o;
-        return id.equals(that.id)
-                && tokenUrl.equals(that.tokenUrl)
-                && credentialUrl.equals(that.credentialUrl);
-    }
-
-    public void setId(String credentialIssuerId) {
-        this.id = credentialIssuerId;
+        return tokenUrl.equals(that.tokenUrl) && credentialUrl.equals(that.credentialUrl);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 
 import java.net.URI;
 import java.text.ParseException;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ExcludeFromGeneratedCoverageReport
@@ -86,6 +87,11 @@ public class CredentialIssuerConfig {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(clientId);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -94,6 +100,8 @@ public class CredentialIssuerConfig {
             return false;
         }
         CredentialIssuerConfig that = (CredentialIssuerConfig) o;
-        return tokenUrl.equals(that.tokenUrl) && credentialUrl.equals(that.credentialUrl);
+        return clientId.equals(that.clientId)
+                && tokenUrl.equals(that.tokenUrl)
+                && credentialUrl.equals(that.credentialUrl);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -152,11 +152,7 @@ public class ConfigService {
                                 credentialIssuerId,
                                 activeConnection));
 
-        CredentialIssuerConfig credentialIssuerConfig =
-                new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
-        credentialIssuerConfig.setId(credentialIssuerId);
-
-        return credentialIssuerConfig;
+        return new ObjectMapper().convertValue(result, CredentialIssuerConfig.class);
     }
 
     public List<String> getClientRedirectUrls(String clientId) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -67,8 +67,6 @@ class ConfigServiceTest {
 
     @Mock SSMProvider ssmProvider;
 
-    @Mock SSMProvider ssmProvider2;
-
     @Mock SecretsProvider secretsProvider;
 
     private ConfigService configService;
@@ -131,8 +129,6 @@ class ConfigServiceTest {
 
         CredentialIssuerConfig expected =
                 new CredentialIssuerConfig(
-                        "passportCri",
-                        "",
                         URI.create(TEST_TOKEN_URL),
                         URI.create(TEST_CREDENTIAL_URL),
                         URI.create(TEST_CREDENTIAL_URL),

--- a/libs/credential-issuer-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerService.java
+++ b/libs/credential-issuer-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerService.java
@@ -77,7 +77,10 @@ public class CredentialIssuerService {
     }
 
     public BearerAccessToken exchangeCodeForToken(
-            String authCode, CredentialIssuerConfig config, String apiKey) {
+            String authCode,
+            CredentialIssuerConfig config,
+            String apiKey,
+            String credentialIssuerId) {
 
         AuthorizationCode authorizationCode = new AuthorizationCode(authCode);
         try {
@@ -110,7 +113,7 @@ public class CredentialIssuerService {
             if (apiKey != null) {
                 LOGGER.info(
                         "Private api key found for cri {}, sending key in header for token request",
-                        config.getId());
+                        credentialIssuerId);
                 httpRequest.setHeader(API_KEY_HEADER, apiKey);
             }
 
@@ -125,7 +128,7 @@ public class CredentialIssuerService {
                                 new ErrorObject("unknown", "unknown"));
                 LOGGER.error(
                         "Failed to exchange token with credential issuer with ID '{}' at '{}'. Code: '{}', Description: {}, HttpStatus code: {}",
-                        config.getId(),
+                        credentialIssuerId,
                         config.getTokenUrl(),
                         errorObject.getCode(),
                         errorObject.getDescription(),
@@ -148,14 +151,17 @@ public class CredentialIssuerService {
     }
 
     public List<SignedJWT> getVerifiableCredential(
-            BearerAccessToken accessToken, CredentialIssuerConfig config, String apiKey) {
+            BearerAccessToken accessToken,
+            CredentialIssuerConfig config,
+            String apiKey,
+            String credentialIssuerId) {
         HTTPRequest credentialRequest =
                 new HTTPRequest(HTTPRequest.Method.POST, config.getCredentialUrl());
 
         if (apiKey != null) {
             LOGGER.info(
                     "Private api key found for cri {}, sending key in header for credential request",
-                    config.getId());
+                    credentialIssuerId);
             credentialRequest.setHeader(API_KEY_HEADER, apiKey);
         }
 

--- a/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigServiceTest.java
+++ b/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigServiceTest.java
@@ -48,11 +48,11 @@ class CredentialIssuerConfigServiceTest {
         HashMap<String, String> response = new HashMap<>();
         response.put("passportCri/tokenUrl", "passportTokenUrl");
         response.put("passportCri/authorizeUrl", "passportAuthUrl");
-        response.put("passportCri/id", "passportCri");
+        response.put("passportCri/clientId", "passportCri");
         response.put("passportCri/name", "passportIssuer");
         response.put("stubCri/tokenUrl", "stubTokenUrl");
         response.put("stubCri/authorizeUrl", "stubAuthUrl");
-        response.put("stubCri/id", "stubCri");
+        response.put("stubCri/clientId", "stubCri");
         response.put("stubCri/name", "stubIssuer");
         response.put("stubCri/allowedSharedAttributes", "name, birthDate, address");
 
@@ -64,21 +64,21 @@ class CredentialIssuerConfigServiceTest {
 
         Optional<CredentialIssuerConfig> passportIssuerConfig =
                 result.stream()
-                        .filter(config -> Objects.equals(config.getId(), "passportCri"))
+                        .filter(config -> Objects.equals(config.getClientId(), "passportCri"))
                         .findFirst();
         assertTrue(passportIssuerConfig.isPresent());
         assertEquals("passportTokenUrl", passportIssuerConfig.get().getTokenUrl().toString());
         assertEquals("passportAuthUrl", passportIssuerConfig.get().getAuthorizeUrl().toString());
-        assertEquals("passportCri", passportIssuerConfig.get().getId());
+        assertEquals("passportCri", passportIssuerConfig.get().getClientId());
 
         Optional<CredentialIssuerConfig> stubIssuerConfig =
                 result.stream()
-                        .filter(config -> Objects.equals(config.getId(), "stubCri"))
+                        .filter(config -> Objects.equals(config.getClientId(), "stubCri"))
                         .findFirst();
         assertTrue(stubIssuerConfig.isPresent());
         assertEquals("stubTokenUrl", stubIssuerConfig.get().getTokenUrl().toString());
         assertEquals("stubAuthUrl", stubIssuerConfig.get().getAuthorizeUrl().toString());
-        assertEquals("stubCri", stubIssuerConfig.get().getId());
+        assertEquals("stubCri", stubIssuerConfig.get().getClientId());
     }
 
     @Test
@@ -109,9 +109,9 @@ class CredentialIssuerConfigServiceTest {
         environmentVariables.set(
                 "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
         HashMap<String, String> response = new HashMap<>();
-        response.put("passportCri/id", "passportCri");
+        response.put("passportCri/clientId", "passportCri");
         response.put("passportCri/tokenUrl", "passportTokenUrl");
-        response.put("stubCri/id", "stubCri");
+        response.put("stubCri/clientId", "stubCri");
         response.put("stubCri/tokenUrl", "stubTokenUrl");
         // This will be ignored - not in pojo
         response.put("stubCri/ipclientid", "stubIpClient");
@@ -122,14 +122,14 @@ class CredentialIssuerConfigServiceTest {
 
         Optional<CredentialIssuerConfig> passportIssuerConfig =
                 result.stream()
-                        .filter(config -> Objects.equals(config.getId(), "passportCri"))
+                        .filter(config -> Objects.equals(config.getClientId(), "passportCri"))
                         .findFirst();
         assertTrue(passportIssuerConfig.isPresent());
         assertEquals("passportTokenUrl", passportIssuerConfig.get().getTokenUrl().toString());
 
         Optional<CredentialIssuerConfig> stubIssuerConfig =
                 result.stream()
-                        .filter(config -> Objects.equals(config.getId(), "stubCri"))
+                        .filter(config -> Objects.equals(config.getClientId(), "stubCri"))
                         .findFirst();
         assertTrue(stubIssuerConfig.isPresent());
         assertEquals("stubTokenUrl", stubIssuerConfig.get().getTokenUrl().toString());

--- a/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerServiceTest.java
+++ b/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerServiceTest.java
@@ -72,6 +72,7 @@ class CredentialIssuerServiceTest {
 
     private CredentialIssuerService credentialIssuerService;
     private final String testApiKey = "test-api-key";
+    private final String cri = "ukPassport";
 
     @BeforeEach
     void setUp() throws Exception {
@@ -98,7 +99,7 @@ class CredentialIssuerServiceTest {
 
         AccessToken accessToken =
                 credentialIssuerService.exchangeCodeForToken(
-                        TEST_AUTH_CODE, credentialIssuerConfig, testApiKey);
+                        TEST_AUTH_CODE, credentialIssuerConfig, testApiKey, cri);
         AccessTokenType type = accessToken.getType();
         assertEquals("Bearer", type.toString());
         assertEquals(3600, accessToken.getLifetime());
@@ -122,7 +123,7 @@ class CredentialIssuerServiceTest {
 
         AccessToken accessToken =
                 credentialIssuerService.exchangeCodeForToken(
-                        TEST_AUTH_CODE, credentialIssuerConfig, testApiKey);
+                        TEST_AUTH_CODE, credentialIssuerConfig, testApiKey, cri);
         AccessTokenType type = accessToken.getType();
         assertEquals("Bearer", type.toString());
         assertEquals(3600, accessToken.getLifetime());
@@ -146,7 +147,7 @@ class CredentialIssuerServiceTest {
 
         AccessToken accessToken =
                 credentialIssuerService.exchangeCodeForToken(
-                        TEST_AUTH_CODE, credentialIssuerConfig, null);
+                        TEST_AUTH_CODE, credentialIssuerConfig, null, cri);
         AccessTokenType type = accessToken.getType();
         assertEquals("Bearer", type.toString());
         assertEquals(3600, accessToken.getLifetime());
@@ -175,7 +176,7 @@ class CredentialIssuerServiceTest {
                         CredentialIssuerException.class,
                         () ->
                                 credentialIssuerService.exchangeCodeForToken(
-                                        TEST_AUTH_CODE, credentialIssuerConfig, testApiKey));
+                                        TEST_AUTH_CODE, credentialIssuerConfig, testApiKey, cri));
 
         assertEquals(HTTPResponse.SC_BAD_REQUEST, exception.getHttpStatusCode());
         assertEquals(ErrorResponse.INVALID_TOKEN_REQUEST, exception.getErrorResponse());
@@ -199,7 +200,7 @@ class CredentialIssuerServiceTest {
                         CredentialIssuerException.class,
                         () ->
                                 credentialIssuerService.exchangeCodeForToken(
-                                        TEST_AUTH_CODE, credentialIssuerConfig, testApiKey));
+                                        TEST_AUTH_CODE, credentialIssuerConfig, testApiKey, cri));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getHttpStatusCode());
         assertEquals(
@@ -335,7 +336,7 @@ class CredentialIssuerServiceTest {
 
         List<SignedJWT> credentials =
                 credentialIssuerService.getVerifiableCredential(
-                        accessToken, credentialIssuerConfig, testApiKey);
+                        accessToken, credentialIssuerConfig, testApiKey, cri);
 
         assertEquals(SIGNED_VC_1, credentials.get(0).serialize());
 
@@ -361,7 +362,7 @@ class CredentialIssuerServiceTest {
 
         List<SignedJWT> credentials =
                 credentialIssuerService.getVerifiableCredential(
-                        accessToken, credentialIssuerConfig, null);
+                        accessToken, credentialIssuerConfig, null, cri);
 
         assertEquals(SIGNED_VC_1, credentials.get(0).serialize());
 
@@ -391,7 +392,7 @@ class CredentialIssuerServiceTest {
 
         List<SignedJWT> credentials =
                 credentialIssuerService.getVerifiableCredential(
-                        accessToken, credentialIssuerConfig, null);
+                        accessToken, credentialIssuerConfig, null, cri);
 
         assertEquals(SIGNED_VC_1, credentials.get(0).serialize());
 
@@ -421,7 +422,7 @@ class CredentialIssuerServiceTest {
                         CredentialIssuerException.class,
                         () ->
                                 credentialIssuerService.getVerifiableCredential(
-                                        accessToken, credentialIssuerConfig, testApiKey));
+                                        accessToken, credentialIssuerConfig, testApiKey, cri));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
         assertEquals(ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER, thrown.getErrorResponse());
@@ -445,7 +446,7 @@ class CredentialIssuerServiceTest {
                         CredentialIssuerException.class,
                         () ->
                                 credentialIssuerService.getVerifiableCredential(
-                                        accessToken, credentialIssuerConfig, testApiKey));
+                                        accessToken, credentialIssuerConfig, testApiKey, cri));
 
         assertEquals(HTTPResponse.SC_SERVER_ERROR, thrown.getHttpStatusCode());
         assertEquals(ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER, thrown.getErrorResponse());
@@ -454,8 +455,6 @@ class CredentialIssuerServiceTest {
     private CredentialIssuerConfig getStubCredentialIssuerConfig(
             WireMockRuntimeInfo wmRuntimeInfo) {
         return new CredentialIssuerConfig(
-                "StubPassport",
-                "any",
                 URI.create("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/token"),
                 URI.create(
                         "http://localhost:" + wmRuntimeInfo.getHttpPort() + "/credentials/issue"),

--- a/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
+++ b/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
@@ -27,8 +27,6 @@ class VcHelperTest {
         try {
             addressConfig =
                     new CredentialIssuerConfig(
-                            "address",
-                            "address",
                             new URI("https://example.com/token"),
                             new URI("https://example.com/credential"),
                             new URI("https://example.com/authorize"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Removed getId, getName from the config class.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- After refactoring infra and param config we don't need id and name for the CRI.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2474](https://govukverify.atlassian.net/browse/PYIC-2474)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2474]: https://govukverify.atlassian.net/browse/PYIC-2474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ