### PR TITLE
PYIC-2768: Removed the evaluate-gpg45-scores from the OpenAPI Gateway

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1649,14 +1649,6 @@ Resources:
                       - EnvironmentConfiguration
                       - !Ref AWS::AccountId
                       - environment
-      Events:
-        IPVCorePrivateAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCorePrivateAPI
-            Path: /journey/evaluate-gpg45-scores
-            Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -62,6 +62,7 @@ import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MITIGATION_JOURNEY_RESPONSE;
 import static uk.gov.di.ipv.core.library.statemachine.BaseJourneyLambda.JOURNEY_ERROR_PATH;
 
+/** Evaluate the gathered credentials against a desired GPG45 profile. */
 public class EvaluateGpg45ScoresHandler implements RequestHandler<JourneyRequest, JourneyResponse> {
 
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -198,42 +198,6 @@ paths:
                 #end
                 $input.body
 
-  /journey/evaluate-gpg45-scores:
-    post:
-      description: "Evaludate the gathered credentials against a desired GPG45 profile. Returns journey response or session end"
-      responses:
-        200:
-          description: "Returns a journeyResponse or session end"
-          content:
-            application/json:
-              schema:
-                type: "object"
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EvaluateGpg45ScoresFunction.Arn}:live/invocations
-        passthroughBehavior: "when_no_match"
-        type: "aws"
-        requestTemplates:
-          application/x-www-form-urlencoded:
-            Fn::Sub: |
-              {
-                "ipvSessionId": "$input.params('ipv-session-id')",
-                "ipAddress": "$input.params('ip-address')",
-                "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
-              }
-        responses:
-          default:
-            statusCode: 200
-            responseTemplates:
-              application/json: |
-                #set ($bodyObj = $util.parseJson($input.body))
-                #if ($bodyObj.statusCode)
-                #set($context.responseOverride.status = $bodyObj.statusCode)
-                #end
-                $input.body
-
   /journey/select-cri:
     post:
       description: "Selects a CRI based on which CRIs the user has not visited. Returns journey response or journey fail"


### PR DESCRIPTION
## Proposed changes

### What changed

* Removed the evaluate-gpg54-scores lambda from the OpenAPI Gateway
* Moved comment describing the Lambda to the handler sources

### Why did it change

evaluate-gpg54-scores no longer required in OpenAPI as it's now called directly by the Journey Step Function.

### Issue tracking

- [PYIC-2768](https://govukverify.atlassian.net/browse/PYIC-2768)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2768]: https://govukverify.atlassian.net/browse/PYIC-2768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ