### PR TITLE
PYIC-2862: Added tests and additional error handling for JourneyRequestLambda

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -54,7 +54,9 @@ public enum ErrorResponse {
     MISSING_IP_ADDRESS(1044, "Missing ip address header"),
     FAILED_BIRTHDATE_CORRELATION(1045, "Failed to correlate gathered birth dates"),
     FAILED_NAME_CORRELATION(1046, "Failed to correlate gathered names"),
-    FAILED_TO_CONSTRUCT_REDIRECT_URI(1047, "Failed to construct redirect uri");
+    FAILED_TO_CONSTRUCT_REDIRECT_URI(1047, "Failed to construct redirect uri"),
+    FAILED_TO_PARSE_JSON_MESSAGE(1048, "Failed to parse JSON message"),
+    FAILED_UNHANDLED_EXCEPTION(1049, "Unhandled exception");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyErrorResponse.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @ExcludeFromGeneratedCoverageReport
 @EqualsAndHashCode(callSuper = true)
+@ToString
 @JsonIgnoreProperties(
         value = {"message"},
         allowGetters = true)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambda.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambda.java
@@ -3,7 +3,12 @@ package uk.gov.di.ipv.core.library.statemachine;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.domain.BaseResponse;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 
 import java.io.IOException;
@@ -11,17 +16,52 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public abstract class JourneyRequestLambda implements RequestStreamHandler {
+    @java.lang.SuppressWarnings(
+            "java:S1075") // These are known addresses used within Process Journey
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
+
+    @java.lang.SuppressWarnings(
+            "java:S1075") // These are known addresses used within Process Journey
     public static final String JOURNEY_NEXT_PATH = "/journey/next";
+
+    @java.lang.SuppressWarnings(
+            "java:S1075") // These are known addresses used within Process Journey
     public static final String JOURNEY_END_PATH = "/journey/end";
 
-    private static ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final Logger LOGGER = LogManager.getLogger();
 
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context)
             throws IOException {
-        JourneyRequest request = mapper.readValue(input, JourneyRequest.class);
-        BaseResponse response = handleRequest(request, context);
+        JourneyRequest request = null;
+        BaseResponse response = null;
+        try {
+            request = mapper.readValue(input, JourneyRequest.class);
+        } catch (Exception e) {
+            LOGGER.error("Unable to parse input request", e);
+            response =
+                    new JourneyErrorResponse(
+                            JOURNEY_ERROR_PATH,
+                            HttpStatus.SC_BAD_REQUEST,
+                            ErrorResponse.FAILED_TO_PARSE_JSON_MESSAGE,
+                            e.getMessage());
+        }
+
+        try {
+            if (response == null) {
+                response = handleRequest(request, context);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Unhandled exception whilst processing Lambda", e);
+            response =
+                    new JourneyErrorResponse(
+                            JOURNEY_ERROR_PATH,
+                            HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                            ErrorResponse.FAILED_UNHANDLED_EXCEPTION,
+                            e.getMessage());
+        }
+
         mapper.writeValue(output, response);
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambdaTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/statemachine/JourneyRequestLambdaTest.java
@@ -1,0 +1,145 @@
+package uk.gov.di.ipv.core.library.statemachine;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.BaseResponse;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
+import uk.gov.di.ipv.core.library.domain.JourneyRequest;
+import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+class JourneyRequestLambdaTest {
+    @Mock private Context mockContext;
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private JourneyRequest journeyRequest;
+
+    @BeforeEach
+    void setup() {
+        journeyRequest =
+                JourneyRequest.builder()
+                        .journey("/journey/testlambda")
+                        .ipvSessionId(UUID.randomUUID().toString())
+                        .ipAddress("192.168.0.1")
+                        .clientOAuthSessionId(UUID.randomUUID().toString())
+                        .featureSet("test")
+                        .build();
+    }
+
+    @Test
+    void returnJourneyResponse() throws Exception {
+        var journeyResponse = new JourneyResponse("/journey/next");
+        var handler =
+                new JourneyRequestLambda() {
+                    @Override
+                    protected BaseResponse handleRequest(JourneyRequest request, Context context) {
+                        assertEquals(journeyRequest, request);
+                        assertEquals(context, mockContext);
+                        return journeyResponse;
+                    }
+                };
+
+        var response = makeRequest(handler, journeyRequest, mockContext, JourneyResponse.class);
+
+        assertEquals(journeyResponse, response);
+    }
+
+    @Test
+    void returnJourneyErrorResponse() throws Exception {
+        var journeyResponse =
+                new JourneyErrorResponse(
+                        "/journey/error",
+                        HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                        ErrorResponse.FAILED_UNHANDLED_EXCEPTION);
+        var handler =
+                new JourneyRequestLambda() {
+                    @Override
+                    protected BaseResponse handleRequest(JourneyRequest request, Context context) {
+                        assertEquals(journeyRequest, request);
+                        assertEquals(context, mockContext);
+                        return journeyResponse;
+                    }
+                };
+
+        var response =
+                makeRequest(handler, journeyRequest, mockContext, JourneyErrorResponse.class);
+
+        assertEquals(journeyResponse, response);
+    }
+
+    @Test
+    void returnJourneyErrorResponseWhenExceptionThrown() throws Exception {
+        var journeyResponse =
+                new JourneyErrorResponse(
+                        "/journey/error",
+                        HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                        ErrorResponse.FAILED_UNHANDLED_EXCEPTION);
+        var handler =
+                new JourneyRequestLambda() {
+                    @Override
+                    protected BaseResponse handleRequest(JourneyRequest request, Context context) {
+                        throw new RuntimeException("The Lambda went bang!");
+                    }
+                };
+
+        var response =
+                makeRequest(handler, journeyRequest, mockContext, JourneyErrorResponse.class);
+
+        assertEquals(journeyResponse, response);
+    }
+
+    @Test
+    void returnJourneyErrorResponseWhenInvalidInput() throws Exception {
+        var journeyResponse =
+                new JourneyErrorResponse(
+                        "/journey/error",
+                        HttpStatus.SC_BAD_REQUEST,
+                        ErrorResponse.FAILED_TO_PARSE_JSON_MESSAGE);
+        var handler =
+                new JourneyRequestLambda() {
+                    @Override
+                    protected BaseResponse handleRequest(JourneyRequest request, Context context) {
+                        return new JourneyResponse("/journey/next");
+                    }
+                };
+
+        var response = makeRequest(handler, "{\"ipv....", mockContext, JourneyErrorResponse.class);
+
+        assertEquals(journeyResponse, response);
+    }
+
+    private <T extends BaseResponse> T makeRequest(
+            RequestStreamHandler handler,
+            JourneyRequest request,
+            Context context,
+            Class<T> classType)
+            throws IOException {
+        return makeRequest(handler, mapper.writeValueAsString(request), context, classType);
+    }
+
+    private <T extends BaseResponse> T makeRequest(
+            RequestStreamHandler handler, String request, Context context, Class<T> classType)
+            throws IOException {
+        try (var inputStream = new ByteArrayInputStream(request.getBytes());
+                var outputStream = new ByteArrayOutputStream()) {
+            handler.handleRequest(inputStream, outputStream, context);
+            return mapper.readValue(outputStream.toString(), classType);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed

* Added error handling to JourneyRequestLambda so that it new returns `/journey/error` if it's unable to parse the input or an unhandled error occurs.
* Added tests for the JourneyRequestLambda to ensure the error handling is working as expected

### Why did it change

It was possible for unhandled Exceptions being thrown if the message could not be parsed or if an unhandled error occurred within the Lambda.

### Issue tracking

- [PYIC-2862](https://govukverify.atlassian.net/browse/PYIC-2862)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2862]: https://govukverify.atlassian.net/browse/PYIC-2862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ