### PR TITLE
The correlation should be against any VCs containing a name or a birth date

### DIFF
--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -188,7 +188,7 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void checkNameCorrelationInCredentialsReturnTrueWhenNameDiffer()
+    void checkNameCorrelationInCredentialsReturnFalseWhenNameDiffer()
             throws HttpResponseExceptionWithErrorBody {
         List<VcStoreItem> vcStoreItems =
                 List.of(
@@ -205,6 +205,122 @@ class UserIdentityServiceTest {
                         USER_ID_1, currentVcStatuses);
 
         assertFalse(isValid);
+    }
+
+    @Test
+    void checkNameCorrelationWithSameNamesAndMissingNameCredentialsForReturnTrue()
+            throws HttpResponseExceptionWithErrorBody {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_NAME,
+                                Instant.now()),
+                        createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_1, Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_NAME,
+                                Instant.now()),
+                        createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_1, Instant.now()));
+
+        List<VcStatusDto> currentVcStatuses = List.of(new VcStatusDto("test-issuer", true));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        when(mockConfigService.getComponentId(any())).thenReturn("test-issuer");
+
+        boolean isValid =
+                userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(
+                        USER_ID_1, currentVcStatuses);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void checkNameCorrelationWithMissingNameCredentialsForReturnTrue()
+            throws HttpResponseExceptionWithErrorBody {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_NAME,
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_NAME,
+                                Instant.now()));
+
+        List<VcStatusDto> currentVcStatuses = List.of(new VcStatusDto("test-issuer", true));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        when(mockConfigService.getComponentId(any())).thenReturn("test-issuer");
+
+        boolean isValid =
+                userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(
+                        USER_ID_1, currentVcStatuses);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void checkNameCorrelationWithSameBirthDatesAndMissingBirthDateCredentialsForReturnTrue()
+            throws HttpResponseExceptionWithErrorBody {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()),
+                        createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_2, Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()),
+                        createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_3, Instant.now()));
+
+        List<VcStatusDto> currentVcStatuses = List.of(new VcStatusDto("test-issuer", true));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        when(mockConfigService.getComponentId(any())).thenReturn("test-issuer");
+
+        boolean isValid =
+                userIdentityService.checkBirthDateCorrelationInCredentials(
+                        USER_ID_1, currentVcStatuses);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void checkNameCorrelationWithMissingBirthDateCredentialsForReturnTrue()
+            throws HttpResponseExceptionWithErrorBody {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()));
+
+        List<VcStatusDto> currentVcStatuses = List.of(new VcStatusDto("test-issuer", true));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        when(mockConfigService.getComponentId(any())).thenReturn("test-issuer");
+
+        boolean isValid =
+                userIdentityService.checkBirthDateCorrelationInCredentials(
+                        USER_ID_1, currentVcStatuses);
+
+        assertTrue(isValid);
     }
 
     @Test


### PR DESCRIPTION
…hdate

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The correlation should be against any VCs containing a name or birthdate. If so, should the correlation check only be performed if the field is present?  

### Why did it change

 If we don't see a name or birth date properties in credentialIssuer's VC.  We don't throw any exception from correlation check for name and birth date.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2688](https://govukverify.atlassian.net/browse/PYIC-2688)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2688]: https://govukverify.atlassian.net/browse/PYIC-2688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ