### PR TITLE
[PYIC-2674] Allow auth requests with no IpvSessionId

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/validation/AuthRequestValidator.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/validation/AuthRequestValidator.java
@@ -20,6 +20,7 @@ public class AuthRequestValidator {
     public static final String REDIRECT_URI_PARAM = "redirect_uri";
     public static final String STATE_PARAM = "state";
     private static final String IPV_SESSION_ID_HEADER_KEY = "ipv-session-id";
+    private static final String CLIENT_SESSION_ID_HEADER_KEY = "client-session-id";
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final ConfigService configService;
@@ -35,9 +36,9 @@ public class AuthRequestValidator {
             return new ValidationResult<>(false, ErrorResponse.MISSING_QUERY_PARAMETERS);
         }
 
-        if (sessionIdMissing(requestHeaders)) {
-            LOGGER.error("Missing IPV session ID from headers");
-            return new ValidationResult<>(false, ErrorResponse.MISSING_IPV_SESSION_ID);
+        if (sessionIdMissing(requestHeaders) && clientSessionIdMissing(requestHeaders)) {
+            LOGGER.error("Missing IPV session and client session ID from headers");
+            return new ValidationResult<>(false, ErrorResponse.MISSING_SESSION_ID);
         }
 
         var errorResult = validateRedirectUrl(queryStringParameters);
@@ -53,6 +54,11 @@ public class AuthRequestValidator {
     private boolean sessionIdMissing(Map<String, String> requestHeaders) {
         return StringUtils.isBlank(
                 RequestHelper.getHeaderByKey(requestHeaders, IPV_SESSION_ID_HEADER_KEY));
+    }
+
+    private boolean clientSessionIdMissing(Map<String, String> requestHeaders) {
+        return StringUtils.isBlank(
+                RequestHelper.getHeaderByKey(requestHeaders, CLIENT_SESSION_ID_HEADER_KEY));
     }
 
     private Optional<ErrorResponse> validateRedirectUrl(

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/validation/AuthRequestValidatorTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/validation/AuthRequestValidatorTest.java
@@ -29,9 +29,10 @@ class AuthRequestValidatorTest {
     private static final String RESPONSE_TYPE_PARAM = "response_type";
     private static final String SCOPE_PARAM = "scope";
     private static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
+    private static final String CLIENT_SESSION_ID_HEADER = "client-session-id";
 
     private static final Map<String, String> REQUEST_HEADERS =
-            Map.of(IPV_SESSION_ID_HEADER, "12345");
+            Map.of(IPV_SESSION_ID_HEADER, "12345", CLIENT_SESSION_ID_HEADER, "12345");
     private static final Map<String, List<String>> VALID_QUERY_STRING_PARAMS =
             Map.of(
                     REDIRECT_URI_PARAM, List.of("http://example.com"),
@@ -84,32 +85,41 @@ class AuthRequestValidatorTest {
     }
 
     @Test
-    void validateRequestReturnsErrorResponseForMissingSessionId() {
+    void validateRequestReturnsErrorResponseForMissingSessionIds() {
         var validationResult =
                 validator.validateRequest(VALID_QUERY_STRING_PARAMS, Collections.emptyMap());
 
         assertFalse(validationResult.isValid());
         assertEquals(
-                ErrorResponse.MISSING_IPV_SESSION_ID.getCode(),
-                validationResult.getError().getCode());
+                ErrorResponse.MISSING_SESSION_ID.getCode(), validationResult.getError().getCode());
         assertEquals(
-                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                ErrorResponse.MISSING_SESSION_ID.getMessage(),
                 validationResult.getError().getMessage());
     }
 
     @Test
-    void validateRequestReturnsErrorResponseForBlankSessionId() {
+    void validateRequestReturnsErrorResponseForBlankSessionIds() {
         var validationResult =
                 validator.validateRequest(
-                        VALID_QUERY_STRING_PARAMS, Map.of(IPV_SESSION_ID_HEADER, ""));
+                        VALID_QUERY_STRING_PARAMS,
+                        Map.of(IPV_SESSION_ID_HEADER, "", CLIENT_SESSION_ID_HEADER, ""));
 
         assertFalse(validationResult.isValid());
         assertEquals(
-                ErrorResponse.MISSING_IPV_SESSION_ID.getCode(),
-                validationResult.getError().getCode());
+                ErrorResponse.MISSING_SESSION_ID.getCode(), validationResult.getError().getCode());
         assertEquals(
-                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                ErrorResponse.MISSING_SESSION_ID.getMessage(),
                 validationResult.getError().getMessage());
+    }
+
+    @Test
+    void validateRequestReturnValidResultForBlankIpvSessionId() {
+        var validationResult =
+                validator.validateRequest(
+                        VALID_QUERY_STRING_PARAMS,
+                        Map.of(IPV_SESSION_ID_HEADER, "", CLIENT_SESSION_ID_HEADER, "12345"));
+
+        assertTrue(validationResult.isValid());
     }
 
     @Test

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/validation/AuthRequestValidatorTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/validation/AuthRequestValidatorTest.java
@@ -114,6 +114,8 @@ class AuthRequestValidatorTest {
 
     @Test
     void validateRequestReturnValidResultForBlankIpvSessionId() {
+        when(mockConfigService.getClientRedirectUrls("12345"))
+                .thenReturn(List.of("http://example.com"));
         var validationResult =
                 validator.validateRequest(
                         VALID_QUERY_STRING_PARAMS,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Additional validation to consider clientSessionId in headers as well

### Why did it change

Requests without ipvSessionId are considered valid as long as there is a clientSessionId instead

### Issue tracking

- [PYIC-2674](https://govukverify.atlassian.net/browse/PYIC-2674)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2674]: https://govukverify.atlassian.net/browse/PYIC-2674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ