### PR TITLE
PYIC-2769: Removed select-cri from OpenAPI Gateway

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1670,14 +1670,6 @@ Resources:
             TableName: !Ref ClientOAuthSessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
-      Events:
-        IPVCorePrivateAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCorePrivateAPI
-            Path: /journey/select-cri
-            Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -44,6 +44,7 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.statemachine.BaseJourneyLambda.JOURNEY_ERROR_PATH;
 
+/** Selects a CRI based on which CRIs the user has not visited */
 public class SelectCriHandler implements RequestHandler<JourneyRequest, JourneyResponse> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String CRI_START_JOURNEY = "/journey/%s";

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -234,42 +234,6 @@ paths:
                 #end
                 $input.body
 
-  /journey/select-cri:
-    post:
-      description: "Selects a CRI based on which CRIs the user has not visited. Returns journey response or journey fail"
-      responses:
-        200:
-          description: "Returns a journeyResponse or journeyFail"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/journeyType"
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SelectCriFunction.Arn}:live/invocations
-        passthroughBehavior: "when_no_match"
-        type: "aws"
-        requestTemplates:
-          application/x-www-form-urlencoded:
-            Fn::Sub: |
-              {
-                "ipvSessionId": "$input.params('ipv-session-id')",
-                "ipAddress": "$input.params('ip-address')",
-                "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
-              }
-        responses:
-          default:
-            statusCode: 200
-            responseTemplates:
-              application/json: |
-                #set ($bodyObj = $util.parseJson($input.body))
-                #if ($bodyObj.statusCode)
-                #set($context.responseOverride.status = $bodyObj.statusCode)
-                #end
-                $input.body
-
   /journey/build-client-oauth-response:
     post:
       description: "Called when the user has completed their user journey in IPV Core"


### PR DESCRIPTION
## Proposed changes

### What changed

* Removed the select-cri lambda from the OpenAPI Gateway
* Moved comment describing the Lambda to the handler sources

### Why did it change

select-cri no longer required in OpenAPI as it's now called directly by the Journey Step Function.

### Issue tracking

- [PYIC-2769](https://govukverify.atlassian.net/browse/PYIC-2769)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2769]: https://govukverify.atlassian.net/browse/PYIC-2769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ