### PR TITLE
PYIC-2667 Use new CRI config api key flags

### DIFF
--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -141,7 +141,8 @@ class BuildCriOauthRequestHandlerTest {
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
                         "http://www.example.com/audience",
-                        URI.create("http://www.example.com/callback/criId"));
+                        URI.create("http://www.example.com/callback/criId"),
+                        true);
 
         addressCredentialIssuerConfig =
                 new CredentialIssuerConfig(
@@ -152,7 +153,8 @@ class BuildCriOauthRequestHandlerTest {
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
                         ADDRESS_ISSUER,
-                        URI.create("http://www.example.com/callback/criId"));
+                        URI.create("http://www.example.com/callback/criId"),
+                        true);
 
         dcmawCredentialIssuerConfig =
                 new CredentialIssuerConfig(
@@ -163,7 +165,8 @@ class BuildCriOauthRequestHandlerTest {
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
                         "http://www.example.com/audience",
-                        URI.create("http://www.example.com/callback/criId"));
+                        URI.create("http://www.example.com/callback/criId"),
+                        true);
 
         kbvCredentialIssuerConfig =
                 new CredentialIssuerConfig(
@@ -174,7 +177,8 @@ class BuildCriOauthRequestHandlerTest {
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
                         "http://www.example.com/audience",
-                        URI.create("http://www.example.com/callback/criId"));
+                        URI.create("http://www.example.com/callback/criId"),
+                        true);
 
         criOAuthSessionItem =
                 CriOAuthSessionItem.builder()

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -106,7 +106,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
@@ -118,7 +119,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -170,7 +172,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
@@ -182,7 +185,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -239,7 +243,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
@@ -251,7 +256,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -284,7 +290,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
@@ -342,7 +349,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
@@ -354,7 +362,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("fraud"))
                 .thenReturn(
@@ -366,7 +375,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-f.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("kbv"))
                 .thenReturn(
@@ -378,7 +388,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-k.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         APIGatewayProxyRequestEvent input = createRequestEvent();
@@ -431,7 +442,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
@@ -443,7 +455,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("fraud"))
                 .thenReturn(
@@ -455,7 +468,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-f.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("kbv"))
                 .thenReturn(
@@ -467,7 +481,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "test-jwk",
                                 "test-jwk",
                                 "https://review-k.integration.account.gov.uk",
-                                URI.create("https://example.com/callback")));
+                                URI.create("https://example.com/callback"),
+                                true));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         APIGatewayProxyRequestEvent input = createRequestEvent();

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -96,7 +96,8 @@ class CheckExistingIdentityHandlerTest {
                             "test-jwk",
                             "test-encryption-jwk",
                             "test-audience",
-                            new URI("http://example.com/redirect"));
+                            new URI("http://example.com/redirect"),
+                            true);
         } catch (URISyntaxException e) {
             e.printStackTrace();
         }

--- a/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandlerTest.java
+++ b/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandlerTest.java
@@ -663,7 +663,8 @@ class EndMitigationJourneyHandlerTest {
                 "test-jwk",
                 "test-jwk",
                 "test-fraud-iss",
-                URI.create("http://example.com/callback"));
+                URI.create("http://example.com/callback"),
+                true);
     }
 
     private SignedJWT generateTestVc(String iss, long nbf, List<String> cis)

--- a/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01ValidationTest.java
+++ b/lambdas/end-mitigation-journey/src/test/java/uk/gov/di/ipv/core/endmitigationjourney/validation/Mj01ValidationTest.java
@@ -205,7 +205,8 @@ class Mj01ValidationTest {
                 "test-jwk",
                 "test-jwk",
                 "test-fraud-iss",
-                URI.create("http://example.com/callback"));
+                URI.create("http://example.com/callback"),
+                true);
     }
 
     private SignedJWT generateTestVc(String iss, long nbf, List<String> cis)

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoreHandlerTest.java
@@ -104,7 +104,8 @@ class EvaluateGpg45ScoreHandlerTest {
                             "test-jwk",
                             "test-encryption-jwk",
                             "test-audience",
-                            new URI("http://example.com/redirect"));
+                            new URI("http://example.com/redirect"),
+                            true);
         } catch (URISyntaxException e) {
             e.printStackTrace();
         }

--- a/lambdas/get-credential-issuer-config/src/test/java/uk/gov/di/ipv/core/getcredentialisserconfig/GetCredentialIssuerConfigHandlerTest.java
+++ b/lambdas/get-credential-issuer-config/src/test/java/uk/gov/di/ipv/core/getcredentialisserconfig/GetCredentialIssuerConfigHandlerTest.java
@@ -39,7 +39,8 @@ class GetCredentialIssuerConfigHandlerTest {
                             EC_PUBLIC_JWK,
                             RSA_ENCRYPTION_PUBLIC_JWK,
                             "test-audience",
-                            URI.create("testRedirectUrl")),
+                            URI.create("testRedirectUrl"),
+                            true),
                     new CredentialIssuerConfig(
                             URI.create("test2TokenUrl"),
                             URI.create("test2credentialUrl"),
@@ -48,7 +49,8 @@ class GetCredentialIssuerConfigHandlerTest {
                             EC_PUBLIC_JWK,
                             RSA_ENCRYPTION_PUBLIC_JWK,
                             "test-audience",
-                            URI.create("test2RedirectUrl")));
+                            URI.create("test2RedirectUrl"),
+                            true));
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -141,7 +141,10 @@ public class RetrieveCriCredentialHandler
             CredentialIssuerConfig credentialIssuerConfig =
                     configService.getCredentialIssuerActiveConnectionConfig(credentialIssuerId);
 
-            String apiKey = configService.getCriPrivateApiKey(credentialIssuerId);
+            String apiKey =
+                    credentialIssuerConfig.requiresApiKey()
+                            ? configService.getCriPrivateApiKey(credentialIssuerId)
+                            : null;
 
             List<SignedJWT> verifiableCredentials =
                     credentialIssuerService.getVerifiableCredential(

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -142,7 +142,7 @@ public class RetrieveCriCredentialHandler
                     configService.getCredentialIssuerActiveConnectionConfig(credentialIssuerId);
 
             String apiKey =
-                    credentialIssuerConfig.requiresApiKey()
+                    credentialIssuerConfig.getRequiresApiKey()
                             ? configService.getCriPrivateApiKey(credentialIssuerId)
                             : null;
 

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -104,7 +104,7 @@ public class RetrieveCriOauthAccessTokenHandler
                     getCredentialIssuerConfig(credentialIssuerId);
 
             String apiKey =
-                    credentialIssuerConfig.requiresApiKey()
+                    credentialIssuerConfig.getRequiresApiKey()
                             ? configService.getCriPrivateApiKey(credentialIssuerId)
                             : null;
 

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -103,7 +103,10 @@ public class RetrieveCriOauthAccessTokenHandler
             CredentialIssuerConfig credentialIssuerConfig =
                     getCredentialIssuerConfig(credentialIssuerId);
 
-            String apiKey = configService.getCriPrivateApiKey(credentialIssuerId);
+            String apiKey =
+                    credentialIssuerConfig.requiresApiKey()
+                            ? configService.getCriPrivateApiKey(credentialIssuerId)
+                            : null;
 
             BearerAccessToken accessToken =
                     credentialIssuerService.exchangeCodeForToken(

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -816,7 +816,8 @@ class SelectCriHandlerTest {
                 "test-jwk",
                 "test-jwk",
                 criIss,
-                new URI("http://example.com/redirect"));
+                new URI("http://example.com/redirect"),
+                true);
     }
 
     private ClientOAuthSessionItem getClientOAuthSessionItem() {

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -528,6 +528,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 "test-jwk",
                 "test-jwk",
                 criIss,
-                new URI("http://www.example.com/credential-issuers/callback/criId"));
+                new URI("http://www.example.com/credential-issuers/callback/criId"),
+                true);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -35,7 +35,7 @@ public class CredentialIssuerConfig {
             String encryptionKey,
             String componentId,
             URI clientCallbackUrl,
-            Boolean requiresApiKey) {
+            boolean requiresApiKey) {
         this.tokenUrl = tokenUrl;
         this.credentialUrl = credentialUrl;
         this.authorizeUrl = authorizeUrl;
@@ -89,7 +89,7 @@ public class CredentialIssuerConfig {
         return clientCallbackUrl;
     }
 
-    public boolean requiresApiKey() {
+    public boolean getRequiresApiKey() {
         return requiresApiKey;
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/CredentialIssuerConfig.java
@@ -21,6 +21,7 @@ public class CredentialIssuerConfig {
     private String encryptionKey;
     private String componentId;
     private URI clientCallbackUrl;
+    private boolean requiresApiKey;
 
     public CredentialIssuerConfig() {}
 
@@ -33,7 +34,8 @@ public class CredentialIssuerConfig {
             String signingKey,
             String encryptionKey,
             String componentId,
-            URI clientCallbackUrl) {
+            URI clientCallbackUrl,
+            Boolean requiresApiKey) {
         this.tokenUrl = tokenUrl;
         this.credentialUrl = credentialUrl;
         this.authorizeUrl = authorizeUrl;
@@ -42,6 +44,7 @@ public class CredentialIssuerConfig {
         this.encryptionKey = encryptionKey;
         this.componentId = componentId;
         this.clientCallbackUrl = clientCallbackUrl;
+        this.requiresApiKey = requiresApiKey;
     }
 
     public URI getTokenUrl() {
@@ -84,6 +87,10 @@ public class CredentialIssuerConfig {
 
     public URI getClientCallbackUrl() {
         return clientCallbackUrl;
+    }
+
+    public boolean requiresApiKey() {
+        return requiresApiKey;
     }
 
     @Override

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -275,7 +275,7 @@ public class ConfigService {
                     "Parameter value is not valid for the current state of the resource, details: {}",
                     e.getMessage());
         } catch (ResourceNotFoundException e) {
-            LOGGER.warn(
+            LOGGER.error(
                     "Failed to find the resource within Secrets manager: {}, details: {}",
                     secretId,
                     e.getMessage());

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -117,7 +117,9 @@ class ConfigServiceTest {
                         "credentialUrl",
                         TEST_CREDENTIAL_URL,
                         "encryptionKey",
-                        RSA_ENCRYPTION_PUBLIC_JWK);
+                        RSA_ENCRYPTION_PUBLIC_JWK,
+                        "requiresApiKey",
+                        "true");
         when(ssmProvider.get("/dev/core/credentialIssuers/passportCri/activeConnection"))
                 .thenReturn("stub");
 
@@ -142,6 +144,7 @@ class ConfigServiceTest {
         assertEquals(expected.getTokenUrl(), result.getTokenUrl());
         assertEquals(expected.getCredentialUrl(), result.getCredentialUrl());
         assertEquals("RSA", result.getEncryptionKey().getKeyType().toString());
+        assertTrue(result.getRequiresApiKey());
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -136,7 +136,8 @@ class ConfigServiceTest {
                         "{}",
                         RSA_ENCRYPTION_PUBLIC_JWK,
                         "test-audience",
-                        URI.create(TEST_REDIRECT_URL));
+                        URI.create(TEST_REDIRECT_URL),
+                        true);
 
         assertEquals(expected.getTokenUrl(), result.getTokenUrl());
         assertEquals(expected.getCredentialUrl(), result.getCredentialUrl());

--- a/libs/credential-issuer-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerService.java
+++ b/libs/credential-issuer-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerService.java
@@ -112,7 +112,7 @@ public class CredentialIssuerService {
             HTTPRequest httpRequest = tokenRequest.toHTTPRequest();
             if (apiKey != null) {
                 LOGGER.info(
-                        "Private api key found for cri {}, sending key in header for token request",
+                        "CRI {} has API key, sending key in header for token request",
                         credentialIssuerId);
                 httpRequest.setHeader(API_KEY_HEADER, apiKey);
             }
@@ -160,7 +160,7 @@ public class CredentialIssuerService {
 
         if (apiKey != null) {
             LOGGER.info(
-                    "Private api key found for cri {}, sending key in header for credential request",
+                    "CRI {} has API key, sending key in header for credential request",
                     credentialIssuerId);
             credentialRequest.setHeader(API_KEY_HEADER, apiKey);
         }

--- a/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerServiceTest.java
+++ b/libs/credential-issuer-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerServiceTest.java
@@ -466,7 +466,8 @@ class CredentialIssuerServiceTest {
                 URI.create(
                         "http://localhost:"
                                 + wmRuntimeInfo.getHttpPort()
-                                + "/credential-issuer/callback?id=StubPassport"));
+                                + "/credential-issuer/callback?id=StubPassport"),
+                true);
     }
 
     private ECPrivateKey getPrivateKey() throws InvalidKeySpecException, NoSuchAlgorithmException {

--- a/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
+++ b/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
@@ -34,7 +34,8 @@ class VcHelperTest {
                             "test-jwk",
                             "test-encryption-jwk",
                             "https://review-a.integration.account.gov.uk",
-                            new URI("https://example.com/redirect"));
+                            new URI("https://example.com/redirect"),
+                            true);
         } catch (URISyntaxException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Proposed changes

### What changed

Use new `requiresApiKey` flags in the CRI config to check whether the CRI requires an api key or not, and only try to fetch the api key if it does require one.

### Why did it change

In the retrieve CRI access token + credential lambdas we always try to retrieve the CRI's api key from secrets manager. In cases where the CRI or env doesn't need an api key, this causes an unnecessary call to secrets provider and results in a warning log to say the api key wasn't found. 

This prevents this by using a new flag in the CRI config to check whether the CRI requires an api key or not. Also makes the existing log error level, so it's flagged as an error when the api key is missing when we actually expect it to be there.

### Issue tracking
- [PYIC-2667](https://govukverify.atlassian.net/browse/PYIC-2667)



[PYIC-2667]: https://govukverify.atlassian.net/browse/PYIC-2667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ