### PR TITLE
PYIC-2804 Remove call to check VC duration validity

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -134,8 +134,6 @@ public class CheckExistingIdentityHandler
             AuditEventUser auditEventUser =
                     new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
 
-            userIdentityService.deleteVcStoreItemsIfAnyInvalid(userId);
-
             List<SignedJWT> credentials =
                     gpg45ProfileEvaluator.parseCredentials(
                             userIdentityService.getUserIssuedCredentials(userId));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove call to check VC duration validity

### Why did it change

The programme has decided that the exp claim on VC JWTs should be ignored, allowing us to use previously collected VCs that had this claim. We also no longer need to check for a globally configured validity period.

### Issue tracking
- [PYIC-2804](https://govukverify.atlassian.net/browse/PYIC-2804)


[PYIC-2804]: https://govukverify.atlassian.net/browse/PYIC-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ