### PR TITLE
feat: add cri response service to retrieve data from datastore

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -6,7 +6,7 @@ import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
 
 import java.util.List;
 
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.USER_ISSUED_CREDENTIALS_TABLE_NAME;
+import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CRI_RESPONSE_TABLE_NAME;
 
 public class CriResponseService {
     private final ConfigService configService;
@@ -18,8 +18,7 @@ public class CriResponseService {
         boolean isRunningLocally = this.configService.isRunningLocally();
         this.dataStore =
                 new DataStore<>(
-                        this.configService.getEnvironmentVariable(
-                                USER_ISSUED_CREDENTIALS_TABLE_NAME),
+                        this.configService.getEnvironmentVariable(CRI_RESPONSE_TABLE_NAME),
                         CriResponseItem.class,
                         DataStore.getClient(isRunningLocally),
                         isRunningLocally,

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.core.library.service;
+
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.persistence.DataStore;
+import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
+
+import java.util.List;
+
+import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.USER_ISSUED_CREDENTIALS_TABLE_NAME;
+
+public class CriResponseService {
+    private final ConfigService configService;
+    private final DataStore<CriResponseItem> dataStore;
+
+    @ExcludeFromGeneratedCoverageReport
+    public CriResponseService(ConfigService configService) {
+        this.configService = configService;
+        boolean isRunningLocally = this.configService.isRunningLocally();
+        this.dataStore =
+                new DataStore<>(
+                        this.configService.getEnvironmentVariable(
+                                USER_ISSUED_CREDENTIALS_TABLE_NAME),
+                        CriResponseItem.class,
+                        DataStore.getClient(isRunningLocally),
+                        isRunningLocally,
+                        configService);
+    }
+
+    public CriResponseService(ConfigService configService, DataStore<CriResponseItem> dataStore) {
+        this.configService = configService;
+        this.dataStore = dataStore;
+    }
+
+    public List<CriResponseItem> getCriResponseItems(String userId) {
+        return dataStore.getItems(userId);
+    }
+
+    public CriResponseItem getCriResponseItem(String userId, String criId) {
+        return dataStore.getItem(userId, criId);
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CriResponseServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CriResponseServiceTest.java
@@ -1,0 +1,78 @@
+package uk.gov.di.ipv.core.library.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.persistence.DataStore;
+import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_VC_1;
+
+@ExtendWith(MockitoExtension.class)
+public class CriResponseServiceTest {
+    @Mock private ConfigService mockConfigService;
+
+    @Mock private DataStore<CriResponseItem> mockDataStore;
+
+    private CriResponseService criResponseService;
+
+    private static final String USER_ID_1 = "user-id-1";
+
+    @BeforeEach
+    void setUp() {
+        criResponseService = new CriResponseService(mockConfigService, mockDataStore);
+    }
+
+    @Test
+    void shouldReturnCredentialFromDataStoreForSpecificCri() {
+        String ipvSessionId = "ipvSessionId";
+        String criId = "criId";
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_1, Instant.now());
+
+        when(mockDataStore.getItem(ipvSessionId, criId)).thenReturn(criResponseItem);
+
+        CriResponseItem retrievedCredentialItem =
+                criResponseService.getCriResponseItem(ipvSessionId, criId);
+
+        assertEquals(criResponseItem, retrievedCredentialItem);
+    }
+
+    @Test
+    void shouldReturnCredentialIssuersFromDataStoreForSpecificUserId() {
+        String userId = "userId";
+        String testCredentialIssuer = "f2f";
+        List<CriResponseItem> criResponseItem =
+                List.of(
+                        createCriResponseStoreItem(
+                                USER_ID_1, testCredentialIssuer, SIGNED_VC_1, Instant.now()));
+
+        when(mockDataStore.getItems(userId)).thenReturn(criResponseItem);
+
+        var criResponseItems = criResponseService.getCriResponseItems(userId);
+
+        assertTrue(
+                criResponseItems.stream()
+                        .map(CriResponseItem::getCredentialIssuer)
+                        .anyMatch(item -> testCredentialIssuer.equals(item)));
+    }
+
+    private CriResponseItem createCriResponseStoreItem(
+            String userId, String credentialIssuer, String issuerResponse, Instant dateCreated) {
+        CriResponseItem criResponseItem = new CriResponseItem();
+        criResponseItem.setUserId(userId);
+        criResponseItem.setCredentialIssuer(credentialIssuer);
+        criResponseItem.setIssuerResponse(issuerResponse);
+        criResponseItem.setDateCreated(dateCreated);
+        criResponseItem.setExpirationTime(dateCreated.plusSeconds(1000L));
+        return criResponseItem;
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Added Cri response service with methods to get data from databstore using user id and cri name.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2984](https://govukverify.atlassian.net/browse/PYIC-2984)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
