### PR TITLE
Revert "PYIC-2764 Remove build-client-oauth-response from Internal API Gateway"

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -446,6 +446,14 @@ Resources:
                 - 'kms:GenerateDataKey'
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
+      Events:
+        IPVCorePrivateAPI:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
+            Path: /journey/build-client-oauth-response
+            Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -53,7 +53,6 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionIdAllowNull;
 
-/** Called when the user has completed their user journey in IPV Core */
 public class BuildClientOauthResponseHandler extends JourneyRequestLambda {
     private static final Logger LOGGER = LogManager.getLogger();
     private final IpvSessionService sessionService;

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -198,6 +198,42 @@ paths:
                 #end
                 $input.body
 
+  /journey/build-client-oauth-response:
+    post:
+      description: "Called when the user has completed their user journey in IPV Core"
+      responses:
+        200:
+          description: "Authorization Code and details"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/journeyType"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildClientOauthResponseFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        type: "aws"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "ipvSessionId": "$input.params('ipv-session-id')",
+                "ipAddress": "$input.params('ip-address')",
+                "clientOAuthSessionId": "$input.params('client-session-id')",
+                "featureSet": "$input.params('feature-set')"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set ($bodyObj = $util.parseJson($input.body))
+                #if ($bodyObj.statusCode)
+                #set($context.responseOverride.status = $bodyObj.statusCode)
+                #end
+                $input.body
+
   /journey/end-mitigation-journey/{mitigationId}:
     post:
       description: "Called when the user has completed the last step of a mitigation journey"


### PR DESCRIPTION
Reverts alphagov/di-ipv-core-back#856

The frontend debug page still uses the 'build-client-oauth-response' directly so we should keep this and it seems to have caused test failures