### PR TITLE
PYIC-2750: Added raw serialisation so that all child types of BaseResponse are serialised

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -47,6 +47,7 @@ import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.CriOAuthSessionService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
+import uk.gov.di.ipv.core.library.statemachine.JourneyRequestLambda;
 
 import java.net.URISyntaxException;
 import java.text.ParseException;
@@ -65,8 +66,7 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getJourney;
 import static uk.gov.di.ipv.core.library.statemachine.BaseJourneyLambda.JOURNEY_ERROR_PATH;
 
-public class BuildCriOauthRequestHandler
-        implements RequestHandler<JourneyRequest, BaseResponse> {
+public class BuildCriOauthRequestHandler extends JourneyRequestLambda {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String DCMAW_CRI_ID = "dcmaw";
     public static final String SHARED_CLAIM_ATTR_NAME = "name";
@@ -124,7 +124,7 @@ public class BuildCriOauthRequestHandler
     @Override
     @Tracing
     @Logging(clearState = true)
-    public BaseResponse handleRequest(JourneyRequest input, Context context) {
+    protected BaseResponse handleRequest(JourneyRequest input, Context context) {
         LogHelper.attachComponentIdToLogs();
         try {
             String ipvSessionId = getIpvSessionId(input);

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.buildcrioauthrequest;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambda.java
@@ -14,7 +14,8 @@ public abstract class JourneyRequestLambda implements RequestStreamHandler {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Override
-    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+    public void handleRequest(InputStream input, OutputStream output, Context context)
+            throws IOException {
         JourneyRequest request = mapper.readValue(input, JourneyRequest.class);
         BaseResponse response = handleRequest(request, context);
         mapper.writeValue(output, response);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambda.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.core.library.statemachine;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.di.ipv.core.library.domain.BaseResponse;
+import uk.gov.di.ipv.core.library.domain.JourneyRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public abstract class JourneyRequestLambda implements RequestStreamHandler {
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+        JourneyRequest request = mapper.readValue(input, JourneyRequest.class);
+        BaseResponse response = handleRequest(request, context);
+        mapper.writeValue(output, response);
+    }
+
+    protected abstract BaseResponse handleRequest(JourneyRequest request, Context context);
+}


### PR DESCRIPTION
## Proposed changes

### What changed

* Added `BaseJourneyLambda` which is able to deserialise JourneyRequest and serialise all objects which inherit BaseResponse.
* Updated `BuildCriOauthRequestHandler` to inherit from `BaseJourneyLambda`

### Why did it change

Default AWS Serialisation resulted in an empty object.

### Issue tracking

- [PYIC-2750](https://govukverify.atlassian.net/browse/PYIC-2750)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2750]: https://govukverify.atlassian.net/browse/PYIC-2750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1278" alt="Screenshot 2023-05-23 at 11 23 02" src="https://github.com/alphagov/di-ipv-core-back/assets/122806395/59e599d5-a840-4b43-bf64-afdda7c884fe">
<img width="1277" alt="Screenshot 2023-05-23 at 11 28 03" src="https://github.com/alphagov/di-ipv-core-back/assets/122806395/3013811f-1701-4883-8421-37a38532a02c">

