### PR TITLE
PYIC-2767: Removed check-existing-identity from API Gateway

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2229,14 +2229,6 @@ Resources:
                       - EnvironmentConfiguration
                       - !Ref AWS::AccountId
                       - environment
-      Events:
-        IPVCorePrivateAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCorePrivateAPI
-            Path: /journey/check-existing-identity
-            Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -314,42 +314,6 @@ paths:
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
 
-  /journey/check-existing-identity:
-    post:
-      description: "Check Existing Identity"
-      responses:
-        200:
-          description: "Check Existing Identity response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/journeyType"
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CheckExistingIdentityFunction.Arn}:live/invocations
-        passthroughBehavior: "when_no_match"
-        type: "aws"
-        requestTemplates:
-          application/x-www-form-urlencoded:
-            Fn::Sub: |
-              {
-                "ipvSessionId": "$input.params('ipv-session-id')",
-                "ipAddress": "$input.params('ip-address')",
-                "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
-              }
-        responses:
-          default:
-            statusCode: 200
-            responseTemplates:
-              application/json: |
-                #set ($bodyObj = $util.parseJson($input.body))
-                #if ($bodyObj.statusCode)
-                #set($context.responseOverride.status = $bodyObj.statusCode)
-                #end
-                $input.body
-
 components:
   schemas:
     journeyType:


### PR DESCRIPTION
## Proposed changes

### What changed

Removed check-existing-identity from API Gateway.

### Why did it change

Lambda check-existing-identity is no longer required by API Gateway as it's called by the Process Journey Step function.

### Issue tracking

- [PYIC-2767](https://govukverify.atlassian.net/browse/PYIC-2767)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2767]: https://govukverify.atlassian.net/browse/PYIC-2767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ