### PR TITLE
Set powertools options to capture less data

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -9,6 +9,8 @@ Globals:
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+        POWERTOOLS_TRACER_CAPTURE_RESPONSE: false
+        POWERTOOLS_TRACER_CAPTURE_ERROR: false
     CodeSigningConfigArn: !If
       - UseCodeSigning
       - !Ref CodeSigningConfigArn


### PR DESCRIPTION
Referenced from:
https://awslabs.github.io/aws-lambda-powertools-java/core/tracing/

## Proposed changes
Stop powertools from including responses/errors in trace metadata as it's exceeding the UDP packet size.

### What changed
Set env vars to prevent collection of this data

### Why did it change
Bug in x-ray/powertools trying to overload UDP packets

### Issue tracking
NA

### Other considerations

We should raise a ticket for this against the powertools project. 
