### PR TITLE
Removed references to the ‘Process Journey Step’ Lambda or ‘Process Journey Step’ State Machine remaining in the CRI Return Journey Step Function 

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -19,7 +19,7 @@
         {
           "ErrorEquals": ["uk.gov.di.ipv.core.library.exceptions.JourneyError"],
           "ResultPath": "$.error",
-          "Next": "ReturnFrontend"
+          "Next": "RetrieveCriOAuthAccessTokenError"
         }
       ],
       "ResultPath": "$.lambdaResult",
@@ -34,6 +34,10 @@
       },
       "ResultPath": "$.lambdaResult",
       "Next": "RouteJourneyResponse"
+    },
+    "RetrieveCriOAuthAccessTokenError": {
+      "Type": "Pass",
+      "Next": "ReturnToFrontend"
     },
     "ReturnToFrontend": {
       "Type": "Succeed",

--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -37,6 +37,9 @@
     },
     "RetrieveCriOAuthAccessTokenError": {
       "Type": "Pass",
+      "Result": {
+        "journey": "/journey/error"
+      },
       "Next": "ReturnToFrontend"
     },
     "ReturnToFrontend": {

--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -19,7 +19,7 @@
         {
           "ErrorEquals": ["uk.gov.di.ipv.core.library.exceptions.JourneyError"],
           "ResultPath": "$.error",
-          "Next": "ProcessJourneyStep-JourneyError"
+          "Next": "ReturnFrontend"
         }
       ],
       "ResultPath": "$.lambdaResult",
@@ -35,28 +35,6 @@
       "ResultPath": "$.lambdaResult",
       "Next": "RouteJourneyResponse"
     },
-    "ProcessJourneyStep": {
-      "Type": "Task",
-      "Resource": "${IPVProcessJourneyStepFunctionArn}",
-      "Parameters": {
-        "ipvSessionId.$": "$.ipvSessionId",
-        "ipAddress.$": "$.ipAddress",
-        "journey.$": "$.lambdaResult.journey"
-      },
-      "ResultPath": "$.lambdaResult",
-      "Next": "RouteJourneyResponse"
-    },
-    "ProcessJourneyStep-JourneyError": {
-      "Type": "Task",
-      "Resource": "${IPVProcessJourneyStepFunctionArn}",
-      "Parameters": {
-        "ipvSessionId.$": "$.ipvSessionId",
-        "ipAddress.$": "$.ipAddress",
-        "journey": "journey/error"
-      },
-      "ResultPath": "$.lambdaResult",
-      "Next": "ReturnToFrontend"
-    },
     "ReturnToFrontend": {
       "Type": "Succeed",
       "OutputPath": "$.lambdaResult"
@@ -70,26 +48,6 @@
             "IsPresent": true
           },
           "Next": "ReturnToFrontend"
-        },
-        {
-          "Variable": "$.lambdaResult.journey",
-          "StringEquals": "/journey/next",
-          "Next": "ProcessJourneyStep"
-        },
-        {
-          "Variable": "$.lambdaResult.journey",
-          "StringEquals": "/journey/access-denied",
-          "Next": "ProcessJourneyStep"
-        },
-        {
-          "Variable": "$.lambdaResult.journey",
-          "StringEquals": "/journey/temporarily-unavailable",
-          "Next": "ProcessJourneyStep"
-        },
-        {
-          "Variable": "$.lambdaResult.journey",
-          "StringEquals": "/journey/error",
-          "Next": "ProcessJourneyStep"
         },
         {
           "Variable": "$.lambdaResult.journey",

--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -17,7 +17,7 @@
       },
       "Catch": [
         {
-          "ErrorEquals": ["uk.gov.di.ipv.core.library.exceptions.JourneyError"],
+          "ErrorEquals": ["uk.gov.di.ipv.core.library.exceptions.JourneyError", "java.lang.IllegalArgumentException"],
           "ResultPath": "$.error",
           "Next": "RetrieveCriOAuthAccessTokenError"
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

  Removed references to the ‘Process Journey Step’ Lambda or ‘Process Journey Step’ State Machine remaining in the CRI Return Journey Step Function 

### Why did it change

   Currently the CRI Return Step Function manages both the CRI Return and also partially tries to manage the Process Journey Step. However, this adds additional complexity to the Step Function and needs to be simplified.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2695](https://govukverify.atlassian.net/browse/PYIC-2695)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2695]: https://govukverify.atlassian.net/browse/PYIC-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ