### PR TITLE
[PYIC-2649] Store clientOAuthSessionId in criOAuthSession table

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -347,7 +347,8 @@ public class BuildCriOauthRequestHandler
     }
 
     @Tracing
-    private void persistCriOauthState(String oauthState, String criId, String clientOAuthSessionId) {
+    private void persistCriOauthState(
+            String oauthState, String criId, String clientOAuthSessionId) {
         criOAuthSessionService.persistCriOAuthSession(oauthState, criId, clientOAuthSessionId);
     }
 }

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -141,9 +141,9 @@ public class BuildCriOauthRequestHandler
             }
 
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
+            String clientOAuthSessionId = ipvSessionItem.getClientOAuthSessionId();
             ClientOAuthSessionItem clientOAuthSessionItem =
-                    clientOAuthSessionDetailsService.getClientOAuthSession(
-                            ipvSessionItem.getClientOAuthSessionId());
+                    clientOAuthSessionDetailsService.getClientOAuthSession(clientOAuthSessionId);
 
             String userId = clientOAuthSessionItem.getUserId();
 
@@ -167,7 +167,7 @@ public class BuildCriOauthRequestHandler
 
             persistOauthState(ipvSessionItem, criId, oauthState);
 
-            persistCriOauthState(oauthState, criId);
+            persistCriOauthState(oauthState, criId, clientOAuthSessionId);
 
             AuditEventUser auditEventUser =
                     new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
@@ -347,7 +347,7 @@ public class BuildCriOauthRequestHandler
     }
 
     @Tracing
-    private void persistCriOauthState(String oauthState, String criId) {
-        criOAuthSessionService.persistCriOAuthSession(oauthState, criId);
+    private void persistCriOauthState(String oauthState, String criId, String clientOAuthSessionId) {
+        criOAuthSessionService.persistCriOAuthSession(oauthState, criId, clientOAuthSessionId);
     }
 }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -179,6 +179,7 @@ class BuildCriOauthRequestHandlerTest {
         criOAuthSessionItem =
                 CriOAuthSessionItem.builder()
                         .criOAuthSessionId(CRI_OAUTH_SESSION_ID)
+                        .clientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID)
                         .criId(CRI_ID)
                         .accessToken("testAccessToken")
                         .authorizationCode("testAuthorizationCode")
@@ -237,7 +238,7 @@ class BuildCriOauthRequestHandlerTest {
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1), IPV_ISSUER),
                                 generateVerifiableCredential(
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2), IPV_ISSUER)));
-        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any()))
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
                 .thenReturn(criOAuthSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -286,7 +287,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(
                 AuditEventTypes.IPV_REDIRECT_TO_CRI, auditEventCaptor.getValue().getEventName());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any());
+        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any(), any());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -312,7 +313,7 @@ class BuildCriOauthRequestHandlerTest {
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1), IPV_ISSUER),
                                 generateVerifiableCredential(
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2), IPV_ISSUER)));
-        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any()))
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
                 .thenReturn(criOAuthSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -362,7 +363,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(
                 AuditEventTypes.IPV_REDIRECT_TO_CRI, auditEventCaptor.getValue().getEventName());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any());
+        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any(), any());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -441,7 +442,7 @@ class BuildCriOauthRequestHandlerTest {
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1), IPV_ISSUER),
                                 generateVerifiableCredential(
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1), IPV_ISSUER)));
-        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any()))
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
                 .thenReturn(criOAuthSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -473,7 +474,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(2, sharedClaims.get("birthDate").size());
         assertEquals(2, sharedClaims.get("address").size());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any());
+        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any(), any());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -498,7 +499,7 @@ class BuildCriOauthRequestHandlerTest {
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2), IPV_ISSUER),
                                 generateVerifiableCredential(
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3), IPV_ISSUER)));
-        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any()))
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
                 .thenReturn(criOAuthSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -528,7 +529,7 @@ class BuildCriOauthRequestHandlerTest {
         JsonNode sharedClaims = claimsSet.get(TEST_SHARED_CLAIMS);
         assertEquals(2, sharedClaims.get("name").size());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any());
+        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any(), any());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -553,7 +554,7 @@ class BuildCriOauthRequestHandlerTest {
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3), IPV_ISSUER),
                                 generateVerifiableCredential(
                                         vcClaim(CREDENTIAL_ATTRIBUTES_4), IPV_ISSUER)));
-        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any()))
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
                 .thenReturn(criOAuthSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -602,7 +603,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals("FamilyName", name2NameParts.get(2).get("type").asText());
         assertEquals("Doe", name2NameParts.get(2).get("value").asText());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any());
+        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any(), any());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -629,7 +630,7 @@ class BuildCriOauthRequestHandlerTest {
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2), IPV_ISSUER),
                                 generateVerifiableCredential(
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3), ADDRESS_ISSUER)));
-        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any()))
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
                 .thenReturn(criOAuthSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -661,7 +662,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(2, sharedClaims.get("birthDate").size());
         assertEquals(1, sharedClaims.get("address").size());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any());
+        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any(), any());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -686,7 +687,7 @@ class BuildCriOauthRequestHandlerTest {
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1), IPV_ISSUER),
                                 generateVerifiableCredential(
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2), ADDRESS_ISSUER)));
-        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any()))
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
                 .thenReturn(criOAuthSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -718,7 +719,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(2, sharedClaims.get("birthDate").size());
         assertEquals(2, sharedClaims.get("address").size());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any());
+        verify(mockCriOAuthSessionService, times(1)).persistCriOAuthSession(any(), any(), any());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -745,7 +746,7 @@ class BuildCriOauthRequestHandlerTest {
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2), IPV_ISSUER),
                                 generateVerifiableCredential(
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3), ADDRESS_ISSUER)));
-        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any()))
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
                 .thenReturn(criOAuthSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/CriOAuthSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/CriOAuthSessionItem.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @AllArgsConstructor
 public class CriOAuthSessionItem implements DynamodbItem {
     private String criOAuthSessionId;
+    private String clientOAuthSessionId;
     private String criId;
     private String accessToken;
     private String authorizationCode;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
@@ -38,10 +38,15 @@ public class CriOAuthSessionService {
         return dataStore.getItem(criOAuthSessionId);
     }
 
-    public CriOAuthSessionItem persistCriOAuthSession(String state, String criId, String clientOAuthSessionId) {
+    public CriOAuthSessionItem persistCriOAuthSession(
+            String state, String criId, String clientOAuthSessionId) {
 
         CriOAuthSessionItem criOAuthSessionItem =
-                CriOAuthSessionItem.builder().criOAuthSessionId(state).criId(criId).clientOAuthSessionId(clientOAuthSessionId).build();
+                CriOAuthSessionItem.builder()
+                        .criOAuthSessionId(state)
+                        .criId(criId)
+                        .clientOAuthSessionId(clientOAuthSessionId)
+                        .build();
 
         dataStore.create(criOAuthSessionItem, BACKEND_SESSION_TTL);
         LOGGER.info(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
@@ -38,10 +38,10 @@ public class CriOAuthSessionService {
         return dataStore.getItem(criOAuthSessionId);
     }
 
-    public CriOAuthSessionItem persistCriOAuthSession(String state, String criId) {
+    public CriOAuthSessionItem persistCriOAuthSession(String state, String criId, String clientOAuthSessionId) {
 
         CriOAuthSessionItem criOAuthSessionItem =
-                CriOAuthSessionItem.builder().criOAuthSessionId(state).criId(criId).build();
+                CriOAuthSessionItem.builder().criOAuthSessionId(state).criId(criId).clientOAuthSessionId(clientOAuthSessionId).build();
 
         dataStore.create(criOAuthSessionItem, BACKEND_SESSION_TTL);
         LOGGER.info(

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionServiceTest.java
@@ -64,7 +64,7 @@ class CriOAuthSessionServiceTest {
 
         CriOAuthSessionItem result =
                 criOauthSessionService.persistCriOAuthSession(
-                        criOAuthSessionItem.getCriOAuthSessionId(), criOAuthSessionItem.getCriId());
+                        criOAuthSessionItem.getCriOAuthSessionId(), criOAuthSessionItem.getCriId(), criOAuthSessionItem.getClientOAuthSessionId());
 
         ArgumentCaptor<CriOAuthSessionItem> criOAuthSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(CriOAuthSessionItem.class);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionServiceTest.java
@@ -64,7 +64,9 @@ class CriOAuthSessionServiceTest {
 
         CriOAuthSessionItem result =
                 criOauthSessionService.persistCriOAuthSession(
-                        criOAuthSessionItem.getCriOAuthSessionId(), criOAuthSessionItem.getCriId(), criOAuthSessionItem.getClientOAuthSessionId());
+                        criOAuthSessionItem.getCriOAuthSessionId(),
+                        criOAuthSessionItem.getCriId(),
+                        criOAuthSessionItem.getClientOAuthSessionId());
 
         ArgumentCaptor<CriOAuthSessionItem> criOAuthSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(CriOAuthSessionItem.class);


### PR DESCRIPTION
Store clientOAuthSessionId in criOAuthSession table

## Proposed changes

### What changed

Add clientOAuthSessionId to persistence for the criOAuthSession in the buildCriOauthRequest lambda

### Why did it change

Required to lookup clientOAuthSessions based on criOAuthSessionId

### Issue tracking

- [PYIC-2649](https://govukverify.atlassian.net/browse/PYIC-2649)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2649]: https://govukverify.atlassian.net/browse/PYIC-2649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ