### PR TITLE
PYIC-2713: add fetureset getter to request helper

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -27,6 +27,7 @@ public class RequestHelper {
     public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
     public static final String CLIENT_SESSION_ID_HEADER = "client-session-id";
     public static final String IP_ADDRESS_HEADER = "ip-address";
+    public static final String FEATURE_SET_HEADER = "feature-set";
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -139,5 +140,14 @@ public class RequestHelper {
         }
         LogHelper.attachClientSessionIdToLogs(clientSessionId);
         return clientSessionId;
+    }
+
+    public static String getFeatureSet(Map<String, String> headers) {
+        String featureSet = RequestHelper.getHeaderByKey(headers, FEATURE_SET_HEADER);
+        if (featureSet == null) {
+            LOGGER.warn("{} not present in header", FEATURE_SET_HEADER);
+            return "default";
+        }
+        return featureSet;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -150,4 +150,8 @@ public class RequestHelper {
         }
         return featureSet;
     }
+
+    public static String getFeatureSet(APIGatewayProxyRequestEvent event) {
+        return getFeatureSet(event.getHeaders());
+    }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -17,9 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.CLIENT_SESSION_ID_HEADER;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.*;
 
 class RequestHelperTest {
 
@@ -192,5 +190,24 @@ class RequestHelperTest {
         event.setHeaders(headers);
 
         assertNull(RequestHelper.getClientOAuthSessionId(event));
+    }
+
+    @Test
+    void getFeatureSetShouldReturnFeatureSetId() throws HttpResponseExceptionWithErrorBody {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of(FEATURE_SET_HEADER, "test-feature-set"));
+
+        assertEquals("test-feature-set", RequestHelper.getFeatureSet(event));
+    }
+
+    @Test
+    void getFeatureSetShouldReturnDefault() {
+        var event = new APIGatewayProxyRequestEvent();
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put(FEATURE_SET_HEADER, null);
+
+        event.setHeaders(headers);
+
+        assertEquals("default", RequestHelper.getFeatureSet(event));
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Added getter method to get featureSet from header and use default in case if not present.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2713](https://govukverify.atlassian.net/browse/PYIC-2713)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2713]: https://govukverify.atlassian.net/browse/PYIC-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ