### PR TITLE
[PYIC-2711] Feature set overrides in multiple property methods

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -117,7 +117,11 @@ public class ConfigService {
     }
 
     public void setFeatureSet(String featureSet) {
-        this.featureSet = featureSet;
+        if (featureSet == null || featureSet.isBlank()) {
+            this.featureSet = null;
+        } else {
+            this.featureSet = featureSet;
+        }
     }
 
     public String getEnvironmentVariable(EnvironmentVariable environmentVariable) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -143,6 +143,14 @@ class ConfigServiceTest {
         assertTrue(result.getRequiresApiKey());
     }
 
+    @ParameterizedTest
+    @CsvSource({",", "' ',", "' \t\n',", "fs0001,fs0001"})
+    void shouldNormaliseNullAndEmptyFeatureSetsToNull(
+            String featureSet, String expectedFeatureSet) {
+        configService.setFeatureSet(featureSet);
+        assertEquals(expectedFeatureSet, configService.getFeatureSet());
+    }
+
     @Test
     void shouldReturnIsEnabled() {
         environmentVariables.set("ENVIRONMENT", "test");

--- a/libs/credential-issuer-config-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigService.java
+++ b/libs/credential-issuer-config-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigService.java
@@ -38,8 +38,7 @@ public class CredentialIssuerConfigService extends ConfigService {
     public List<CredentialIssuerConfig> getCredentialIssuers()
             throws ParseCredentialIssuerConfigException {
         Map<String, String> params =
-                getSsmParameters(
-                        resolvePath(ConfigurationVariable.CREDENTIAL_ISSUERS.getPath()), true);
+                getSsmParameters(ConfigurationVariable.CREDENTIAL_ISSUERS.getPath(), true);
 
         Map<String, Map<String, Object>> map = new HashMap<>();
         for (Map.Entry<String, String> entry : params.entrySet()) {


### PR DESCRIPTION
## Proposed changes

### What changed
Enable feature set to override base config properties - multiple property methods.

### Why did it change
Introduction of featureSet capability: Note propagation of featureSet into the lambdas is not yet wired in.

### Issue tracking
- [PYIC-2711](https://govukverify.atlassian.net/browse/PYIC-2711)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations

[PYIC-2711]: https://govukverify.atlassian.net/browse/PYIC-2711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ