### PR TITLE
Pyic 2834 modify state machine definition to send user to claimed identity cri

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -195,6 +195,13 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
+    f2f:
+      type: basic
+      name: f2f
+      targetState: CRI_F2F
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/f2f
     kbv:
       type: basic
       name: kbv
@@ -290,6 +297,9 @@ CRI_FRAUD:
 CRI_CLAIMED_IDENTITY:
   name: CRI_CLAIMED_IDENTITY
   parent: CRI_STATE
+CRI_F2F:
+  name: CRI_F2F
+  parent: CRI_STATE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE
@@ -364,12 +374,10 @@ MULTIPLE_DOC_CHECK_PAGE:
     end:
       type: basic
       name: end
-      # targetState: END
-      targetState: CRI_CLAIMED_IDENTITY
+      targetState: END
       response:
         type: journey
-        # journeyStepId: /journey/build-client-oauth-response
-        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
+        journeyStepId: /journey/build-client-oauth-response
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -188,6 +188,13 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/fraud
+    claimedIdentity:
+      type: basic
+      name: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
     kbv:
       type: basic
       name: kbv
@@ -280,6 +287,9 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_CLAIMED_IDENTITY:
+  name: CRI_CLAIMED_IDENTITY
+  parent: CRI_STATE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE
@@ -344,13 +354,22 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/drivingLicence
+    claimedIdentity:
+      type: basic
+      name: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
     end:
       type: basic
       name: end
-      targetState: END
+      # targetState: END
+      targetState: CRI_CLAIMED_IDENTITY
       response:
         type: journey
-        journeyStepId: /journey/build-client-oauth-response
+        # journeyStepId: /journey/build-client-oauth-response
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE


### PR DESCRIPTION
## Proposed changes

### What changed

* Added claimedIdentity and f2f to the SELECT_CRI journey
* Added the CRI states CRI_CLAIMED_IDENTITY and CRI_F2F
* Added claimedIdentity to MULTIPLE_DOC_CHECK_PAGE

### Why did it change

* Added the following to the SELECT_CRI journey:
  * claimedIdentity - When the Claimed Identity CRI needs to be called
  * f2f - When the Face to Face CRI needs to be invoked
* Added the CRI states
  * CRI_CLAIMED_IDENTITY - Handle responses from the CRI_CLAIMED_IDENTITY
  * CRI_F2F - Handle responses from the CRI_F2F
* Added claimedIdentity to MULTIPLE_DOC_CHECK_PAGE

### Issue tracking

- [PYIC-2834](https://govukverify.atlassian.net/browse/PYIC-2834)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2834]: https://govukverify.atlassian.net/browse/PYIC-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ