### PR TITLE
PYIC-2912 update gpg 45 handler to accept claimed identity response

### DIFF
--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.core.library.service.UserIdentityService.BIRTH_DATE_PROPERTY_NAME;
@@ -222,9 +223,12 @@ public class BuildProvenUserIdentityDetailsHandler extends JourneyRequestLambda 
 
         for (VcStoreItem item : credentials) {
             SignedJWT signedJWT = SignedJWT.parse(item.getCredential());
-            CredentialIssuerConfig addressCriConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI);
-            boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, addressCriConfig);
+            List<CredentialIssuerConfig> excludedCriConfig =
+                    List.of(
+                            configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI),
+                            configService.getCredentialIssuerActiveConnectionConfig(
+                                    CLAIMED_IDENTITY_CRI));
+            boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, excludedCriConfig);
 
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));
         }

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -99,6 +99,19 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 createVcStoreItem(
                                         "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
+                .thenReturn(
+                        new CredentialIssuerConfig(
+                                URI.create("https://example.com/token"),
+                                URI.create("https://example.com/credential"),
+                                URI.create("https://example.com/authorize"),
+                                "ipv-core",
+                                "test-jwk",
+                                "test-jwk",
+                                "https://review-c.integration.account.gov.uk",
+                                URI.create("https://example.com/callback"),
+                                true));
+
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
                         new CredentialIssuerConfig(
@@ -158,6 +171,19 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                         "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
                                         "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
+                .thenReturn(
+                        new CredentialIssuerConfig(
+                                URI.create("https://example.com/token"),
+                                URI.create("https://example.com/credential"),
+                                URI.create("https://example.com/authorize"),
+                                "ipv-core",
+                                "test-jwk",
+                                "test-jwk",
+                                "https://review-c.integration.account.gov.uk",
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
@@ -224,6 +250,19 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 createVcStoreItem(
                                         "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
 
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
+                .thenReturn(
+                        new CredentialIssuerConfig(
+                                URI.create("https://example.com/token"),
+                                URI.create("https://example.com/credential"),
+                                URI.create("https://example.com/authorize"),
+                                "ipv-core",
+                                "test-jwk",
+                                "test-jwk",
+                                "https://review-c.integration.account.gov.uk",
+                                URI.create("https://example.com/callback"),
+                                true));
+
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
                         new CredentialIssuerConfig(
@@ -265,6 +304,18 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     @Test
     void shouldReceive400ResponseCodeWhenEvidenceVcIsMissing() throws Exception {
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
+                .thenReturn(
+                        new CredentialIssuerConfig(
+                                URI.create("https://example.com/token"),
+                                URI.create("https://example.com/credential"),
+                                URI.create("https://example.com/authorize"),
+                                "ipv-core",
+                                "test-jwk",
+                                "test-jwk",
+                                "https://review-c.integration.account.gov.uk",
+                                URI.create("https://example.com/callback"),
+                                true));
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(
                         new CredentialIssuerConfig(
@@ -277,6 +328,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 "https://review-a.integration.account.gov.uk",
                                 URI.create("https://example.com/callback"),
                                 true));
+
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
@@ -317,6 +369,19 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                         "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
                                         "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
+                .thenReturn(
+                        new CredentialIssuerConfig(
+                                URI.create("https://example.com/token"),
+                                URI.create("https://example.com/credential"),
+                                URI.create("https://example.com/authorize"),
+                                "ipv-core",
+                                "test-jwk",
+                                "test-jwk",
+                                "https://review-c.integration.account.gov.uk",
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
@@ -404,6 +469,19 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                         "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
                                         "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
+                .thenReturn(
+                        new CredentialIssuerConfig(
+                                URI.create("https://example.com/token"),
+                                URI.create("https://example.com/credential"),
+                                URI.create("https://example.com/authorize"),
+                                "ipv-core",
+                                "test-jwk",
+                                "test-jwk",
+                                "https://review-c.integration.account.gov.uk",
+                                URI.create("https://example.com/callback"),
+                                true));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
                 .thenReturn(
@@ -540,5 +618,18 @@ class BuildProvenUserIdentityDetailsHandlerTest {
             underTest.handleRequest(inputStream, outputStream, context);
             return objectMapper.readValue(outputStream.toString(), classType);
         }
+    }
+
+    private static CredentialIssuerConfig createCredentialIssuerConfig(String componentId) {
+        return new CredentialIssuerConfig(
+                URI.create("https://example.com/token"),
+                URI.create("https://example.com/credential"),
+                URI.create("https://example.com/authorize"),
+                "ipv-core",
+                "test-jwk",
+                "test-jwk",
+                componentId,
+                URI.create("https://example.com/callback"),
+                true);
     }
 }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE_TXN;
@@ -264,9 +265,11 @@ public class CheckExistingIdentityHandler extends JourneyRequestLambda {
         List<VcStatusDto> vcStatuses = new ArrayList<>();
         for (SignedJWT signedJWT : credentials) {
 
-            CredentialIssuerConfig addressCriConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI);
-            boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, addressCriConfig);
+            List<CredentialIssuerConfig> excludedCriConfigs =
+                    List.of(
+                            configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI),
+                            configService.getCredentialIssuerActiveConnectionConfig();
+            boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, excludedCriConfigs);
 
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));
         }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -268,7 +268,8 @@ public class CheckExistingIdentityHandler extends JourneyRequestLambda {
             List<CredentialIssuerConfig> excludedCriConfigs =
                     List.of(
                             configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI),
-                            configService.getCredentialIssuerActiveConnectionConfig();
+                            configService.getCredentialIssuerActiveConnectionConfig(
+                                    CLAIMED_IDENTITY_CRI));
             boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, excludedCriConfigs);
 
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -87,6 +87,7 @@ class CheckExistingIdentityHandlerTest {
                     M1A_VERIFICATION_VC,
                     M1B_DCMAW_VC);
     private static CredentialIssuerConfig addressConfig = null;
+    private static CredentialIssuerConfig claimedIdentityConfig = null;
     private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
 
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
@@ -106,6 +107,18 @@ class CheckExistingIdentityHandlerTest {
                             "test-jwk",
                             "test-encryption-jwk",
                             "test-audience",
+                            new URI("http://example.com/redirect"),
+                            true);
+
+            claimedIdentityConfig =
+                    new CredentialIssuerConfig(
+                            new URI("http://example.com/token"),
+                            new URI("http://example.com/credential"),
+                            new URI("http://example.com/authorize"),
+                            "ipv-core",
+                            "test-jwk",
+                            "test-encryption-jwk",
+                            "test-claimed-identity",
                             new URI("http://example.com/redirect"),
                             true);
         } catch (URISyntaxException e) {
@@ -164,6 +177,8 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
         when(configService.getCredentialIssuerActiveConnectionConfig("address"))
                 .thenReturn(addressConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
+                .thenReturn(claimedIdentityConfig);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_MITIGATION_JOURNEYS_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE_TXN;
@@ -369,12 +370,15 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
     private List<VcStatusDto> generateVcSuccessStatuses(List<SignedJWT> credentials)
             throws ParseException {
         List<VcStatusDto> vcStatuses = new ArrayList<>();
+        List<CredentialIssuerConfig> ignoredCriConfigurations =
+                List.of(
+                        configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI),
+                        configService.getCredentialIssuerActiveConnectionConfig(
+                                CLAIMED_IDENTITY_CRI));
 
         for (SignedJWT signedJWT : credentials) {
-
-            CredentialIssuerConfig addressCriConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI);
-            boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, addressCriConfig);
+            boolean isSuccessful =
+                    VcHelper.isSuccessfulVcIgnoringCi(signedJWT, ignoredCriConfigurations);
 
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));
         }

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
@@ -161,9 +162,13 @@ public class RetrieveCriCredentialHandler
             for (SignedJWT vc : verifiableCredentials) {
                 verifiableCredentialJwtValidator.validate(vc, credentialIssuerConfig, userId);
 
-                CredentialIssuerConfig addressCriConfig =
-                        configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI);
-                boolean isSuccessful = VcHelper.isSuccessfulVc(vc, addressCriConfig);
+                List<CredentialIssuerConfig> excludedCriConfigs =
+                        List.of(
+                                configService.getCredentialIssuerActiveConnectionConfig(
+                                        ADDRESS_CRI),
+                                configService.getCredentialIssuerActiveConnectionConfig(
+                                        CLAIMED_IDENTITY_CRI));
+                boolean isSuccessful = VcHelper.isSuccessfulVc(vc, excludedCriConfigs);
 
                 sendIpvVcReceivedAuditEvent(auditEventUser, vc, isSuccessful);
 

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATORS;
@@ -93,6 +94,7 @@ class RetrieveCriCredentialHandlerTest {
     private static final String testApiKey = "test-api-key";
     private static final String testComponentId = "https://ipv-core-test.example.com";
     private static CredentialIssuerConfig addressConfig = null;
+    private static CredentialIssuerConfig claimedIdentityConfig = null;
 
     static {
         try {
@@ -105,6 +107,17 @@ class RetrieveCriCredentialHandlerTest {
                             "test-jwk",
                             "test-encryption-jwk",
                             "test-audience",
+                            new URI("http://example.com/redirect"),
+                            true);
+            claimedIdentityConfig =
+                    new CredentialIssuerConfig(
+                            new URI("http://example.com/token"),
+                            new URI("http://example.com/credential"),
+                            new URI("http://example.com/authorize"),
+                            "ipv-core",
+                            "test-jwk",
+                            "test-encryption-jwk",
+                            "test-claimed-identity",
                             new URI("http://example.com/redirect"),
                             true);
         } catch (URISyntaxException e) {
@@ -141,6 +154,10 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldReturnJourneyResponseOnSuccessfulRequest() throws Exception {
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressConfig);
         when(verifiableCredentialService.getVerifiableCredential(
                         testBearerAccessToken,
                         testPassportIssuer,
@@ -168,6 +185,10 @@ class RetrieveCriCredentialHandlerTest {
     void shouldUpdateSessionWithDetailsOfVisitedCri() throws ParseException {
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(testPassportIssuer);
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressConfig);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
         when(verifiableCredentialService.getVerifiableCredential(
@@ -230,6 +251,10 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldReturnErrorJourneyResponseIfSqsExceptionIsThrown() throws Exception {
         mockServiceCallsAndSessionItem();
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressConfig);
         when(verifiableCredentialService.getVerifiableCredential(
                         testBearerAccessToken,
                         testPassportIssuer,
@@ -272,6 +297,10 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldSendIpvVcReceivedAuditEvent() throws Exception {
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressConfig);
         when(verifiableCredentialService.getVerifiableCredential(
                         testBearerAccessToken,
                         testPassportIssuer,
@@ -313,6 +342,8 @@ class RetrieveCriCredentialHandlerTest {
                 .thenReturn(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)));
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
         mockServiceCallsAndSessionItem();
 
         handler.handleRequest(testInput, context);
@@ -349,6 +380,8 @@ class RetrieveCriCredentialHandlerTest {
                 .thenReturn(testPassportIssuer);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
@@ -400,6 +433,10 @@ class RetrieveCriCredentialHandlerTest {
                         false);
         when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
                 .thenReturn(testCriNotRequiringApiKey);
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressConfig);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);

--- a/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
+++ b/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
@@ -44,24 +44,28 @@ class VcHelperTest {
 
     @Test
     void shouldReturnTrueOnSuccessfulPassportVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC), List.of(addressConfig)));
+        assertTrue(
+                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnFalseOnFailedPassportVc() throws Exception {
         assertFalse(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FAILED_PASSPORT_VC), List.of(addressConfig)));
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_FAILED_PASSPORT_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnFalseOnPassportVcContainingCi() throws Exception {
         assertFalse(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), List.of(addressConfig)));
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulAddressVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_ADDRESS_VC), List.of(addressConfig)));
+        assertTrue(
+                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_ADDRESS_VC), List.of(addressConfig)));
     }
 
     @Test
@@ -71,24 +75,30 @@ class VcHelperTest {
 
     @Test
     void shouldReturnFalseOnFailedFraudVc() throws Exception {
-        assertFalse(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FAILED_FRAUD_VC), List.of(addressConfig)));
+        assertFalse(
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_FAILED_FRAUD_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnFalseOnFraudVcContainingCi() throws Exception {
         assertFalse(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), List.of(addressConfig)));
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnFraudVcContainingA01Ci() throws Exception {
         assertFalse(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), List.of(addressConfig)));
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulKbvVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_VERIFICATION_VC), List.of(addressConfig)));
+        assertTrue(
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_VERIFICATION_VC), List.of(addressConfig)));
     }
 
     @Test

--- a/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
+++ b/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
@@ -6,6 +6,7 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,69 +44,69 @@ class VcHelperTest {
 
     @Test
     void shouldReturnTrueOnSuccessfulPassportVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC), addressConfig));
+        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnFalseOnFailedPassportVc() throws Exception {
         assertFalse(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FAILED_PASSPORT_VC), addressConfig));
+                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FAILED_PASSPORT_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnFalseOnPassportVcContainingCi() throws Exception {
         assertFalse(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), addressConfig));
+                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulAddressVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_ADDRESS_VC), addressConfig));
+        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_ADDRESS_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulFraudVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC), addressConfig));
+        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnFalseOnFailedFraudVc() throws Exception {
-        assertFalse(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FAILED_FRAUD_VC), addressConfig));
+        assertFalse(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FAILED_FRAUD_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnFalseOnFraudVcContainingCi() throws Exception {
         assertFalse(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), addressConfig));
+                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnFraudVcContainingA01Ci() throws Exception {
         assertFalse(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), addressConfig));
+                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulKbvVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_VERIFICATION_VC), addressConfig));
+        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_VERIFICATION_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulDcmawVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1B_DCMAW_VC), addressConfig));
+        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1B_DCMAW_VC), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnFalseOnVcMissingEvidenceBlock() throws Exception {
         assertFalse(
                 VcHelper.isSuccessfulVc(
-                        SignedJWT.parse(M1_PASSPORT_VC_MISSING_EVIDENCE), addressConfig));
+                        SignedJWT.parse(M1_PASSPORT_VC_MISSING_EVIDENCE), List.of(addressConfig)));
     }
 
     @Test
     void shouldReturnTrueOnPassportVcContainingCiWhenIgnoringCi() throws Exception {
         assertTrue(
                 VcHelper.isSuccessfulVcIgnoringCi(
-                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), addressConfig));
+                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), List.of(addressConfig)));
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

The Claimed Identity handler does not provide GPG45 information. Several functions were updated in order to support the Claimed Identity which works in a similar way to Address.

### Why did it change

The Claimed Identity handler does not provide GPG45 information. Several functions were updated in order to support the Claimed Identity which works in a similar way to Address.

### Issue tracking

- [PYIC-2912](https://govukverify.atlassian.net/browse/PYIC-2912)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2912]: https://govukverify.atlassian.net/browse/PYIC-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ