### PR TITLE
Update gpg45 evaluator to handle F2F VC

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -69,7 +69,7 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
     private static final JourneyResponse JOURNEY_END = new JourneyResponse(JOURNEY_END_PATH);
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse(JOURNEY_NEXT_PATH);
     private static final String JOURNEY_PYI_NO_MATCH = "/journey/pyi-no-match";
-    public static final String JOURNEY_ERROR_PATH = "/journey/error";
+    private static final String JOURNEY_ERROR_PATH = "/journey/error";
     private static final String VOT_P2 = "P2";
     private static final Logger LOGGER = LogManager.getLogger();
     private static final int ONLY = 0;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -151,8 +151,7 @@ public class Gpg45ProfileEvaluator {
     }
 
     private List<CredentialEvidenceItem> convertEvidenceToGpg45EvidenceItem(
-            CredentialEvidenceItem evidenceItem)
-            throws UnknownEvidenceTypeException {
+            CredentialEvidenceItem evidenceItem) throws UnknownEvidenceTypeException {
         if (isRelevantEvidence(evidenceItem)) {
             return convertEvidenceItemToGpg45EvidenceItems(evidenceItem);
         }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -153,12 +153,8 @@ public class Gpg45ProfileEvaluator {
     private List<CredentialEvidenceItem> convertEvidenceToGpg45EvidenceItem(
             CredentialEvidenceItem evidenceItem, CredentialEvidenceItem.EvidenceType evidenceType)
             throws UnknownEvidenceTypeException {
-        if (evidenceType == CredentialEvidenceItem.EvidenceType.DCMAW) {
-            return convertEvidenceItemToGpg45EvidenceItems(
-                    evidenceItem, CredentialEvidenceItem.EvidenceType.DCMAW);
-        } else if (evidenceType == CredentialEvidenceItem.EvidenceType.F2F) {
-            return convertEvidenceItemToGpg45EvidenceItems(
-                    evidenceItem, CredentialEvidenceItem.EvidenceType.F2F);
+        if (isRelevantEvidence(evidenceItem)) {
+            return convertEvidenceItemToGpg45EvidenceItems(evidenceItem);
         }
         return Collections.emptyList();
     }
@@ -180,10 +176,7 @@ public class Gpg45ProfileEvaluator {
                     parseCredentialEvidence(signedJWT);
             for (CredentialEvidenceItem evidenceItem : credentialEvidenceList) {
 
-                if (evidenceItem.getType().equals(CredentialEvidenceItem.EvidenceType.DCMAW)
-                        && doesEvidenceContainEvidenceType(evidenceItem, evidenceType)) {
-                    return Optional.of(signedJWT);
-                } else if (evidenceItem.getType().equals(CredentialEvidenceItem.EvidenceType.F2F)
+                if (isRelevantEvidence(evidenceItem)
                         && doesEvidenceContainEvidenceType(evidenceItem, evidenceType)) {
                     return Optional.of(signedJWT);
                 }
@@ -196,11 +189,17 @@ public class Gpg45ProfileEvaluator {
         return Optional.empty();
     }
 
+    private boolean isRelevantEvidence(CredentialEvidenceItem evidenceItem)
+            throws UnknownEvidenceTypeException {
+        return (evidenceItem.getType().equals(CredentialEvidenceItem.EvidenceType.DCMAW)
+                || evidenceItem.getType().equals(CredentialEvidenceItem.EvidenceType.F2F));
+    }
+
     private boolean doesEvidenceContainEvidenceType(
             CredentialEvidenceItem evidenceItem, CredentialEvidenceItem.EvidenceType evidenceType)
             throws UnknownEvidenceTypeException {
         List<CredentialEvidenceItem> evidenceItems =
-                convertEvidenceItemToGpg45EvidenceItems(evidenceItem, evidenceType);
+                convertEvidenceItemToGpg45EvidenceItems(evidenceItem);
         for (CredentialEvidenceItem item : evidenceItems) {
             if (item.getType().equals(evidenceType)) {
                 return true;
@@ -210,8 +209,7 @@ public class Gpg45ProfileEvaluator {
     }
 
     private List<CredentialEvidenceItem> convertEvidenceItemToGpg45EvidenceItems(
-            CredentialEvidenceItem evidenceItem, CredentialEvidenceItem.EvidenceType evidenceType)
-            throws UnknownEvidenceTypeException {
+            CredentialEvidenceItem evidenceItem) throws UnknownEvidenceTypeException {
         List<CredentialEvidenceItem> gpg45CredentialItems = new ArrayList<>();
 
         gpg45CredentialItems.add(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -142,7 +142,7 @@ public class Gpg45ProfileEvaluator {
         List<CredentialEvidenceItem> evidenceItems = evidenceMap.get(evidenceType);
         for (CredentialEvidenceItem evidenceItem : evidenceItems) {
             List<CredentialEvidenceItem> gpg45EvidenceItems =
-                    convertEvidenceToGpg45EvidenceItem(evidenceItem, evidenceType);
+                    convertEvidenceToGpg45EvidenceItem(evidenceItem);
 
             for (CredentialEvidenceItem gpg45EvidenceItem : gpg45EvidenceItems) {
                 evidenceMap.get(gpg45EvidenceItem.getType()).add(gpg45EvidenceItem);
@@ -151,7 +151,7 @@ public class Gpg45ProfileEvaluator {
     }
 
     private List<CredentialEvidenceItem> convertEvidenceToGpg45EvidenceItem(
-            CredentialEvidenceItem evidenceItem, CredentialEvidenceItem.EvidenceType evidenceType)
+            CredentialEvidenceItem evidenceItem)
             throws UnknownEvidenceTypeException {
         if (isRelevantEvidence(evidenceItem)) {
             return convertEvidenceItemToGpg45EvidenceItems(evidenceItem);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
@@ -20,6 +20,7 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
     public static final Evidence EV_22 = new Gpg45Scores.Evidence(2, 2);
     public static final Evidence EV_32 = new Gpg45Scores.Evidence(3, 2);
     public static final Evidence EV_33 = new Gpg45Scores.Evidence(3, 3);
+    public static final Evidence EV_40 = new Gpg45Scores.Evidence(4, 0);
     public static final Evidence EV_42 = new Gpg45Scores.Evidence(4, 2);
     public static final Evidence EV_43 = new Gpg45Scores.Evidence(4, 3);
     public static final Evidence EV_44 = new Gpg45Scores.Evidence(4, 4);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CheckDetail.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CheckDetail.java
@@ -7,7 +7,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @Getter
 @Setter
 @ExcludeFromGeneratedCoverageReport
-public class DcmawCheckMethod {
+public class CheckDetail {
     private String checkMethod;
     private String identityCheckPolicy;
     private String activityFrom;

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -48,6 +48,11 @@ class Gpg45ProfileEvaluatorTest {
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWsuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk5MTcsImV4cCI6MTY1ODgzNzExNywidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eG4iOiI3TEFLUlRBN0ZTIiwidmVyaWZpY2F0aW9uU2NvcmUiOjIsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIn0seyJhZGRyZXNzQ291bnRyeSI6IkdCIiwidXBybiI6MTAwMTIwMDEyMDc3LCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJ2YWxpZEZyb20iOiIyMDAwLTAxLTAxIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX19fQ.MEUCIAD3CkUQctCBxPIonRsYylmAsWsodyzpLlRzSTKvJBxHAiEAsewH-Ke7x8R3879-KQCwGAcYPt_14Wq7a6bvsb5tH_8";
     private final String M1B_DCMAW_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJhdWQiOiJodHRwczovL2lkZW50aXR5LmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwibmJmIjoxNjU4ODI5NjQ3LCJpc3MiOiJodHRwczovL3Jldmlldy1iLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwiZXhwIjoxNjU4ODM2ODQ3LCJ2YyI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InZhbHVlIjoiSm9lIFNobW9lIiwidHlwZSI6IkdpdmVuTmFtZSJ9LHsidmFsdWUiOiJEb2UgVGhlIEJhbGwiLCJ0eXBlIjoiRmFtaWx5TmFtZSJ9XX1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk4NS0wMi0wOCJ9XSwiYWRkcmVzcyI6W3sidXBybiI6IjEwMDIyODEyOTI5Iiwib3JnYW5pc2F0aW9uTmFtZSI6IkZJTkNIIEdST1VQIiwic3ViQnVpbGRpbmdOYW1lIjoiVU5JVCAyQiIsImJ1aWxkaW5nTnVtYmVyICI6IjE2IiwiYnVpbGRpbmdOYW1lIjoiQ09ZIFBPTkQgQlVTSU5FU1MgUEFSSyIsImRlcGVuZGVudFN0cmVldE5hbWUiOiJLSU5HUyBQQVJLIiwic3RyZWV0TmFtZSI6IkJJRyBTVFJFRVQiLCJkb3VibGVEZXBlbmRlbnRBZGRyZXNzTG9jYWxpdHkiOiJTT01FIERJU1RSSUNUIiwiZGVwZW5kZW50QWRkcmVzc0xvY2FsaXR5IjoiTE9ORyBFQVRPTiIsImFkZHJlc3NMb2NhbGl0eSI6IkdSRUFUIE1JU1NFTkRFTiIsInBvc3RhbENvZGUiOiJIUDE2IDBBTCIsImFkZHJlc3NDb3VudHJ5IjoiR0IifV0sImRyaXZpbmdQZXJtaXQiOlt7InBlcnNvbmFsTnVtYmVyIjoiRE9FOTk4MDIwODVKOTlGRyIsImV4cGlyeURhdGUiOiIyMDIzLTAxLTE4IiwiaXNzdWVOdW1iZXIiOm51bGwsImlzc3VlZEJ5IjpudWxsLCJpc3N1ZURhdGUiOm51bGx9XSwiZXZpZGVuY2UiOlt7InR5cGUiOiJJZGVudGl0eUNoZWNrIiwidHhuIjoiZWEyZmVlZmUtNDVhMy00YTI5LTkyM2YtNjA0Y2Q0MDE3ZWMwIiwic3RyZW5ndGhTY29yZSI6MywidmFsaWRpdHlTY29yZSI6MiwiYWN0aXZpdHlIaXN0b3J5U2NvcmUiOiIxIiwiY2hlY2tEZXRhaWxzIjpbeyJjaGVja01ldGhvZCI6InZyaSIsImlkZW50aXR5Q2hlY2tQb2xpY3kiOiJwdWJsaXNoZWQiLCJhY3Rpdml0eUZyb20iOiIyMDE5LTAxLTAxIn0seyJjaGVja01ldGhvZCI6ImJ2ciIsImJpb21ldHJpY1ZlcmlmaWNhdGlvblByb2Nlc3NMZXZlbCI6Mn1dfV19fQ.5Na1l3oeQq_PN68eb27xRypaG6J2fSjqEj6vwwkhPDqBZITRUpC86fzySkHWeFCBV5N9SIUPVmHlV40YkBZjBQ";
+    private final String M1A_F2F_VC =
+            "eyJhbGciOiJFUzI1NiJ9.eyJ2YyI6eyJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJNYXJ5In0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiV2F0c29uIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTMyLTAyLTI1In1dLCJwYXNzcG9ydCI6W3siZXhwaXJ5RGF0ZSI6IjIwMzAtMDEtMDEiLCJkb2N1bWVudE51bWJlciI6IjgyNDE1OTEyMSJ9XX0sImV2aWRlbmNlIjpbeyJ2YWxpZGl0eVNjb3JlIjoyLCJzdHJlbmd0aFNjb3JlIjo0LCJ2ZXJpZmljYXRpb25TY29yZSI6MiwiY2hlY2tEZXRhaWxzIjpbeyJjaGVja01ldGhvZCI6InZyaSIsInR4biI6IjI0OTI5ZDM4LTQyMGMtNGJhOS1iODQ2LTMwMDVlZTY5MWUyNiIsImlkZW50aXR5Q2hlY2tQb2xpY3kiOiJwdWJsaXNoZWQifSx7ImNoZWNrTWV0aG9kIjoicHZyIiwidHhuIjoiMjQ5MjlkMzgtNDIwYy00YmE5LWI4NDYtMzAwNWVlNjkxZTI2IiwiYmlvbWV0cmljVmVyaWZpY2F0aW9uUHJvY2Vzc0xldmVsIjozfV0sInR4biI6IjI0OTI5ZDM4LTQyMGMtNGJhOS1iODQ2LTMwMDVlZTY5MWUyNiIsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dfSwiaXNzIjoiaHR0cHM6Ly9kZXZlbG9wbWVudC1kaS1pcHYtY3JpLXVrLXBhc3Nwb3J0LXN0dWIubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsIiwic3ViIjoidXJuOnV1aWQ6YWYxMGVjOTQtZDExYy00NTlmLTg3ODItZTJlMDM3M2I4MTAxIiwibmJmIjoxNjg1NDUzNjkzfQ.LRNTe3i4boG_IbU55_T9fIuUAiud_5_a-TaXsuUFYh1Ncu85l_i-9U8D-WMvyRxlN6kS2o0Spo-DKI_xAvuMZA";
+
+    private final String M1A_F2F_VC_VERIFICATION_SCORE_ZERO =
+            "eyJhbGciOiJFUzI1NiJ9.eyJ2YyI6eyJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJNYXJ5In0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiV2F0c29uIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTMyLTAyLTI1In1dLCJwYXNzcG9ydCI6W3siZXhwaXJ5RGF0ZSI6IjIwMzAtMDEtMDEiLCJkb2N1bWVudE51bWJlciI6IjgyNDE1OTEyMSJ9XX0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInN0cmVuZ3RoU2NvcmUiOjQsInZhbGlkaXR5U2NvcmUiOjAsInZlcmlmaWNhdGlvblNjb3JlIjozLCJjaSI6WyJEMTQiXSwiZmFpbGVkQ2hlY2tEZXRhaWxzIjpbeyJjaGVja01ldGhvZCI6InZjcnlwdCIsImlkZW50aXR5Q2hlY2tQb2xpY3kiOiJwdWJsaXNoZWQifSx7ImNoZWNrTWV0aG9kIjoiYnZyIiwiYmlvbWV0cmljVmVyaWZpY2F0aW9uUHJvY2Vzc0xldmVsIjozfV19XX0sImlzcyI6Imh0dHBzOi8vZGV2ZWxvcG1lbnQtZGktaXB2LWNyaS11ay1wYXNzcG9ydC1zdHViLmxvbmRvbi5jbG91ZGFwcHMuZGlnaXRhbCIsInN1YiI6InVybjp1dWlkOmFmMTBlYzk0LWQxMWMtNDU5Zi04NzgyLWUyZTAzNzNiODEwMSIsIm5iZiI6MTY4NTQ1MzY5M30.XLGc1AIvEJdpo7ArSRTWaDfWbWRC1Q2VgXXQQ4_fPX9_d0OdUFMmyAfPIEcvmBmwi8Z7ixZ4GO7UrOa_tl4sQQ";
 
     @Test
     void getFirstMatchingProfileShouldReturnSatisfiedProfile() throws Exception {
@@ -229,6 +234,23 @@ class Gpg45ProfileEvaluatorTest {
     }
 
     @Test
+    void buildScoreShouldReturnCorrectScoreForF2FCredential() throws Exception {
+        Gpg45Scores builtScores = evaluator.buildScore(List.of(SignedJWT.parse(M1A_F2F_VC)));
+        Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_42, 0, 0, 2);
+
+        assertEquals(expectedScores, builtScores);
+    }
+
+    @Test
+    void buildScoreShouldReturnCorrectScoreForF2FCredentialAndZeroScores() throws Exception {
+        Gpg45Scores builtScores =
+                evaluator.buildScore(List.of(SignedJWT.parse(M1A_F2F_VC_VERIFICATION_SCORE_ZERO)));
+        Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_40, 0, 0, 3);
+
+        assertEquals(expectedScores, builtScores);
+    }
+
+    @Test
     void parseCredentialsParsesCredentials() throws Exception {
         List<String> expected = List.of(M1A_PASSPORT_VC, M1A_ADDRESS_VC, M1A_FRAUD_VC, M1A_KBV_VC);
 
@@ -274,6 +296,29 @@ class Gpg45ProfileEvaluatorTest {
         JWTClaimsSet jwtClaimsSet = result.get().getJWTClaimsSet();
 
         assertEquals("https://review-b.integration.account.gov.uk", jwtClaimsSet.getIssuer());
+    }
+
+    @Test
+    void getCredentialByTypeShouldReturnCorrectTypeForF2F() throws Exception {
+        List<SignedJWT> parsedCredentials =
+                evaluator.parseCredentials(
+                        List.of(
+                                M1A_F2F_VC,
+                                M1A_F2F_VC_VERIFICATION_SCORE_ZERO,
+                                M1A_ADDRESS_VC,
+                                M1A_FRAUD_VC));
+
+        Optional<SignedJWT> result =
+                evaluator.getCredentialByType(
+                        parsedCredentials, CredentialEvidenceItem.EvidenceType.EVIDENCE);
+
+        assertTrue(result.isPresent());
+
+        JWTClaimsSet jwtClaimsSet = result.get().getJWTClaimsSet();
+
+        assertEquals(
+                "https://development-di-ipv-cri-uk-passport-stub.london.cloudapps.digital",
+                jwtClaimsSet.getIssuer());
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/validation/Gpg45DcmawValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/validation/Gpg45DcmawValidatorTest.java
@@ -1,8 +1,8 @@
 package uk.gov.di.ipv.core.library.domain.gpg45.validation;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.domain.gpg45.domain.CheckDetail;
 import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
-import uk.gov.di.ipv.core.library.domain.gpg45.domain.DcmawCheckMethod;
 
 import java.util.Collections;
 
@@ -19,7 +19,7 @@ class Gpg45DcmawValidatorTest {
                         2,
                         1,
                         2,
-                        Collections.singletonList(new DcmawCheckMethod()),
+                        Collections.singletonList(new CheckDetail()),
                         null,
                         Collections.emptyList());
 
@@ -35,7 +35,7 @@ class Gpg45DcmawValidatorTest {
                         1,
                         2,
                         null,
-                        Collections.singletonList(new DcmawCheckMethod()),
+                        Collections.singletonList(new CheckDetail()),
                         Collections.emptyList());
 
         assertFalse(Gpg45DcmawValidator.isSuccessful(credentialEvidenceItem));
@@ -49,7 +49,7 @@ class Gpg45DcmawValidatorTest {
                         0,
                         1,
                         2,
-                        Collections.singletonList(new DcmawCheckMethod()),
+                        Collections.singletonList(new CheckDetail()),
                         null,
                         Collections.emptyList());
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The GPG45 evaulator has been updated to now handle the F2F VC

### Why did it change
This change was implement to handle the F2F credentials.

- [PYIC-2868](https://govukverify.atlassian.net/browse/PYIC-2868)


[PYIC-2868]: https://govukverify.atlassian.net/browse/PYIC-2868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ