### PR TITLE
[BAU] Bump gradle build action as per CVE-2023-30853

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: "3.8"
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.3.3
+        uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.3
 


### PR DESCRIPTION
## Proposed changes

### What changed

Bump gradle build action to latest v2 as per [CVE-2023-30853](https://github.com/gradle/gradle-build-action/security/advisories/GHSA-h3qr-39j9-4r5v).

### Why did it change

Response to CVE-2023-30853 - potential for data written to GitHub actions cache to expose secrets

### Issue tracking

n/a

## Checklists

### Environment variables or secrets

- No environment variables or secrets were added or changed

### Other considerations

- [ ] Advisory recommends clearing configuration-cache-* entries and rotation of potentially exposed secrets
