### PR TITLE
[PYIC-2867] Move Verifiable Credential classes out to library

### DIFF
--- a/lambdas/retrieve-cri-credential/build.gradle
+++ b/lambdas/retrieve-cri-credential/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			project(":lib"),
 			project(":libs:vc-helper")
+	implementation project(path: ':libs:verifiable-credentials')
 
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
 			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -37,9 +37,9 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.CriOAuthSessionService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.vchelper.VcHelper;
-import uk.gov.di.ipv.core.retrievecricredential.exception.VerifiableCredentialException;
-import uk.gov.di.ipv.core.retrievecricredential.service.VerifiableCredentialService;
-import uk.gov.di.ipv.core.retrievecricredential.validation.VerifiableCredentialJwtValidator;
+import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
+import uk.gov.di.ipv.core.library.verifiablecredential.validation.VerifiableCredentialJwtValidator;
 
 import java.text.ParseException;
 import java.util.List;

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -31,9 +31,9 @@ import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.CriOAuthSessionService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
-import uk.gov.di.ipv.core.retrievecricredential.exception.VerifiableCredentialException;
-import uk.gov.di.ipv.core.retrievecricredential.service.VerifiableCredentialService;
-import uk.gov.di.ipv.core.retrievecricredential.validation.VerifiableCredentialJwtValidator;
+import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
+import uk.gov.di.ipv.core.library.verifiablecredential.validation.VerifiableCredentialJwtValidator;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -1,0 +1,63 @@
+plugins {
+	// Apply the java-library plugin for API and implementation separation.
+	id 'java-library'
+	id "idea"
+	id "jacoco"
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
+			"com.amazonaws:aws-java-sdk-lambda:$rootProject.ext.dependencyVersions.awsJavaSdkLambda",
+			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
+			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
+			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+			"software.amazon.awssdk:kms:$rootProject.ext.dependencyVersions.kms",
+			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+			project(":lib")
+
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.0",
+			"org.junit.jupiter:junit-jupiter:5.9.3",
+			"org.mockito:mockito-junit-jupiter:5.3.1",
+			"uk.org.webcompere:system-stubs-jupiter:2.0.2",
+			project(":lib").sourceSets.test.output
+
+	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_11
+	targetCompatibility = JavaVersion.VERSION_11
+	withSourcesJar()
+}
+
+tasks.withType(Jar).configureEach { Jar jar ->
+	jar.preserveFileTimestamps = false
+	jar.reproducibleFileOrder = true
+}
+
+tasks.named('jar') {
+	manifest {
+		attributes('Implementation-Title': project.name,
+		'Implementation-Version': project.version)
+	}
+}
+
+test {
+	useJUnitPlatform ()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required.set(true)
+	}
+}

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/exception/VerifiableCredentialException.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/exception/VerifiableCredentialException.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.retrievecricredential.exception;
+package uk.gov.di.ipv.core.library.verifiablecredential.exception;
 
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.retrievecricredential.service;
+package uk.gov.di.ipv.core.library.verifiablecredential.service;
 
 import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.jwt.SignedJWT;
@@ -22,7 +22,7 @@ import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
-import uk.gov.di.ipv.core.retrievecricredential.exception.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialException;
 
 import java.io.IOException;
 import java.time.Instant;

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validation/VerifiableCredentialJwtValidator.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validation/VerifiableCredentialJwtValidator.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.retrievecricredential.validation;
+package uk.gov.di.ipv.core.library.verifiablecredential.validation;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
@@ -16,7 +16,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.retrievecricredential.exception.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialException;
 
 import java.text.ParseException;
 import java.util.Arrays;

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.retrievecricredential.service;
+package uk.gov.di.ipv.core.library.verifiablecredential.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,7 +23,7 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
-import uk.gov.di.ipv.core.retrievecricredential.exception.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialException;
 
 import java.net.URI;
 import java.security.KeyFactory;

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validation/VerifiableCredentialJwtValidatorTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validation/VerifiableCredentialJwtValidatorTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.retrievecricredential.validation;
+package uk.gov.di.ipv.core.library.verifiablecredential.validation;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.crypto.impl.ECDSA;
@@ -13,7 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
-import uk.gov.di.ipv.core.retrievecricredential.exception.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialException;
 
 import java.text.ParseException;
 import java.util.Arrays;

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,4 +20,5 @@ include "lib",
 		"integration-test",
 		"libs:credential-issuer-config-service",
 		"libs:kms-es256-signer",
-		"libs:vc-helper"
+		"libs:vc-helper",
+		"libs:verifiable-credentials"


### PR DESCRIPTION
## Proposed changes

### What changed
The following Verifiable Credential classes have been moved from the `retrieve-cri-credential` lambda out to a `verifiable-credentials` library.
- `exception/VerifiableCredentialException`
- `service/VerifiableCredentialService`
- `validation/VerifiableCredentialJwtValidator`

### Why did it change
VC validation and persistence to be shared between sync and async VC return lambdas.

### Issue tracking
- [PYIC-2867](https://govukverify.atlassian.net/browse/PYIC-2867)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations


[PYIC-2867]: https://govukverify.atlassian.net/browse/PYIC-2867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ