### PR TITLE
[PYIC-2777]: Add featureSet getter/setter

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -53,13 +53,13 @@ public class ConfigService {
     private final SecretsProvider secretsProvider;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final String featureSet;
+    private String featureSet;
 
     public ConfigService(
             SSMProvider ssmProvider, SecretsProvider secretsProvider, String featureSet) {
         this.ssmProvider = ssmProvider;
         this.secretsProvider = secretsProvider;
-        this.featureSet = featureSet;
+        setFeatureSet(featureSet);
     }
 
     public ConfigService(SSMProvider ssmProvider, SecretsProvider secretsProvider) {
@@ -98,7 +98,7 @@ public class ConfigService {
                                             .build())
                             .defaultMaxAge(3, MINUTES);
         }
-        this.featureSet = featureSet;
+        setFeatureSet(featureSet);
     }
 
     public ConfigService() {
@@ -107,6 +107,14 @@ public class ConfigService {
 
     public SSMProvider getSsmProvider() {
         return ssmProvider;
+    }
+
+    public String getFeatureSet() {
+        return featureSet;
+    }
+
+    public void setFeatureSet(String featureSet) {
+        this.featureSet = featureSet;
     }
 
     public String getEnvironmentVariable(EnvironmentVariable environmentVariable) {


### PR DESCRIPTION
## Proposed changes

### What changed

Add getter/setter for config service feature set

### Why did it change

Feature set is not known when config service is created.

### Issue tracking

- [PYIC-2777](https://govukverify.atlassian.net/browse/PYIC-2777)

## Checklists

### Environment variables or secrets

- No environment variables or secrets were added or changed

### Other considerations



[PYIC-2777]: https://govukverify.atlassian.net/browse/PYIC-2777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ