### PR TITLE
Set ttl on prod VC table

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2185,7 +2185,7 @@ Resources:
         AttributeName: "ttl"
         Enabled: !If
           - IsProduction
-          - false
+          - true #false set to true until user privacy notice is updated
           - true
       SSESpecification:
         SSEEnabled: true


### PR DESCRIPTION
until user privacy notice is update

## Proposed changes
TTL being switched back on due to privacy policy needing to be updated before letting VCs be long lived.

### What changed
The TTL (time to live) on the VC table entries

### Why did it change
See above

### Other considerations
It's likely we will want to revert this or update it back to not being applied when the privacy policy is updated again.

