### PR TITLE
Pyic 2760 add the check existing identity lambda to the journey engine step function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled class file
 *.class
+lambdas/*/bin
 
 # Log file
 *.log

--- a/deploy/journey_engine.asl.json
+++ b/deploy/journey_engine.asl.json
@@ -4,7 +4,59 @@
     "ProcessJourneyStep": {
       "Type": "Task",
       "Resource": "${IPVProcessJourneyStepFunctionArn}",
-      "End": true
+      "Parameters": {
+        "journey.$": "$.journey",
+        "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
+        "ipAddress.$": "$$.Execution.Input.ipAddress"
+      },
+      "Next": "ProcessJourneyStepResult"
+    },
+    "ProcessJourneyStepResult": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.journey",
+          "IsPresent": false,
+          "Next": "Success"
+        },
+        {
+          "Variable": "$.journey",
+          "StringMatches": "/journey/check-existing-identity",
+          "Next": "CheckExistingIdentityLambda"
+        }
+      ],
+      "Default": "Success"
+    },
+    "CheckExistingIdentityLambda": {
+      "Type": "Task",
+      "Resource": "${CheckExistingIdentityFunctionArn}",
+      "Parameters": {
+        "journey.$": "$.journey",
+        "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
+        "ipAddress.$": "$$.Execution.Input.ipAddress",
+        "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
+        "featureSet.$": "$$.Execution.Input.featureSet"
+      },
+      "Next": "ProcessNextJourney"
+    },
+    "ProcessNextJourney": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.journey",
+          "IsPresent": false,
+          "Next": "Success"
+        },
+        {
+          "Variable": "$.journey",
+          "StringMatches": "/journey/*",
+          "Next": "ProcessJourneyStep"
+        }
+      ],
+      "Default": "Success"
+    },
+    "Success": {
+      "Type": "Succeed"
     }
   }
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1379,6 +1379,7 @@ Resources:
       DefinitionUri: journey_engine.asl.json
       DefinitionSubstitutions:
         IPVProcessJourneyStepFunctionArn: !GetAtt IPVProcessJourneyStepFunction.Arn
+        CheckExistingIdentityFunctionArn: !GetAtt CheckExistingIdentityFunction.Arn
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1396,6 +1397,8 @@ Resources:
       Policies:
         - LambdaInvokePolicy:
             FunctionName: !Ref IPVProcessJourneyStepFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref CheckExistingIdentityFunction
         - Statement:
             - Sid: CloudWatchLogsAccess
               Effect: Allow

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -1,11 +1,8 @@
 package uk.gov.di.ipv.core.library.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -13,8 +10,6 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
-import java.nio.charset.Charset;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -29,20 +24,9 @@ public class RequestHelper {
     public static final String CLIENT_SESSION_ID_HEADER = "client-session-id";
     public static final String IP_ADDRESS_HEADER = "ip-address";
     public static final String FEATURE_SET_HEADER = "feature-set";
-    private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final Logger LOGGER = LogManager.getLogger();
 
     private RequestHelper() {}
-
-    public static Map<String, String> parseRequestBody(String body) {
-        Map<String, String> queryPairs = new HashMap<>();
-
-        for (NameValuePair pair : URLEncodedUtils.parse(body, Charset.defaultCharset())) {
-            queryPairs.put(pair.getName(), pair.getValue());
-        }
-
-        return queryPairs;
-    }
 
     public static Optional<String> getHeader(Map<String, String> headers, String headerKey) {
         if (headers == null) {
@@ -124,7 +108,7 @@ public class RequestHelper {
                                 LOG_MESSAGE_DESCRIPTION.getFieldName(),
                                 "Client session id missing in header.");
         validateClientOAuthSessionId(clientSessionId, message);
-        return clientSessionId;
+        return StringUtils.isBlank(clientSessionId) ? null : clientSessionId;
     }
 
     public static String getIpvSessionId(JourneyRequest request, boolean allowNull)
@@ -140,7 +124,7 @@ public class RequestHelper {
     public static String getFeatureSet(JourneyRequest request) {
         String featureSet = request.getFeatureSet();
         LogHelper.attachFeatureSetToLogs(featureSet);
-        return featureSet;
+        return StringUtils.isBlank(featureSet) ? null : featureSet;
     }
 
     private static String getFeatureSet(Map<String, String> headers) {

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -129,7 +129,7 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\", \"journey\": \"/journey/$input.params('journeyStep')\"}",
+                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\", \"journey\": \"/journey/$input.params('journeyStep')\", \"clientOAuthSessionId\": \"$input.params('client-session-id')\", \"featureSet\": \"$input.params('feature-set')\"}",
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${JourneyEngineStepFunction.Name}"
               }
         responses:
@@ -311,7 +311,9 @@ paths:
             Fn::Sub: |
               {
                 "ipvSessionId": "$input.params('ipv-session-id')", 
-                "ipAddress": "$input.params('ip-address')"
+                "ipAddress": "$input.params('ip-address')",
+                "clientOAuthSessionId": "$input.params('client-session-id')",
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:


### PR DESCRIPTION
## Proposed changes

### What changed

* Added the basic structure of the different paths which can be taken. New Lambdas can now be added to the ProcessJourneyStepResult
* Added the CheckExistingIdentityLambda Lambda to the Journey Engine Step Function
  * Also passes through clientOAuthSessionId and featureSet from request.
* Added null checking to RequestHelper for featureSet and clientOAuthSessionId as changes were causing null pointer exceptions.
* Updated `/journey/{journeyStep}` so that the clientOAuthSessionId and featureSet were passed in.
* Added `lambdas/*/bin` to .gitignore so that it's easier to see for uncommited changed when developing.

### Why did it change

Added CheckExistingIdentityLambda to Process Journey State Machine

### Issue tracking

- [PYIC-2760](https://govukverify.atlassian.net/browse/PYIC-2760)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2760]: https://govukverify.atlassian.net/browse/PYIC-2760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ