### PR TITLE
[PYIC-2838] Create CRI Response table

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2186,6 +2186,30 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
 
+  CRIResponseTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
+      TableName: !Sub "cri-response-${Environment}"
+      BillingMode: "PAY_PER_REQUEST"
+      AttributeDefinitions:
+        - AttributeName: "userId"
+          AttributeType: "S"
+        - AttributeName: "credentialIssuer"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "userId"
+          KeyType: "HASH"
+        - AttributeName: "credentialIssuer"
+          KeyType: "RANGE"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: true
+      SSESpecification:
+        SSEEnabled: true
+        SSEType: KMS
+        KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
+
   SessionsTable:
     Type: AWS::DynamoDB::Table
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed

Added CRI Response table for non-VC CRI responses

### Why did it change

Need to persist non-VC CRI responses for async CRI flows.

### Issue tracking

- [PYIC-2838](https://govukverify.atlassian.net/browse/PYIC-2838)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations



[PYIC-2838]: https://govukverify.atlassian.net/browse/PYIC-2838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ