### PR TITLE
PYIC-2824: Migrated check-existing-identity to use JourneyRequestLambda and updated tests

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.checkexistingidentity;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nimbusds.jwt.SignedJWT;
@@ -41,6 +40,7 @@ import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
+import uk.gov.di.ipv.core.library.statemachine.JourneyRequestLambda;
 import uk.gov.di.ipv.core.library.vchelper.VcHelper;
 
 import java.text.ParseException;
@@ -58,8 +58,7 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 
 /** Check Existing Identity response Lambda */
-public class CheckExistingIdentityHandler
-        implements RequestHandler<JourneyRequest, JourneyResponse> {
+public class CheckExistingIdentityHandler extends JourneyRequestLambda {
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
     private static final String VOT_P2 = "P2";
@@ -68,7 +67,6 @@ public class CheckExistingIdentityHandler
 
     private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
-    public static final String JOURNEY_ERROR_PATH = "/journey/error";
 
     private final ConfigService configService;
     private final UserIdentityService userIdentityService;

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.checkexistingidentity;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,10 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
-import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
-import uk.gov.di.ipv.core.library.domain.JourneyRequest;
-import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.domain.*;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
@@ -34,6 +32,9 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
@@ -91,6 +92,7 @@ class CheckExistingIdentityHandlerTest {
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
     private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     static {
         try {
@@ -164,8 +166,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
 
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
@@ -184,7 +185,8 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnJourneyReuseResponseIfScoresSatisfyM1BGpg45Profile() throws SqsException {
+    void shouldReturnJourneyReuseResponseIfScoresSatisfyM1BGpg45Profile()
+            throws SqsException, IOException {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
@@ -194,8 +196,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
         verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
@@ -211,7 +212,7 @@ class CheckExistingIdentityHandlerTest {
 
     @Test
     void shouldReturnJourneyNextResponseIfScoresDoNotSatisfyM1AGpg45Profile()
-            throws ParseException, SqsException {
+            throws ParseException, SqsException, IOException {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
@@ -222,8 +223,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
         assertEquals(JOURNEY_NEXT, journeyResponse);
 
         verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID);
@@ -239,7 +239,7 @@ class CheckExistingIdentityHandlerTest {
 
     @Test
     void shouldReturnJourneyNextResponseIfVcsFailCiScoreCheck()
-            throws ParseException, SqsException {
+            throws ParseException, SqsException, IOException {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
@@ -248,8 +248,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
         assertEquals("/journey/next", journeyResponse.getJourney());
 
         verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID);
@@ -264,7 +263,7 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldNotSendAuditEventIfNewUser() throws ParseException, SqsException {
+    void shouldNotSendAuditEventIfNewUser() throws ParseException, SqsException, IOException {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(Collections.emptyList());
@@ -274,8 +273,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
         assertEquals("/journey/next", journeyResponse.getJourney());
         verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
 
@@ -286,17 +284,17 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfSessionIdNotInHeader() {
+    void shouldReturn400IfSessionIdNotInHeader() throws IOException {
         JourneyRequest eventWithoutHeaders = new JourneyRequest(null, null, null, null, null);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(eventWithoutHeaders, context);
+        var journeyResponse =
+                handleRequest(eventWithoutHeaders, context, JourneyErrorResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
-        assertEquals(HttpStatus.SC_BAD_REQUEST, errorResponse.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), errorResponse.getCode());
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), errorResponse.getMessage());
+        assertEquals(HttpStatus.SC_BAD_REQUEST, journeyResponse.getStatusCode());
+        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID.getCode(), journeyResponse.getCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(), journeyResponse.getMessage());
         verify(clientOAuthSessionDetailsService, times(0)).getClientOAuthSession(any());
     }
 
@@ -307,8 +305,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
         JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
@@ -331,8 +328,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
         JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
@@ -357,8 +353,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
         JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
@@ -385,8 +380,7 @@ class CheckExistingIdentityHandlerTest {
                 .when(auditService)
                 .sendAuditEvent((AuditEvent) any());
 
-        JourneyResponse journeyResponse =
-                checkExistingIdentityHandler.handleRequest(event, context);
+        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
         JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
@@ -395,5 +389,15 @@ class CheckExistingIdentityHandlerTest {
         assertEquals(
                 ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getMessage(), errorResponse.getMessage());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+    }
+
+    private <T extends BaseResponse> T handleRequest(
+            JourneyRequest request, Context context, Class<T> classType) throws IOException {
+        try (var inputStream =
+                        new ByteArrayInputStream(mapper.writeValueAsString(request).getBytes());
+                var outputStream = new ByteArrayOutputStream()) {
+            checkExistingIdentityHandler.handleRequest(inputStream, outputStream, context);
+            return mapper.readValue(outputStream.toString(), classType);
+        }
     }
 }

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -305,17 +305,16 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
+        var journeyResponse = handleRequest(event, context, JourneyErrorResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, journeyResponse.getStatusCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getCode(),
-                errorResponse.getCode());
+                journeyResponse.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(),
-                errorResponse.getMessage());
+                journeyResponse.getMessage());
 
         verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
@@ -328,17 +327,16 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
+        var journeyResponse = handleRequest(event, context, JourneyErrorResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, journeyResponse.getStatusCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getCode(),
-                errorResponse.getCode());
+                journeyResponse.getCode());
         assertEquals(
                 ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE.getMessage(),
-                errorResponse.getMessage());
+                journeyResponse.getMessage());
 
         verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
@@ -353,14 +351,13 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
-        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
+        var journeyResponse = handleRequest(event, context, JourneyErrorResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_GET_STORED_CIS.getCode(), errorResponse.getCode());
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, journeyResponse.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_TO_GET_STORED_CIS.getCode(), journeyResponse.getCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_GET_STORED_CIS.getMessage(), errorResponse.getMessage());
+                ErrorResponse.FAILED_TO_GET_STORED_CIS.getMessage(), journeyResponse.getMessage());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 
@@ -380,14 +377,14 @@ class CheckExistingIdentityHandlerTest {
                 .when(auditService)
                 .sendAuditEvent((AuditEvent) any());
 
-        var journeyResponse = handleRequest(event, context, JourneyResponse.class);
+        var journeyResponse = handleRequest(event, context, JourneyErrorResponse.class);
         assertEquals("/journey/error", journeyResponse.getJourney());
 
-        JourneyErrorResponse errorResponse = (JourneyErrorResponse) journeyResponse;
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse.getStatusCode());
-        assertEquals(ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getCode(), errorResponse.getCode());
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, journeyResponse.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getCode(), journeyResponse.getCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getMessage(), errorResponse.getMessage());
+                ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT.getMessage(),
+                journeyResponse.getMessage());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambda.java
@@ -11,7 +11,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public abstract class JourneyRequestLambda implements RequestStreamHandler {
-    private ObjectMapper mapper = new ObjectMapper();
+    public static final String JOURNEY_ERROR_PATH = "/journey/error";
+    public static final String JOURNEY_NEXT_PATH = "/journey/next";
+    private static ObjectMapper mapper = new ObjectMapper();
 
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context)


### PR DESCRIPTION
## Proposed changes

### What changed

* Updated CheckExistingIdentityHandler to use JourneyRequestLambda
* Updated Unit tests to use serialiser to ensure that serialisation is working as expected

### Why did it change

Existing approach misses additional fields when an error occurs.

### Issue tracking

- [PYIC-2824](https://govukverify.atlassian.net/browse/PYIC-2824)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2824]: https://govukverify.atlassian.net/browse/PYIC-2824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ