### PR TITLE
[PYIC-2675] Generate clientOAuthSessionId error page

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
@@ -91,7 +92,7 @@ public class BuildClientOauthResponseHandler
 
             LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
 
-            IpvSessionItem ipvSessionItem = null;
+            IpvSessionItem ipvSessionItem;
             ClientOAuthSessionItem clientOAuthSessionItem;
             if (!StringUtils.isBlank(ipvSessionId)) {
                 ipvSessionItem = sessionService.getIpvSession(ipvSessionId);
@@ -103,9 +104,14 @@ public class BuildClientOauthResponseHandler
                         clientOAuthSessionService.getClientOAuthSession(clientSessionId);
                 var mapMessage =
                         new StringMapMessage()
-                                .with("message", "No ipvSession for existing ClientOAuthSession")
+                                .with(
+                                        "description",
+                                        "No ipvSession for existing ClientOAuthSession")
                                 .with("clientOAuthSessionId", clientSessionId);
                 LOGGER.info(mapMessage);
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        HttpStatus.SC_OK,
+                        generateClientOAuthSessionErrorResponse(clientOAuthSessionItem));
             } else {
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_SESSION_ID);
@@ -126,7 +132,7 @@ public class BuildClientOauthResponseHandler
 
             ClientResponse clientResponse;
 
-            if (ipvSessionItem != null && ipvSessionItem.getErrorCode() != null) {
+            if (ipvSessionItem.getErrorCode() != null) {
                 clientResponse =
                         generateClientErrorResponse(ipvSessionItem, clientOAuthSessionItem);
             } else {
@@ -141,14 +147,12 @@ public class BuildClientOauthResponseHandler
                 }
 
                 AuthorizationCode authorizationCode = new AuthorizationCode();
-                if (ipvSessionItem != null) {
-                    AuthorizationRequest authorizationRequest =
-                            AuthorizationRequest.parse(authParameters);
-                    sessionService.setAuthorizationCode(
-                            ipvSessionItem,
-                            authorizationCode.getValue(),
-                            authorizationRequest.getRedirectionURI().toString());
-                }
+                AuthorizationRequest authorizationRequest =
+                        AuthorizationRequest.parse(authParameters);
+                sessionService.setAuthorizationCode(
+                        ipvSessionItem,
+                        authorizationCode.getValue(),
+                        authorizationRequest.getRedirectionURI().toString());
 
                 clientResponse =
                         generateClientSuccessResponse(
@@ -205,6 +209,19 @@ public class BuildClientOauthResponseHandler
         URIBuilder uriBuilder = new URIBuilder(clientOAuthSessionItem.getRedirectUri());
         uriBuilder.addParameter("error", ipvSessionItem.getErrorCode());
         uriBuilder.addParameter("error_description", ipvSessionItem.getErrorDescription());
+
+        if (StringUtils.isNotBlank(clientOAuthSessionItem.getState())) {
+            uriBuilder.addParameter("state", clientOAuthSessionItem.getState());
+        }
+
+        return new ClientResponse(new ClientDetails(uriBuilder.build().toString()));
+    }
+
+    private ClientResponse generateClientOAuthSessionErrorResponse(
+            ClientOAuthSessionItem clientOAuthSessionItem) throws URISyntaxException {
+        URIBuilder uriBuilder = new URIBuilder(clientOAuthSessionItem.getRedirectUri());
+        uriBuilder.addParameter("error", OAuth2Error.ACCESS_DENIED.getCode());
+        uriBuilder.addParameter("error_description", "Missing Context");
 
         if (StringUtils.isNotBlank(clientOAuthSessionItem.getState())) {
             uriBuilder.addParameter("state", clientOAuthSessionItem.getState());


### PR DESCRIPTION
## Proposed changes

### What changed

Update `build-oauth-client-response` to return `ACCESS_DENIED` error after determining no ipv session but client oauth session present

### Why did it change

Redirect scenario

### Issue tracking

- [PYIC-2675](https://govukverify.atlassian.net/browse/PYIC-2675)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2675]: https://govukverify.atlassian.net/browse/PYIC-2675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ