### PR TITLE
BAU: Disable static analysis for dependabot builds

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -70,6 +70,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Perform Static Analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Proposed changes

### What changed

Disable the Static Analysis step for dependabot builds.

### Why did it change

Dependabot builds are not able to access the required secret for the Static Analysis step to run.

### Issue tracking
N/A

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

N/A