### PR TITLE
[PYIC-2710] FeatureSet overrides in scalar methods

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -50,7 +50,9 @@ public class LogHelper {
         LOG_JOURNEY_STEP("journeyStep"),
         LOG_ERROR("error"),
         LOG_PAYLOAD("payload"),
-        LOG_STATUS_CODE("statusCode");
+        LOG_STATUS_CODE("statusCode"),
+        LOG_PARAMETER_PATH("parameterPath"),
+        LOG_FEATURE_SET("featureSet");
         private final String fieldName;
 
         LogField(String fieldName) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -8,15 +8,20 @@ import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
 import software.amazon.awssdk.services.secretsmanager.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.secretsmanager.model.InvalidParameterException;
 import software.amazon.awssdk.services.secretsmanager.model.InvalidRequestException;
 import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
@@ -25,7 +30,6 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.net.URI;
-import java.security.cert.CertificateException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,13 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TIMEOUT;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_ISSUER;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_FRONT_CALLBACK_URL;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 
 @WireMockTest(httpPort = ConfigService.LOCALHOST_PORT)
@@ -60,6 +57,7 @@ class ConfigServiceTest {
     private static final String TEST_REDIRECT_URL = "http:example.com/callbackUrl/testCri";
     private static final String TEST_CERT =
             "MIIC/TCCAeWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwHhcNMjExMjE3MTEwNTM5WhcNMjIxMjE3MTEwNTM5WjAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDYIxWKwYNoz2MIDvYb2ip4nhCOGUccufIqwSHXl5FBOoOxOZh1rV57sWhdKO/hyZYbF5YUYTwzV4rW7DgLkfx0sN/p5igk74BZRSXvV/s+XCkVC5c0NDhNGh6WK5rc8Qbm0Ad5vEO1JpQih5y2mPGCwfLBqcY8AC7fwZinP/4YoMTCtEk5ueA0HwZLHXOEMWl/QCkj7WlSBL4i6ozk4So3RFL4awYP6nvhY7OLAcad7g/ZW0dXvztPOJnT9rwi1p6BNoD/Zk6jMJHhbvKyGsluUy7PYVGYCQ36Uuzby2Jq8cG5qNS+CBjy0/d/RmrClKd7gcnLY/J5NOC+YSynoHXRAgMBAAGjKjAoMA4GA1UdDwEB/wQEAwIFoDAWBgNVHSUBAf8EDDAKBggrBgEFBQcDBDANBgkqhkiG9w0BAQsFAAOCAQEAvHT2AGTymh02A9HWrnGm6PEXx2Ye3NXV9eJNU1z6J298mS2kYq0Z4D0hj9i8+IoCQRbWOxLTAWBNt/CmH7jWltE4uqoAwTZD6mDgkC2eo5dY+RcuydsvJNfTcvUOyi47KKGGEcddfLti4NuX51BQIY5vSBfqZXt8+y28WuWqBMh6eny2wJtxNHo20wQei5g7w19lqwJu2F+l/ykX9K5DHjhXqZUJ77YWmY8sy/WROLjOoZZRy6YuzV8S/+c/nsPzqDAkD4rpWwASjsEDaTcH22xpGq5XUAf1hwwNsuiyXKGUHCxafYYS781LR8pLg6DpEAgcn8tBbq6MoiEGVeOp7Q==";
+    private static final String TEST_CERT_FS01 = "not a real cert";
 
     @SystemStub private EnvironmentVariables environmentVariables;
 
@@ -193,50 +191,6 @@ class ConfigServiceTest {
     }
 
     @Test
-    void shouldReturnValidClientCertificateForAuth() throws CertificateException {
-        environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/clients/aClientId/publicKeyMaterialForCoreToVerify"))
-                .thenReturn(TEST_CERT);
-
-        assertEquals(
-                TEST_CERT,
-                configService.getSsmParameter(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY, "aClientId"));
-    }
-
-    @Test
-    void shouldReturnClientIssuer() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String clientIssuer = "aClientIssuer";
-        when(ssmProvider.get("/test/core/clients/aClientId/issuer")).thenReturn(clientIssuer);
-        assertEquals(clientIssuer, configService.getSsmParameter(CLIENT_ISSUER, "aClientId"));
-    }
-
-    @Test
-    void shouldReturnMaxAllowedAuthClientTtl() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String clientIssuer = "aClientTokenTtl";
-        when(ssmProvider.get("/test/core/self/maxAllowedAuthClientTtl")).thenReturn(clientIssuer);
-        assertEquals(clientIssuer, configService.getSsmParameter(MAX_ALLOWED_AUTH_CLIENT_TTL));
-    }
-
-    @Test
-    void shouldReturnCoreFrontCallbackUrl() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String coreFrontCallbackUrl = "aCoreFrontCallbackUrl";
-        when(ssmProvider.get("/test/core/self/coreFrontCallbackUrl"))
-                .thenReturn(coreFrontCallbackUrl);
-        assertEquals(coreFrontCallbackUrl, configService.getSsmParameter(CORE_FRONT_CALLBACK_URL));
-    }
-
-    @Test
-    void shouldReturnCoreVtmClaim() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String coreVtmClaim = "aCoreVtmClaim";
-        when(ssmProvider.get("/test/core/self/coreVtmClaim")).thenReturn(coreVtmClaim);
-        assertEquals(coreVtmClaim, configService.getSsmParameter(CORE_VTM_CLAIM));
-    }
-
-    @Test
     void shouldGetSecretValueFromSecretsManager() {
         Map<String, String> apiKeySecret = Map.of("apiKey", "api-key-value");
         when(secretsProvider.get(any())).thenReturn(gson.toJson(apiKeySecret));
@@ -306,21 +260,6 @@ class ConfigServiceTest {
     }
 
     @Test
-    void shouldReturnBackendSessionTimeout() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String ttl = "7200";
-        when(ssmProvider.get("/test/core/self/backendSessionTimeout")).thenReturn(ttl);
-        assertEquals(ttl, configService.getSsmParameter(BACKEND_SESSION_TIMEOUT));
-    }
-
-    @Test
-    void shouldReturnBackendSessionTtl() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/self/backendSessionTtl")).thenReturn("7200");
-        assertEquals("7200", configService.getSsmParameter(BACKEND_SESSION_TTL));
-    }
-
-    @Test
     void shouldGetContraIndicatorScoresMap() {
         String scoresJsonString =
                 "[{ \"ci\": \"X01\", \"detectedScore\": 3, \"checkedScore\": -3, \"fidCode\": \"YZ01\" }, { \"ci\": \"Z03\", \"detectedScore\": 5, \"checkedScore\": -3 }]";
@@ -331,5 +270,139 @@ class ConfigServiceTest {
         assertEquals(2, scoresMap.size());
         assertTrue(scoresMap.containsKey("X01"));
         assertTrue(scoresMap.containsKey("Z03"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY,",
+        "PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY,FS01",
+        "CLIENT_ISSUER,",
+        "CLIENT_ISSUER,FS02",
+        "CLIENT_ISSUER,FS03_NO_OVERRIDE"
+    })
+    void shouldAccountForFeatureSetWhenRetrievingParameterForClient(
+            String configVariableName, String featureSet) {
+        configService = new ConfigService(ssmProvider, secretsProvider, featureSet);
+        environmentVariables.set("ENVIRONMENT", "test");
+        ConfigurationVariable configurationVariable =
+                ConfigurationVariable.valueOf(configVariableName);
+        TestConfiguration testConfiguration = TestConfiguration.valueOf(configVariableName);
+        testConfiguration.setupMockConfig(ssmProvider);
+        assertEquals(
+                testConfiguration.getExpectedValue(featureSet),
+                configService.getSsmParameter(configurationVariable, "aClientId"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "MAX_ALLOWED_AUTH_CLIENT_TTL,",
+        "MAX_ALLOWED_AUTH_CLIENT_TTL,FS01",
+        "CORE_FRONT_CALLBACK_URL,",
+        "CORE_FRONT_CALLBACK_URL,FS01",
+        "CORE_VTM_CLAIM,",
+        "CORE_VTM_CLAIM,FS02",
+        "BACKEND_SESSION_TIMEOUT,",
+        "BACKEND_SESSION_TIMEOUT,FS03",
+        "BACKEND_SESSION_TTL,",
+        "BACKEND_SESSION_TTL,FS04",
+        "BACKEND_SESSION_TTL,FS05_NO_OVERRIDE",
+    })
+    void shouldAccountForFeatureSetWhenRetrievingParameter(
+            String configVariableName, String featureSet) {
+        configService = new ConfigService(ssmProvider, secretsProvider, featureSet);
+        environmentVariables.set("ENVIRONMENT", "test");
+        ConfigurationVariable configurationVariable =
+                ConfigurationVariable.valueOf(configVariableName);
+        TestConfiguration testConfiguration = TestConfiguration.valueOf(configVariableName);
+        testConfiguration.setupMockConfig(ssmProvider);
+        assertEquals(
+                testConfiguration.getExpectedValue(featureSet),
+                configService.getSsmParameter(configurationVariable));
+    }
+
+    private enum TestConfiguration {
+        PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY(
+                "clients/aClientId/publicKeyMaterialForCoreToVerify",
+                TEST_CERT,
+                Map.of("FS01", TEST_CERT_FS01),
+                Map.of()),
+        CLIENT_ISSUER(
+                "clients/aClientId/issuer",
+                "aClientIssuer",
+                Map.of("FS02", "aDifferentIssuer"),
+                Map.of("FS03_NO_OVERRIDE", ParameterNotFoundException.class)),
+        MAX_ALLOWED_AUTH_CLIENT_TTL(
+                "self/maxAllowedAuthClientTtl",
+                "aClientTokenTtl",
+                Map.of("FS01", "aDifferentClientTokenTtl"),
+                Map.of()),
+        CORE_FRONT_CALLBACK_URL(
+                "self/coreFrontCallbackUrl",
+                "aCoreFrontCallbackUrl",
+                Map.of("FS01", "aDifferentCoreFrontCallbackUrl"),
+                Map.of()),
+        CORE_VTM_CLAIM(
+                "self/coreVtmClaim",
+                "aCoreVtmClaim",
+                Map.of("FS02", "aDifferentCoreVtmClaim"),
+                Map.of()),
+        BACKEND_SESSION_TIMEOUT(
+                "self/backendSessionTimeout",
+                "7200",
+                Map.of("FS02", "7300", "FS03", "7400"),
+                Map.of()),
+        BACKEND_SESSION_TTL(
+                "self/backendSessionTtl",
+                "3600",
+                Map.of("FS03", "3700", "FS04", "3800"),
+                Map.of("FS05_NO_OVERRIDE", ParameterNotFoundException.class));
+
+        private final String path;
+        private final String baseValue;
+        private final Map<String, String> featureSetValues;
+        private final Map<String, Class> featureSetExceptions;
+
+        TestConfiguration(
+                String path,
+                String baseValue,
+                Map<String, String> featureSetValues,
+                Map<String, Class> featureSetExceptions) {
+            this.path = path;
+            this.baseValue = baseValue;
+            this.featureSetValues = featureSetValues;
+            this.featureSetExceptions = featureSetExceptions;
+        }
+
+        public void setupMockConfig(SSMProvider ssmProvider) {
+            Mockito.lenient().when(ssmProvider.get("/test/core/" + path)).thenReturn(baseValue);
+            featureSetValues.forEach(
+                    (featureSet, valueOverride) ->
+                            Mockito.lenient()
+                                    .when(
+                                            ssmProvider.get(
+                                                    "/test/core/featureSet/"
+                                                            + featureSet
+                                                            + "/"
+                                                            + path))
+                                    .thenReturn(valueOverride));
+            featureSetExceptions.forEach(
+                    (featureSet, clazz) ->
+                            Mockito.lenient()
+                                    .when(
+                                            ssmProvider.get(
+                                                    "/test/core/featureSet/"
+                                                            + featureSet
+                                                            + "/"
+                                                            + path))
+                                    .thenThrow(clazz));
+        }
+
+        public String getExpectedValue(String featureSet) {
+            if (featureSet == null) {
+                return baseValue;
+            } else {
+                return featureSetValues.getOrDefault(featureSet, baseValue);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Update SSM parameter retrieval methods to fetch featureSet value if set otherwise to fall back to the corresponding base configuration value.

### Why did it change

Require the capability to override base configuration with featureSet-specific values.

### Issue tracking

- [PYIC-2710](https://govukverify.atlassian.net/browse/PYIC-2710)

## Checklists

### Environment variables or secrets

- No environment variables or secrets were added or changed

### Other considerations



[PYIC-2710]: https://govukverify.atlassian.net/browse/PYIC-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ