### PR TITLE
[PYIC-2782] Enable feature set overriding of further config items

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -14,6 +14,7 @@ public enum ConfigurationVariable {
     DCMAW_ALLOWED_USER_IDS("self/journey/dcmawAllowedUserIds"),
     AUTH_CODE_EXPIRY_SECONDS("self/authCodeExpirySeconds"),
     PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("clients/%s/publicKeyMaterialForCoreToVerify"),
+    CLIENT_VALID_REDIRECT_URLS("clients/%s/validRedirectUrls"),
     CI_SCORING_CONFIG("self/ci-scoring-config"),
     CI_SCORING_THRESHOLD("self/ciScoringThreshold"),
     CI_MITIGATION_JOURNEYS_ENABLED("self/journey/ciMitigationsEnabled"),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -134,24 +134,24 @@ public class ConfigService {
 
     public String getSsmParameter(
             ConfigurationVariable configurationVariable, String... pathProperties) {
+        return getSsmParameterWithOverride(configurationVariable.getPath(), pathProperties);
+    }
+
+    private String getSsmParameterWithOverride(String templatePath, String... pathProperties) {
         if (getFeatureSet() != null) {
-            var featureSetPath =
-                    resolveFeatureSetPath(configurationVariable.getPath(), pathProperties);
             try {
-                return ssmProvider.get(featureSetPath);
+                return ssmProvider.get(resolveFeatureSetPath(templatePath, pathProperties));
             } catch (ParameterNotFoundException ignored) {
                 LOGGER.debug(
                         (new StringMapMessage())
                                 .with(
                                         LOG_MESSAGE_DESCRIPTION.getFieldName(),
                                         "Parameter not present for featureSet")
-                                .with(
-                                        LOG_PARAMETER_PATH.getFieldName(),
-                                        configurationVariable.getPath())
+                                .with(LOG_PARAMETER_PATH.getFieldName(), templatePath)
                                 .with(LOG_FEATURE_SET.getFieldName(), getFeatureSet()));
             }
         }
-        return ssmProvider.get(resolvePath(configurationVariable.getPath(), pathProperties));
+        return ssmProvider.get(resolvePath(templatePath, pathProperties));
     }
 
     private String resolveBasePath() {
@@ -195,8 +195,7 @@ public class ConfigService {
 
     public List<String> getClientRedirectUrls(String clientId) {
         String redirectUrlStrings =
-                ssmProvider.get(resolvePath("clients/%s/validRedirectUrls", clientId));
-
+                getSsmParameter(ConfigurationVariable.CLIENT_VALID_REDIRECT_URLS, clientId);
         return Arrays.asList(redirectUrlStrings.split(CLIENT_REDIRECT_URL_SEPARATOR));
     }
 
@@ -236,7 +235,7 @@ public class ConfigService {
     public String getActiveConnection(String credentialIssuerId) {
         final String pathTemplate =
                 ConfigurationVariable.CREDENTIAL_ISSUERS.getPath() + "/%s/activeConnection";
-        return getSsmParameter(resolvePath(pathTemplate, credentialIssuerId));
+        return getSsmParameterWithOverride(pathTemplate, credentialIssuerId);
     }
 
     public String getComponentId(String credentialIssuerId) {
@@ -244,25 +243,25 @@ public class ConfigService {
         final String pathTemplate =
                 ConfigurationVariable.CREDENTIAL_ISSUERS.getPath()
                         + "/%s/connections/%s/componentId";
-        return getSsmParameter(resolvePath(pathTemplate, credentialIssuerId, activeConnection));
+        return getSsmParameterWithOverride(pathTemplate, credentialIssuerId, activeConnection);
     }
 
     public boolean isUnavailable(String credentialIssuerId) {
         final String pathTemplate =
                 ConfigurationVariable.CREDENTIAL_ISSUERS.getPath() + "/%s/unavailable";
-        return Boolean.parseBoolean(getSsmParameter(resolvePath(pathTemplate, credentialIssuerId)));
+        return Boolean.parseBoolean(getSsmParameterWithOverride(pathTemplate, credentialIssuerId));
     }
 
     public String getAllowedSharedAttributes(String credentialIssuerId) {
         final String pathTemplate =
                 ConfigurationVariable.CREDENTIAL_ISSUERS.getPath() + "/%s/allowedSharedAttributes";
-        return getSsmParameter(resolvePath(pathTemplate, credentialIssuerId));
+        return getSsmParameterWithOverride(pathTemplate, credentialIssuerId);
     }
 
     public boolean isEnabled(String credentialIssuerId) {
         final String pathTemplate =
                 ConfigurationVariable.CREDENTIAL_ISSUERS.getPath() + "/%s/enabled";
-        return Boolean.parseBoolean(getSsmParameter(resolvePath(pathTemplate, credentialIssuerId)));
+        return Boolean.parseBoolean(getSsmParameterWithOverride(pathTemplate, credentialIssuerId));
     }
 
     public Map<String, ContraIndicatorScore> getContraIndicatorScoresMap() {


### PR DESCRIPTION
## Proposed changes

### What changed
Enable feature set overriding of further config items, viz.
- client redirect URLs (`getClientRedirectUrls`)
- active connection (`getActiveConnection`)
- active config for a credential issuer (`getCredentialIssuerActiveConnectionConfig`)
- cri availability (`isUnavailable`)
- cri allowed shared attributes (`getAllowedSharedAttributes`)
- cri enabled (`isEnabled`)
- active connection component id (`getComponentId`)

### Why did it change
Completeness and consistency.

### Issue tracking
- [PYIC-2782](https://govukverify.atlassian.net/browse/PYIC-2782)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations


[PYIC-2782]: https://govukverify.atlassian.net/browse/PYIC-2782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ