### PR TITLE
PYIC-2706: use featureset from header to get config

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -49,6 +49,7 @@ import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_R
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_REDIRECT_URI;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getClientOAuthSessionId;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionIdAllowNull;
 
@@ -96,7 +97,7 @@ public class BuildClientOauthResponseHandler extends BaseJourneyLambda {
             String ipvSessionId = getIpvSessionIdAllowNull(input);
             String ipAddress = getIpAddress(input);
             String clientSessionId = getClientOAuthSessionId(input);
-            String featureSet = RequestHelper.getFeatureSet(input);
+            String featureSet = getFeatureSet(input);
             configService.setFeatureSet(featureSet);
 
             LogHelper.attachIpvSessionIdToLogs(ipvSessionId);

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -96,6 +96,8 @@ public class BuildClientOauthResponseHandler extends BaseJourneyLambda {
             String ipvSessionId = getIpvSessionIdAllowNull(input);
             String ipAddress = getIpAddress(input);
             String clientSessionId = getClientOAuthSessionId(input);
+            String featureSet = RequestHelper.getFeatureSet(input);
+            configService.setFeatureSet(featureSet);
 
             LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
 

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -56,7 +56,13 @@ class BuildClientOauthResponseHandlerTest {
     private static final Map<String, String> TEST_EVENT_HEADERS =
             Map.of("ipv-session-id", "12345", "ip-address", "192.168.1.100");
     private static final Map<String, String> TEST_EVENT_HEADERS_NO_IPV_SESSION =
-            Map.of("client-session-id", "54321", "ip-address", "192.168.1.100");
+            Map.of(
+                    "client-session-id",
+                    "54321",
+                    "ip-address",
+                    "192.168.1.100",
+                    "feature-set",
+                    "fs-001");
     private static final Map<String, String> TEST_EVENT_HEADERS_NO_IPV_AND_CLIENT_SESSION =
             Map.of("ip-address", "192.168.1.100");
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -115,6 +121,7 @@ class BuildClientOauthResponseHandlerTest {
 
         ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
         verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        verify(mockConfigService).setFeatureSet("default");
         assertEquals(AuditEventTypes.IPV_JOURNEY_END, auditEventCaptor.getValue().getEventName());
 
         URI expectedRedirectUrl =
@@ -154,6 +161,7 @@ class BuildClientOauthResponseHandlerTest {
         assertEquals("access_denied", params.get(0).getValue());
         assertEquals("Missing Context", params.get(1).getValue());
         assertEquals("test-state", params.get(2).getValue());
+        verify(mockConfigService).setFeatureSet("fs-001");
     }
 
     @Test

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -121,7 +121,6 @@ class BuildClientOauthResponseHandlerTest {
 
         ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
         verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
-        verify(mockConfigService).setFeatureSet("default");
         assertEquals(AuditEventTypes.IPV_JOURNEY_END, auditEventCaptor.getValue().getEventName());
 
         URI expectedRedirectUrl =

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -127,6 +127,7 @@ public class BuildCriOauthRequestHandler
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
             String ipAddress = RequestHelper.getIpAddress(input);
+            String featureSet = RequestHelper.getFeatureSet(input);
             Map<String, String> pathParameters = input.getPathParameters();
 
             var errorResponse = validate(pathParameters);

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -128,6 +128,7 @@ public class BuildCriOauthRequestHandler
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
             String ipAddress = RequestHelper.getIpAddress(input);
             String featureSet = RequestHelper.getFeatureSet(input);
+            credentialIssuerConfigService.setFeatureSet(featureSet);
             Map<String, String> pathParameters = input.getPathParameters();
 
             var errorResponse = validate(pathParameters);

--- a/lambdas/build-debug-credential-data/src/main/java/uk/gov/di/ipv/core/builddebugcredentialdata/BuildDebugCredentialDataHandler.java
+++ b/lambdas/build-debug-credential-data/src/main/java/uk/gov/di/ipv/core/builddebugcredentialdata/BuildDebugCredentialDataHandler.java
@@ -69,6 +69,8 @@ public class BuildDebugCredentialDataHandler
         LogHelper.attachComponentIdToLogs();
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
+            String featureSet = RequestHelper.getFeatureSet(input);
+            configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
 
             ClientOAuthSessionItem clientOAuthSessionItem =

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -89,6 +89,8 @@ public class BuildProvenUserIdentityDetailsHandler
         ProvenUserIdentityDetails.ProvenUserIdentityDetailsBuilder
                 provenUserIdentityDetailsBuilder = ProvenUserIdentityDetails.builder();
         try {
+            String featureSet = RequestHelper.getFeatureSet(input);
+            configService.setFeatureSet(featureSet);
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
 

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -85,6 +85,8 @@ public class BuildUserIdentityHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
+            String featureSet = RequestHelper.getFeatureSet(input);
+            configService.setFeatureSet(featureSet);
             AccessToken accessToken =
                     AccessToken.parse(
                             RequestHelper.getHeaderByKey(

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -32,6 +32,7 @@ import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -119,6 +120,8 @@ public class CheckExistingIdentityHandler
         try {
             String ipvSessionId = getIpvSessionId(event);
             String ipAddress = getIpAddress(event);
+            String featureSet = RequestHelper.getFeatureSet(event);
+            configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionDetailsService.getClientOAuthSession(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -63,10 +63,15 @@ class CheckExistingIdentityHandlerTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
+
+    private static final String TEST_FEATURE_SET = "test-feature-set";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     private static final JourneyRequest event =
             new JourneyRequest(
-                    TEST_SESSION_ID, TEST_CLIENT_SOURCE_IP, TEST_CLIENT_OAUTH_SESSION_ID);
+                    TEST_SESSION_ID,
+                    TEST_CLIENT_SOURCE_IP,
+                    TEST_CLIENT_OAUTH_SESSION_ID,
+                    TEST_FEATURE_SET);
     private static final List<String> CREDENTIALS =
             List.of(
                     M1A_PASSPORT_VC,
@@ -277,7 +282,7 @@ class CheckExistingIdentityHandlerTest {
 
     @Test
     void shouldReturn400IfSessionIdNotInHeader() {
-        JourneyRequest eventWithoutHeaders = new JourneyRequest(null, null, null);
+        JourneyRequest eventWithoutHeaders = new JourneyRequest(null, null, null, null);
 
         JourneyResponse journeyResponse =
                 checkExistingIdentityHandler.handleRequest(eventWithoutHeaders, context);

--- a/lambdas/end-mitigation-journey/src/main/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandler.java
+++ b/lambdas/end-mitigation-journey/src/main/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandler.java
@@ -89,6 +89,8 @@ public class EndMitigationJourneyHandler
 
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(input);
+            String featureSet = RequestHelper.getFeatureSet(input);
+            configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
 
             String ipAddress = RequestHelper.getIpAddress(input);

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -121,6 +121,8 @@ public class EvaluateGpg45ScoresHandler extends BaseJourneyLambda {
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(event);
             String ipAddress = RequestHelper.getIpAddress(event);
+            String featureSet = RequestHelper.getFeatureSet(event);
+            configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionDetailsService.getClientOAuthSession(

--- a/lambdas/get-credential-issuer-config/src/main/java/uk/gov/di/ipv/core/getcredentialissuerconfig/GetCredentialIssuerConfigHandler.java
+++ b/lambdas/get-credential-issuer-config/src/main/java/uk/gov/di/ipv/core/getcredentialissuerconfig/GetCredentialIssuerConfigHandler.java
@@ -41,6 +41,7 @@ public class GetCredentialIssuerConfigHandler
         LogHelper.attachComponentIdToLogs();
         try {
             String featureSet = RequestHelper.getFeatureSet(input);
+            credentialIssuerConfigService.setFeatureSet(featureSet);
             List<CredentialIssuerConfig> config =
                     credentialIssuerConfigService.getCredentialIssuers();
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, config);

--- a/lambdas/get-credential-issuer-config/src/main/java/uk/gov/di/ipv/core/getcredentialissuerconfig/GetCredentialIssuerConfigHandler.java
+++ b/lambdas/get-credential-issuer-config/src/main/java/uk/gov/di/ipv/core/getcredentialissuerconfig/GetCredentialIssuerConfigHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ParseCredentialIssuerConfigException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 
 import java.util.List;
 
@@ -39,6 +40,7 @@ public class GetCredentialIssuerConfigHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
+            String featureSet = RequestHelper.getFeatureSet(input);
             List<CredentialIssuerConfig> config =
                     credentialIssuerConfigService.getCredentialIssuers();
             return ApiGatewayResponseGenerator.proxyJsonResponse(200, config);

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -103,6 +103,7 @@ public class InitialiseIpvSessionHandler
         try {
             String ipAddress = RequestHelper.getIpAddress(input);
             String featureSet = RequestHelper.getFeatureSet(input);
+            configService.setFeatureSet(featureSet);
             Map<String, String> sessionParams =
                     objectMapper.readValue(input.getBody(), new TypeReference<>() {});
             Optional<ErrorResponse> error = validateSessionParams(sessionParams);

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -102,6 +102,7 @@ public class InitialiseIpvSessionHandler
 
         try {
             String ipAddress = RequestHelper.getIpAddress(input);
+            String featureSet = RequestHelper.getFeatureSet(input);
             Map<String, String> sessionParams =
                     objectMapper.readValue(input.getBody(), new TypeReference<>() {});
             Optional<ErrorResponse> error = validateSessionParams(sessionParams);

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -29,6 +29,7 @@ import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
@@ -83,6 +84,8 @@ public class IssueClientAccessTokenHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
+            String featureSet = RequestHelper.getFeatureSet(input);
+            configService.setFeatureSet(featureSet);
             tokenRequestValidator.authenticateClient(input.getBody());
 
             AuthorizationCodeGrant authorizationGrant =

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -74,6 +75,7 @@ public class ProcessJourneyStepHandler
         try {
             String ipvSessionId = StepFunctionHelpers.getIpvSessionId(input);
             String journeyStep = StepFunctionHelpers.getJourneyStep(input);
+            String featureSet = RequestHelper.getFeatureSet(input);
 
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             if (ipvSessionItem == null) {

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -14,7 +14,6 @@ import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -75,7 +74,7 @@ public class ProcessJourneyStepHandler
         try {
             String ipvSessionId = StepFunctionHelpers.getIpvSessionId(input);
             String journeyStep = StepFunctionHelpers.getJourneyStep(input);
-            String featureSet = RequestHelper.getFeatureSet(input);
+            String featureSet = StepFunctionHelpers.getFeatureSet(input);
             configService.setFeatureSet(featureSet);
 
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -76,6 +76,7 @@ public class ProcessJourneyStepHandler
             String ipvSessionId = StepFunctionHelpers.getIpvSessionId(input);
             String journeyStep = StepFunctionHelpers.getJourneyStep(input);
             String featureSet = RequestHelper.getFeatureSet(input);
+            configService.setFeatureSet(featureSet);
 
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             if (ipvSessionItem == null) {

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.core.library.exceptions.CiPutException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
@@ -107,6 +108,8 @@ public class RetrieveCriCredentialHandler
         LogHelper.attachComponentIdToLogs();
 
         String ipAddress = StepFunctionHelpers.getIpAddress(input);
+        String featureSet = RequestHelper.getFeatureSet(input);
+        configService.setFeatureSet(featureSet);
 
         IpvSessionItem ipvSessionItem;
         try {

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -26,7 +26,6 @@ import uk.gov.di.ipv.core.library.exceptions.CiPutException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
@@ -108,7 +107,7 @@ public class RetrieveCriCredentialHandler
         LogHelper.attachComponentIdToLogs();
 
         String ipAddress = StepFunctionHelpers.getIpAddress(input);
-        String featureSet = RequestHelper.getFeatureSet(input);
+        String featureSet = StepFunctionHelpers.getFeatureSet(input);
         configService.setFeatureSet(featureSet);
 
         IpvSessionItem ipvSessionItem;

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.JourneyError;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
 import uk.gov.di.ipv.core.library.kmses256signer.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -87,6 +88,8 @@ public class RetrieveCriOauthAccessTokenHandler
         String credentialIssuerId = null;
 
         String ipAddress = StepFunctionHelpers.getIpAddress(input);
+        String featureSet = RequestHelper.getFeatureSet(input);
+        configService.setFeatureSet(featureSet);
 
         try {
             String ipvSessionId = StepFunctionHelpers.getIpvSessionId(input);

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -22,7 +22,6 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.JourneyError;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
 import uk.gov.di.ipv.core.library.kmses256signer.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -88,7 +87,7 @@ public class RetrieveCriOauthAccessTokenHandler
         String credentialIssuerId = null;
 
         String ipAddress = StepFunctionHelpers.getIpAddress(input);
-        String featureSet = RequestHelper.getFeatureSet(input);
+        String featureSet = StepFunctionHelpers.getFeatureSet(input);
         configService.setFeatureSet(featureSet);
 
         try {

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -80,6 +80,7 @@ public class SelectCriHandler extends BaseJourneyLambda {
         LogHelper.attachComponentIdToLogs();
         try {
             String ipvSessionId = getIpvSessionId(event);
+            String featureSet = RequestHelper.getFeatureSet(event);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.getClientOAuthSession(

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -81,6 +81,7 @@ public class SelectCriHandler extends BaseJourneyLambda {
         try {
             String ipvSessionId = getIpvSessionId(event);
             String featureSet = RequestHelper.getFeatureSet(event);
+            configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.getClientOAuthSession(

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
@@ -40,7 +41,6 @@ import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 
 public class SelectCriHandler extends BaseJourneyLambda {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -79,7 +79,7 @@ public class SelectCriHandler extends BaseJourneyLambda {
     protected JourneyResponse handleRequest(JourneyRequest event, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
-            String ipvSessionId = getIpvSessionId(event);
+            String ipvSessionId = RequestHelper.getIpvSessionId(event);
             String featureSet = RequestHelper.getFeatureSet(event);
             configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -114,6 +114,8 @@ public class ValidateOAuthCallbackHandler
         try {
             String ipvSessionId = callbackRequest.getIpvSessionId();
             String criOAuthSessionId = callbackRequest.getState();
+            String featureSet = callbackRequest.getFeatureSet();
+            configService.setFeatureSet(featureSet);
 
             if (!StringUtils.isBlank(ipvSessionId)) {
                 ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/dto/CriCallbackRequest.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/dto/CriCallbackRequest.java
@@ -18,4 +18,5 @@ public class CriCallbackRequest {
     private String error;
     private String errorDescription;
     private String ipAddress;
+    private String featureSet;
 }

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -56,6 +56,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
+    private static final String TEST_FEATURE_SET = "fs001";
     private static final String CODE = "code";
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
@@ -517,7 +518,8 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 TEST_OAUTH_STATE,
                 null,
                 null,
-                TEST_IP_ADDRESS);
+                TEST_IP_ADDRESS,
+                TEST_FEATURE_SET);
     }
 
     private CredentialIssuerConfig createCriConfig(String criIss) throws URISyntaxException {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -11,4 +11,5 @@ public class JourneyRequest {
     private String ipvSessionId;
     private String ipAddress;
     private String clientOAuthSessionId;
+    private String featureSet;
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -84,8 +84,8 @@ public class LogHelper {
         attachFieldToLogs(LogField.LOG_IPV_SESSION_ID, sessionId);
     }
 
-    public static void attachFeatureSetToLogs(String sessionId) {
-        attachFieldToLogs(LogField.LOG_FEATURE_SET, sessionId);
+    public static void attachFeatureSetToLogs(String featureSet) {
+        attachFieldToLogs(LogField.LOG_FEATURE_SET, featureSet);
     }
 
     public static void attachClientSessionIdToLogs(String sessionId) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -84,6 +84,10 @@ public class LogHelper {
         attachFieldToLogs(LogField.LOG_IPV_SESSION_ID, sessionId);
     }
 
+    public static void attachFeatureSetToLogs(String sessionId) {
+        attachFieldToLogs(LogField.LOG_FEATURE_SET, sessionId);
+    }
+
     public static void attachClientSessionIdToLogs(String sessionId) {
         attachFieldToLogs(LogField.LOG_CLIENT_OAUTH_SESSION_ID, sessionId);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -143,7 +143,7 @@ public class RequestHelper {
         return featureSet;
     }
 
-    public static String getFeatureSet(Map<String, String> headers) {
+    private static String getFeatureSet(Map<String, String> headers) {
         return RequestHelper.getHeaderByKey(headers, FEATURE_SET_HEADER);
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -139,21 +139,12 @@ public class RequestHelper {
 
     public static String getFeatureSet(JourneyRequest request) {
         String featureSet = request.getFeatureSet();
-
-        if (featureSet == null || featureSet.isEmpty()) {
-            featureSet = "default";
-        }
         LogHelper.attachFeatureSetToLogs(featureSet);
         return featureSet;
     }
 
     public static String getFeatureSet(Map<String, String> headers) {
-        String featureSet = RequestHelper.getHeaderByKey(headers, FEATURE_SET_HEADER);
-        if (featureSet == null) {
-            LOGGER.warn("{} not present in header", FEATURE_SET_HEADER);
-            return "default";
-        }
-        return featureSet;
+        return RequestHelper.getHeaderByKey(headers, FEATURE_SET_HEADER);
     }
 
     public static String getFeatureSet(APIGatewayProxyRequestEvent event) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -137,6 +137,16 @@ public class RequestHelper {
         return ipvSessionId;
     }
 
+    public static String getFeatureSet(JourneyRequest request) {
+        String featureSet = request.getFeatureSet();
+
+        if (featureSet == null || featureSet.isEmpty()) {
+            featureSet = "default";
+        }
+        LogHelper.attachFeatureSetToLogs(featureSet);
+        return featureSet;
+    }
+
     public static String getFeatureSet(Map<String, String> headers) {
         String featureSet = RequestHelper.getHeaderByKey(headers, FEATURE_SET_HEADER);
         if (featureSet == null) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
@@ -17,6 +17,7 @@ public class StepFunctionHelpers {
     private static final String IP_ADDRESS = "ipAddress";
     private static final String TYPE = "type";
     private static final String PAGE = "page";
+    private static final String FEATURE_SET = "featureSet";
 
     private StepFunctionHelpers() {
         throw new IllegalStateException("Utility class");
@@ -38,6 +39,10 @@ public class StepFunctionHelpers {
 
     public static String getIpAddress(Map<String, String> input) {
         return input.get(IP_ADDRESS);
+    }
+
+    public static String getFeatureSet(Map<String, String> input) {
+        return input.get(FEATURE_SET);
     }
 
     public static String getJourneyStep(Map<String, String> input)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -130,7 +130,7 @@ public class ConfigService {
 
     public String getSsmParameter(
             ConfigurationVariable configurationVariable, String... pathProperties) {
-        if (getFeatureSet() != null) {
+        if (getFeatureSet() != null && !getFeatureSet().equals("default")) {
             var featureSetPath =
                     resolveFeatureSetPath(configurationVariable.getPath(), pathProperties);
             try {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -130,7 +130,7 @@ public class ConfigService {
 
     public String getSsmParameter(
             ConfigurationVariable configurationVariable, String... pathProperties) {
-        if (getFeatureSet() != null && !getFeatureSet().equals("default")) {
+        if (getFeatureSet() != null) {
             var featureSetPath =
                     resolveFeatureSetPath(configurationVariable.getPath(), pathProperties);
             try {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
@@ -48,8 +48,8 @@ public abstract class BaseJourneyLambda
                     OBJECT_MAPPER.convertValue(event, APIGatewayProxyRequestEvent.class);
 
             var clientOAuthSessionId = RequestHelper.getClientOAuthSessionId(request);
-            var ipvSessionId = RequestHelper.getIpvSessionId(request);
-            var ipAddress = RequestHelper.getIpAddress(request);
+            var ipvSessionId = getIpvSessionId(request);
+            var ipAddress = getIpAddress(request);
             var featureSet = RequestHelper.getFeatureSet(request);
             var journeyRequest =
                     new JourneyRequest(ipvSessionId, ipAddress, clientOAuthSessionId, featureSet);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
@@ -18,6 +18,9 @@ import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getClientOAuthSessionId;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
+
 public abstract class BaseJourneyLambda
         implements RequestHandler<Map<String, Object>, Map<String, Object>> {
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
@@ -47,10 +50,10 @@ public abstract class BaseJourneyLambda
             APIGatewayProxyRequestEvent request =
                     OBJECT_MAPPER.convertValue(event, APIGatewayProxyRequestEvent.class);
 
-            var clientOAuthSessionId = RequestHelper.getClientOAuthSessionId(request);
+            var clientOAuthSessionId = getClientOAuthSessionId(request);
             var ipvSessionId = getIpvSessionId(request);
             var ipAddress = getIpAddress(request);
-            var featureSet = RequestHelper.getFeatureSet(request);
+            var featureSet = getFeatureSet(request);
             var journeyRequest =
                     new JourneyRequest(ipvSessionId, ipAddress, clientOAuthSessionId, featureSet);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
@@ -51,7 +51,8 @@ public abstract class BaseJourneyLambda
             var ipvSessionId = RequestHelper.getIpvSessionId(request);
             var ipAddress = RequestHelper.getIpAddress(request);
             var featureSet = RequestHelper.getFeatureSet(request);
-            var journeyRequest = new JourneyRequest(ipvSessionId, ipAddress, clientOAuthSessionId, featureSet);
+            var journeyRequest =
+                    new JourneyRequest(ipvSessionId, ipAddress, clientOAuthSessionId, featureSet);
 
             var journeyResponse = handleRequest(journeyRequest, context);
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
@@ -48,9 +48,11 @@ public abstract class BaseJourneyLambda
                     OBJECT_MAPPER.convertValue(event, APIGatewayProxyRequestEvent.class);
 
             var clientOAuthSessionId = RequestHelper.getClientOAuthSessionId(request);
-            var journeyRequest =
-                    new JourneyRequest(
-                            getIpvSessionId(request), getIpAddress(request), clientOAuthSessionId);
+            var ipvSessionId = RequestHelper.getIpvSessionId(request);
+            var ipAddress = RequestHelper.getIpAddress(request);
+            var featureSet = RequestHelper.getFeatureSet(request);
+            var journeyRequest = new JourneyRequest(ipvSessionId, ipAddress, clientOAuthSessionId, featureSet);
+
             var journeyResponse = handleRequest(journeyRequest, context);
 
             apiGatewayResponse =

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -32,6 +32,8 @@ class RequestHelperTest {
     private final String TEST_IP_ADDRESS = "127.0.0.1";
     private final String TEST_FEATURE_SET = "test-feature-set";
 
+    private final String TEST_CLIENT_SESSION_ID = "client-session-id";
+
     @ParameterizedTest(name = "with matching header: {0}")
     @ValueSource(strings = {"Baz", "baz"})
     void matchHeaderByDownCasing(String headerName) {
@@ -77,7 +79,12 @@ class RequestHelperTest {
     @Test
     void getIpvSessionIdShouldReturnSessionIdFromJourney()
             throws HttpResponseExceptionWithErrorBody {
-        var event = new JourneyRequest(TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_FEATURE_SET);
+        var event =
+                new JourneyRequest(
+                        TEST_IPV_SESSION_ID,
+                        TEST_IP_ADDRESS,
+                        TEST_CLIENT_SESSION_ID,
+                        TEST_FEATURE_SET);
 
         assertEquals("a-session-id", RequestHelper.getIpvSessionId(event));
     }
@@ -210,11 +217,13 @@ class RequestHelperTest {
         String clientSessionId = "client-session-id";
         String ipvSessionId = "a-session-id";
         String ipAddress = "a-ipaddress";
-        var event = new JourneyRequest(ipvSessionId, ipAddress, clientSessionId);
+        String featureSet = "a-feature-set";
+        var event = new JourneyRequest(ipvSessionId, ipAddress, clientSessionId, featureSet);
 
         assertEquals(clientSessionId, RequestHelper.getClientOAuthSessionId(event));
         assertEquals(ipvSessionId, RequestHelper.getIpvSessionId(event));
         assertEquals(ipAddress, RequestHelper.getIpAddress(event));
+        assertEquals(featureSet, RequestHelper.getFeatureSet(event));
     }
 
     @Test
@@ -222,7 +231,8 @@ class RequestHelperTest {
             throws HttpResponseExceptionWithErrorBody {
         String clientSessionId = "client-session-id";
         String ipAddress = "a-ipaddress";
-        var event = new JourneyRequest(null, ipAddress, clientSessionId);
+        String featureSet = "a-feature-set";
+        var event = new JourneyRequest(null, ipAddress, clientSessionId, featureSet);
 
         assertNull(RequestHelper.getIpvSessionIdAllowNull(event));
     }
@@ -248,13 +258,20 @@ class RequestHelperTest {
 
     @Test
     void getFeatureSetShouldReturnFeatureSetIdFromJourney() {
-        var event = new JourneyRequest(TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_FEATURE_SET);
+        var event =
+                new JourneyRequest(
+                        TEST_IPV_SESSION_ID,
+                        TEST_IP_ADDRESS,
+                        TEST_CLIENT_SESSION_ID,
+                        TEST_FEATURE_SET);
         assertEquals("test-feature-set", RequestHelper.getFeatureSet(event));
     }
 
     @Test
     void getFeatureSetShouldReturnDefaultFeatureSetIdFromJourneyWhenNotPresent() {
-        var event = new JourneyRequest(TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, null);
+        var event =
+                new JourneyRequest(
+                        TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_CLIENT_SESSION_ID, null);
         assertEquals("default", RequestHelper.getFeatureSet(event));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -28,6 +28,10 @@ class RequestHelperTest {
                     "Foo", "bar",
                     "baz", "bar");
 
+    private final String TEST_IPV_SESSION_ID = "a-session-id";
+    private final String TEST_IP_ADDRESS = "127.0.0.1";
+    private final String TEST_FEATURE_SET = "test-feature-set";
+
     @ParameterizedTest(name = "with matching header: {0}")
     @ValueSource(strings = {"Baz", "baz"})
     void matchHeaderByDownCasing(String headerName) {
@@ -66,6 +70,14 @@ class RequestHelperTest {
     void getIpvSessionIdShouldReturnSessionId() throws HttpResponseExceptionWithErrorBody {
         var event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(IPV_SESSION_ID_HEADER, "a-session-id"));
+
+        assertEquals("a-session-id", RequestHelper.getIpvSessionId(event));
+    }
+
+    @Test
+    void getIpvSessionIdShouldReturnSessionIdFromJourney()
+            throws HttpResponseExceptionWithErrorBody {
+        var event = new JourneyRequest(TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_FEATURE_SET);
 
         assertEquals("a-session-id", RequestHelper.getIpvSessionId(event));
     }
@@ -231,6 +243,18 @@ class RequestHelperTest {
 
         event.setHeaders(headers);
 
+        assertEquals("default", RequestHelper.getFeatureSet(event));
+    }
+
+    @Test
+    void getFeatureSetShouldReturnFeatureSetIdFromJourney() {
+        var event = new JourneyRequest(TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_FEATURE_SET);
+        assertEquals("test-feature-set", RequestHelper.getFeatureSet(event));
+    }
+
+    @Test
+    void getFeatureSetShouldReturnDefaultFeatureSetIdFromJourneyWhenNotPresent() {
+        var event = new JourneyRequest(TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, null);
         assertEquals("default", RequestHelper.getFeatureSet(event));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -246,17 +246,6 @@ class RequestHelperTest {
     }
 
     @Test
-    void getFeatureSetShouldReturnDefault() {
-        var event = new APIGatewayProxyRequestEvent();
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put(FEATURE_SET_HEADER, null);
-
-        event.setHeaders(headers);
-
-        assertEquals("default", RequestHelper.getFeatureSet(event));
-    }
-
-    @Test
     void getFeatureSetShouldReturnFeatureSetIdFromJourney() {
         var event =
                 new JourneyRequest(
@@ -265,21 +254,5 @@ class RequestHelperTest {
                         TEST_CLIENT_SESSION_ID,
                         TEST_FEATURE_SET);
         assertEquals("test-feature-set", RequestHelper.getFeatureSet(event));
-    }
-
-    @Test
-    void getFeatureSetShouldReturnDefaultFeatureSetIdFromJourneyWhenNotPresent() {
-        var event =
-                new JourneyRequest(
-                        TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_CLIENT_SESSION_ID, null);
-        assertEquals("default", RequestHelper.getFeatureSet(event));
-    }
-
-    @Test
-    void getFeatureSetShouldReturnDefaultFeatureSetIdFromJourneyWhenEmpty() {
-        var event =
-                new JourneyRequest(
-                        TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_CLIENT_SESSION_ID, "");
-        assertEquals("default", RequestHelper.getFeatureSet(event));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -274,4 +274,12 @@ class RequestHelperTest {
                         TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_CLIENT_SESSION_ID, null);
         assertEquals("default", RequestHelper.getFeatureSet(event));
     }
+
+    @Test
+    void getFeatureSetShouldReturnDefaultFeatureSetIdFromJourneyWhenEmpty() {
+        var event =
+                new JourneyRequest(
+                        TEST_IPV_SESSION_ID, TEST_IP_ADDRESS, TEST_CLIENT_SESSION_ID, "");
+        assertEquals("default", RequestHelper.getFeatureSet(event));
+    }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
@@ -88,4 +88,11 @@ class StepFunctionHelpersTest {
         assertEquals(
                 expected, StepFunctionHelpers.generatePageOutputMap("error", 400, "some-page"));
     }
+
+    @Test
+    void getFeatureSetShouldReturnFeatureSet() throws Exception {
+        Map<String, String> input = Map.of("featureSet", "test-feature-set");
+
+        assertEquals("test-feature-set", StepFunctionHelpers.getFeatureSet(input));
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Passing featureset to config service from all lambda using setter method.

### What changed

- Added extra call to config service to set featureset.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2706](https://govukverify.atlassian.net/browse/PYIC-2706)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2706]: https://govukverify.atlassian.net/browse/PYIC-2706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ