### PR TITLE
PYIC-2743 Reconfigure API Gateway so it calls select-cri using JSON

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -204,7 +204,23 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SelectCriFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
-        type: "aws_proxy"
+        type: "aws"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "ipvSessionId": "$input.params('ipv-session-id')"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set ($bodyObj = $util.parseJson($input.body))
+                #if ($bodyObj.statusCode)
+                #set($context.responseOverride.status = $bodyObj.statusCode)
+                #end
+                $input.body
 
   /journey/build-client-oauth-response:
     post:


### PR DESCRIPTION
## Proposed changes

### What changed

Reconfigure API Gateway so it calls the select-cri lambda using JSON

### Why did it change

We'll be calling these journey lambdas within the journey engine step function so will be removing API Gateway

### Issue tracking
- [PYIC-2743](https://govukverify.atlassian.net/browse/PYIC-2743)



[PYIC-2743]: https://govukverify.atlassian.net/browse/PYIC-2743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ