### PR TITLE
[PYIC-2839] Update retrieve-cri-credential for initial F2F response

### DIFF
--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -3,9 +3,11 @@ package uk.gov.di.ipv.core.retrievecricredential;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -35,9 +37,14 @@ import uk.gov.di.ipv.core.library.service.CiStorageService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.CriOAuthSessionService;
+import uk.gov.di.ipv.core.library.service.CriResponseService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.vchelper.VcHelper;
+import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialResponse;
+import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialStatus;
+import uk.gov.di.ipv.core.library.verifiablecredential.dto.VerifiableCredentialResponseDto;
 import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialResponseException;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 import uk.gov.di.ipv.core.library.verifiablecredential.validation.VerifiableCredentialJwtValidator;
 
@@ -47,6 +54,7 @@ import java.util.Map;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
@@ -56,6 +64,8 @@ public class RetrieveCriCredentialHandler
     private static final String EVIDENCE = "evidence";
     private static final String JOURNEY = "journey";
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Map<String, Object> JOURNEY_NEXT = Map.of(JOURNEY, "/journey/next");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
 
@@ -67,6 +77,7 @@ public class RetrieveCriCredentialHandler
     private final CiStorageService ciStorageService;
     private final CriOAuthSessionService criOAuthSessionService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionService;
+    private final CriResponseService criResponseService;
 
     private String componentId;
 
@@ -78,7 +89,8 @@ public class RetrieveCriCredentialHandler
             VerifiableCredentialJwtValidator verifiableCredentialJwtValidator,
             CiStorageService ciStorageService,
             CriOAuthSessionService criOAuthSessionService,
-            ClientOAuthSessionDetailsService clientOAuthSessionService) {
+            ClientOAuthSessionDetailsService clientOAuthSessionService,
+            CriResponseService criResponseService) {
         this.verifiableCredentialService = verifiableCredentialService;
         this.ipvSessionService = ipvSessionService;
         this.configService = configService;
@@ -87,6 +99,7 @@ public class RetrieveCriCredentialHandler
         this.ciStorageService = ciStorageService;
         this.criOAuthSessionService = criOAuthSessionService;
         this.clientOAuthSessionService = clientOAuthSessionService;
+        this.criResponseService = criResponseService;
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -99,6 +112,7 @@ public class RetrieveCriCredentialHandler
         this.ciStorageService = new CiStorageService(configService);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
+        this.criResponseService = new CriResponseService(configService);
     }
 
     @Override
@@ -136,12 +150,6 @@ public class RetrieveCriCredentialHandler
             LogHelper.attachGovukSigninJourneyIdToLogs(
                     clientOAuthSessionItem.getGovukSigninJourneyId());
 
-            AuditEventUser auditEventUser =
-                    new AuditEventUser(
-                            userId,
-                            ipvSessionItem.getIpvSessionId(),
-                            clientOAuthSessionItem.getGovukSigninJourneyId(),
-                            ipAddress);
             this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
 
             CredentialIssuerConfig credentialIssuerConfig =
@@ -152,44 +160,35 @@ public class RetrieveCriCredentialHandler
                             ? configService.getCriPrivateApiKey(credentialIssuerId)
                             : null;
 
-            List<SignedJWT> verifiableCredentials =
-                    verifiableCredentialService.getVerifiableCredential(
+            VerifiableCredentialResponse verifiableCredentialResponse =
+                    verifiableCredentialService.getVerifiableCredentialResponse(
                             BearerAccessToken.parse(criOAuthSessionItem.getAccessToken()),
                             credentialIssuerConfig,
                             apiKey,
                             credentialIssuerId);
 
-            for (SignedJWT vc : verifiableCredentials) {
-                verifiableCredentialJwtValidator.validate(vc, credentialIssuerConfig, userId);
-
-                List<CredentialIssuerConfig> excludedCriConfigs =
-                        List.of(
-                                configService.getCredentialIssuerActiveConnectionConfig(
-                                        ADDRESS_CRI),
-                                configService.getCredentialIssuerActiveConnectionConfig(
-                                        CLAIMED_IDENTITY_CRI));
-                boolean isSuccessful = VcHelper.isSuccessfulVc(vc, excludedCriConfigs);
-
-                sendIpvVcReceivedAuditEvent(auditEventUser, vc, isSuccessful);
-
-                submitVcToCiStorage(
-                        vc, clientOAuthSessionItem.getGovukSigninJourneyId(), ipAddress);
-
-                verifiableCredentialService.persistUserCredentials(vc, credentialIssuerId, userId);
+            if (VerifiableCredentialStatus.PENDING.equals(
+                    verifiableCredentialResponse.getCredentialStatus())) {
+                return processPendingResponse(
+                        userId,
+                        credentialIssuerId,
+                        verifiableCredentialResponse,
+                        clientOAuthSessionItem,
+                        ipvSessionItem);
+            } else {
+                return processVerifiableCredentials(
+                        userId,
+                        credentialIssuerId,
+                        credentialIssuerConfig,
+                        ipAddress,
+                        verifiableCredentialResponse.getVerifiableCredentials(),
+                        clientOAuthSessionItem,
+                        ipvSessionItem);
             }
 
-            updateVisitedCredentials(ipvSessionItem, credentialIssuerId, true, null);
-
-            var message =
-                    new StringMapMessage()
-                            .with(
-                                    LOG_LAMBDA_RESULT.getFieldName(),
-                                    "Successfully retrieved CRI credential.")
-                            .with(LOG_CRI_ID.getFieldName(), credentialIssuerId);
-            LOGGER.info(message);
-
-            return JOURNEY_NEXT;
-        } catch (VerifiableCredentialException | CiPutException e) {
+        } catch (VerifiableCredentialException
+                | VerifiableCredentialResponseException
+                | CiPutException e) {
             updateVisitedCredentials(
                     ipvSessionItem, credentialIssuerId, false, OAuth2Error.SERVER_ERROR_CODE);
 
@@ -207,6 +206,89 @@ public class RetrieveCriCredentialHandler
 
             return JOURNEY_ERROR;
         }
+    }
+
+    private Map<String, Object> processPendingResponse(
+            String userId,
+            String credentialIssuerId,
+            VerifiableCredentialResponse verifiableCredentialResponse,
+            ClientOAuthSessionItem clientOAuthSessionItem,
+            IpvSessionItem ipvSessionItem)
+            throws JsonProcessingException {
+        // Validate the response
+        if (!userId.equals(verifiableCredentialResponse.getUserId())) {
+            throw new VerifiableCredentialResponseException(
+                    HTTPResponse.SC_SERVER_ERROR,
+                    FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE);
+        }
+        // Create cri response item
+        VerifiableCredentialResponseDto verifiableCredentialResponseDto =
+                VerifiableCredentialResponseDto.builder()
+                        .userId(userId)
+                        .credentialStatus(
+                                verifiableCredentialResponse.getCredentialStatus().getStatus())
+                        .build();
+        criResponseService.persistCriResponse(
+                userId,
+                credentialIssuerId,
+                OBJECT_MAPPER.writeValueAsString(verifiableCredentialResponseDto),
+                clientOAuthSessionItem.getState());
+        // Update session to indicate no VC, but no error
+        updateVisitedCredentials(ipvSessionItem, credentialIssuerId, false, null);
+        // Audit
+        LOGGER.info(
+                new StringMapMessage()
+                        .with(
+                                LOG_LAMBDA_RESULT.getFieldName(),
+                                "Successfully processed CRI pending response.")
+                        .with(LOG_CRI_ID.getFieldName(), credentialIssuerId));
+        return JOURNEY_NEXT;
+    }
+
+    private Map<String, Object> processVerifiableCredentials(
+            String userId,
+            String credentialIssuerId,
+            CredentialIssuerConfig credentialIssuerConfig,
+            String ipAddress,
+            List<SignedJWT> verifiableCredentials,
+            ClientOAuthSessionItem clientOAuthSessionItem,
+            IpvSessionItem ipvSessionItem)
+            throws ParseException, SqsException, JsonProcessingException, CiPutException {
+        final AuditEventUser auditEventUser =
+                new AuditEventUser(
+                        userId,
+                        ipvSessionItem.getIpvSessionId(),
+                        clientOAuthSessionItem.getGovukSigninJourneyId(),
+                        ipAddress);
+
+        final List<CredentialIssuerConfig> excludedCriConfigs =
+                List.of(
+                        configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI),
+                        configService.getCredentialIssuerActiveConnectionConfig(
+                                CLAIMED_IDENTITY_CRI));
+
+        for (SignedJWT vc : verifiableCredentials) {
+            verifiableCredentialJwtValidator.validate(vc, credentialIssuerConfig, userId);
+
+            boolean isSuccessful = VcHelper.isSuccessfulVc(vc, excludedCriConfigs);
+
+            sendIpvVcReceivedAuditEvent(auditEventUser, vc, isSuccessful);
+
+            submitVcToCiStorage(vc, clientOAuthSessionItem.getGovukSigninJourneyId(), ipAddress);
+
+            verifiableCredentialService.persistUserCredentials(vc, credentialIssuerId, userId);
+        }
+
+        updateVisitedCredentials(ipvSessionItem, credentialIssuerId, true, null);
+
+        LOGGER.info(
+                new StringMapMessage()
+                        .with(
+                                LOG_LAMBDA_RESULT.getFieldName(),
+                                "Successfully retrieved CRI credential.")
+                        .with(LOG_CRI_ID.getFieldName(), credentialIssuerId));
+
+        return JOURNEY_NEXT;
     }
 
     @Tracing

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -68,6 +68,7 @@ public class RetrieveCriCredentialHandler
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Map<String, Object> JOURNEY_NEXT = Map.of(JOURNEY, "/journey/next");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
+    private static final Map<String, Object> JOURNEY_PENDING = Map.of(JOURNEY, "/journey/pending");
 
     private final VerifiableCredentialService verifiableCredentialService;
     private final IpvSessionService ipvSessionService;
@@ -242,7 +243,7 @@ public class RetrieveCriCredentialHandler
                                 LOG_LAMBDA_RESULT.getFieldName(),
                                 "Successfully processed CRI pending response.")
                         .with(LOG_CRI_ID.getFieldName(), credentialIssuerId));
-        return JOURNEY_NEXT;
+        return JOURNEY_PENDING;
     }
 
     private Map<String, Object> processVerifiableCredentials(

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -498,7 +498,7 @@ class RetrieveCriCredentialHandlerTest {
     }
 
     @Test
-    void shouldReturnJourneyNextResponseOnSuccessfulPendingCriResponse() throws Exception {
+    void shouldReturnJourneyPendingResponseOnSuccessfulPendingCriResponse() throws Exception {
         final String expectedIssuerResponse =
                 "{\"sub\":\""
                         + TEST_USER_ID
@@ -519,7 +519,7 @@ class RetrieveCriCredentialHandlerTest {
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
-        assertEquals("/journey/next", output.get("journey"));
+        assertEquals("/journey/pending", output.get("journey"));
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
 
         verifyPersistedCriResponse(

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.AuditExtensionsVcEvidence;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.CiPutException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
@@ -30,7 +31,10 @@ import uk.gov.di.ipv.core.library.service.CiStorageService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.CriOAuthSessionService;
+import uk.gov.di.ipv.core.library.service.CriResponseService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
+import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialResponse;
+import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialStatus;
 import uk.gov.di.ipv.core.library.verifiablecredential.exception.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 import uk.gov.di.ipv.core.library.verifiablecredential.validation.VerifiableCredentialJwtValidator;
@@ -41,6 +45,7 @@ import java.text.ParseException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -72,6 +77,8 @@ class RetrieveCriCredentialHandlerTest {
     private static final String CODE = "code";
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
+
+    private static final String TEST_IPV_SESSION_ID = UUID.randomUUID().toString();
     private static final String passportIssuerId = CREDENTIAL_ISSUER_ID;
 
     @Mock private Context context;
@@ -84,6 +91,8 @@ class RetrieveCriCredentialHandlerTest {
     @Mock private CiStorageService ciStorageService;
     @Mock private CriOAuthSessionService criOAuthSessionService;
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionService;
+
+    @Mock private CriResponseService criResponseService;
     private static CriOAuthSessionItem criOAuthSessionItem;
     @InjectMocks private RetrieveCriCredentialHandler handler;
 
@@ -158,12 +167,15 @@ class RetrieveCriCredentialHandlerTest {
                 .thenReturn(claimedIdentityConfig);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressConfig);
-        when(verifiableCredentialService.getVerifiableCredential(
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
                         testApiKey,
                         CREDENTIAL_ISSUER_ID))
-                .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_VC_1)))
+                                .build());
 
         mockServiceCallsAndSessionItem();
 
@@ -191,12 +203,15 @@ class RetrieveCriCredentialHandlerTest {
                 .thenReturn(addressConfig);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
-        when(verifiableCredentialService.getVerifiableCredential(
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
                         testApiKey,
                         CREDENTIAL_ISSUER_ID))
-                .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_VC_1)))
+                                .build());
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId("someIpvSessionId");
@@ -234,9 +249,9 @@ class RetrieveCriCredentialHandlerTest {
 
     @Test
     void shouldReturnErrorJourneyResponseIfCredentialIssuerServiceGetCredentialThrows() {
-        mockServiceCallsAndSessionItem();
+        mockServiceCalls();
 
-        when(verifiableCredentialService.getVerifiableCredential(
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
                         any(), any(), anyString(), anyString()))
                 .thenThrow(
                         new VerifiableCredentialException(
@@ -255,12 +270,15 @@ class RetrieveCriCredentialHandlerTest {
                 .thenReturn(claimedIdentityConfig);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressConfig);
-        when(verifiableCredentialService.getVerifiableCredential(
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
                         testApiKey,
                         CREDENTIAL_ISSUER_ID))
-                .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_VC_1)))
+                                .build());
 
         doThrow(new SqsException("Test sqs error"))
                 .when(auditService)
@@ -273,12 +291,19 @@ class RetrieveCriCredentialHandlerTest {
 
     @Test
     void shouldReturnErrorJourneyIfVCFailsValidation() throws Exception {
-        when(verifiableCredentialService.getVerifiableCredential(
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressConfig);
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
                         testApiKey,
                         CREDENTIAL_ISSUER_ID))
-                .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_VC_1)))
+                                .build());
 
         mockServiceCallsAndSessionItem();
 
@@ -301,12 +326,16 @@ class RetrieveCriCredentialHandlerTest {
                 .thenReturn(claimedIdentityConfig);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressConfig);
-        when(verifiableCredentialService.getVerifiableCredential(
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
                         testApiKey,
                         CREDENTIAL_ISSUER_ID))
-                .thenReturn(List.of(SignedJWT.parse(SIGNED_CONTRA_INDICATORS)));
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .verifiableCredentials(
+                                        List.of(SignedJWT.parse(SIGNED_CONTRA_INDICATORS)))
+                                .build());
         mockServiceCallsAndSessionItem();
 
         handler.handleRequest(testInput, context);
@@ -334,12 +363,15 @@ class RetrieveCriCredentialHandlerTest {
 
     @Test
     void shouldSendIpvVcReceivedAuditEventWhenVcEvidenceIsMissing() throws Exception {
-        when(verifiableCredentialService.getVerifiableCredential(
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
                         testApiKey,
                         CREDENTIAL_ISSUER_ID))
-                .thenReturn(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)));
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)))
+                                .build());
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressConfig);
         when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
@@ -370,12 +402,15 @@ class RetrieveCriCredentialHandlerTest {
 
     @Test
     void shouldNotStoreVcIfFailedToSubmitItToTheCiStorageSystem() throws Exception {
-        when(verifiableCredentialService.getVerifiableCredential(
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
                         testApiKey,
                         CREDENTIAL_ISSUER_ID))
-                .thenReturn(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)));
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)))
+                                .build());
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(testPassportIssuer);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
@@ -444,13 +479,17 @@ class RetrieveCriCredentialHandlerTest {
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
                 .thenReturn(getClientOAuthSessionItem());
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-        when(verifiableCredentialService.getVerifiableCredential(any(), any(), any(), any()))
-                .thenReturn(List.of(SignedJWT.parse(SIGNED_VC_1)));
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
+                        any(), any(), any(), any()))
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_VC_1)))
+                                .build());
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
         verify(verifiableCredentialService)
-                .getVerifiableCredential(
+                .getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testCriNotRequiringApiKey,
                         null,
@@ -458,14 +497,85 @@ class RetrieveCriCredentialHandlerTest {
         assertEquals("/journey/next", output.get("journey"));
     }
 
+    @Test
+    void shouldReturnJourneyNextResponseOnSuccessfulPendingCriResponse() throws Exception {
+        final String expectedIssuerResponse =
+                "{\"sub\":\""
+                        + TEST_USER_ID
+                        + "\","
+                        + "\"https://vocab.account.gov.uk/v1/credentialStatus\":\"pending\"}";
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .userId(TEST_USER_ID)
+                                .credentialStatus(VerifiableCredentialStatus.PENDING)
+                                .build());
+
+        mockServiceCalls(makeTestIpvSessionItem(TEST_IPV_SESSION_ID));
+
+        Map<String, Object> output = handler.handleRequest(testInput, context);
+
+        assertEquals("/journey/next", output.get("journey"));
+        verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
+
+        verifyPersistedCriResponse(
+                TEST_USER_ID, CREDENTIAL_ISSUER_ID, expectedIssuerResponse, TEST_STATE);
+
+        verifyPersistedVisitedCredentialIssuerDetails(CREDENTIAL_ISSUER_ID, false, null);
+    }
+
+    @Test
+    void shouldReturnErrorJourneyOnPendingCriResponseWithMismatchedUser() throws Exception {
+        when(verifiableCredentialService.getVerifiableCredentialResponse(
+                        testBearerAccessToken,
+                        testPassportIssuer,
+                        testApiKey,
+                        CREDENTIAL_ISSUER_ID))
+                .thenReturn(
+                        VerifiableCredentialResponse.builder()
+                                .userId("mismatched-user-id")
+                                .credentialStatus(VerifiableCredentialStatus.PENDING)
+                                .build());
+
+        mockServiceCalls(makeTestIpvSessionItem(TEST_IPV_SESSION_ID));
+
+        Map<String, Object> output = handler.handleRequest(testInput, context);
+
+        assertEquals("/journey/error", output.get("journey"));
+
+        verify(criResponseService, times(0)).persistCriResponse(any(), any(), any(), any());
+
+        verifyPersistedVisitedCredentialIssuerDetails(
+                CREDENTIAL_ISSUER_ID, false, OAuth2Error.SERVER_ERROR_CODE);
+    }
+
     private void mockServiceCallsAndSessionItem() {
+        mockServiceCalls();
+        when(ipvSessionItem.getIpvSessionId()).thenReturn(testSessionId);
+    }
+
+    private void mockServiceCalls() {
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(testPassportIssuer);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);
-        when(ipvSessionItem.getIpvSessionId()).thenReturn(testSessionId);
+        when(mockClientOAuthSessionService.getClientOAuthSession(any()))
+                .thenReturn(getClientOAuthSessionItem());
+    }
+
+    private void mockServiceCalls(IpvSessionItem testIpvSessionItem) {
+        when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
+                .thenReturn(testPassportIssuer);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
+        when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
+        when(ipvSessionService.getIpvSession(anyString())).thenReturn(testIpvSessionItem);
+        when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
                 .thenReturn(getClientOAuthSessionItem());
     }
@@ -474,10 +584,67 @@ class RetrieveCriCredentialHandlerTest {
         return ClientOAuthSessionItem.builder()
                 .clientOAuthSessionId(SecureTokenHelper.generate())
                 .responseType("code")
-                .state("test-state")
+                .state(TEST_STATE)
                 .redirectUri("https://example.com/redirect")
                 .govukSigninJourneyId("test-journey-id")
                 .userId("test-user-id")
                 .build();
+    }
+
+    private void verifyPersistedCriResponse(
+            String expectedUserId,
+            String expectedCredentialIssuerId,
+            String expectedIssuerResponse,
+            String expectedOauthState) {
+        ArgumentCaptor<String> persistedUserIdCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> persistedCredentialIssuerIdCaptor =
+                ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> persistedIssuerResponseCaptor =
+                ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> persistedOAuthStateCaptor = ArgumentCaptor.forClass(String.class);
+        verify(criResponseService, times(1))
+                .persistCriResponse(
+                        persistedUserIdCaptor.capture(),
+                        persistedCredentialIssuerIdCaptor.capture(),
+                        persistedIssuerResponseCaptor.capture(),
+                        persistedOAuthStateCaptor.capture());
+        assertEquals(expectedUserId, persistedUserIdCaptor.getAllValues().get(0));
+        assertEquals(
+                expectedCredentialIssuerId,
+                persistedCredentialIssuerIdCaptor.getAllValues().get(0));
+        assertEquals(expectedIssuerResponse, persistedIssuerResponseCaptor.getAllValues().get(0));
+        assertEquals(expectedOauthState, persistedOAuthStateCaptor.getAllValues().get(0));
+    }
+
+    private void verifyPersistedVisitedCredentialIssuerDetails(
+            String expectedCredentialIssuerId,
+            boolean expectedIsReturnedWithVc,
+            String expectedOauthError) {
+        ArgumentCaptor<IpvSessionItem> persistedIpvSessionItemCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService, times(1))
+                .updateIpvSession(persistedIpvSessionItemCaptor.capture());
+        assertEquals(
+                1,
+                persistedIpvSessionItemCaptor
+                        .getAllValues()
+                        .get(0)
+                        .getVisitedCredentialIssuerDetails()
+                        .size());
+        VisitedCredentialIssuerDetailsDto visitedCredentialIssuerDetails =
+                persistedIpvSessionItemCaptor
+                        .getAllValues()
+                        .get(0)
+                        .getVisitedCredentialIssuerDetails()
+                        .get(0);
+        assertEquals(expectedCredentialIssuerId, visitedCredentialIssuerDetails.getCriId());
+        assertEquals(expectedIsReturnedWithVc, visitedCredentialIssuerDetails.isReturnedWithVc());
+        assertEquals(expectedOauthError, visitedCredentialIssuerDetails.getOauthError());
+    }
+
+    private IpvSessionItem makeTestIpvSessionItem(String ipvSessionId) {
+        final IpvSessionItem testIpvSessionItem = new IpvSessionItem();
+        testIpvSessionItem.setIpvSessionId(ipvSessionId);
+        return testIpvSessionItem;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -20,7 +20,8 @@ public enum ConfigurationVariable {
     CI_MITIGATION_JOURNEYS_ENABLED("self/journey/ciMitigationsEnabled"),
     VC_TTL("self/vcTtl"),
     CREDENTIAL_ISSUERS("credentialIssuers"),
-    FEATURE_FLAGS("featureFlags/%s");
+    FEATURE_FLAGS("featureFlags/%s"),
+    CRI_RESPONSE_TTL("self/criResponseTtl");
 
     private final String path;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -56,7 +56,9 @@ public enum ErrorResponse {
     FAILED_NAME_CORRELATION(1046, "Failed to correlate gathered names"),
     FAILED_TO_CONSTRUCT_REDIRECT_URI(1047, "Failed to construct redirect uri"),
     FAILED_TO_PARSE_JSON_MESSAGE(1048, "Failed to parse JSON message"),
-    FAILED_UNHANDLED_EXCEPTION(1049, "Unhandled exception");
+    FAILED_UNHANDLED_EXCEPTION(1049, "Unhandled exception"),
+    FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE(
+            1051, "Failed to validate verifiable credential response");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/CriResponseItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/CriResponseItem.java
@@ -21,8 +21,8 @@ public class CriResponseItem implements DynamodbItem {
     private String userId;
     private String credentialIssuer;
     private String issuerResponse;
+    private String oauthState;
     private Instant dateCreated;
-    private Instant expirationTime;
     private long ttl;
 
     @DynamoDbPartitionKey

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -1,9 +1,11 @@
 package uk.gov.di.ipv.core.library.service;
 
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
 
+import java.time.Instant;
 import java.util.List;
 
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CRI_RESPONSE_TABLE_NAME;
@@ -36,5 +38,18 @@ public class CriResponseService {
 
     public CriResponseItem getCriResponseItem(String userId, String criId) {
         return dataStore.getItem(userId, criId);
+    }
+
+    public void persistCriResponse(
+            String userId, String credentialIssuer, String issuerResponse, String oauthState) {
+        CriResponseItem criResponseItem =
+                CriResponseItem.builder()
+                        .userId(userId)
+                        .credentialIssuer(credentialIssuer)
+                        .issuerResponse(issuerResponse)
+                        .oauthState(oauthState)
+                        .dateCreated(Instant.now())
+                        .build();
+        dataStore.create(criResponseItem, ConfigurationVariable.CRI_RESPONSE_TTL);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CriResponseServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CriResponseServiceTest.java
@@ -72,7 +72,6 @@ public class CriResponseServiceTest {
         criResponseItem.setCredentialIssuer(credentialIssuer);
         criResponseItem.setIssuerResponse(issuerResponse);
         criResponseItem.setDateCreated(dateCreated);
-        criResponseItem.setExpirationTime(dateCreated.plusSeconds(1000L));
         return criResponseItem;
     }
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/domain/VerifiableCredentialResponse.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/domain/VerifiableCredentialResponse.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.core.library.verifiablecredential.domain;
+
+import com.nimbusds.jwt.SignedJWT;
+import lombok.Builder;
+import lombok.Getter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.List;
+
+@ExcludeFromGeneratedCoverageReport
+@Builder
+@Getter
+public class VerifiableCredentialResponse {
+    private String userId;
+    private VerifiableCredentialStatus credentialStatus;
+    private List<SignedJWT> verifiableCredentials;
+}

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/domain/VerifiableCredentialStatus.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/domain/VerifiableCredentialStatus.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.core.library.verifiablecredential.domain;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+public enum VerifiableCredentialStatus {
+    CREATED("created"),
+    PENDING("pending");
+    private static final Map<String, VerifiableCredentialStatus> STATUSES =
+            Arrays.stream(VerifiableCredentialStatus.values())
+                    .collect(
+                            (Collectors.toMap(
+                                    VerifiableCredentialStatus::getStatus, Function.identity())));
+    private final String status;
+
+    VerifiableCredentialStatus(String status) {
+        this.status = status;
+    }
+
+    public static VerifiableCredentialStatus fromStatusString(String status) {
+        return STATUSES.get(status);
+    }
+}

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/dto/VerifiableCredentialResponseDto.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/dto/VerifiableCredentialResponseDto.java
@@ -1,0 +1,31 @@
+package uk.gov.di.ipv.core.library.verifiablecredential.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.List;
+
+@ExcludeFromGeneratedCoverageReport
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class VerifiableCredentialResponseDto {
+    @JsonProperty(value = "sub")
+    private String userId;
+
+    @JsonProperty(value = "https://vocab.account.gov.uk/v1/credentialStatus")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String credentialStatus;
+
+    @JsonProperty(value = "https://vocab.account.gov.uk/v1/credentialJWT")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<String> verifiableCredentials;
+}

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/exception/VerifiableCredentialResponseException.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/exception/VerifiableCredentialResponseException.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.core.library.verifiablecredential.exception;
+
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+
+public class VerifiableCredentialResponseException extends RuntimeException {
+
+    private final ErrorResponse errorResponse;
+
+    private final int httpStatusCode;
+
+    public VerifiableCredentialResponseException(int httpStatusCode, ErrorResponse errorResponse) {
+        this.errorResponse = errorResponse;
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public ErrorResponse getErrorResponse() {
+        return errorResponse;
+    }
+
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+}

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validation/VerifiableCredentialJwtValidator.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validation/VerifiableCredentialJwtValidator.java
@@ -25,8 +25,8 @@ import java.util.HashSet;
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
 
 public class VerifiableCredentialJwtValidator {
-    private static final Logger LOGGER = LogManager.getLogger();
     public static final String VC_CLAIM_NAME = "vc";
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public void validate(
             SignedJWT verifiableCredential,

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/domain/VerifiableCredentialStatusTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/domain/VerifiableCredentialStatusTest.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.core.library.verifiablecredential.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class VerifiableCredentialStatusTest {
+    @Test
+    void shouldGetVerifiableCredentialStatusFromStatusString() {
+        var verifiableCredentialStatus = VerifiableCredentialStatus.fromStatusString("pending");
+        assertEquals(VerifiableCredentialStatus.PENDING, verifiableCredentialStatus);
+    }
+
+    @Test
+    void shouldReturnNullForUnknownStatus() {
+        var verifiableCredentialStatus =
+                VerifiableCredentialStatus.fromStatusString("invalid_status");
+        assertNull(verifiableCredentialStatus);
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed
retrieve-cri-credential updated to handle the initial 'pending` response from F2F CRI

### Why did it change
Integration with F2F CRI

### Issue tracking
- [PYIC-2839](https://govukverify.atlassian.net/browse/PYIC-2839)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations


[PYIC-2839]: https://govukverify.atlassian.net/browse/PYIC-2839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ