### PR TITLE
[PYIC-2786] Attach feature set to logs for APIGatewayProxyRequestEvents

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -132,7 +132,9 @@ public class RequestHelper {
     }
 
     public static String getFeatureSet(APIGatewayProxyRequestEvent event) {
-        return getFeatureSet(event.getHeaders());
+        String featureSet = getFeatureSet(event.getHeaders());
+        LogHelper.attachFeatureSetToLogs(featureSet);
+        return featureSet;
     }
 
     private static String getIpvSessionId(Map<String, String> headers, boolean allowNull)


### PR DESCRIPTION
Attaches feature set information to logging context for APIGatewayProxyRequestEvents

## Proposed changes

### What changed

Request helper now adds feature set information or adds featureSet: null to logs for APIGatewayProxyRequestEvents

### Why did it change

All log messages / context should include information about feature sets or lack of feature set (null) even if feature set is not included in the request

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2786](https://govukverify.atlassian.net/browse/PYIC-2786)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2786]: https://govukverify.atlassian.net/browse/PYIC-2786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ