### PR TITLE
PYIC-2738: Added initial migration for check-existing-identity lambda

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -50,9 +50,7 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_PROFILE;
 
-/**
- * Check Existing Identity response Lambda
- */
+/** Check Existing Identity response Lambda */
 public class CheckExistingIdentityHandler extends BaseJourneyLambda {
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -1,13 +1,9 @@
 package uk.gov.di.ipv.core.checkexistingidentity;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nimbusds.jwt.SignedJWT;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -20,7 +16,6 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.AuditExtensionGpg45ProfileMatched;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
-import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
@@ -29,11 +24,8 @@ import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeExce
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
-import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
-import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -42,6 +34,8 @@ import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
+import uk.gov.di.ipv.core.library.statemachine.BaseJourneyLambda;
+import uk.gov.di.ipv.core.library.statemachine.JourneyRequest;
 import uk.gov.di.ipv.core.library.vchelper.VcHelper;
 
 import java.text.ParseException;
@@ -56,12 +50,12 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_PROFILE;
 
-public class CheckExistingIdentityHandler
-        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+/**
+ * Check Existing Identity response Lambda
+ */
+public class CheckExistingIdentityHandler extends BaseJourneyLambda {
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
-    private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
-    private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
     private static final String VOT_P2 = "P2";
     private static final int ONLY = 0;
     private static final Logger LOGGER = LogManager.getLogger();
@@ -75,6 +69,7 @@ public class CheckExistingIdentityHandler
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final String componentId;
 
+    @SuppressWarnings("unused") // Used by AWS
     public CheckExistingIdentityHandler(
             ConfigService configService,
             UserIdentityService userIdentityService,
@@ -93,6 +88,7 @@ public class CheckExistingIdentityHandler
         this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
+    @SuppressWarnings("unused") // Used through dependency injection
     @ExcludeFromGeneratedCoverageReport
     public CheckExistingIdentityHandler() {
         this.configService = new ConfigService();
@@ -108,13 +104,12 @@ public class CheckExistingIdentityHandler
     @Override
     @Tracing
     @Logging(clearState = true)
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent event, Context context) {
+    protected JourneyResponse handleRequest(JourneyRequest event, Context context) {
         LogHelper.attachComponentIdToLogs();
 
         try {
-            String ipvSessionId = RequestHelper.getIpvSessionId(event);
-            String ipAddress = RequestHelper.getIpAddress(event);
+            String ipvSessionId = event.getIpvSessionId();
+            String ipAddress = event.getIpAddress();
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionDetailsService.getClientOAuthSession(
@@ -178,8 +173,7 @@ public class CheckExistingIdentityHandler
 
                     updateSuccessfulVcStatuses(ipvSessionItem, credentials);
 
-                    return ApiGatewayResponseGenerator.proxyJsonResponse(
-                            HttpStatus.SC_OK, JOURNEY_REUSE);
+                    return JOURNEY_REUSE;
                 }
             }
 
@@ -207,28 +201,19 @@ public class CheckExistingIdentityHandler
                 LOGGER.info(message);
             }
 
-            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, JOURNEY_NEXT);
-        } catch (HttpResponseExceptionWithErrorBody e) {
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    e.getResponseCode(), e.getErrorBody());
+            return JOURNEY_NEXT;
         } catch (ParseException e) {
             LOGGER.error("Unable to parse existing credentials", e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
+            return JOURNEY_ERROR;
         } catch (CiRetrievalException e) {
             LOGGER.error("Error when fetching CIs from storage system", e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_GET_STORED_CIS);
+            return JOURNEY_ERROR;
         } catch (UnknownEvidenceTypeException e) {
             LOGGER.error("Unable to determine type of credential", e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE);
+            return JOURNEY_ERROR;
         } catch (SqsException e) {
             LOGGER.error("Failed to send audit event to SQS queue", e);
-            return ApiGatewayResponseGenerator.proxyJsonResponse(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
+            return JOURNEY_ERROR;
         }
     }
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -377,7 +377,8 @@ class CheckExistingIdentityHandlerTest {
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
-    private APIGatewayProxyResponseEvent makeRequest(APIGatewayProxyRequestEvent event, Context context) {
+    private APIGatewayProxyResponseEvent makeRequest(
+            APIGatewayProxyRequestEvent event, Context context) {
         final var requestType = new TypeReference<Map<String, Object>>() {};
         final var request = objectMapper.convertValue(event, requestType);
         final var response = checkExistingIdentityHandler.handleRequest(request, context);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -326,7 +326,9 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals("/journey/error", responseValue.getJourney());
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getCode(), responseValue.getCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getCode(),
+                responseValue.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(),
                 responseValue.getMessage());
@@ -348,7 +350,9 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals("/journey/error", responseValue.getJourney());
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getCode(), responseValue.getCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getCode(),
+                responseValue.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getMessage(),
                 responseValue.getMessage());

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -308,7 +308,7 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals("/journey/error", responseValue.getJourney());
         assertEquals(HttpStatus.SC_BAD_REQUEST, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID, responseValue.getCode());
+        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), responseValue.getCode());
         assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), responseValue.getMessage());
         verify(clientOAuthSessionDetailsService, times(0)).getClientOAuthSession(any());
     }
@@ -326,7 +326,7 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals("/journey/error", responseValue.getJourney());
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS, responseValue.getCode());
+        assertEquals(ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getCode(), responseValue.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(),
                 responseValue.getMessage());
@@ -348,7 +348,7 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals("/journey/error", responseValue.getJourney());
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE, responseValue.getCode());
+        assertEquals(ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getCode(), responseValue.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getMessage(),
                 responseValue.getMessage());
@@ -372,7 +372,7 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals("/journey/error", responseValue.getJourney());
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_GET_STORED_CIS, responseValue.getCode());
+        assertEquals(ErrorResponse.FAILED_TO_GET_STORED_CIS.getCode(), responseValue.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_GET_STORED_CIS.getMessage(), responseValue.getMessage());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
@@ -400,7 +400,7 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals("/journey/error", responseValue.getJourney());
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT, responseValue.getCode());
+        assertEquals(ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getCode(), responseValue.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getMessage(), responseValue.getMessage());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -1,7 +1,9 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
@@ -77,5 +79,20 @@ public enum ErrorResponse {
 
     public String getMessage() {
         return message;
+    }
+
+    @JsonValue()
+    public int toValue() {
+        return this.getCode();
+    }
+
+    @JsonCreator
+    public static ErrorResponse forCode(int code) {
+        for (ErrorResponse element : values()) {
+            if (element.getCode() == code) {
+                return element;
+            }
+        }
+        return null;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.library.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -81,11 +81,6 @@ public enum ErrorResponse {
         return message;
     }
 
-    @JsonValue()
-    public int toValue() {
-        return this.getCode();
-    }
-
     @JsonCreator
     public static ErrorResponse forCode(int code) {
         for (ErrorResponse element : values()) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyErrorResponse.java
@@ -1,0 +1,55 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(
+        value = {"message"},
+        allowGetters = true)
+public class JourneyErrorResponse extends JourneyResponse {
+    @JsonProperty private int statusCode;
+
+    @JsonProperty private ErrorResponse code;
+
+    private String message;
+
+    @JsonCreator
+    public JourneyErrorResponse(
+            @JsonProperty(value = "journey", required = true) String journey,
+            @JsonProperty(value = "statusCode") int statusCode,
+            @JsonProperty(value = "code") ErrorResponse code) {
+        this(journey, statusCode, code, null);
+    }
+
+    public JourneyErrorResponse(
+            String journey, int statusCode, ErrorResponse code, String message) {
+        super(journey);
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    @JsonProperty("message")
+    public String getMessage() {
+        if (this.message != null) {
+            return this.message;
+        }
+        if (this.code != null) {
+            return this.code.getMessage();
+        }
+        return null;
+    }
+
+    public int getStatusCode() {
+        return this.statusCode;
+    }
+
+    public ErrorResponse getCode() {
+        return code;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyErrorResponse.java
@@ -49,7 +49,7 @@ public class JourneyErrorResponse extends JourneyResponse {
         return this.statusCode;
     }
 
-    public ErrorResponse getCode() {
-        return code;
+    public int getCode() {
+        return this.code != null ? this.code.getCode() : 0;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.library.statemachine;
+package uk.gov.di.ipv.core.library.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -84,6 +85,11 @@ public class RequestHelper {
         return getIpvSessionId(event.getHeaders(), false);
     }
 
+    public static String getIpvSessionId(JourneyRequest event)
+            throws HttpResponseExceptionWithErrorBody {
+        return getIpvSessionId(event, false);
+    }
+
     public static String getIpvSessionIdAllowNull(APIGatewayProxyRequestEvent event)
             throws HttpResponseExceptionWithErrorBody {
         return getIpvSessionId(event.getHeaders(), true);
@@ -98,21 +104,51 @@ public class RequestHelper {
         return getClientOAuthSessionId(event.getHeaders());
     }
 
-    private static String getIpvSessionId(Map<String, String> headers, boolean allowNull)
+    public static String getIpvSessionId(JourneyRequest request, boolean allowNull)
+            throws HttpResponseExceptionWithErrorBody {
+        String ipvSessionId = request.getIpvSessionId();
+
+        validateIpvSessionId(ipvSessionId, "ipvSessionId not present in request", allowNull);
+
+        LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
+        return ipvSessionId;
+    }
+
+    public static String getIpvSessionId(Map<String, String> headers, boolean allowNull)
             throws HttpResponseExceptionWithErrorBody {
         String ipvSessionId = RequestHelper.getHeaderByKey(headers, IPV_SESSION_ID_HEADER);
+        String message = String.format("%s not present in header", IPV_SESSION_ID_HEADER);
+
+        validateIpvSessionId(ipvSessionId, message, allowNull);
+
+        LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
+        return ipvSessionId;
+    }
+
+    private static void validateIpvSessionId(
+            String ipvSessionId,
+            String errorMessage,
+            boolean allowNull) throws HttpResponseExceptionWithErrorBody {
         if (ipvSessionId == null) {
-            String message = String.format("%s not present in header", IPV_SESSION_ID_HEADER);
             if (allowNull) {
-                LOGGER.warn(message);
+                LOGGER.warn(errorMessage);
             } else {
-                LOGGER.error(message);
+                LOGGER.error(errorMessage);
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
             }
         }
-        LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
-        return ipvSessionId;
+    }
+
+    public static String getIpAddress(JourneyRequest request)
+            throws HttpResponseExceptionWithErrorBody {
+        String ipAddress = request.getIpAddress();
+        if (ipAddress == null) {
+            LOGGER.error("ipAddress not present in request");
+            throw new HttpResponseExceptionWithErrorBody(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IP_ADDRESS);
+        }
+        return ipAddress;
     }
 
     public static String getIpAddress(Map<String, String> headers)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -142,23 +142,24 @@ public class RequestHelper {
     public static String getIpAddress(JourneyRequest request)
             throws HttpResponseExceptionWithErrorBody {
         String ipAddress = request.getIpAddress();
-        if (ipAddress == null) {
-            LOGGER.error("ipAddress not present in request");
-            throw new HttpResponseExceptionWithErrorBody(
-                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IP_ADDRESS);
-        }
+        validateIpAddress(ipAddress, "ipAddress not present in request");
         return ipAddress;
     }
 
     public static String getIpAddress(Map<String, String> headers)
             throws HttpResponseExceptionWithErrorBody {
         String ipAddress = RequestHelper.getHeaderByKey(headers, IP_ADDRESS_HEADER);
+        validateIpAddress(ipAddress, String.format("%s not present in header", IP_ADDRESS_HEADER));
+        return ipAddress;
+    }
+
+    private static void validateIpAddress(String ipAddress, String errorMessage)
+            throws HttpResponseExceptionWithErrorBody {
         if (ipAddress == null) {
-            LOGGER.error("{} not present in header", IP_ADDRESS_HEADER);
+            LOGGER.error(errorMessage, IP_ADDRESS_HEADER);
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IP_ADDRESS);
         }
-        return ipAddress;
     }
 
     public static String getClientOAuthSessionId(Map<String, String> headers) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -10,8 +10,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -126,9 +126,8 @@ public class RequestHelper {
     }
 
     private static void validateIpvSessionId(
-            String ipvSessionId,
-            String errorMessage,
-            boolean allowNull) throws HttpResponseExceptionWithErrorBody {
+            String ipvSessionId, String errorMessage, boolean allowNull)
+            throws HttpResponseExceptionWithErrorBody {
         if (ipvSessionId == null) {
             if (allowNull) {
                 LOGGER.warn(errorMessage);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
@@ -1,0 +1,59 @@
+package uk.gov.di.ipv.core.library.statemachine;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpStatus;
+import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
+import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+
+import java.util.Map;
+
+public abstract class BaseJourneyLambda
+    implements RequestHandler<Map<String, Object>, Map<String, Object>> {
+
+    public static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
+    public static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
+    public static final JourneyResponse JOURNEY_ERROR = new JourneyResponse("/journey/error");
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private static final TypeReference<Map<String, Object>> RETURN_TYPE_REFERENCE =
+            new TypeReference<>() {};
+
+    @Override
+    public Map<String, Object> handleRequest(Map<String, Object> event, Context context) {
+        if (event.containsKey("ipvSessionId")) {
+            final var journeyRequest = OBJECT_MAPPER.convertValue(event, JourneyRequest.class);
+            final var journeyResponse = handleRequest(journeyRequest, context);
+
+            return OBJECT_MAPPER.convertValue(journeyResponse, RETURN_TYPE_REFERENCE);
+        }
+
+        APIGatewayProxyResponseEvent apiGatewayResponse;
+        try {
+            APIGatewayProxyRequestEvent request = OBJECT_MAPPER.convertValue(event, APIGatewayProxyRequestEvent.class);
+
+            final var ipvSessionId = RequestHelper.getIpvSessionId(request);
+            final var ipAddress = RequestHelper.getIpAddress(request);
+            final var journeyRequest = new JourneyRequest(ipvSessionId, ipAddress);
+
+            final var journeyResponse = handleRequest(journeyRequest, context);
+            apiGatewayResponse = ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, journeyResponse);
+        } catch (HttpResponseExceptionWithErrorBody e) {
+            apiGatewayResponse = ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_BAD_REQUEST, JOURNEY_ERROR);
+        }
+
+        return OBJECT_MAPPER.convertValue(apiGatewayResponse, RETURN_TYPE_REFERENCE);
+    }
+
+    protected abstract JourneyResponse handleRequest(JourneyRequest request, Context context);
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
+import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
@@ -33,8 +34,8 @@ public abstract class BaseJourneyLambda
     @Override
     public Map<String, Object> handleRequest(Map<String, Object> event, Context context) {
         if (event.containsKey("ipvSessionId")) {
-            final var journeyRequest = OBJECT_MAPPER.convertValue(event, JourneyRequest.class);
-            final var journeyResponse = handleRequest(journeyRequest, context);
+            var journeyRequest = OBJECT_MAPPER.convertValue(event, JourneyRequest.class);
+            var journeyResponse = handleRequest(journeyRequest, context);
 
             return OBJECT_MAPPER.convertValue(journeyResponse, RETURN_TYPE_REFERENCE);
         }
@@ -44,11 +45,11 @@ public abstract class BaseJourneyLambda
             APIGatewayProxyRequestEvent request =
                     OBJECT_MAPPER.convertValue(event, APIGatewayProxyRequestEvent.class);
 
-            final var ipvSessionId = RequestHelper.getIpvSessionId(request);
-            final var ipAddress = RequestHelper.getIpAddress(request);
-            final var journeyRequest = new JourneyRequest(ipvSessionId, ipAddress);
+            var ipvSessionId = RequestHelper.getIpvSessionId(request);
+            var ipAddress = RequestHelper.getIpAddress(request);
+            var journeyRequest = new JourneyRequest(ipvSessionId, ipAddress);
 
-            final var journeyResponse = handleRequest(journeyRequest, context);
+            var journeyResponse = handleRequest(journeyRequest, context);
             apiGatewayResponse =
                     ApiGatewayResponseGenerator.proxyJsonResponse(
                             HttpStatus.SC_OK, journeyResponse);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/BaseJourneyLambda.java
@@ -16,15 +16,16 @@ import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import java.util.Map;
 
 public abstract class BaseJourneyLambda
-    implements RequestHandler<Map<String, Object>, Map<String, Object>> {
+        implements RequestHandler<Map<String, Object>, Map<String, Object>> {
 
     public static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
     public static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
     public static final JourneyResponse JOURNEY_ERROR = new JourneyResponse("/journey/error");
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper()
+                    .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private static final TypeReference<Map<String, Object>> RETURN_TYPE_REFERENCE =
             new TypeReference<>() {};
@@ -40,16 +41,21 @@ public abstract class BaseJourneyLambda
 
         APIGatewayProxyResponseEvent apiGatewayResponse;
         try {
-            APIGatewayProxyRequestEvent request = OBJECT_MAPPER.convertValue(event, APIGatewayProxyRequestEvent.class);
+            APIGatewayProxyRequestEvent request =
+                    OBJECT_MAPPER.convertValue(event, APIGatewayProxyRequestEvent.class);
 
             final var ipvSessionId = RequestHelper.getIpvSessionId(request);
             final var ipAddress = RequestHelper.getIpAddress(request);
             final var journeyRequest = new JourneyRequest(ipvSessionId, ipAddress);
 
             final var journeyResponse = handleRequest(journeyRequest, context);
-            apiGatewayResponse = ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, journeyResponse);
+            apiGatewayResponse =
+                    ApiGatewayResponseGenerator.proxyJsonResponse(
+                            HttpStatus.SC_OK, journeyResponse);
         } catch (HttpResponseExceptionWithErrorBody e) {
-            apiGatewayResponse = ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_BAD_REQUEST, JOURNEY_ERROR);
+            apiGatewayResponse =
+                    ApiGatewayResponseGenerator.proxyJsonResponse(
+                            HttpStatus.SC_BAD_REQUEST, JOURNEY_ERROR);
         }
 
         return OBJECT_MAPPER.convertValue(apiGatewayResponse, RETURN_TYPE_REFERENCE);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequest.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.core.library.statemachine;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class JourneyRequest {
+    private String ipvSessionId;
+    private String ipAddress;
+}


### PR DESCRIPTION
## Proposed changes

### What changed

* Migrated check-existing-identity lambda to respond to both Lambdas and API Gateway.
* Updated check-existing-identity lambda to return `/journey/error` in response to an error, so that it may be processed by `project-journey-step`

### Why did it change

Needs to check-existing-identity lambda to respond to both Lambdas and API Gateway.

### Issue tracking
- [PYIC-2725: Update the check-existing-identity lambda so that it can be called directly using JSON](https://govukverify.atlassian.net/browse/PYIC-2725)
  - [PYIC-2738: Update the Lambda to support both API Gateway and JSON requests](https://govukverify.atlassian.net/browse/PYIC-2738)
  - [PYIC-2739: Reconfigure API Gateway so that it calls the Lambda using JSON](https://govukverify.atlassian.net/browse/PYIC-2739)
  - [PYIC-2747: Update pertinent Integration tests if required](https://govukverify.atlassian.net/browse/PYIC-2747)
  - [PYIC-2753: Update the Lambda removing support for API Gateway requests](https://govukverify.atlassian.net/browse/PYIC-2753)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

N/A

[PYIC-2738]: https://govukverify.atlassian.net/browse/PYIC-2738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ