### PR TITLE
PYIC-2909 Updated select-cri to return currect journey event when f2f is enabled. Also added new journey event and removed event stubUkPassportAndDrivingLicence.

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -167,10 +167,10 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    ukPassportDrivingLicenceAndF2F:
       type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
+      name: ukPassportDrivingLicenceAndF2F
+      targetState: MULTIPLE_DOC_CHECK_F2F_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
@@ -389,6 +389,31 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
+MULTIPLE_DOC_CHECK_F2F_PAGE:
+  name: MULTIPLE_DOC_CHECK_F2F_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    ukPassport:
+      type: basic
+      name: ukPassport
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: drivingLicence
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -55,8 +55,8 @@ public class SelectCriHandler extends JourneyRequestLambda {
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
     private static final String UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
             "ukPassportAndDrivingLicence";
-    private static final String STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
-            "stubUkPassportAndDrivingLicence";
+    private static final String UK_PASSPORT_DRIVING_LICENCE_AND_F2F_PAGE =
+            "ukPassportDrivingLicenceAndF2F";
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
@@ -323,10 +323,11 @@ public class SelectCriHandler extends JourneyRequestLambda {
     }
 
     private Optional<JourneyResponse> getMultipleDocCheckPage() {
-        if (configService.getActiveConnection(DRIVING_LICENCE_CRI).equals("stub")) {
-            return Optional.of(getJourneyResponse(STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
-        }
-        return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
+        JourneyResponse journeyResponse =
+                configService.isEnabled(F2F_CRI)
+                        ? getJourneyResponse(UK_PASSPORT_DRIVING_LICENCE_AND_F2F_PAGE)
+                        : getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE);
+        return Optional.of(journeyResponse);
     }
 
     private boolean hasPassportVc(List<VcStatusDto> currentVcStatuses) {

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
@@ -57,6 +57,8 @@ class SelectCriHandlerTest {
     private static final String UK_PASSPORT_JOURNEY = "/journey/ukPassport";
     private static final String UK_PASSPORT_AND_DRIVING_LICENCE_JOURNEY =
             "/journey/ukPassportAndDrivingLicence";
+    private static final String UK_PASSPORT_DRIVING_LICENCE_AND_F2F_JOURNEY =
+            "/journey/ukPassportDrivingLicenceAndF2F";
     private static final String ADDRESS_JOURNEY = "/journey/address";
     private static final String PYI_NO_MATCH_JOURNEY = "/journey/pyi-no-match";
     private static final String FRAUD_JOURNEY = "/journey/fraud";
@@ -117,15 +119,41 @@ class SelectCriHandlerTest {
                 .thenReturn(Collections.emptyList());
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
                 .thenReturn(createCriConfig(DRIVING_LICENCE_CRI));
-        when(mockConfigService.getActiveConnection(DRIVING_LICENCE_CRI)).thenReturn("main");
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(false);
         when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(true);
+        when(mockConfigService.isEnabled(F2F_CRI)).thenReturn(false);
 
         JourneyRequest input = createRequestEvent();
 
         JourneyResponse response = handleRequest(input, context);
 
         assertEquals(UK_PASSPORT_AND_DRIVING_LICENCE_JOURNEY, response.getJourney());
+    }
+
+    @Test
+    void shouldReturnPassportDrivingLicenceAndF2FCriJourneyResponseWhenF2FCriEnabled()
+            throws Exception {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
+                .thenReturn(createCriConfig(DRIVING_LICENCE_CRI));
+        List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
+                List.of(new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null));
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(Collections.emptyList());
+        when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(false);
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(true);
+        when(mockConfigService.isEnabled(F2F_CRI)).thenReturn(true);
+
+        JourneyRequest input = createRequestEvent();
+
+        JourneyResponse response = handleRequest(input, context);
+
+        assertEquals(UK_PASSPORT_DRIVING_LICENCE_AND_F2F_JOURNEY, response.getJourney());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Also updated state machine  definition added new journey event (ukPassportDrivingLicenceAndF2F) and removed event (stubUkPassportAndDrivingLicence).
Updated select-cri to return currect journey event when f2f is enabled. 

### What changed
Updated state machine  and select-cri.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2909](https://govukverify.atlassian.net/browse/PYIC-2909)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2909]: https://govukverify.atlassian.net/browse/PYIC-2909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ