### PR TITLE
BAU: Updated journey lambdas to include the clientSessionId and featureSet in OpenAPI requests

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -193,7 +193,9 @@ paths:
             Fn::Sub: |
               {
                 "ipvSessionId": "$input.params('ipv-session-id')",
-                "ipAddress": "$input.params('ip-address')"
+                "ipAddress": "$input.params('ip-address')",
+                "clientOAuthSessionId": "$input.params('client-session-id')",
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:
@@ -226,7 +228,10 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "ipvSessionId": "$input.params('ipv-session-id')"
+                "ipvSessionId": "$input.params('ipv-session-id')",
+                "ipAddress": "$input.params('ip-address')",
+                "clientOAuthSessionId": "$input.params('client-session-id')",
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:
@@ -259,9 +264,10 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "ipvSessionId": "$input.params('ipv-session-id')", 
+                "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
-                "clientOAuthSessionId": "$input.params('client-session-id')"
+                "clientOAuthSessionId": "$input.params('client-session-id')",
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:
@@ -273,6 +279,7 @@ paths:
                 #set($context.responseOverride.status = $bodyObj.statusCode)
                 #end
                 $input.body
+
   /journey/end-mitigation-journey/{mitigationId}:
     post:
       description: "Called when the user has completed the last step of a mitigation journey"


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the following lambdas to make sure that clientSessionId and featureSet are passed to the Lambdas:
* /journey/evaluate-gpg45-scores
* /journey/select-cri
* /journey/build-client-oauth-response

### Why did it change

The lambdas requires the clientSessionId and featureSet passed down to them.

### Issue tracking
N/A

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

N/A