### PR TITLE
PYIC-2582 Change made to handle scenario when ipvSession is null in h…

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -31,7 +31,10 @@ import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
-import uk.gov.di.ipv.core.library.service.*;
+import uk.gov.di.ipv.core.library.service.AuditService;
+import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -103,8 +106,6 @@ public class BuildClientOauthResponseHandler
                                 .with("message", "No ipvSession for existing ClientOAuthSession")
                                 .with("clientOAuthSessionId", clientSessionId);
                 LOGGER.info(mapMessage);
-                // We don't have ipvSession here.....should we generate a IPVSession here with this
-                // clientSessionId and then update its auth code below
             } else {
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_SESSION_ID);

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -89,7 +89,7 @@ public class BuildProvenUserIdentityDetailsHandler
         ProvenUserIdentityDetails.ProvenUserIdentityDetailsBuilder
                 provenUserIdentityDetailsBuilder = ProvenUserIdentityDetails.builder();
         try {
-            String ipvSessionId = RequestHelper.getIpvSessionId(input.getHeaders());
+            String ipvSessionId = RequestHelper.getIpvSessionId(input);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
 
             ClientOAuthSessionItem clientOAuthSessionItem =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -15,6 +15,7 @@ public enum ErrorResponse {
     INVALID_CREDENTIAL_ISSUER_ID(1008, "Invalid credential issuer id"),
     INVALID_TOKEN_REQUEST(1009, "Invalid token request"),
     MISSING_IPV_SESSION_ID(1010, "Missing ipv session id header"),
+    MISSING_SESSION_ID(1010, "Missing ipv session id and client session id in header"),
     MISSING_IP_ADDRESS(1010, "Missing ip address header"),
     FAILED_TO_GET_CREDENTIAL_FROM_ISSUER(1011, "Failed to get credential from issuer"),
     FAILED_TO_SAVE_CREDENTIAL(1012, "Failed to save credential"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -15,8 +15,6 @@ public enum ErrorResponse {
     INVALID_CREDENTIAL_ISSUER_ID(1008, "Invalid credential issuer id"),
     INVALID_TOKEN_REQUEST(1009, "Invalid token request"),
     MISSING_IPV_SESSION_ID(1010, "Missing ipv session id header"),
-    MISSING_SESSION_ID(1010, "Missing ipv session id and client session id in header"),
-    MISSING_IP_ADDRESS(1010, "Missing ip address header"),
     FAILED_TO_GET_CREDENTIAL_FROM_ISSUER(1011, "Failed to get credential from issuer"),
     FAILED_TO_SAVE_CREDENTIAL(1012, "Failed to save credential"),
     FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS(
@@ -50,7 +48,9 @@ public enum ErrorResponse {
     FAILED_TO_SEND_AUDIT_EVENT(1040, "Failed to send audit event"),
     FAILED_TO_INITIALISE_STATE_MACHINE(1041, "Failed to initialise state machine"),
     FAILED_TO_GENERATE_PROVEN_USER_IDENTITY_DETAILS(
-            1042, "Failed to generate the proven user identity details");
+            1042, "Failed to generate the proven user identity details"),
+    MISSING_SESSION_ID(1043, "Missing ipv session id and client session id in header"),
+    MISSING_IP_ADDRESS(1044, "Missing ip address header");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -24,6 +24,7 @@ public class LogHelper {
         ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
         GOVUK_SIGNIN_JOURNEY_ID_FIELD("govuk_signin_journey_id"),
         IPV_SESSION_ID_LOG_FIELD("ipvSessionId"),
+        CLIENT_SESSION_ID_LOG_FIELD("clientSessionId"),
         JTI_LOG_FIELD("jti"),
         JTI_USED_AT_LOG_FIELD("jtiUsedAt"),
         NUMBER_OF_VCS("numberOfVCs"),
@@ -59,6 +60,10 @@ public class LogHelper {
 
     public static void attachIpvSessionIdToLogs(String sessionId) {
         attachFieldToLogs(LogField.IPV_SESSION_ID_LOG_FIELD, sessionId);
+    }
+
+    public static void attachClientSessionIdToLogs(String sessionId) {
+        attachFieldToLogs(LogField.CLIENT_SESSION_ID_LOG_FIELD, sessionId);
     }
 
     public static void attachGovukSigninJourneyIdToLogs(String govukSigninJourneyId) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -97,10 +97,11 @@ public class RequestHelper {
             throws HttpResponseExceptionWithErrorBody {
         String ipvSessionId = RequestHelper.getHeaderByKey(headers, IPV_SESSION_ID_HEADER);
         if (ipvSessionId == null) {
+            String message = String.format("%s not present in header", IPV_SESSION_ID_HEADER);
             if (allowNull) {
-                LOGGER.warn("{} not present in header", IPV_SESSION_ID_HEADER);
+                LOGGER.warn(message);
             } else {
-                LOGGER.error("{} not present in header", IPV_SESSION_ID_HEADER);
+                LOGGER.error(message);
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
             }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -17,8 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.*;
 
 class RequestHelperTest {
 
@@ -107,6 +106,30 @@ class RequestHelperTest {
     }
 
     @Test
+    void getIpvSessionIdShouldReturnNullIfSessionIdIsNull()
+            throws HttpResponseExceptionWithErrorBody {
+        var event = new APIGatewayProxyRequestEvent();
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(IPV_SESSION_ID_HEADER, null);
+
+        event.setHeaders(headers);
+
+        assertNull(RequestHelper.getIpvSessionIdAllowNull(event));
+    }
+
+    @Test
+    void getIpvSessionIdShouldReturnNullIfSessionIdIsEmpty()
+            throws HttpResponseExceptionWithErrorBody {
+        var event = new APIGatewayProxyRequestEvent();
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(IPV_SESSION_ID_HEADER, "");
+
+        event.setHeaders(headers);
+
+        assertNull(RequestHelper.getIpvSessionIdAllowNull(event));
+    }
+
+    @Test
     void getIpAddressShouldReturnIpAddress() throws HttpResponseExceptionWithErrorBody {
         var event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(IP_ADDRESS_HEADER, "a-client-source-ip"));
@@ -148,5 +171,24 @@ class RequestHelperTest {
         assertEquals(
                 ErrorResponse.MISSING_IP_ADDRESS.getMessage(),
                 exception.getErrorResponse().getMessage());
+    }
+
+    @Test
+    void getClientOAuthSessionIdShouldReturnClientSessionId() {
+        var event = new APIGatewayProxyRequestEvent();
+        String clientSessionIdInHeader = "client-session-id";
+        event.setHeaders(Map.of(CLIENT_SESSION_ID_HEADER, clientSessionIdInHeader));
+
+        assertEquals(clientSessionIdInHeader, RequestHelper.getClientOAuthSessionId(event));
+    }
+
+    @Test
+    void getClientOAuthSessionIdShouldReturnNullIfClientSessionIdIsNull() {
+        var event = new APIGatewayProxyRequestEvent();
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(CLIENT_SESSION_ID_HEADER, null);
+        event.setHeaders(headers);
+
+        assertNull(RequestHelper.getClientOAuthSessionId(event));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -17,7 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.*;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.CLIENT_SESSION_ID_HEADER;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
 
 class RequestHelperTest {
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Handle scenario cross browser situation when ipvSession is null in header.
### What changed
Change made to handle scenario when ipvSession is null in header instead use clientSessionId in header.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2582](https://govukverify.atlassian.net/browse/PYIC-2582)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2582]: https://govukverify.atlassian.net/browse/PYIC-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ