### PR TITLE
[PYIC-2841] Update journey engine to take user to F2F result page (dev)

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -300,6 +300,17 @@ CRI_CLAIMED_IDENTITY:
 CRI_F2F:
   name: CRI_F2F
   parent: CRI_STATE
+  events:
+    pending:
+      type: basic
+      name: pending
+      targetState: CRI_F2F_HANDOFF
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
+CRI_F2F_HANDOFF:
+  name: CRI_F2F_HANDOFF
+  parent: CRI_F2F
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE


### PR DESCRIPTION

## Proposed changes

### What changed
New `pending` event progression to `page-face-to-face-handoff` page for F2F CRI.
Note this is just for dev engine config: Subsequent PRs will extend this to higher environments.

### Why did it change
Integration of F2F CRI


### Issue tracking
- [PYIC-2841](https://govukverify.atlassian.net/browse/PYIC-2841)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations



[PYIC-2841]: https://govukverify.atlassian.net/browse/PYIC-2841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ