### PR TITLE
Reconfigure API Gateway so that it calls the Lambda using JSON

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -158,6 +158,12 @@ paths:
   /journey/cri/build-oauth-request/{criId}:
     post:
       description: Called when the frontend begins the CRI journey.
+      parameters:
+        - name: criId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         200:
           description: "Returns the id, clientId and authorizationUrl for a CRI."
@@ -175,11 +181,11 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
+                "journey": "$input.params('criId')",
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')",
-                "journey": "$input.params('journey')"
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:
@@ -215,8 +221,7 @@ paths:
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')",
-                "journey": "$input.params('journey')"
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:
@@ -252,8 +257,7 @@ paths:
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')",
-                "journey": "$input.params('journey')"
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:
@@ -289,8 +293,7 @@ paths:
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')",
-                "journey": "$input.params('journey')"
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:
@@ -360,8 +363,7 @@ paths:
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')",
-                "journey": "$input.params('journey')"
+                "featureSet": "$input.params('feature-set')"
               }
         responses:
           default:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -181,7 +181,7 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "journey": "$input.params('criId')",
+                "journey": "/journey/cri/build-oauth-request/$input.params('criId')",
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -170,7 +170,27 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildCriOauthRequestFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
-        type: "aws_proxy"
+        type: "aws"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "ipvSessionId": "$input.params('ipv-session-id')",
+                "ipAddress": "$input.params('ip-address')",
+                "clientOAuthSessionId": "$input.params('client-session-id')",
+                "featureSet": "$input.params('feature-set')",
+                "journey": "$input.params('journey')"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set ($bodyObj = $util.parseJson($input.body))
+                #if ($bodyObj.statusCode)
+                #set($context.responseOverride.status = $bodyObj.statusCode)
+                #end
+                $input.body
 
   /journey/evaluate-gpg45-scores:
     post:
@@ -195,7 +215,8 @@ paths:
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
+                "featureSet": "$input.params('feature-set')",
+                "journey": "$input.params('journey')"
               }
         responses:
           default:
@@ -231,7 +252,8 @@ paths:
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
+                "featureSet": "$input.params('feature-set')",
+                "journey": "$input.params('journey')"
               }
         responses:
           default:
@@ -267,7 +289,8 @@ paths:
                 "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
+                "featureSet": "$input.params('feature-set')",
+                "journey": "$input.params('journey')"
               }
         responses:
           default:
@@ -334,10 +357,11 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "ipvSessionId": "$input.params('ipv-session-id')", 
+                "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
+                "featureSet": "$input.params('feature-set')",
+                "journey": "$input.params('journey')"
               }
         responses:
           default:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Reconfigure API Gateway so it calls the build-cri-oauth-request lambda using JSON

### Why did it change

We'll be calling these journey lambdas within the journey engine step function so will be removing API Gateway

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2733](https://govukverify.atlassian.net/browse/PYIC-2733)


[PYIC-2733]: https://govukverify.atlassian.net/browse/PYIC-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ