### PR TITLE
PYIC-2753 update the lambda removing support for api gateway requests

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -57,7 +57,8 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 
 /** Check Existing Identity response Lambda */
-public class CheckExistingIdentityHandler implements RequestHandler<JourneyRequest, JourneyResponse>  {
+public class CheckExistingIdentityHandler
+        implements RequestHandler<JourneyRequest, JourneyResponse> {
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
     private static final String VOT_P2 = "P2";

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -63,7 +63,8 @@ class CheckExistingIdentityHandlerTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
-    private static final JourneyRequest event = new JourneyRequest(TEST_SESSION_ID, TEST_CLIENT_SOURCE_IP);
+    private static final JourneyRequest event =
+            new JourneyRequest(TEST_SESSION_ID, TEST_CLIENT_SOURCE_IP);
     private static final List<String> CREDENTIALS =
             List.of(
                     M1A_PASSPORT_VC,
@@ -152,7 +153,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
 
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
@@ -181,7 +183,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
         verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
@@ -208,7 +211,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals(JOURNEY_NEXT, journeyResponse);
 
         verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID);
@@ -233,7 +237,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals("/journey/next", journeyResponse.getJourney());
 
         verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID);
@@ -258,7 +263,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals("/journey/next", journeyResponse.getJourney());
         verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
 
@@ -272,10 +278,11 @@ class CheckExistingIdentityHandlerTest {
     void shouldReturn400IfSessionIdNotInHeader() {
         JourneyRequest eventWithoutHeaders = new JourneyRequest(null, null);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(eventWithoutHeaders, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(eventWithoutHeaders, context);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
         assertEquals(HttpStatus.SC_BAD_REQUEST, errorResponse.getStatusCode());
         assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), errorResponse.getCode());
         assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), errorResponse.getMessage());
@@ -289,10 +296,11 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getCode(),
@@ -312,10 +320,11 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getCode(),
@@ -337,10 +346,11 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
         assertEquals(ErrorResponse.FAILED_TO_GET_STORED_CIS.getCode(), errorResponse.getCode());
         assertEquals(
@@ -364,10 +374,11 @@ class CheckExistingIdentityHandlerTest {
                 .when(auditService)
                 .sendAuditEvent((AuditEvent) any());
 
-        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        JourneyResponse journeyResponse =
+                checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
         assertEquals(ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getCode(), errorResponse.getCode());
         assertEquals(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -65,7 +65,8 @@ class CheckExistingIdentityHandlerTest {
     private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     private static final JourneyRequest event =
-            new JourneyRequest(TEST_SESSION_ID, TEST_CLIENT_SOURCE_IP, TEST_CLIENT_OAUTH_SESSION_ID);
+            new JourneyRequest(
+                    TEST_SESSION_ID, TEST_CLIENT_SOURCE_IP, TEST_CLIENT_OAUTH_SESSION_ID);
     private static final List<String> CREDENTIALS =
             List.of(
                     M1A_PASSPORT_VC,

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1,11 +1,6 @@
 package uk.gov.di.ipv.core.checkexistingidentity;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,6 +15,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
+import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
@@ -44,7 +40,6 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,15 +56,14 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1B_DCMAW_VC;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
 
 @ExtendWith(MockitoExtension.class)
 class CheckExistingIdentityHandlerTest {
     private static final String TEST_SESSION_ID = "test-session-id";
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
-    private static final APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+    private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
+    private static final JourneyRequest event = new JourneyRequest(TEST_SESSION_ID, TEST_CLIENT_SOURCE_IP);
     private static final List<String> CREDENTIALS =
             List.of(
                     M1A_PASSPORT_VC,
@@ -77,7 +71,6 @@ class CheckExistingIdentityHandlerTest {
                     M1A_FRAUD_VC,
                     M1A_VERIFICATION_VC,
                     M1B_DCMAW_VC);
-    private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
     private static CredentialIssuerConfig addressConfig = null;
     private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
 
@@ -105,8 +98,6 @@ class CheckExistingIdentityHandlerTest {
         }
     }
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
     @Mock private Context context;
     @Mock private UserIdentityService userIdentityService;
     @Mock private IpvSessionService ipvSessionService;
@@ -117,19 +108,11 @@ class CheckExistingIdentityHandlerTest {
     @Mock private ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     @InjectMocks private CheckExistingIdentityHandler checkExistingIdentityHandler;
 
-    private final Gson gson = new Gson();
-
     private IpvSessionItem ipvSessionItem;
     private ClientOAuthSessionItem clientOAuthSessionItem;
 
     @BeforeAll
     static void setUp() throws Exception {
-        event.setHeaders(
-                Map.of(
-                        IPV_SESSION_ID_HEADER,
-                        TEST_SESSION_ID,
-                        IP_ADDRESS_HEADER,
-                        TEST_CLIENT_SOURCE_IP));
         for (String cred : CREDENTIALS) {
             PARSED_CREDENTIALS.add(SignedJWT.parse(cred));
         }
@@ -169,10 +152,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var response = makeRequest(event, context);
-        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
 
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
         verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
@@ -200,10 +181,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var response = makeRequest(event, context);
-        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
         verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
@@ -230,10 +208,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var response = makeRequest(event, context);
-        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals(JOURNEY_NEXT, journeyResponse);
 
         verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID);
@@ -258,10 +233,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var response = makeRequest(event, context);
-        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals("/journey/next", journeyResponse.getJourney());
 
         verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID);
@@ -286,10 +258,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var response = makeRequest(event, context);
-        JourneyResponse journeyResponse = gson.fromJson(response.getBody(), JourneyResponse.class);
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
         assertEquals("/journey/next", journeyResponse.getJourney());
         verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
 
@@ -300,16 +269,16 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfSessionIdNotInHeader() throws Exception {
-        APIGatewayProxyRequestEvent eventWithoutHeaders = new APIGatewayProxyRequestEvent();
+    void shouldReturn400IfSessionIdNotInHeader() {
+        JourneyRequest eventWithoutHeaders = new JourneyRequest(null, null);
 
-        var response = makeRequest(eventWithoutHeaders, context);
-        var responseValue = objectMapper.readValue(response.getBody(), JourneyErrorResponse.class);
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(eventWithoutHeaders, context);
+        assertEquals("/journey/error", journeyResponse.getJourney());
 
-        assertEquals("/journey/error", responseValue.getJourney());
-        assertEquals(HttpStatus.SC_BAD_REQUEST, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), responseValue.getCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), responseValue.getMessage());
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        assertEquals(HttpStatus.SC_BAD_REQUEST, errorResponse.getStatusCode());
+        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), errorResponse.getCode());
+        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), errorResponse.getMessage());
         verify(clientOAuthSessionDetailsService, times(0)).getClientOAuthSession(any());
     }
 
@@ -320,18 +289,17 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var response = makeRequest(event, context);
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        assertEquals("/journey/error", journeyResponse.getJourney());
 
-        var responseValue = objectMapper.readValue(response.getBody(), JourneyErrorResponse.class);
-
-        assertEquals("/journey/error", responseValue.getJourney());
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getCode(),
-                responseValue.getCode());
+                errorResponse.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(),
-                responseValue.getMessage());
+                errorResponse.getMessage());
 
         verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
@@ -344,18 +312,17 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var response = makeRequest(event, context);
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        assertEquals("/journey/error", journeyResponse.getJourney());
 
-        var responseValue = objectMapper.readValue(response.getBody(), JourneyErrorResponse.class);
-
-        assertEquals("/journey/error", responseValue.getJourney());
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getCode(),
-                responseValue.getCode());
+                errorResponse.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getMessage(),
-                responseValue.getMessage());
+                errorResponse.getMessage());
 
         verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
@@ -370,15 +337,14 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var response = makeRequest(event, context);
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        assertEquals("/journey/error", journeyResponse.getJourney());
 
-        var responseValue = objectMapper.readValue(response.getBody(), JourneyErrorResponse.class);
-
-        assertEquals("/journey/error", responseValue.getJourney());
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_GET_STORED_CIS.getCode(), responseValue.getCode());
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_TO_GET_STORED_CIS.getCode(), errorResponse.getCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_GET_STORED_CIS.getMessage(), responseValue.getMessage());
+                ErrorResponse.FAILED_TO_GET_STORED_CIS.getMessage(), errorResponse.getMessage());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -398,24 +364,14 @@ class CheckExistingIdentityHandlerTest {
                 .when(auditService)
                 .sendAuditEvent((AuditEvent) any());
 
-        var response = makeRequest(event, context);
+        JourneyResponse journeyResponse = checkExistingIdentityHandler.handleRequest(event, context);
+        assertEquals("/journey/error", journeyResponse.getJourney());
 
-        var responseValue = objectMapper.readValue(response.getBody(), JourneyErrorResponse.class);
-
-        assertEquals("/journey/error", responseValue.getJourney());
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, responseValue.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getCode(), responseValue.getCode());
+        JourneyErrorResponse errorResponse = (JourneyErrorResponse)journeyResponse;
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getCode(), errorResponse.getCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getMessage(), responseValue.getMessage());
+                ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getMessage(), errorResponse.getMessage());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-    }
-
-    private APIGatewayProxyResponseEvent makeRequest(
-            APIGatewayProxyRequestEvent event, Context context) {
-        final var requestType = new TypeReference<Map<String, Object>>() {};
-        final var request = objectMapper.convertValue(event, requestType);
-        final var response = checkExistingIdentityHandler.handleRequest(request, context);
-
-        return objectMapper.convertValue(response, APIGatewayProxyResponseEvent.class);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -1,11 +1,27 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
-@AllArgsConstructor
-@Data
+@Getter
+@ExcludeFromGeneratedCoverageReport
 public class JourneyRequest {
+    @JsonProperty
     private String ipvSessionId;
+
+    @JsonProperty
     private String ipAddress;
+
+    @JsonCreator
+    public JourneyRequest(
+            @JsonProperty(value = "ipvSessionId") String ipvSessionId,
+            @JsonProperty(value = "ipAddress") String ipAddress
+    ) {
+        this.ipvSessionId = ipvSessionId;
+        this.ipAddress = ipAddress;
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -2,25 +2,20 @@ package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @Getter
 @ExcludeFromGeneratedCoverageReport
 public class JourneyRequest {
-    @JsonProperty
-    private String ipvSessionId;
+    @JsonProperty private String ipvSessionId;
 
-    @JsonProperty
-    private String ipAddress;
+    @JsonProperty private String ipAddress;
 
     @JsonCreator
     public JourneyRequest(
             @JsonProperty(value = "ipvSessionId") String ipvSessionId,
-            @JsonProperty(value = "ipAddress") String ipAddress
-    ) {
+            @JsonProperty(value = "ipAddress") String ipAddress) {
         this.ipvSessionId = ipvSessionId;
         this.ipAddress = ipAddress;
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -2,10 +2,12 @@ package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
-@Getter
+@NoArgsConstructor
+@Data
 @ExcludeFromGeneratedCoverageReport
 public class JourneyRequest {
     @JsonProperty private String ipvSessionId;

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -277,8 +277,7 @@ paths:
             Fn::Sub: |
               {
                 "ipvSessionId": "$input.params('ipv-session-id')", 
-                "ipAddress": "$input.params('ip-address')",
-                "body-json": "$input.json('$')"
+                "ipAddress": "$input.params('ip-address')"
               }
         responses:
           default:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -271,7 +271,25 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CheckExistingIdentityFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
-        type: "aws_proxy"
+        type: "aws"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "ipvSessionId": "$input.params('ipv-session-id')", 
+                "ipAddress": "$input.params('ip-address')",
+                "body-json": "$input.json('$')"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set ($bodyObj = $util.parseJson($input.body))
+                #if ($bodyObj.statusCode)
+                #set($context.responseOverride.status = $bodyObj.statusCode)
+                #end
+                $input.body
 
 components:
   schemas:


### PR DESCRIPTION
## Proposed changes

### What changed

Migrated to just using JourneyRequest and JourneyResponse and removed API Gateway Proxy support.

### Why did it change

No longer required.

### Issue tracking
- [PYIC-2753](https://govukverify.atlassian.net/browse/PYIC-2753)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2753]: https://govukverify.atlassian.net/browse/PYIC-2753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ