### PR TITLE
WIP: [PYIC-2645] Update ValidateOAuthCallbackHandler to return access denied when no i…

### DIFF
--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -111,20 +111,19 @@ public class ValidateOAuthCallbackHandler
             String ipvSessionId = callbackRequest.getIpvSessionId();
             String criOAuthSessionId = callbackRequest.getState();
 
-            if (ipvSessionId != null) {
+            if (ipvSessionId != null && !ipvSessionId.isEmpty()) {
                 ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
-            } else if (criOAuthSessionId == null) {
+            } else if (criOAuthSessionId != null && !criOAuthSessionId.isEmpty()) {
+                criOAuthSessionItem = criOAuthSessionService.getCriOauthSessionItem(criOAuthSessionId);
+                var mapMessage =
+                        new StringMapMessage()
+                                .with("message", "No ipvSession for existing CriOAuthSession")
+                                .with("criId", callbackRequest.getCredentialIssuerId());
+                LOGGER.info(mapMessage);
+                return JOURNEY_ACCESS_DENIED;
+            } else {
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_OAUTH_STATE);
-            } else {
-                ipvSessionItem =
-                        ipvSessionService
-                                .getIpvSessionByCriOAuthSessionId(criOAuthSessionId)
-                                .orElseThrow(
-                                        () ->
-                                                new HttpResponseExceptionWithErrorBody(
-                                                        HttpStatus.SC_BAD_REQUEST,
-                                                        ErrorResponse.UNRECOVERABLE_OAUTH_STATE));
             }
 
             LogHelper.attachIpvSessionIdToLogs(ipvSessionItem.getIpvSessionId());

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -29,7 +29,6 @@ import uk.gov.di.ipv.core.validateoauthcallback.dto.CriCallbackRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -224,22 +223,18 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     }
 
     @Test
-    void shouldReceive400ResponseCodeIfSessionNotPresentForCriOAuthSession() {
+    void shouldReceiveAccessDeniedJourneyIfSessionNotPresentForCriOAuthSession() {
         CriCallbackRequest criCallbackRequestWithoutSessionId = validCriCallbackRequest();
         criCallbackRequestWithoutSessionId.setIpvSessionId(null);
-        criCallbackRequestWithoutSessionId.setState(null);
         criCallbackRequestWithoutSessionId.setState(TEST_OAUTH_STATE);
 
-        when(mockIpvSessionService.getIpvSessionByCriOAuthSessionId(anyString()))
-                .thenReturn(Optional.empty());
+        when(mockCriOAuthSessionService.getCriOauthSessionItem(anyString()))
+                .thenReturn(criOAuthSessionItem);
 
         Map<String, Object> output =
                 underTest.handleRequest(criCallbackRequestWithoutSessionId, context);
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
-        assertEquals(ErrorResponse.UNRECOVERABLE_OAUTH_STATE.getCode(), output.get(CODE));
-        assertEquals(ErrorResponse.UNRECOVERABLE_OAUTH_STATE.getMessage(), output.get(MESSAGE));
-        verify(mockCriOAuthSessionService, times(0)).getCriOauthSessionItem(any());
+        assertEquals("/journey/access-denied", output.get("journey"));
     }
 
     @Test


### PR DESCRIPTION
…pvSession

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update validateOAuthCallback lambda to return ACCESS_DENIED journey when no ipvSessionId

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

- [PYIC-2645](https://govukverify.atlassian.net/browse/PYIC-2645)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2645]: https://govukverify.atlassian.net/browse/PYIC-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ