### PR TITLE
PYIC-2755 Update select-cri lambda removing support for API Gateway

### DIFF
--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.selectcri;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,13 +18,11 @@ import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
-import uk.gov.di.ipv.core.library.statemachine.BaseJourneyLambda;
 
 import java.text.ParseException;
 import java.util.Arrays;
@@ -41,8 +40,11 @@ import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
+import static uk.gov.di.ipv.core.library.statemachine.BaseJourneyLambda.JOURNEY_ERROR_PATH;
 
-public class SelectCriHandler extends BaseJourneyLambda {
+public class SelectCriHandler implements RequestHandler<JourneyRequest, JourneyResponse> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String CRI_START_JOURNEY = "/journey/%s";
     private static final String JOURNEY_FAIL = "/journey/fail";
@@ -76,11 +78,11 @@ public class SelectCriHandler extends BaseJourneyLambda {
     @Override
     @Tracing
     @Logging(clearState = true)
-    protected JourneyResponse handleRequest(JourneyRequest event, Context context) {
+    public JourneyResponse handleRequest(JourneyRequest event, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
-            String ipvSessionId = RequestHelper.getIpvSessionId(event);
-            String featureSet = RequestHelper.getFeatureSet(event);
+            String ipvSessionId = getIpvSessionId(event);
+            String featureSet = getFeatureSet(event);
             configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientOAuthSessionItem clientOAuthSessionItem =

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/credentialissuer/SelectCriHandlerTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.JourneyRequest;
+import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
@@ -23,7 +25,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -71,11 +72,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", false));
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/ukPassport", response.get("journey"));
+        assertEquals("/journey/ukPassport", response.getJourney());
     }
 
     @Test
@@ -93,11 +94,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(false);
         when(mockConfigService.isEnabled("drivingLicence")).thenReturn(true);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/ukPassportAndDrivingLicence", response.get("journey"));
+        assertEquals("/journey/ukPassportAndDrivingLicence", response.getJourney());
     }
 
     @Test
@@ -119,11 +120,11 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/address", response.get("journey"));
+        assertEquals("/journey/address", response.getJourney());
     }
 
     @Test
@@ -146,11 +147,11 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/address", response.get("journey"));
+        assertEquals("/journey/address", response.getJourney());
     }
 
     @Test
@@ -171,11 +172,11 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/pyi-no-match", response.get("journey"));
+        assertEquals("/journey/pyi-no-match", response.getJourney());
     }
 
     @Test
@@ -204,11 +205,11 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/fraud", response.get("journey"));
+        assertEquals("/journey/fraud", response.getJourney());
     }
 
     @Test
@@ -242,11 +243,11 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/kbv", response.get("journey"));
+        assertEquals("/journey/kbv", response.getJourney());
     }
 
     @Test
@@ -282,11 +283,11 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/fail", response.get("journey"));
+        assertEquals("/journey/fail", response.getJourney());
     }
 
     @Test
@@ -306,11 +307,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/dcmaw", response.get("journey"));
+        assertEquals("/journey/dcmaw", response.getJourney());
     }
 
     @Test
@@ -330,11 +331,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/dcmaw-success", response.get("journey"));
+        assertEquals("/journey/dcmaw-success", response.getJourney());
     }
 
     @Test
@@ -362,11 +363,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/fraud", response.get("journey"));
+        assertEquals("/journey/fraud", response.getJourney());
     }
 
     @Test
@@ -390,11 +391,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/address", response.get("journey"));
+        assertEquals("/journey/address", response.getJourney());
     }
 
     @Test
@@ -434,11 +435,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
                 .thenReturn(createCriConfig(FRAUD_CRI, "test-fraud-iss", true));
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/fail", response.get("journey"));
+        assertEquals("/journey/fail", response.getJourney());
     }
 
     @Test
@@ -458,11 +459,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", false));
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/ukPassport", response.get("journey"));
+        assertEquals("/journey/ukPassport", response.getJourney());
     }
 
     @Test
@@ -485,11 +486,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", false));
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/ukPassport", response.get("journey"));
+        assertEquals("/journey/ukPassport", response.getJourney());
     }
 
     @Test
@@ -512,11 +513,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("true");
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/pyi-no-match", response.get("journey"));
+        assertEquals("/journey/pyi-no-match", response.getJourney());
     }
 
     @Test
@@ -536,11 +537,11 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getCurrentVcStatuses())
                 .thenReturn(List.of(new VcStatusDto("test-driving-licence-iss", false)));
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/pyi-no-match", response.get("journey"));
+        assertEquals("/journey/pyi-no-match", response.getJourney());
     }
 
     @Test
@@ -575,11 +576,11 @@ class SelectCriHandlerTest {
                                 new VcStatusDto("test-kbv-iss", false)));
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(false);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/pyi-kbv-thin-file", response.get("journey"));
+        assertEquals("/journey/pyi-kbv-thin-file", response.getJourney());
     }
 
     @Test
@@ -597,11 +598,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("drivingLicence"))
                 .thenReturn(createCriConfig("drivingLicence", "drivingLicence", false));
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/ukPassport", response.get("journey"));
+        assertEquals("/journey/ukPassport", response.getJourney());
     }
 
     @Test
@@ -623,11 +624,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getSsmParameter(DCMAW_ALLOWED_USER_IDS))
                 .thenReturn("test-user-id,test-user-id-2,test-user-id-3");
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/dcmaw", response.get("journey"));
+        assertEquals("/journey/dcmaw", response.getJourney());
     }
 
     @Test
@@ -651,11 +652,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(true);
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS)).thenReturn("false");
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/dcmaw", response.get("journey"));
+        assertEquals("/journey/dcmaw", response.getJourney());
     }
 
     @Test
@@ -681,11 +682,11 @@ class SelectCriHandlerTest {
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/ukPassport", response.get("journey"));
+        assertEquals("/journey/ukPassport", response.getJourney());
     }
 
     @Test
@@ -707,11 +708,11 @@ class SelectCriHandlerTest {
         when(mockConfigService.getSsmParameter(DCMAW_SHOULD_SEND_ALL_USERS))
                 .thenReturn(String.valueOf(true));
 
-        Map<String, Object> input = createRequestEvent();
+        JourneyRequest input = createRequestEvent();
 
-        Map<String, Object> response = underTest.handleRequest(input, context);
+        JourneyResponse response = underTest.handleRequest(input, context);
 
-        assertEquals("/journey/dcmaw", response.get("journey"));
+        assertEquals("/journey/dcmaw", response.getJourney());
     }
 
     private void mockIpvSessionService() {
@@ -720,8 +721,8 @@ class SelectCriHandlerTest {
                 .thenReturn(getClientOAuthSessionItem());
     }
 
-    private Map<String, Object> createRequestEvent() {
-        return Map.of("ipvSessionId", TEST_SESSION_ID);
+    private JourneyRequest createRequestEvent() {
+        return new JourneyRequest(TEST_SESSION_ID, null, null, null);
     }
 
     private CredentialIssuerConfig createCriConfig(String criId, String criIss, boolean enabled)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update the select-cri lambda removing support for API Gateway requests

### Why did it change

No longer required now we are using JSON requests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2755](https://govukverify.atlassian.net/browse/PYIC-2755)


[PYIC-2755]: https://govukverify.atlassian.net/browse/PYIC-2755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ