### PR TITLE
[PYIC-2645] Update `validate-cri-callback` to return pyi-timeout-recoverable if the passed OAuth `state` does not match an active CRI OAuth session

### DIFF
--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -66,6 +66,7 @@ public class ValidateOAuthCallbackHandler
                     OAuth2Error.SERVER_ERROR_CODE,
                     OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE);
     private static final String PYI_ATTEMPT_RECOVERY_PAGE_ID = "pyi-attempt-recovery";
+    private static final String PYI_TIMEOUT_RECOVERABLE_PAGE_ID = "pyi-timeout-recoverable";
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
     private final AuditService auditService;
@@ -120,11 +121,15 @@ public class ValidateOAuthCallbackHandler
                         new StringMapMessage()
                                 .with("message", "No ipvSession for existing CriOAuthSession")
                                 .with("criId", criOAuthSessionItem.getCriId())
-                                .with(
-                                        "criOAuthSessionId",
-                                        criOAuthSessionItem.getCriOAuthSessionId());
+                                .with("criOAuthSessionId", criOAuthSessionId);
                 LOGGER.info(mapMessage);
-                return JOURNEY_ACCESS_DENIED;
+                Map<String, Object> pageOutput =
+                        StepFunctionHelpers.generatePageOutputMap(
+                                "error",
+                                HttpStatus.SC_UNAUTHORIZED,
+                                PYI_TIMEOUT_RECOVERABLE_PAGE_ID);
+                pageOutput.put("criOAuthSessionId", criOAuthSessionId);
+                return pageOutput;
             } else {
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_OAUTH_STATE);

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -117,18 +117,19 @@ public class ValidateOAuthCallbackHandler
             } else if (criOAuthSessionId != null && !criOAuthSessionId.isEmpty()) {
                 criOAuthSessionItem =
                         criOAuthSessionService.getCriOauthSessionItem(criOAuthSessionId);
+                String clientOAuthSessionId = criOAuthSessionItem.getClientOAuthSessionId();
                 var mapMessage =
                         new StringMapMessage()
                                 .with("message", "No ipvSession for existing CriOAuthSession")
                                 .with("criId", criOAuthSessionItem.getCriId())
-                                .with("criOAuthSessionId", criOAuthSessionId);
+                                .with("clientOAuthSessionId", clientOAuthSessionId);
                 LOGGER.info(mapMessage);
                 Map<String, Object> pageOutput =
                         StepFunctionHelpers.generatePageOutputMap(
                                 "error",
                                 HttpStatus.SC_UNAUTHORIZED,
                                 PYI_TIMEOUT_RECOVERABLE_PAGE_ID);
-                pageOutput.put("criOAuthSessionId", criOAuthSessionId);
+                pageOutput.put("clientOAuthSessionId", clientOAuthSessionId);
                 return pageOutput;
             } else {
                 throw new HttpResponseExceptionWithErrorBody(

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -119,7 +119,10 @@ public class ValidateOAuthCallbackHandler
                 var mapMessage =
                         new StringMapMessage()
                                 .with("message", "No ipvSession for existing CriOAuthSession")
-                                .with("criId", callbackRequest.getCredentialIssuerId());
+                                .with("criId", criOAuthSessionItem.getCriId())
+                                .with(
+                                        "criOAuthSessionId",
+                                        criOAuthSessionItem.getCriOAuthSessionId());
                 LOGGER.info(mapMessage);
                 return JOURNEY_ACCESS_DENIED;
             } else {

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -111,20 +111,19 @@ public class ValidateOAuthCallbackHandler
             String ipvSessionId = callbackRequest.getIpvSessionId();
             String criOAuthSessionId = callbackRequest.getState();
 
-            if (ipvSessionId != null) {
+            if (ipvSessionId != null && !ipvSessionId.isEmpty()) {
                 ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
-            } else if (criOAuthSessionId == null) {
+            } else if (criOAuthSessionId != null && !criOAuthSessionId.isEmpty()) {
+                criOAuthSessionItem = criOAuthSessionService.getCriOauthSessionItem(criOAuthSessionId);
+                var mapMessage =
+                        new StringMapMessage()
+                                .with("message", "No ipvSession for existing CriOAuthSession")
+                                .with("criId", callbackRequest.getCredentialIssuerId());
+                LOGGER.info(mapMessage);
+                return JOURNEY_ACCESS_DENIED;
+            } else {
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_OAUTH_STATE);
-            } else {
-                ipvSessionItem =
-                        ipvSessionService
-                                .getIpvSessionByCriOAuthSessionId(criOAuthSessionId)
-                                .orElseThrow(
-                                        () ->
-                                                new HttpResponseExceptionWithErrorBody(
-                                                        HttpStatus.SC_BAD_REQUEST,
-                                                        ErrorResponse.UNRECOVERABLE_OAUTH_STATE));
             }
 
             LogHelper.attachIpvSessionIdToLogs(ipvSessionItem.getIpvSessionId());

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -114,7 +114,8 @@ public class ValidateOAuthCallbackHandler
             if (ipvSessionId != null && !ipvSessionId.isEmpty()) {
                 ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             } else if (criOAuthSessionId != null && !criOAuthSessionId.isEmpty()) {
-                criOAuthSessionItem = criOAuthSessionService.getCriOauthSessionItem(criOAuthSessionId);
+                criOAuthSessionItem =
+                        criOAuthSessionService.getCriOauthSessionItem(criOAuthSessionId);
                 var mapMessage =
                         new StringMapMessage()
                                 .with("message", "No ipvSession for existing CriOAuthSession")

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -112,9 +112,9 @@ public class ValidateOAuthCallbackHandler
             String ipvSessionId = callbackRequest.getIpvSessionId();
             String criOAuthSessionId = callbackRequest.getState();
 
-            if (ipvSessionId != null && !ipvSessionId.isEmpty()) {
+            if (!StringUtils.isBlank(ipvSessionId)) {
                 ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
-            } else if (criOAuthSessionId != null && !criOAuthSessionId.isEmpty()) {
+            } else if (!StringUtils.isBlank(criOAuthSessionId)) {
                 criOAuthSessionItem =
                         criOAuthSessionService.getCriOauthSessionItem(criOAuthSessionId);
                 String clientOAuthSessionId = criOAuthSessionItem.getClientOAuthSessionId();

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -29,7 +29,6 @@ import uk.gov.di.ipv.core.validateoauthcallback.dto.CriCallbackRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -224,22 +223,18 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     }
 
     @Test
-    void shouldReceive400ResponseCodeIfSessionNotPresentForCriOAuthSession() {
+    void shouldReceiveAccessDeniedJourneyIfSessionNotPresentForCriOAuthSession() {
         CriCallbackRequest criCallbackRequestWithoutSessionId = validCriCallbackRequest();
         criCallbackRequestWithoutSessionId.setIpvSessionId(null);
-        criCallbackRequestWithoutSessionId.setState(null);
         criCallbackRequestWithoutSessionId.setState(TEST_OAUTH_STATE);
 
-        when(mockIpvSessionService.getIpvSessionByCriOAuthSessionId(anyString()))
-                .thenReturn(Optional.empty());
+        when(mockCriOAuthSessionService.getCriOauthSessionItem(anyString()))
+                .thenReturn(criOAuthSessionItem);
 
         Map<String, Object> output =
                 underTest.handleRequest(criCallbackRequestWithoutSessionId, context);
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, output.get(STATUS_CODE));
-        assertEquals(ErrorResponse.UNRECOVERABLE_OAUTH_STATE.getCode(), output.get(CODE));
-        assertEquals(ErrorResponse.UNRECOVERABLE_OAUTH_STATE.getMessage(), output.get(MESSAGE));
-        verify(mockCriOAuthSessionService, times(0)).getCriOauthSessionItem(any());
+        assertEquals("/journey/access-denied", output.get("journey"));
     }
 
     @Test

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -238,7 +238,9 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         assertEquals(HttpStatus.SC_UNAUTHORIZED, output.get(STATUS_CODE));
         assertEquals("pyi-timeout-recoverable", output.get(PAGE));
         assertEquals("error", output.get(TYPE));
-        assertEquals(clientOAuthSessionItem.getClientOAuthSessionId(), output.get("clientOAuthSessionId"));
+        assertEquals(
+                clientOAuthSessionItem.getClientOAuthSessionId(),
+                output.get("clientOAuthSessionId"));
     }
 
     @Test

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -96,6 +96,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         criOAuthSessionItem =
                 CriOAuthSessionItem.builder()
                         .criOAuthSessionId(TEST_OAUTH_STATE)
+                        .clientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID)
                         .criId(TEST_CREDENTIAL_ISSUER_ID)
                         .accessToken("testAccessToken")
                         .authorizationCode(TEST_AUTHORIZATION_CODE)
@@ -228,7 +229,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         criCallbackRequestWithoutSessionId.setIpvSessionId(null);
         criCallbackRequestWithoutSessionId.setState(TEST_OAUTH_STATE);
 
-        when(mockCriOAuthSessionService.getCriOauthSessionItem(anyString()))
+        when(mockCriOAuthSessionService.getCriOauthSessionItem(any()))
                 .thenReturn(criOAuthSessionItem);
 
         Map<String, Object> output =
@@ -237,7 +238,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         assertEquals(HttpStatus.SC_UNAUTHORIZED, output.get(STATUS_CODE));
         assertEquals("pyi-timeout-recoverable", output.get(PAGE));
         assertEquals("error", output.get(TYPE));
-        assertEquals(TEST_OAUTH_STATE, output.get("criOAuthSessionId"));
+        assertEquals(clientOAuthSessionItem.getClientOAuthSessionId(), output.get("clientOAuthSessionId"));
     }
 
     @Test

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -234,7 +234,10 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         Map<String, Object> output =
                 underTest.handleRequest(criCallbackRequestWithoutSessionId, context);
 
-        assertEquals("/journey/access-denied", output.get("journey"));
+        assertEquals(HttpStatus.SC_UNAUTHORIZED, output.get(STATUS_CODE));
+        assertEquals("pyi-timeout-recoverable", output.get(PAGE));
+        assertEquals("error", output.get(TYPE));
+        assertEquals(TEST_OAUTH_STATE, output.get("criOAuthSessionId"));
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -55,12 +55,6 @@ public class IpvSessionService {
         return dataStore.getItem(ipvSessionId);
     }
 
-    public Optional<IpvSessionItem> getIpvSessionByCriOAuthSessionId(String criOAuthSessionId) {
-        IpvSessionItem ipvSessionItem =
-                dataStore.getItemByIndex("criOAuthSessionId", criOAuthSessionId);
-        return Optional.ofNullable(ipvSessionItem);
-    }
-
     public Optional<IpvSessionItem> getIpvSessionByAuthorizationCode(String authorizationCode) {
         IpvSessionItem ipvSessionItem =
                 dataStore.getItemByIndex(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -59,23 +59,6 @@ class IpvSessionServiceTest {
     }
 
     @Test
-    void shouldReturnSessionItemByCriOAuthSessionId() {
-        String ipvSessionID = SecureTokenHelper.generate();
-        String criOAuthSessionId = "test-session-id";
-
-        IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(ipvSessionID);
-
-        when(mockDataStore.getItemByIndex(eq("criOAuthSessionId"), anyString()))
-                .thenReturn(ipvSessionItem);
-
-        IpvSessionItem result =
-                ipvSessionService.getIpvSessionByCriOAuthSessionId(criOAuthSessionId).orElseThrow();
-
-        assertEquals(result, ipvSessionItem);
-    }
-
-    @Test
     void shouldReturnSessionItemByAuthorizationCode() {
         String ipvSessionID = SecureTokenHelper.generate();
         String authorizationCode = "12345";


### PR DESCRIPTION
## Proposed changes

### What changed

Updates validate-cri-callback lambda to return pyi-timeout-recoverable journey when no ipvSessionId
Removes ability to lookup ipvSession by criOAuthSessionId

### Why did it change

Required to support mobile app browser change bug

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2645](https://govukverify.atlassian.net/browse/PYIC-2645)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2645]: https://govukverify.atlassian.net/browse/PYIC-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ