### PR TITLE
PYIC-2739: Added call to /journey/check-existing-identity through JSON request

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -602,7 +602,6 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
@@ -744,7 +743,6 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
@@ -884,7 +882,6 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub build-cri-oauth-request-${Environment}
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
@@ -1005,7 +1002,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt ClientOAuthSessionsTable.Arn ] ]
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -1104,7 +1100,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub get-credential-issuer-config-${Environment}
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -1531,7 +1526,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           CI_STORAGE_GET_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
             - contra_indicator_storage_account_id: !FindInMap
@@ -1657,7 +1651,6 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub select-cri-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
       VpcConfig:
@@ -1745,7 +1738,6 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub validate-oauth-callback-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CRI_OAUTH_SESSIONS_TABLE_NAME: !Ref CriOAuthSessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
@@ -1852,7 +1844,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           CI_STORAGE_GET_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
             - contra_indicator_storage_account_id: !FindInMap
@@ -2002,7 +1993,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2098,7 +2088,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX: !Sub "/${Environment}/core/credentialIssuers"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CI_STORAGE_GET_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -41,12 +41,10 @@ Conditions:
     - !Equals
       - !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
       -  0
-  IsDevelopment: !Not
-    - !Or
-      - !Equals [ !Ref Environment, "build"]
-      - !Equals [ !Ref Environment, "staging"]
-      - !Equals [ !Ref Environment, "integration"]
-      - !Equals [ !Ref Environment, "production"]
+  IsDevelopment: !Or
+    - !Equals [ !Ref AWS::AccountId, "130355686670"]
+    - !Equals [ !Ref AWS::AccountId, "175872367215"]
+  IsOldDevelopment: !Equals [ !Ref AWS::AccountId, "130355686670"]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
   IsProduction: !Equals [ !Ref Environment, "production"]
   UseCodeSigning:
@@ -65,7 +63,14 @@ Conditions:
 # mapping up to date with each developer environment.
 Mappings:
   EnvironmentConfiguration:
-    "130355686670": # Development
+    "130355686670": # Old Development Account
+      provisionedConcurrency: 0
+      ciStorageAccountId: 322814139578 # di-ipv-cri-dev
+      environment: dev
+      criReturnStepFunctionLogLevel: ALL
+      pgw500ErrorLimit: 2
+      egw500ErrorLimit: 2
+    "175872367215": # New Development Account
       provisionedConcurrency: 0
       ciStorageAccountId: 322814139578 # di-ipv-cri-dev
       environment: dev
@@ -148,7 +153,7 @@ Resources:
           FromPort: 443
           ToPort: 443
         - DestinationSecurityGroupId: !If
-            - IsDevelopment
+            - IsOldDevelopment
             - !ImportValue InterfaceVpcEndpointSecurityGroupId
             - Fn::ImportValue:  !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
           Description: Allow outbound HTTPS traffic to AWS Services vpc endpoint security group
@@ -178,7 +183,7 @@ Resources:
       EndpointConfiguration:
         Type: PRIVATE
         VPCEndpointIds: !If
-          - IsDevelopment
+          - IsOldDevelopment
           - - !ImportValue "network-shared-development-ApiGatewayVpcEndpointId"
           - - Fn::ImportValue: !Sub "${VpcStackName}-ExecuteApiGatewayEndpointId"
       DefinitionBody:
@@ -206,7 +211,7 @@ Resources:
               Condition:
                 StringNotEquals:
                   'aws:SourceVpce': !If
-                    - IsDevelopment
+                    - IsOldDevelopment
                     - !ImportValue "network-shared-development-ApiGatewayVpcEndpointId"
                     - Fn::ImportValue:
                         !Sub "${VpcStackName}-ExecuteApiGatewayEndpointId"

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -233,7 +233,6 @@ public class EvaluateGpg45ScoresHandler
                     .with(
                             LOG_ERROR_DESCRIPTION.getFieldName(),
                             ErrorResponse.FAILED_NAME_CORRELATION.getMessage())
-                    .with("userId", userId)
                     .with(LOG_ERROR_JOURNEY_RESPONSE.getFieldName(), JOURNEY_PYI_NO_MATCH);
             LOGGER.error(message);
             return false;
@@ -248,7 +247,6 @@ public class EvaluateGpg45ScoresHandler
                     .with(
                             LOG_ERROR_DESCRIPTION.getFieldName(),
                             ErrorResponse.FAILED_BIRTHDATE_CORRELATION.getMessage())
-                    .with("userId", userId)
                     .with(LOG_ERROR_JOURNEY_RESPONSE.getFieldName(), JOURNEY_PYI_NO_MATCH);
             LOGGER.error(message);
             return false;

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -1,11 +1,7 @@
 package uk.gov.di.ipv.core.credentialissuer;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,7 +42,7 @@ class SelectCriHandlerTest {
 
     private static final String TEST_SESSION_ID = "the-session-id";
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Mock private Context context;
     @Mock private ConfigService mockConfigService;
@@ -64,8 +60,7 @@ class SelectCriHandlerTest {
     }
 
     @Test
-    void shouldReturnPassportCriJourneyResponse()
-            throws JsonProcessingException, URISyntaxException {
+    void shouldReturnPassportCriJourneyResponse() throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -76,19 +71,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", false));
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/ukPassport", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/ukPassport", response.get("journey"));
     }
 
     @Test
     void shouldReturnPassportAndDrivingLicenceCriJourneyResponseWhenDrivingLicenceCriEnabled()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -97,20 +89,19 @@ class SelectCriHandlerTest {
                 .thenReturn(Collections.emptyList());
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", true));
+        when(mockConfigService.getActiveConnection("drivingLicence")).thenReturn("main");
+        when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(false);
+        when(mockConfigService.isEnabled("drivingLicence")).thenReturn(true);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        //        assertEquals("/journey/ukPassportAndDrivingLicence", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/ukPassportAndDrivingLicence", response.get("journey"));
     }
 
     @Test
-    void shouldReturnAddressCriJourneyResponseWhenVisitedPassport()
-            throws JsonProcessingException, URISyntaxException {
+    void shouldReturnAddressCriJourneyResponseWhenVisitedPassport() throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -128,19 +119,16 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/address", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/address", response.get("journey"));
     }
 
     @Test
     void shouldReturnAddressCriJourneyResponseWhenVisitedDrivingLicence()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -158,19 +146,16 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/address", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/address", response.get("journey"));
     }
 
     @Test
     void shouldReturnPyiNoMatchErrorResponseIfAddressCriHasPreviouslyFailed()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -186,18 +171,15 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/pyi-no-match", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/pyi-no-match", response.get("journey"));
     }
 
     @Test
-    void shouldReturnFraudCriJourneyResponse() throws JsonProcessingException, URISyntaxException {
+    void shouldReturnFraudCriJourneyResponse() throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -222,18 +204,15 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/fraud", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/fraud", response.get("journey"));
     }
 
     @Test
-    void shouldReturnKBVCriJourneyResponse() throws JsonProcessingException, URISyntaxException {
+    void shouldReturnKBVCriJourneyResponse() throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -263,19 +242,15 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/kbv", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/kbv", response.get("journey"));
     }
 
     @Test
-    void shouldReturnJourneyFailedIfAllCriVisited()
-            throws JsonProcessingException, URISyntaxException {
+    void shouldReturnJourneyFailedIfAllCriVisited() throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -307,19 +282,15 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/fail", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/fail", response.get("journey"));
     }
 
     @Test
-    void shouldReturnDcmawCriJourneyResponseIfUserHasNotVisited()
-            throws JsonProcessingException, URISyntaxException {
+    void shouldReturnDcmawCriJourneyResponseIfUserHasNotVisited() throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -335,19 +306,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/dcmaw", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/dcmaw", response.get("journey"));
     }
 
     @Test
     void shouldReturnDcmawSuccessJourneyResponseIfUserHasVisitedDcmawSuccessfully()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -362,19 +330,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/dcmaw-success", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/dcmaw-success", response.get("journey"));
     }
 
     @Test
     void shouldReturnFraudCriJourneyResponseIfUserHasVisitedDcmawAndAddressSuccessfully()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -397,19 +362,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/fraud", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/fraud", response.get("journey"));
     }
 
     @Test
     void shouldReturnAddressdCriJourneyResponseIfUserHasNotVistedAppButAlreadyHasPassportVC()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -428,19 +390,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/address", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/address", response.get("journey"));
     }
 
     @Test
     void shouldReturnPyiNoMatchJourneyResponseIfUserHasVisitedDcmawAndAddressAndFraudSuccessfully()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -475,19 +434,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
                 .thenReturn(createCriConfig(FRAUD_CRI, "test-fraud-iss", true));
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/fail", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/fail", response.get("journey"));
     }
 
     @Test
     void shouldReturnPassportCriJourneyResponseIfUserHasVisitedDcmawButItFailedWithAVc()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -502,19 +458,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", false));
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/ukPassport", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/ukPassport", response.get("journey"));
     }
 
     @Test
     void shouldReturnPassportCriJourneyResponseIfUserHasVisitedDcmawButItFailedWithoutAVc()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -532,19 +485,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", false));
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/ukPassport", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/ukPassport", response.get("journey"));
     }
 
     @Test
     void shouldReturnPyiNoMatchErrorJourneyResponseIfUserHasAPreviouslyFailedVisitToAddress()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -562,19 +512,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/pyi-no-match", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/pyi-no-match", response.get("journey"));
     }
 
     @Test
     void shouldReturnPyiNoMatchErrorJourneyResponseIfUserHasAPreviouslyFailedVisitToDrivingLicence()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -589,19 +536,16 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-driving-licence-iss", false)));
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/pyi-no-match", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/pyi-no-match", response.get("journey"));
     }
 
     @Test
     void shouldReturnKbvThinFileErrorJourneyResponseIfUserHasAPreviouslyFailedVisitKbvWithoutCis()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -631,19 +575,15 @@ class SelectCriHandlerTest {
                                 new VcStatusDto("test-kbv-iss", false)));
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(false);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/pyi-kbv-thin-file", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/pyi-kbv-thin-file", response.get("journey"));
     }
 
     @Test
-    void shouldReturnCorrectJourneyResponseWhenVcStatusesAreNull()
-            throws JsonProcessingException, URISyntaxException {
+    void shouldReturnCorrectJourneyResponseWhenVcStatusesAreNull() throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -657,19 +597,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", false));
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/ukPassport", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/ukPassport", response.get("journey"));
     }
 
     @Test
     void shouldReturnDcmawCriJourneyResponseIfUserIsIncludedInAllowedList()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -686,19 +623,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.getSsmParameter(DCMAW_ALLOWED_USER_IDS))
                 .thenReturn("test-user-id,test-user-id-2,test-user-id-3");
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/dcmaw", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/dcmaw", response.get("journey"));
     }
 
     @Test
     void shouldReturnDcmawCriJourneyResponseIfUserIdHasAppJourneyPrefix()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
@@ -717,19 +651,16 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("false");
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/dcmaw", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/dcmaw", response.get("journey"));
     }
 
     @Test
     void shouldReturnPassportCriJourneyResponseIfUserIsNotIncludedInAllowedList()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -750,19 +681,16 @@ class SelectCriHandlerTest {
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/ukPassport", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/ukPassport", response.get("journey"));
     }
 
     @Test
     void shouldReturnDcmawCriJourneyResponseIfShouldSendAllUsersToAppVarIsTrue()
-            throws JsonProcessingException, URISyntaxException {
+            throws URISyntaxException {
         mockIpvSessionService();
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -779,14 +707,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS))
                 .thenReturn(String.valueOf(true));
 
-        APIGatewayProxyRequestEvent input = createRequestEvent();
+        Map<String, Object> input = createRequestEvent();
 
-        APIGatewayProxyResponseEvent response = underTest.handleRequest(input, context);
+        Map<String, Object> response = underTest.handleRequest(input, context);
 
-        Map<String, String> responseBody = getResponseBodyAsMap(response);
-
-        assertEquals("/journey/dcmaw", responseBody.get("journey"));
-        assertEquals(HTTPResponse.SC_OK, response.getStatusCode());
+        assertEquals("/journey/dcmaw", response.get("journey"));
     }
 
     private void mockIpvSessionService() {
@@ -795,15 +720,8 @@ class SelectCriHandlerTest {
                 .thenReturn(getClientOAuthSessionItem());
     }
 
-    private APIGatewayProxyRequestEvent createRequestEvent() {
-        APIGatewayProxyRequestEvent input = new APIGatewayProxyRequestEvent();
-        input.setHeaders(Map.of("ipv-session-id", TEST_SESSION_ID));
-        return input;
-    }
-
-    private Map<String, String> getResponseBodyAsMap(APIGatewayProxyResponseEvent response)
-            throws JsonProcessingException {
-        return objectMapper.readValue(response.getBody(), Map.class);
+    private Map<String, Object> createRequestEvent() {
+        return Map.of("ipvSessionId", TEST_SESSION_ID);
     }
 
     private CredentialIssuerConfig createCriConfig(String criId, String criIss, boolean enabled)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -1,33 +1,33 @@
 package uk.gov.di.ipv.core.library.config;
 
 public enum ConfigurationVariable {
-    BACKEND_SESSION_TIMEOUT("/%s/core/self/backendSessionTimeout"),
-    BACKEND_SESSION_TTL("/%s/core/self/backendSessionTtl"),
-    CLIENT_ISSUER("/%s/core/clients/%s/issuer"),
-    COMPONENT_ID("/%s/core/self/componentId"),
-    CORE_FRONT_CALLBACK_URL("/%s/core/self/coreFrontCallbackUrl"),
-    CORE_VTM_CLAIM("/%s/core/self/coreVtmClaim"),
-    JAR_KMS_ENCRYPTION_KEY_ID("/%s/core/self/jarKmsEncryptionKeyId"),
-    JWT_TTL_SECONDS("/%s/core/self/jwtTtlSeconds"),
-    MAX_ALLOWED_AUTH_CLIENT_TTL("/%s/core/self/maxAllowedAuthClientTtl"),
-    DCMAW_SHOULD_SEND_ALL_USERS("/%s/core/self/journey/dcmawShouldSendAllUsers"),
-    DCMAW_ALLOWED_USER_IDS("/%s/core/self/journey/dcmawAllowedUserIds"),
-    AUTH_CODE_EXPIRY_SECONDS("/%s/core/self/authCodeExpirySeconds"),
-    PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("/%s/core/clients/%s/publicKeyMaterialForCoreToVerify"),
-    CI_SCORING_CONFIG("/%s/core/self/ci-scoring-config"),
-    CI_SCORING_THRESHOLD("/%s/core/self/ciScoringThreshold"),
-    CI_MITIGATION_JOURNEYS_ENABLED("/%s/core/self/journey/ciMitigationsEnabled"),
-    VC_TTL("/%s/core/self/vcTtl"),
-    VC_VALID_DURATION("/%s/core/self/vcValidDuration");
+    BACKEND_SESSION_TIMEOUT("self/backendSessionTimeout"),
+    BACKEND_SESSION_TTL("self/backendSessionTtl"),
+    CLIENT_ISSUER("clients/%s/issuer"),
+    COMPONENT_ID("self/componentId"),
+    CORE_FRONT_CALLBACK_URL("self/coreFrontCallbackUrl"),
+    CORE_VTM_CLAIM("self/coreVtmClaim"),
+    JAR_KMS_ENCRYPTION_KEY_ID("self/jarKmsEncryptionKeyId"),
+    JWT_TTL_SECONDS("self/jwtTtlSeconds"),
+    MAX_ALLOWED_AUTH_CLIENT_TTL("self/maxAllowedAuthClientTtl"),
+    DCMAW_SHOULD_SEND_ALL_USERS("self/journey/dcmawShouldSendAllUsers"),
+    DCMAW_ALLOWED_USER_IDS("self/journey/dcmawAllowedUserIds"),
+    AUTH_CODE_EXPIRY_SECONDS("self/authCodeExpirySeconds"),
+    PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("clients/%s/publicKeyMaterialForCoreToVerify"),
+    CI_SCORING_CONFIG("self/ci-scoring-config"),
+    CI_SCORING_THRESHOLD("self/ciScoringThreshold"),
+    CI_MITIGATION_JOURNEYS_ENABLED("self/journey/ciMitigationsEnabled"),
+    VC_TTL("self/vcTtl"),
+    VC_VALID_DURATION("self/vcValidDuration");
 
-    private final String value;
+    private final String path;
 
-    ConfigurationVariable(String value) {
+    ConfigurationVariable(String path) {
 
-        this.value = value;
+        this.path = path;
     }
 
-    public String getValue() {
-        return value;
+    public String getPath() {
+        return path;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -18,7 +18,8 @@ public enum ConfigurationVariable {
     CI_SCORING_THRESHOLD("self/ciScoringThreshold"),
     CI_MITIGATION_JOURNEYS_ENABLED("self/journey/ciMitigationsEnabled"),
     VC_TTL("self/vcTtl"),
-    VC_VALID_DURATION("self/vcValidDuration");
+    VC_VALID_DURATION("self/vcValidDuration"),
+    CREDENTIAL_ISSUERS("credentialIssuers");
 
     private final String path;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/EnvironmentVariable.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.library.config;
 public enum EnvironmentVariable {
     BEARER_TOKEN_TTL,
     CLIENT_AUTH_JWT_IDS_TABLE_NAME,
-    CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX,
     ENVIRONMENT,
     IPV_SESSIONS_TABLE_NAME,
     CLIENT_OAUTH_SESSIONS_TABLE_NAME,

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -1,11 +1,27 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
-@AllArgsConstructor
-@Data
+@Getter
+@ExcludeFromGeneratedCoverageReport
 public class JourneyRequest {
+    @JsonProperty
     private String ipvSessionId;
+
+    @JsonProperty
     private String ipAddress;
+
+    @JsonCreator
+    public JourneyRequest(
+            @JsonProperty(value = "ipvSessionId") String ipvSessionId,
+            @JsonProperty(value = "ipAddress") String ipAddress
+    ) {
+        this.ipvSessionId = ipvSessionId;
+        this.ipAddress = ipAddress;
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -2,25 +2,20 @@ package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @Getter
 @ExcludeFromGeneratedCoverageReport
 public class JourneyRequest {
-    @JsonProperty
-    private String ipvSessionId;
+    @JsonProperty private String ipvSessionId;
 
-    @JsonProperty
-    private String ipAddress;
+    @JsonProperty private String ipAddress;
 
     @JsonCreator
     public JourneyRequest(
             @JsonProperty(value = "ipvSessionId") String ipvSessionId,
-            @JsonProperty(value = "ipAddress") String ipAddress
-    ) {
+            @JsonProperty(value = "ipAddress") String ipAddress) {
         this.ipvSessionId = ipvSessionId;
         this.ipAddress = ipAddress;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -2,10 +2,12 @@ package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
+@NoArgsConstructor
+@Data
 @ExcludeFromGeneratedCoverageReport
 public class JourneyRequest {
     @JsonProperty private String ipvSessionId;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -45,7 +45,6 @@ public class LogHelper {
         LOG_ERROR_JOURNEY_RESPONSE("errorJourneyResponse"),
         LOG_MITIGATION_JOURNEY_ID("mitigationJourneyId"),
         LOG_MITIGATION_JOURNEY_RESPONSE("mitigationJourneyResponse"),
-        LOG_LIST_OF_CUSTOMER_NAMES("listOfCustomerNames"),
         LOG_MISSING_HEADER_FIELD("missingHeaderField"),
         LOG_USER_STATE("userState"),
         LOG_JOURNEY_STEP("journeyStep"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -50,7 +50,9 @@ public class LogHelper {
         LOG_JOURNEY_STEP("journeyStep"),
         LOG_ERROR("error"),
         LOG_PAYLOAD("payload"),
-        LOG_STATUS_CODE("statusCode");
+        LOG_STATUS_CODE("statusCode"),
+        LOG_PARAMETER_PATH("parameterPath"),
+        LOG_FEATURE_SET("featureSet");
         private final String fieldName;
 
         LogField(String fieldName) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -53,13 +53,13 @@ public class ConfigService {
     private final SecretsProvider secretsProvider;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final String featureSet;
+    private String featureSet;
 
     public ConfigService(
             SSMProvider ssmProvider, SecretsProvider secretsProvider, String featureSet) {
         this.ssmProvider = ssmProvider;
         this.secretsProvider = secretsProvider;
-        this.featureSet = featureSet;
+        setFeatureSet(featureSet);
     }
 
     public ConfigService(SSMProvider ssmProvider, SecretsProvider secretsProvider) {
@@ -98,7 +98,7 @@ public class ConfigService {
                                             .build())
                             .defaultMaxAge(3, MINUTES);
         }
-        this.featureSet = featureSet;
+        setFeatureSet(featureSet);
     }
 
     public ConfigService() {
@@ -107,6 +107,14 @@ public class ConfigService {
 
     public SSMProvider getSsmProvider() {
         return ssmProvider;
+    }
+
+    public String getFeatureSet() {
+        return featureSet;
+    }
+
+    public void setFeatureSet(String featureSet) {
+        this.featureSet = featureSet;
     }
 
     public String getEnvironmentVariable(EnvironmentVariable environmentVariable) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -47,7 +47,6 @@ import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ISSUER;
-import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LIST_OF_CUSTOMER_NAMES;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 
 public class UserIdentityService {
@@ -517,10 +516,6 @@ public class UserIdentityService {
                                 })
                         .map(String::trim)
                         .collect(Collectors.toList());
-        var mapMessage =
-                new StringMapMessage()
-                        .with(LOG_LIST_OF_CUSTOMER_NAMES.getFieldName(), userFullNames);
-        LOGGER.info(mapMessage);
         return userFullNames;
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -34,8 +34,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
@@ -96,9 +103,7 @@ class ConfigServiceTest {
 
     @Test
     void shouldGetCredentialIssuerFromParameterStore() throws Exception {
-        environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers");
-
+        environmentVariables.set("ENVIRONMENT", "test");
         Map<String, String> credentialIssuerParameters =
                 Map.of(
                         "activeConnection",
@@ -111,10 +116,10 @@ class ConfigServiceTest {
                         RSA_ENCRYPTION_PUBLIC_JWK,
                         "requiresApiKey",
                         "true");
-        when(ssmProvider.get("/dev/core/credentialIssuers/passportCri/activeConnection"))
+        when(ssmProvider.get("/test/core/credentialIssuers/passportCri/activeConnection"))
                 .thenReturn("stub");
 
-        when(ssmProvider.getMultiple("/dev/core/credentialIssuers/passportCri/connections/stub"))
+        when(ssmProvider.getMultiple("/test/core/credentialIssuers/passportCri/connections/stub"))
                 .thenReturn(credentialIssuerParameters);
 
         CredentialIssuerConfig result =
@@ -140,29 +145,31 @@ class ConfigServiceTest {
 
     @Test
     void shouldReturnIsEnabled() {
-        environmentVariables.set("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "passportCri");
-        when(ssmProvider.get("passportCri/aClientId/enabled")).thenReturn("true");
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/credentialIssuers/passportCri/enabled"))
+                .thenReturn("true");
 
-        boolean isEnabled = configService.isEnabled("aClientId");
+        boolean isEnabled = configService.isEnabled("passportCri");
         assertTrue(isEnabled);
     }
 
     @Test
     void shouldReturnIsAvailableOrNot() {
-        environmentVariables.set("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "passportCri");
-        when(ssmProvider.get("passportCri/aClientId/unavailable")).thenReturn("false");
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/credentialIssuers/passportCri/unavailable"))
+                .thenReturn("false");
 
-        boolean isUnavailable = configService.isUnavailable("aClientId");
+        boolean isUnavailable = configService.isUnavailable("passportCri");
         assertFalse(isUnavailable);
     }
 
     @Test
     void shouldReturnAllowedSharedAttributes() {
-        environmentVariables.set("CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "passportCri");
-        when(ssmProvider.get("passportCri/aClientId/allowedSharedAttributes"))
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/credentialIssuers/passportCri/allowedSharedAttributes"))
                 .thenReturn("address,name");
 
-        String sharedAttributes = configService.getAllowedSharedAttributes("aClientId");
+        String sharedAttributes = configService.getAllowedSharedAttributes("passportCri");
         assertEquals("address,name", sharedAttributes);
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -8,15 +8,20 @@ import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
 import software.amazon.awssdk.services.secretsmanager.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.secretsmanager.model.InvalidParameterException;
 import software.amazon.awssdk.services.secretsmanager.model.InvalidRequestException;
 import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
@@ -25,7 +30,6 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import java.net.URI;
-import java.security.cert.CertificateException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,13 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TIMEOUT;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_ISSUER;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_FRONT_CALLBACK_URL;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.MAX_ALLOWED_AUTH_CLIENT_TTL;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 
 @WireMockTest(httpPort = ConfigService.LOCALHOST_PORT)
@@ -60,6 +57,7 @@ class ConfigServiceTest {
     private static final String TEST_REDIRECT_URL = "http:example.com/callbackUrl/testCri";
     private static final String TEST_CERT =
             "MIIC/TCCAeWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwHhcNMjExMjE3MTEwNTM5WhcNMjIxMjE3MTEwNTM5WjAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDYIxWKwYNoz2MIDvYb2ip4nhCOGUccufIqwSHXl5FBOoOxOZh1rV57sWhdKO/hyZYbF5YUYTwzV4rW7DgLkfx0sN/p5igk74BZRSXvV/s+XCkVC5c0NDhNGh6WK5rc8Qbm0Ad5vEO1JpQih5y2mPGCwfLBqcY8AC7fwZinP/4YoMTCtEk5ueA0HwZLHXOEMWl/QCkj7WlSBL4i6ozk4So3RFL4awYP6nvhY7OLAcad7g/ZW0dXvztPOJnT9rwi1p6BNoD/Zk6jMJHhbvKyGsluUy7PYVGYCQ36Uuzby2Jq8cG5qNS+CBjy0/d/RmrClKd7gcnLY/J5NOC+YSynoHXRAgMBAAGjKjAoMA4GA1UdDwEB/wQEAwIFoDAWBgNVHSUBAf8EDDAKBggrBgEFBQcDBDANBgkqhkiG9w0BAQsFAAOCAQEAvHT2AGTymh02A9HWrnGm6PEXx2Ye3NXV9eJNU1z6J298mS2kYq0Z4D0hj9i8+IoCQRbWOxLTAWBNt/CmH7jWltE4uqoAwTZD6mDgkC2eo5dY+RcuydsvJNfTcvUOyi47KKGGEcddfLti4NuX51BQIY5vSBfqZXt8+y28WuWqBMh6eny2wJtxNHo20wQei5g7w19lqwJu2F+l/ykX9K5DHjhXqZUJ77YWmY8sy/WROLjOoZZRy6YuzV8S/+c/nsPzqDAkD4rpWwASjsEDaTcH22xpGq5XUAf1hwwNsuiyXKGUHCxafYYS781LR8pLg6DpEAgcn8tBbq6MoiEGVeOp7Q==";
+    private static final String TEST_CERT_FS01 = "not a real cert";
 
     @SystemStub private EnvironmentVariables environmentVariables;
 
@@ -193,50 +191,6 @@ class ConfigServiceTest {
     }
 
     @Test
-    void shouldReturnValidClientCertificateForAuth() throws CertificateException {
-        environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/clients/aClientId/publicKeyMaterialForCoreToVerify"))
-                .thenReturn(TEST_CERT);
-
-        assertEquals(
-                TEST_CERT,
-                configService.getSsmParameter(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY, "aClientId"));
-    }
-
-    @Test
-    void shouldReturnClientIssuer() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String clientIssuer = "aClientIssuer";
-        when(ssmProvider.get("/test/core/clients/aClientId/issuer")).thenReturn(clientIssuer);
-        assertEquals(clientIssuer, configService.getSsmParameter(CLIENT_ISSUER, "aClientId"));
-    }
-
-    @Test
-    void shouldReturnMaxAllowedAuthClientTtl() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String clientIssuer = "aClientTokenTtl";
-        when(ssmProvider.get("/test/core/self/maxAllowedAuthClientTtl")).thenReturn(clientIssuer);
-        assertEquals(clientIssuer, configService.getSsmParameter(MAX_ALLOWED_AUTH_CLIENT_TTL));
-    }
-
-    @Test
-    void shouldReturnCoreFrontCallbackUrl() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String coreFrontCallbackUrl = "aCoreFrontCallbackUrl";
-        when(ssmProvider.get("/test/core/self/coreFrontCallbackUrl"))
-                .thenReturn(coreFrontCallbackUrl);
-        assertEquals(coreFrontCallbackUrl, configService.getSsmParameter(CORE_FRONT_CALLBACK_URL));
-    }
-
-    @Test
-    void shouldReturnCoreVtmClaim() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String coreVtmClaim = "aCoreVtmClaim";
-        when(ssmProvider.get("/test/core/self/coreVtmClaim")).thenReturn(coreVtmClaim);
-        assertEquals(coreVtmClaim, configService.getSsmParameter(CORE_VTM_CLAIM));
-    }
-
-    @Test
     void shouldGetSecretValueFromSecretsManager() {
         Map<String, String> apiKeySecret = Map.of("apiKey", "api-key-value");
         when(secretsProvider.get(any())).thenReturn(gson.toJson(apiKeySecret));
@@ -306,21 +260,6 @@ class ConfigServiceTest {
     }
 
     @Test
-    void shouldReturnBackendSessionTimeout() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        String ttl = "7200";
-        when(ssmProvider.get("/test/core/self/backendSessionTimeout")).thenReturn(ttl);
-        assertEquals(ttl, configService.getSsmParameter(BACKEND_SESSION_TIMEOUT));
-    }
-
-    @Test
-    void shouldReturnBackendSessionTtl() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/self/backendSessionTtl")).thenReturn("7200");
-        assertEquals("7200", configService.getSsmParameter(BACKEND_SESSION_TTL));
-    }
-
-    @Test
     void shouldGetContraIndicatorScoresMap() {
         String scoresJsonString =
                 "[{ \"ci\": \"X01\", \"detectedScore\": 3, \"checkedScore\": -3, \"fidCode\": \"YZ01\" }, { \"ci\": \"Z03\", \"detectedScore\": 5, \"checkedScore\": -3 }]";
@@ -331,5 +270,139 @@ class ConfigServiceTest {
         assertEquals(2, scoresMap.size());
         assertTrue(scoresMap.containsKey("X01"));
         assertTrue(scoresMap.containsKey("Z03"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY,",
+        "PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY,FS01",
+        "CLIENT_ISSUER,",
+        "CLIENT_ISSUER,FS02",
+        "CLIENT_ISSUER,FS03_NO_OVERRIDE"
+    })
+    void shouldAccountForFeatureSetWhenRetrievingParameterForClient(
+            String configVariableName, String featureSet) {
+        configService = new ConfigService(ssmProvider, secretsProvider, featureSet);
+        environmentVariables.set("ENVIRONMENT", "test");
+        ConfigurationVariable configurationVariable =
+                ConfigurationVariable.valueOf(configVariableName);
+        TestConfiguration testConfiguration = TestConfiguration.valueOf(configVariableName);
+        testConfiguration.setupMockConfig(ssmProvider);
+        assertEquals(
+                testConfiguration.getExpectedValue(featureSet),
+                configService.getSsmParameter(configurationVariable, "aClientId"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "MAX_ALLOWED_AUTH_CLIENT_TTL,",
+        "MAX_ALLOWED_AUTH_CLIENT_TTL,FS01",
+        "CORE_FRONT_CALLBACK_URL,",
+        "CORE_FRONT_CALLBACK_URL,FS01",
+        "CORE_VTM_CLAIM,",
+        "CORE_VTM_CLAIM,FS02",
+        "BACKEND_SESSION_TIMEOUT,",
+        "BACKEND_SESSION_TIMEOUT,FS03",
+        "BACKEND_SESSION_TTL,",
+        "BACKEND_SESSION_TTL,FS04",
+        "BACKEND_SESSION_TTL,FS05_NO_OVERRIDE",
+    })
+    void shouldAccountForFeatureSetWhenRetrievingParameter(
+            String configVariableName, String featureSet) {
+        configService = new ConfigService(ssmProvider, secretsProvider, featureSet);
+        environmentVariables.set("ENVIRONMENT", "test");
+        ConfigurationVariable configurationVariable =
+                ConfigurationVariable.valueOf(configVariableName);
+        TestConfiguration testConfiguration = TestConfiguration.valueOf(configVariableName);
+        testConfiguration.setupMockConfig(ssmProvider);
+        assertEquals(
+                testConfiguration.getExpectedValue(featureSet),
+                configService.getSsmParameter(configurationVariable));
+    }
+
+    private enum TestConfiguration {
+        PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY(
+                "clients/aClientId/publicKeyMaterialForCoreToVerify",
+                TEST_CERT,
+                Map.of("FS01", TEST_CERT_FS01),
+                Map.of()),
+        CLIENT_ISSUER(
+                "clients/aClientId/issuer",
+                "aClientIssuer",
+                Map.of("FS02", "aDifferentIssuer"),
+                Map.of("FS03_NO_OVERRIDE", ParameterNotFoundException.class)),
+        MAX_ALLOWED_AUTH_CLIENT_TTL(
+                "self/maxAllowedAuthClientTtl",
+                "aClientTokenTtl",
+                Map.of("FS01", "aDifferentClientTokenTtl"),
+                Map.of()),
+        CORE_FRONT_CALLBACK_URL(
+                "self/coreFrontCallbackUrl",
+                "aCoreFrontCallbackUrl",
+                Map.of("FS01", "aDifferentCoreFrontCallbackUrl"),
+                Map.of()),
+        CORE_VTM_CLAIM(
+                "self/coreVtmClaim",
+                "aCoreVtmClaim",
+                Map.of("FS02", "aDifferentCoreVtmClaim"),
+                Map.of()),
+        BACKEND_SESSION_TIMEOUT(
+                "self/backendSessionTimeout",
+                "7200",
+                Map.of("FS02", "7300", "FS03", "7400"),
+                Map.of()),
+        BACKEND_SESSION_TTL(
+                "self/backendSessionTtl",
+                "3600",
+                Map.of("FS03", "3700", "FS04", "3800"),
+                Map.of("FS05_NO_OVERRIDE", ParameterNotFoundException.class));
+
+        private final String path;
+        private final String baseValue;
+        private final Map<String, String> featureSetValues;
+        private final Map<String, Class> featureSetExceptions;
+
+        TestConfiguration(
+                String path,
+                String baseValue,
+                Map<String, String> featureSetValues,
+                Map<String, Class> featureSetExceptions) {
+            this.path = path;
+            this.baseValue = baseValue;
+            this.featureSetValues = featureSetValues;
+            this.featureSetExceptions = featureSetExceptions;
+        }
+
+        public void setupMockConfig(SSMProvider ssmProvider) {
+            Mockito.lenient().when(ssmProvider.get("/test/core/" + path)).thenReturn(baseValue);
+            featureSetValues.forEach(
+                    (featureSet, valueOverride) ->
+                            Mockito.lenient()
+                                    .when(
+                                            ssmProvider.get(
+                                                    "/test/core/featureSet/"
+                                                            + featureSet
+                                                            + "/"
+                                                            + path))
+                                    .thenReturn(valueOverride));
+            featureSetExceptions.forEach(
+                    (featureSet, clazz) ->
+                            Mockito.lenient()
+                                    .when(
+                                            ssmProvider.get(
+                                                    "/test/core/featureSet/"
+                                                            + featureSet
+                                                            + "/"
+                                                            + path))
+                                    .thenThrow(clazz));
+        }
+
+        public String getExpectedValue(String featureSet) {
+            if (featureSet == null) {
+                return baseValue;
+            } else {
+                return featureSetValues.getOrDefault(featureSet, baseValue);
+            }
+        }
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -34,15 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;

--- a/libs/credential-issuer-config-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigService.java
+++ b/libs/credential-issuer-config-service/src/main/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigService.java
@@ -6,6 +6,7 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ParseCredentialIssuerConfigException;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -14,8 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX;
 
 public class CredentialIssuerConfigService extends ConfigService {
 
@@ -40,7 +39,7 @@ public class CredentialIssuerConfigService extends ConfigService {
             throws ParseCredentialIssuerConfigException {
         Map<String, String> params =
                 getSsmParameters(
-                        getEnvironmentVariable(CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX), true);
+                        resolvePath(ConfigurationVariable.CREDENTIAL_ISSUERS.getPath()), true);
 
         Map<String, Map<String, Object>> map = new HashMap<>();
         for (Map.Entry<String, String> entry : params.entrySet()) {

--- a/libs/credential-issuer-config-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigServiceTest.java
+++ b/libs/credential-issuer-config-service/src/test/java/uk/gov/di/ipv/core/library/credentialissuer/CredentialIssuerConfigServiceTest.java
@@ -42,9 +42,7 @@ class CredentialIssuerConfigServiceTest {
     @Test
     void shouldGetAllCredentialIssuersFromParameterStore()
             throws ParseCredentialIssuerConfigException {
-
-        environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
+        environmentVariables.set("ENVIRONMENT", "test");
         HashMap<String, String> response = new HashMap<>();
         response.put("passportCri/tokenUrl", "passportTokenUrl");
         response.put("passportCri/authorizeUrl", "passportAuthUrl");
@@ -57,7 +55,7 @@ class CredentialIssuerConfigServiceTest {
         response.put("stubCri/allowedSharedAttributes", "name, birthDate, address");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/test/core/credentialIssuers")).thenReturn(response);
         List<CredentialIssuerConfig> result = credentialIssuerConfigService.getCredentialIssuers();
 
         assertEquals(2, result.size());
@@ -83,8 +81,7 @@ class CredentialIssuerConfigServiceTest {
 
     @Test
     void shouldThrowExceptionWhenCriConfigIsIncorrect() {
-        environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
+        environmentVariables.set("ENVIRONMENT", "test");
         HashMap<String, String> response = new HashMap<>();
         response.put("incorrectPathName", "passportTokenUrl");
         response.put("passportCri/authorizeUrl", "passportAuthUrl");
@@ -92,7 +89,7 @@ class CredentialIssuerConfigServiceTest {
         response.put("passportCri/name", "passportIssuer");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/test/core/credentialIssuers")).thenReturn(response);
         ParseCredentialIssuerConfigException exception =
                 assertThrows(
                         ParseCredentialIssuerConfigException.class,
@@ -105,9 +102,7 @@ class CredentialIssuerConfigServiceTest {
     @Test
     void shouldGetAllCredentialIssuersFromParameterStoreNewAndIgnoreInExistingFields()
             throws ParseCredentialIssuerConfigException {
-
-        environmentVariables.set(
-                "CREDENTIAL_ISSUERS_CONFIG_PARAM_PREFIX", "/dev/core/credentialIssuers/");
+        environmentVariables.set("ENVIRONMENT", "test");
         HashMap<String, String> response = new HashMap<>();
         response.put("passportCri/clientId", "passportCri");
         response.put("passportCri/tokenUrl", "passportTokenUrl");
@@ -117,7 +112,7 @@ class CredentialIssuerConfigServiceTest {
         response.put("stubCri/ipclientid", "stubIpClient");
 
         when(ssmProvider.recursive()).thenReturn(ssmProvider2);
-        when(ssmProvider2.getMultiple("/dev/core/credentialIssuers/")).thenReturn(response);
+        when(ssmProvider2.getMultiple("/test/core/credentialIssuers")).thenReturn(response);
         List<CredentialIssuerConfig> result = credentialIssuerConfigService.getCredentialIssuers();
 
         Optional<CredentialIssuerConfig> passportIssuerConfig =

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -277,8 +277,7 @@ paths:
             Fn::Sub: |
               {
                 "ipvSessionId": "$input.params('ipv-session-id')", 
-                "ipAddress": "$input.params('ip-address')",
-                "body-json": "$input.json('$')"
+                "ipAddress": "$input.params('ip-address')"
               }
         responses:
           default:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -277,7 +277,12 @@ paths:
             Fn::Sub: |
               {
                 "ipvSessionId": "$input.params('ipv-session-id')", 
+<<<<<<< HEAD
                 "ipAddress": "$input.params('ip-address')"
+=======
+                "ipAddress": "$input.params('ip-address')",
+                "body-json": "$input.json('$')"
+>>>>>>> 0df0f14f (PYIC-2739: Updated merge conflict of JourneyRequest.java)
               }
         responses:
           default:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -271,7 +271,25 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CheckExistingIdentityFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
-        type: "aws_proxy"
+        type: "aws"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "ipvSessionId": "$input.params('ipv-session-id')", 
+                "ipAddress": "$input.params('ip-address')",
+                "body-json": "$input.json('$')"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set ($bodyObj = $util.parseJson($input.body))
+                #if ($bodyObj.statusCode)
+                #set($context.responseOverride.status = $bodyObj.statusCode)
+                #end
+                $input.body
 
 components:
   schemas:


### PR DESCRIPTION
## Proposed changes

### What changed

Reconfigured /journey/check-existing-identity API Gateway endpoint to call the check-existing-identity Lambda using a plane JSON request rather than an AWS Proxy request.

### Why did it change

So that the check-existing-identity Lambda can be migrated to be called by the Process Journey Step State Machine.

### Issue tracking

- [PYIC-2739](https://govukverify.atlassian.net/browse/PYIC-2739)

## Checklists

### Environment variables or secrets
- [X] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2739]: https://govukverify.atlassian.net/browse/PYIC-2739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ