### PR TITLE
[PYIC-2717] Propagate featureSet to and within Step Functions

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -13,7 +13,8 @@
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
         "ipAddress.$": "$.ipAddress",
-        "journey.$": "$.lambdaResult.journey"
+        "journey.$": "$.lambdaResult.journey",
+        "featureSet.$": "$.featureSet"
       },
       "Catch": [
         {
@@ -30,7 +31,8 @@
       "Resource": "${RetrieveCriCredentialFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$.ipvSessionId",
-        "ipAddress.$": "$.ipAddress"
+        "ipAddress.$": "$.ipAddress",
+        "featureSet.$": "$.featureSet"
       },
       "ResultPath": "$.lambdaResult",
       "Next": "ReturnToFrontend"

--- a/deploy/journey_engine.asl.json
+++ b/deploy/journey_engine.asl.json
@@ -7,7 +7,8 @@
       "Parameters": {
         "journey.$": "$.journey",
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
-        "ipAddress.$": "$$.Execution.Input.ipAddress"
+        "ipAddress.$": "$$.Execution.Input.ipAddress",
+        "featureSet.$": "$$.Execution.Input.featureSet"
       },
       "Next": "ProcessJourneyStepResult"
     },

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -81,7 +81,7 @@ paths:
             Fn::Sub: |
               #set($inputRoot = $input.path('$'))
               {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\"#foreach($key in $inputRoot.keySet()), \"$key\": \"$inputRoot.get($key)\"#end}",
+                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"featureSet\": \"$input.params('feature-set')\", \"ipAddress\": \"$input.params('ip-address')\"#foreach($key in $inputRoot.keySet()), \"$key\": \"$inputRoot.get($key)\"#end}",
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CriReturnStepFunction.Name}"
               }
         responses:
@@ -129,7 +129,7 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"ipAddress\": \"$input.params('ip-address')\", \"journey\": \"/journey/$input.params('journeyStep')\", \"clientOAuthSessionId\": \"$input.params('client-session-id')\", \"featureSet\": \"$input.params('feature-set')\"}",
+                "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"featureSet\": \"$input.params('feature-set')\", \"ipAddress\": \"$input.params('ip-address')\", \"journey\": \"/journey/$input.params('journeyStep')\", \"clientOAuthSessionId\": \"$input.params('client-session-id')\", \"featureSet\": \"$input.params('feature-set')\"}",
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${JourneyEngineStepFunction.Name}"
               }
         responses:
@@ -334,7 +334,7 @@ paths:
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {
-                "ipvSessionId": "$input.params('ipv-session-id')", 
+                "ipvSessionId": "$input.params('ipv-session-id')",
                 "ipAddress": "$input.params('ip-address')",
                 "clientOAuthSessionId": "$input.params('client-session-id')",
                 "featureSet": "$input.params('feature-set')"


### PR DESCRIPTION
## Proposed changes

### What changed

The featureSet passed to the API Gateway criReturn and journey engine Step Function endpoints needs to be passed to the initial and subsequent steps in the same way as ipvSessionId is propagated through the step function steps.

### Why did it change

IPV Core front passes the (front-end) session featureSet on all interactions with the back end; additionally, the back-end step functions must propagate the featureSet on the back-end only flows

### Issue tracking
- [PYIC-2717](https://govukverify.atlassian.net/browse/PYIC-2717)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations

[PYIC-2717]: https://govukverify.atlassian.net/browse/PYIC-2717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ