### PR TITLE
[PYIC-2795] Enable lambdas to access features subtrees

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -352,6 +352,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/clients/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/clients/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
       Events:
         IPVCoreExternalAPI:
           Type: Api
@@ -535,6 +539,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/clients/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/clients/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -660,6 +668,12 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/*/api-key-*
         - SQSSendMessagePolicy:
@@ -799,6 +813,12 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/*/api-key-*
         - SQSSendMessagePolicy:
@@ -930,6 +950,12 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -1038,6 +1064,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -1126,6 +1156,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1213,6 +1247,8 @@ Resources:
             TableName: !Ref UserIssuedCredentialsV2Table
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1479,6 +1515,8 @@ Resources:
             TableName: !Ref CriOAuthSessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
@@ -1571,6 +1609,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - AWSSecretsManagerGetSecretValuePolicy:
@@ -1685,6 +1727,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/self/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1779,6 +1825,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -1935,6 +1985,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
       Events:
@@ -2032,6 +2086,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -2138,6 +2196,10 @@ Resources:
             ParameterName: !Sub ${Environment}/core/credentialIssuers/*
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/self/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/credentialIssuers/*
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/features/*/self/*
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
         - SQSSendMessagePolicy:

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -160,7 +160,7 @@ public class ConfigService {
 
     private String resolveFeatureSetPath(String path, String... pathProperties) {
         return resolveBasePath()
-                + String.format("featureSet/%s/", getFeatureSet())
+                + String.format("features/%s/", getFeatureSet())
                 + String.format(path, (Object[]) pathProperties);
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -429,7 +429,7 @@ class ConfigServiceTest {
                             Mockito.lenient()
                                     .when(
                                             ssmProvider.get(
-                                                    "/test/core/featureSet/"
+                                                    "/test/core/features/"
                                                             + featureSet
                                                             + "/"
                                                             + path))
@@ -439,7 +439,7 @@ class ConfigServiceTest {
                             Mockito.lenient()
                                     .when(
                                             ssmProvider.get(
-                                                    "/test/core/featureSet/"
+                                                    "/test/core/features/"
                                                             + featureSet
                                                             + "/"
                                                             + path))


### PR DESCRIPTION
## Proposed changes

### What changed

- The lambdas only have access to `{environment}/core/` config subtrees from which they require config items. With the introduction of feature sets, they will also need access to the corresponding `{environment}/core/features/{featureSet}` config subtrees.
- Corrected the feature Set property path in the code from `.../core/featureSet` to `.../core/features`

### Why did it change
Back end lambdas need to be able to read feature set equivalent config sub trees.

### Issue tracking
- [PYIC-2795](https://govukverify.atlassian.net/browse/PYIC-2795)

## Checklists

### Environment variables or secrets
-  No environment variables or secrets were added or changed

### Other considerations


[PYIC-2795]: https://govukverify.atlassian.net/browse/PYIC-2795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ