### PR TITLE
PYIC-2803 Remove call to check VC expiry

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -131,7 +131,6 @@ public class CheckExistingIdentityHandler
             AuditEventUser auditEventUser =
                     new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
 
-            userIdentityService.deleteVcStoreItemsIfAnyExpired(userId);
             userIdentityService.deleteVcStoreItemsIfAnyInvalid(userId);
 
             List<SignedJWT> credentials =


### PR DESCRIPTION
## Proposed changes

### What changed

Remove call to check VC expiry

### Why did it change

The programme has decided that the `exp` claim on VC JWTs should be ignored, allowing us to use previously collected VCs that had this claim.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2803](https://govukverify.atlassian.net/browse/PYIC-2803)



[PYIC-2803]: https://govukverify.atlassian.net/browse/PYIC-2803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ