### PR TITLE
WIP: Starting the f2f journey

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -174,10 +174,10 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    ukPassportAndDrivingLicenceF2F:
       type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
+      name: ukPassportAndDrivingLicence
+      targetState: MULTIPLE_DOC_CHECK_F2F_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
@@ -188,6 +188,20 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/address
+    claimedIdentity:
+      type: basic
+      name: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
+    f2f:
+      type: basic
+      name: f2f
+      targetState: CRI_F2F
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/f2f
     fraud:
       type: basic
       name: fraud
@@ -284,6 +298,12 @@ CRI_DRIVING_LICENCE:
 CRI_ADDRESS:
   name: CRI_ADDRESS
   parent: CRI_STATE
+CRI_CLAIMED_IDENTITY:
+  name: CRI_CLAIMED_IDENTITY
+  parent: CRI_STATE
+CRI_F2F:
+  name: CRI_F2F
+  parent: CRI_STATE
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
@@ -330,13 +350,6 @@ MULTIPLE_DOC_CHECK_PAGE:
   name: MULTIPLE_DOC_CHECK_PAGE
   parent: ATTEMPT_RECOVERY_STATE
   events:
-    next:
-      type: basic
-      name: next
-      targetState: CRI_UK_PASSPORT
-      response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/ukPassport
     ukPassport:
       type: basic
       name: ukPassport
@@ -358,6 +371,31 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
+MULTIPLE_DOC_CHECK_F2F_PAGE:
+  name: MULTIPLE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    ukPassport:
+      type: basic
+      name: ukPassport
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: drivingLicence
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -35,6 +35,7 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_SHOU
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DRIVING_LICENCE_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.FRAUD_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.KBV_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
@@ -53,6 +54,8 @@ public class SelectCriHandler extends JourneyRequestLambda {
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
     private static final String UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
             "ukPassportAndDrivingLicence";
+    private static final String UK_PASSPORT_AND_DRIVING_LICENCE_F2F_PAGE =
+            "ukPassportAndDrivingLicenceF2F";
     private static final String STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
             "stubUkPassportAndDrivingLicence";
 
@@ -302,7 +305,11 @@ public class SelectCriHandler extends JourneyRequestLambda {
         if (configService.getActiveConnection(DRIVING_LICENCE_CRI).equals("stub")) {
             return Optional.of(getJourneyResponse(STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
         }
-        return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
+        if (configService.isEnabled(F2F_CRI)){
+            return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_F2F_PAGE));
+        } else {
+            return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
+        }
     }
 
     private boolean hasPassportVc(List<VcStatusDto> currentVcStatuses) {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
@@ -14,4 +14,5 @@ public class CriConstants {
     public static final String KBV_CRI = "kbv";
     public static final String ADDRESS_CRI = "address";
     public static final String DCMAW_CRI = "dcmaw";
+    public static final String F2F_CRI = "f2f";
 }


### PR DESCRIPTION
This is a quick bash at what we need to do to get the Select CRI onto the F2F journey when F2F is enabled. This doesn't include the config. It's completely untested. I've not even tried to run it.

The State Machine definition has been updated and I think that is probably good enough for what we need this week.

The updates to the Select CRI lambda are minimal, but I think are enough to return the event that will cause the state machine to go to the new state, and then when the user selects the "prove another way" option will be taken to Claimed Identity.

I think on the next step Select CRI will probably be lost as it won't know what to do at that stage, but it should be on a more straightforward path.