### PR TITLE
PYIC-2835: Modify select cri to pick address cri after claimed identity cri

### DIFF
--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -159,8 +159,6 @@ public class SelectCriHandler extends JourneyRequestLambda {
                         DRIVING_LICENCE_CRI,
                         DRIVING_LICENCE_CRI,
                         userId);
-        // Check that at least one of the CRIs has been accessed in which it will be empty.
-        // If none of the CRIs has returned a valid response then execute one of them.
         if (claimedIdentityResponse.isPresent() && passportResponse.isPresent() && drivingLicenceResponse.isPresent()) {
             if (userHasVisited(visitedCredentialIssuers, DRIVING_LICENCE_CRI)) {
                 return drivingLicenceResponse.get();

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -159,7 +159,9 @@ public class SelectCriHandler extends JourneyRequestLambda {
                         DRIVING_LICENCE_CRI,
                         DRIVING_LICENCE_CRI,
                         userId);
-        if (claimedIdentityResponse.isPresent() && passportResponse.isPresent() && drivingLicenceResponse.isPresent()) {
+        if (claimedIdentityResponse.isPresent()
+                && passportResponse.isPresent()
+                && drivingLicenceResponse.isPresent()) {
             if (userHasVisited(visitedCredentialIssuers, DRIVING_LICENCE_CRI)) {
                 return drivingLicenceResponse.get();
             }

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -71,6 +71,7 @@ public class SelectCriHandler extends JourneyRequestLambda {
         this.clientOAuthSessionService = clientOAuthSessionService;
     }
 
+    @SuppressWarnings("unused") // Used by AWS Lambda
     @ExcludeFromGeneratedCoverageReport
     public SelectCriHandler() {
         this.configService = new ConfigService();
@@ -162,6 +163,9 @@ public class SelectCriHandler extends JourneyRequestLambda {
         if (claimedIdentityResponse.isPresent()
                 && passportResponse.isPresent()
                 && drivingLicenceResponse.isPresent()) {
+            if (userHasVisited(visitedCredentialIssuers, CLAIMED_IDENTITY_CRI)) {
+                return claimedIdentityResponse.get();
+            }
             if (userHasVisited(visitedCredentialIssuers, DRIVING_LICENCE_CRI)) {
                 return drivingLicenceResponse.get();
             }

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
@@ -157,6 +157,32 @@ class SelectCriHandlerTest {
     }
 
     @Test
+    void shouldReturnPyiNoMatchErrorResponseIfClaimedIdentityHasPreviouslyFailed() throws Exception {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
+                .thenReturn(createCriConfig(DRIVING_LICENSE_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
+
+        List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
+                List.of(new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, false, null));
+
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(List.of(new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, false)));
+
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(visitedCredentialIssuerDetails);
+
+        JourneyRequest input = createRequestEvent();
+        JourneyResponse response = handleRequest(input, context);
+
+        assertEquals(PYI_NO_MATCH_JOURNEY, response.getJourney());
+    }
+
+    @Test
     void shouldReturnFraudCriJourneyResponseWhenVisitedClaimedIdentityAndAddress()
             throws Exception {
         mockIpvSessionService();
@@ -190,6 +216,40 @@ class SelectCriHandlerTest {
         JourneyResponse response = handleRequest(input, context);
 
         assertEquals(FRAUD_JOURNEY, response.getJourney());
+    }
+
+    @Test
+    void shouldReturnPyiNoMatchErrorResponseWhenVisitedClaimedIdentityAndAddressFailed()
+            throws Exception {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
+                .thenReturn(createCriConfig(DRIVING_LICENSE_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ISS));
+
+        List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
+                List.of(
+                        new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null),
+                        new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI, true, null));
+
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true),
+                                new VcStatusDto(ADDRESS_CRI_ISS, false)));
+
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(visitedCredentialIssuerDetails);
+
+        JourneyRequest input = createRequestEvent();
+        JourneyResponse response = handleRequest(input, context);
+
+        assertEquals(PYI_NO_MATCH_JOURNEY, response.getJourney());
     }
 
     @Test
@@ -230,6 +290,44 @@ class SelectCriHandlerTest {
         JourneyResponse response = handleRequest(input, context);
 
         assertEquals(F2F_JOURNEY, response.getJourney());
+    }
+
+    @Test
+    void shouldReturnPyiNoMatchErrorResponseWhenVisitedClaimedIdentityAddressAndFraudFailed()
+            throws Exception {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
+                .thenReturn(createCriConfig(DRIVING_LICENSE_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
+                .thenReturn(createCriConfig(FRAUD_CRI_ISS));
+
+        List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
+                List.of(
+                        new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null),
+                        new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI, true, null),
+                        new VisitedCredentialIssuerDetailsDto(FRAUD_CRI, true, null));
+
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true),
+                                new VcStatusDto(ADDRESS_CRI_ISS, true),
+                                new VcStatusDto(FRAUD_CRI_ISS, false)));
+
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(visitedCredentialIssuerDetails);
+
+        JourneyRequest input = createRequestEvent();
+        JourneyResponse response = handleRequest(input, context);
+
+        assertEquals(PYI_NO_MATCH_JOURNEY, response.getJourney());
     }
 
     @Test

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
@@ -157,7 +157,8 @@ class SelectCriHandlerTest {
     }
 
     @Test
-    void shouldReturnPyiNoMatchErrorResponseIfClaimedIdentityHasPreviouslyFailed() throws Exception {
+    void shouldReturnPyiNoMatchErrorResponseIfClaimedIdentityHasPreviouslyFailed()
+            throws Exception {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
@@ -33,8 +33,10 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ALLOWED_USER_IDS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_SHOULD_SEND_ALL_USERS;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DRIVING_LICENCE_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.FRAUD_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.KBV_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
@@ -50,6 +52,8 @@ class SelectCriHandlerTest {
     private static final String DRIVING_LICENSE_CRI_ISS = "test-driving-licence-iss";
     private static final String FRAUD_CRI_ISS = "test-fraud-iss";
     private static final String KBV_CRI_ISS = "test-kbv-iss";
+    private static final String CLAIMED_IDENTITY_CRI_ISS = "test-claimed-identity-iss";
+    private static final String F2F_CRI_ISS = "test-f2f-iss";
     private static final String UK_PASSPORT_JOURNEY = "/journey/ukPassport";
     private static final String UK_PASSPORT_AND_DRIVING_LICENCE_JOURNEY =
             "/journey/ukPassportAndDrivingLicence";
@@ -61,6 +65,7 @@ class SelectCriHandlerTest {
     private static final String DCMAW_JOURNEY = "/journey/dcmaw";
     private static final String DCMAW_SUCCESS_JOURNEY = "/journey/dcmaw-success";
     private static final String PYI_KBV_THIN_FILE_JOURNEY = "/journey/pyi-kbv-thin-file";
+    private static final String F2F_JOURNEY = "/journey/f2f";
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Mock private Context context;
@@ -82,6 +87,8 @@ class SelectCriHandlerTest {
     void shouldReturnPassportCriJourneyResponse() throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -102,6 +109,8 @@ class SelectCriHandlerTest {
             throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -120,9 +129,107 @@ class SelectCriHandlerTest {
     }
 
     @Test
+    void shouldReturnAddressCriJourneyResponseWhenVisitedClaimedIdentity() throws Exception {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
+                .thenReturn(createCriConfig(DRIVING_LICENSE_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ISS));
+
+        List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
+                List.of(new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null));
+
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(List.of(new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true)));
+
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(visitedCredentialIssuerDetails);
+
+        JourneyRequest input = createRequestEvent();
+        JourneyResponse response = handleRequest(input, context);
+
+        assertEquals(ADDRESS_JOURNEY, response.getJourney());
+    }
+
+    @Test
+    void shouldReturnFraudCriJourneyResponseWhenVisitedClaimedIdentityAndAddress() throws Exception {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
+                .thenReturn(createCriConfig(DRIVING_LICENSE_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
+                .thenReturn(createCriConfig(FRAUD_CRI_ISS));
+
+        List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
+                List.of(new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null),
+                        new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI, true, null));
+
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(List.of(new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true),
+                        new VcStatusDto(ADDRESS_CRI_ISS, true)));
+
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(visitedCredentialIssuerDetails);
+
+        JourneyRequest input = createRequestEvent();
+        JourneyResponse response = handleRequest(input, context);
+
+        assertEquals(FRAUD_JOURNEY, response.getJourney());
+    }
+
+    @Test
+    void shouldReturnF2FCriJourneyResponseWhenVisitedClaimedIdentityAddressAndFraud() throws Exception {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
+                .thenReturn(createCriConfig(DRIVING_LICENSE_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(createCriConfig(ADDRESS_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
+                .thenReturn(createCriConfig(FRAUD_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(F2F_CRI))
+                .thenReturn(createCriConfig(F2F_CRI_ISS));
+
+        List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
+                List.of(new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null),
+                        new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI, true, null),
+                        new VisitedCredentialIssuerDetailsDto(FRAUD_CRI, true, null));
+
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(List.of(new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true),
+                        new VcStatusDto(ADDRESS_CRI_ISS, true),
+                        new VcStatusDto(FRAUD_CRI_ISS, true)));
+
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(visitedCredentialIssuerDetails);
+
+        JourneyRequest input = createRequestEvent();
+        JourneyResponse response = handleRequest(input, context);
+
+        assertEquals(F2F_JOURNEY, response.getJourney());
+    }
+
+    @Test
     void shouldReturnAddressCriJourneyResponseWhenVisitedPassport() throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
@@ -149,6 +256,8 @@ class SelectCriHandlerTest {
     void shouldReturnAddressCriJourneyResponseWhenVisitedDrivingLicence() throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
@@ -175,6 +284,8 @@ class SelectCriHandlerTest {
     void shouldReturnPyiNoMatchErrorResponseIfAddressCriHasPreviouslyFailed() throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
@@ -199,6 +310,8 @@ class SelectCriHandlerTest {
     void shouldReturnFraudCriJourneyResponse() throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
@@ -232,6 +345,8 @@ class SelectCriHandlerTest {
     void shouldReturnKBVCriJourneyResponse() throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
@@ -270,6 +385,8 @@ class SelectCriHandlerTest {
     void shouldReturnJourneyFailedIfAllCriVisited() throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
@@ -391,6 +508,8 @@ class SelectCriHandlerTest {
             throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
                 .thenReturn(createCriConfig(DCMAW_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -463,6 +582,8 @@ class SelectCriHandlerTest {
             throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
                 .thenReturn(createCriConfig(DCMAW_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -487,6 +608,8 @@ class SelectCriHandlerTest {
             throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
                 .thenReturn(createCriConfig(DCMAW_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
@@ -541,6 +664,8 @@ class SelectCriHandlerTest {
             throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
@@ -565,6 +690,8 @@ class SelectCriHandlerTest {
             throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
@@ -603,6 +730,8 @@ class SelectCriHandlerTest {
     void shouldReturnCorrectJourneyResponseWhenVcStatusesAreNull() throws Exception {
         mockIpvSessionService();
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
@@ -680,6 +809,8 @@ class SelectCriHandlerTest {
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(Collections.emptyList());
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
                 .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
 

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
@@ -157,7 +157,8 @@ class SelectCriHandlerTest {
     }
 
     @Test
-    void shouldReturnFraudCriJourneyResponseWhenVisitedClaimedIdentityAndAddress() throws Exception {
+    void shouldReturnFraudCriJourneyResponseWhenVisitedClaimedIdentityAndAddress()
+            throws Exception {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
@@ -172,12 +173,15 @@ class SelectCriHandlerTest {
                 .thenReturn(createCriConfig(FRAUD_CRI_ISS));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
-                List.of(new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null),
+                List.of(
+                        new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null),
                         new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI, true, null));
 
         when(mockIpvSessionItem.getCurrentVcStatuses())
-                .thenReturn(List.of(new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true),
-                        new VcStatusDto(ADDRESS_CRI_ISS, true)));
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true),
+                                new VcStatusDto(ADDRESS_CRI_ISS, true)));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);
@@ -189,7 +193,8 @@ class SelectCriHandlerTest {
     }
 
     @Test
-    void shouldReturnF2FCriJourneyResponseWhenVisitedClaimedIdentityAddressAndFraud() throws Exception {
+    void shouldReturnF2FCriJourneyResponseWhenVisitedClaimedIdentityAddressAndFraud()
+            throws Exception {
         mockIpvSessionService();
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
@@ -206,14 +211,17 @@ class SelectCriHandlerTest {
                 .thenReturn(createCriConfig(F2F_CRI_ISS));
 
         List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
-                List.of(new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null),
+                List.of(
+                        new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null),
                         new VisitedCredentialIssuerDetailsDto(ADDRESS_CRI, true, null),
                         new VisitedCredentialIssuerDetailsDto(FRAUD_CRI, true, null));
 
         when(mockIpvSessionItem.getCurrentVcStatuses())
-                .thenReturn(List.of(new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true),
-                        new VcStatusDto(ADDRESS_CRI_ISS, true),
-                        new VcStatusDto(FRAUD_CRI_ISS, true)));
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto(CLAIMED_IDENTITY_CRI_ISS, true),
+                                new VcStatusDto(ADDRESS_CRI_ISS, true),
+                                new VcStatusDto(FRAUD_CRI_ISS, true)));
 
         when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
                 .thenReturn(visitedCredentialIssuerDetails);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
@@ -14,4 +14,6 @@ public class CriConstants {
     public static final String KBV_CRI = "kbv";
     public static final String ADDRESS_CRI = "address";
     public static final String DCMAW_CRI = "dcmaw";
+    public static final String CLAIMED_IDENTITY_CRI = "claimedIdentity";
+    public static final String F2F_CRI = "f2f";
 }


### PR DESCRIPTION
## Proposed changes

### What changed

* Added Claimed Identities to the Select CRI Handler
* Updated unit tests and tested for the following scenarios:
  * Claimed Identity (:white_check_mark: Passed) > :link: `/journey/address`
  * Claimed Identity (:x: Failed) > :scream: `/journey/pyi-no-match`
  * Claimed Identity (:white_check_mark: Passed) > Address (:white_check_mark: Passed) > :link: `/journey/fraud`
  * Claimed Identity (:white_check_mark: Passed) > Address (:x: Failed) > :scream: `/journey/pyi-no-match`
  * Claimed Identity (:white_check_mark: Passed) > Address (:white_check_mark: Passed) > Fraud (:white_check_mark: Passed) > :link: `/journey/f2f`
  * Claimed Identity (:white_check_mark: Passed) > Address (:white_check_mark: Passed) > Fraud (:x: Failed) > :scream: `/journey/pyi-no-match`

### Why did it change

There is a requirement for the Claimed Identities CRI and F2F CRI to the Select CRI Handler Lambda. This results in the following CRIs being called in order:
1. Claimed Identities (CRI) - Picked by the user in the front end
2. Address CRI
3. Fraud CRI
4. F2F CRI

### Issue tracking

This ticket resolves the following tickets:
- [PYIC-2835](https://govukverify.atlassian.net/browse/PYIC-2835) Modify select-cri to pick Address CRI after Claimed Identity CRI
- [PYIC-2863](https://govukverify.atlassian.net/browse/PYIC-2863) Modify select-cri to pick Fraud CRI after Claimed Identity CRI - Address CRI sequence
- [PYIC-2864](https://govukverify.atlassian.net/browse/PYIC-2864) Modify select-cri to pick F2F CRI after Claimed Identity CRI - Address CRI - Fraud CRI sequence

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2835]: https://govukverify.atlassian.net/browse/PYIC-2835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ