### PR TITLE
[PYIC-2708] Replace CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX with ENVIRONMENT equivalent

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -597,7 +597,6 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
@@ -739,7 +738,6 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
@@ -879,7 +877,6 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub build-cri-oauth-request-${Environment}
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
@@ -1000,7 +997,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt ClientOAuthSessionsTable.Arn ] ]
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -1099,7 +1095,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub get-credential-issuer-config-${Environment}
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -1526,7 +1521,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           CI_STORAGE_GET_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
             - contra_indicator_storage_account_id: !FindInMap
@@ -1652,7 +1646,6 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub select-cri-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
       VpcConfig:
@@ -1740,7 +1733,6 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub validate-oauth-callback-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CRI_OAUTH_SESSIONS_TABLE_NAME: !Ref CriOAuthSessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
@@ -1847,7 +1839,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           CI_STORAGE_GET_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
             - contra_indicator_storage_account_id: !FindInMap
@@ -1997,7 +1988,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2093,7 +2083,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CI_STORAGE_GET_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -18,7 +18,8 @@ public enum ConfigurationVariable {
     CI_SCORING_THRESHOLD("self/ciScoringThreshold"),
     CI_MITIGATION_JOURNEYS_ENABLED("self/journey/ciMitigationsEnabled"),
     VC_TTL("self/vcTtl"),
-    VC_VALID_DURATION("self/vcValidDuration");
+    VC_VALID_DURATION("self/vcValidDuration"),
+    CREDENTIAL_ISSUERS("credentialIssuers");
 
     private final String path;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.library.config;
 public enum EnvironmentVariable {
     BEARER_TOKEN_TTL,
     CLIENT_AUTH_JWT_IDS_TABLE_NAME,
-    CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX,
     ENVIRONMENT,
     IPV_SESSIONS_TABLE_NAME,
     CLIENT_OAUTH_SESSIONS_TABLE_NAME,

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -34,8 +34,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
@@ -96,9 +103,7 @@ class ConfigServiceTest {
 
     @Test
     void shouldGetCredentialIssuerFromParameterStore() throws Exception {
-        environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers");
-
+        environmentVariables.set("ENVIRONMENT", "test");
         Map<String, String> credentialIssuerParameters =
                 Map.of(
                         "activeConnection",
@@ -111,10 +116,10 @@ class ConfigServiceTest {
                         RSA_ENCRYPTION_PUBLIC_JWK,
                         "requiresApiKey",
                         "true");
-        when(ssmProvider.get("/dev/core/credentialIssuers/passportCri/activeConnection"))
+        when(ssmProvider.get("/test/core/credentialIssuers/passportCri/activeConnection"))
                 .thenReturn("stub");
 
-        when(ssmProvider.getMultiple("/dev/core/credentialIssuers/passportCri/connections/stub"))
+        when(ssmProvider.getMultiple("/test/core/credentialIssuers/passportCri/connections/stub"))
                 .thenReturn(credentialIssuerParameters);
 
         CredentialIssuerConfig result =
@@ -140,29 +145,31 @@ class ConfigServiceTest {
 
     @Test
     void shouldReturnIsEnabled() {
-        environmentVariables.set("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "passportCri");
-        when(ssmProvider.get("passportCri/aClientId/enabled")).thenReturn("true");
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/credentialIssuers/passportCri/enabled"))
+                .thenReturn("true");
 
-        boolean isEnabled = configService.isEnabled("aClientId");
+        boolean isEnabled = configService.isEnabled("passportCri");
         assertTrue(isEnabled);
     }
 
     @Test
     void shouldReturnIsAvailableOrNot() {
-        environmentVariables.set("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "passportCri");
-        when(ssmProvider.get("passportCri/aClientId/unavailable")).thenReturn("false");
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/credentialIssuers/passportCri/unavailable"))
+                .thenReturn("false");
 
-        boolean isUnavailable = configService.isUnavailable("aClientId");
+        boolean isUnavailable = configService.isUnavailable("passportCri");
         assertFalse(isUnavailable);
     }
 
     @Test
     void shouldReturnAllowedSharedAttributes() {
-        environmentVariables.set("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "passportCri");
-        when(ssmProvider.get("passportCri/aClientId/allowedSharedAttributes"))
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/credentialIssuers/passportCri/allowedSharedAttributes"))
                 .thenReturn("address,name");
 
-        String sharedAttributes = configService.getAllowedSharedAttributes("aClientId");
+        String sharedAttributes = configService.getAllowedSharedAttributes("passportCri");
         assertEquals("address,name", sharedAttributes);
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -34,15 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;

--- a/libs/credential-issuer-config-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigService.java
+++ b/libs/credential-issuer-config-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigService.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ParseCredentialIssuerConfigException;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -14,8 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX;
 
 public class CredentialIssuerConfigService extends ConfigService {
 
@@ -40,7 +39,7 @@ public class CredentialIssuerConfigService extends ConfigService {
             throws ParseCredentialIssuerConfigException {
         Map<String, String> params =
                 getSsmParameters(
-                        getEnvironmentVariable(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), true);
+                        resolvePath(ConfigurationVariable.CREDENTIAL_ISSUERS.getPath()), true);
 
         Map<String, Map<String, Object>> map = new HashMap<>();
         for (Map.Entry<String, String> entry : params.entrySet()) {

--- a/libs/credential-issuer-config-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigServiceTest.java
+++ b/libs/credential-issuer-config-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigServiceTest.java
@@ -42,9 +42,7 @@ class CredentialIssuerConfigServiceTest {
     @Test
     void shouldGetAllCredentialIssuersFromParameterStore()
             throws ParseCredentialIssuerConfigException {
-
-        environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
+        environmentVariables.set("ENVIRONMENT", "test");
         HashMap<String, String> response = new HashMap<>();
         response.put("passportCri/tokenUrl", "passportTokenUrl");
         response.put("passportCri/authorizeUrl", "passportAuthUrl");
@@ -57,7 +55,7 @@ class CredentialIssuerConfigServiceTest {
         response.put("stubCri/allowedSharedAttributes", "name, birthDate, address");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/test/core/credentialIssuers")).thenReturn(response);
         List<CredentialIssuerConfig> result = credentialIssuerConfigService.getCredentialIssuers();
 
         assertEquals(2, result.size());
@@ -83,8 +81,7 @@ class CredentialIssuerConfigServiceTest {
 
     @Test
     void shouldThrowExceptionWhenCriConfigIsIncorrect() {
-        environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
+        environmentVariables.set("ENVIRONMENT", "test");
         HashMap<String, String> response = new HashMap<>();
         response.put("incorrectPathName", "passportTokenUrl");
         response.put("passportCri/authorizeUrl", "passportAuthUrl");
@@ -92,7 +89,7 @@ class CredentialIssuerConfigServiceTest {
         response.put("passportCri/name", "passportIssuer");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/test/core/credentialIssuers")).thenReturn(response);
         ParseCredentialIssuerConfigException exception =
                 assertThrows(
                         ParseCredentialIssuerConfigException.class,
@@ -105,9 +102,7 @@ class CredentialIssuerConfigServiceTest {
     @Test
     void shouldGetAllCredentialIssuersFromParameterStoreNewAndIgnoreInExistingFields()
             throws ParseCredentialIssuerConfigException {
-
-        environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
+        environmentVariables.set("ENVIRONMENT", "test");
         HashMap<String, String> response = new HashMap<>();
         response.put("passportCri/clientId", "passportCri");
         response.put("passportCri/tokenUrl", "passportTokenUrl");
@@ -117,7 +112,7 @@ class CredentialIssuerConfigServiceTest {
         response.put("stubCri/ipclientid", "stubIpClient");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/test/core/credentialIssuers")).thenReturn(response);
         List<CredentialIssuerConfig> result = credentialIssuerConfigService.getCredentialIssuers();
 
         Optional<CredentialIssuerConfig> passportIssuerConfig =


### PR DESCRIPTION
## Proposed changes

### What changed

Definition of environment variable `CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX`, and usage thereof, have been replaced with resolution of `credentialIssuers` property paths based off `ENVIRONMENT` environment variable.

### Why did it change

Move to relative paths to enable overriding base (environment) configuration with `featureSet`'ed overrides.

### Issue tracking

- [PYIC-2708](https://govukverify.atlassian.net/browse/PYIC-2708)

## Checklists

### Environment variables or secrets

- Environment variable `CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX` has been *removed*.

### Other considerations


[PYIC-2708]: https://govukverify.atlassian.net/browse/PYIC-2708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ