### PR TITLE
PYIC-2761: Added evaluate-gpg45-score lambda to Journey Step Function

### DIFF
--- a/deploy/journey_engine.asl.json
+++ b/deploy/journey_engine.asl.json
@@ -23,6 +23,11 @@
           "Variable": "$.journey",
           "StringMatches": "/journey/check-existing-identity",
           "Next": "CheckExistingIdentityLambda"
+        },
+        {
+          "Variable": "$.journey",
+          "StringMatches": "/journey/evaluate-gpg45-scores",
+          "Next": "EvaluateGpg45ScoresFunction"
         }
       ],
       "Default": "Success"
@@ -30,6 +35,18 @@
     "CheckExistingIdentityLambda": {
       "Type": "Task",
       "Resource": "${CheckExistingIdentityFunctionArn}",
+      "Parameters": {
+        "journey.$": "$.journey",
+        "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
+        "ipAddress.$": "$$.Execution.Input.ipAddress",
+        "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
+        "featureSet.$": "$$.Execution.Input.featureSet"
+      },
+      "Next": "ProcessNextJourney"
+    },
+    "EvaluateGpg45ScoresFunction": {
+      "Type": "Task",
+      "Resource": "${EvaluateGpg45ScoresFunctionArn}",
       "Parameters": {
         "journey.$": "$.journey",
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1380,6 +1380,7 @@ Resources:
       DefinitionSubstitutions:
         IPVProcessJourneyStepFunctionArn: !GetAtt IPVProcessJourneyStepFunction.Arn
         CheckExistingIdentityFunctionArn: !GetAtt CheckExistingIdentityFunction.Arn
+        EvaluateGpg45ScoresFunctionArn: !GetAtt EvaluateGpg45ScoresFunction.Arn
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1399,6 +1400,8 @@ Resources:
             FunctionName: !Ref IPVProcessJourneyStepFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref CheckExistingIdentityFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref EvaluateGpg45ScoresFunction
         - Statement:
             - Sid: CloudWatchLogsAccess
               Effect: Allow


### PR DESCRIPTION
## Proposed changes

### What changed

Added evaluate-gpg45-scores lambda to the Journey Step Function.

### Why did it change

So that the Process Journey Step Function calls the Lambda rather than requiring di-ipv-core-front to call it.

### Issue tracking

- [PYIC-2761](https://govukverify.atlassian.net/browse/PYIC-2761)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2761]: https://govukverify.atlassian.net/browse/PYIC-2761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ