### PR TITLE
PYIC-2834: Modify state machine definition to send user to Claimed Identity CRI

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -181,6 +181,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicenceF2F:
+      type: basic
+      name: ukPassportAndDrivingLicenceF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address
@@ -195,6 +202,20 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/fraud
+    claimedIdentity:
+      type: basic
+      name: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
+    f2f:
+      type: basic
+      name: f2f
+      targetState: CRI_F2F
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/f2f
     kbv:
       type: basic
       name: kbv
@@ -287,6 +308,23 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_CLAIMED_IDENTITY:
+  name: CRI_CLAIMED_IDENTITY
+  parent: CRI_STATE
+CRI_F2F:
+  name: CRI_F2F
+  parent: CRI_STATE
+  events:
+    pending:
+      type: basic
+      name: pending
+      targetState: CRI_F2F_HANDOFF
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
+CRI_F2F_HANDOFF:
+  name: CRI_F2F_HANDOFF
+  parent: CRI_F2F
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE
@@ -358,6 +396,38 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
+MULTIPLE_DOC_CHECK_PAGE_F2F:
+  name: MULTIPLE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    ukPassport:
+      type: basic
+      name: ukPassport
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: drivingLicence
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -174,6 +174,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicenceF2F:
+      type: basic
+      name: ukPassportAndDrivingLicenceF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address
@@ -375,13 +382,6 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/drivingLicence
-    claimedIdentity:
-      type: basic
-      name: claimedIdentity
-      targetState: CRI_CLAIMED_IDENTITY
-      response:
-        type: journey
-        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
     end:
       type: basic
       name: end
@@ -389,6 +389,38 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
+MULTIPLE_DOC_CHECK_PAGE_F2F:
+  name: MULTIPLE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    ukPassport:
+      type: basic
+      name: ukPassport
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: drivingLicence
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -55,6 +55,8 @@ public class SelectCriHandler extends JourneyRequestLambda {
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
     private static final String UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
             "ukPassportAndDrivingLicence";
+    private static final String UK_PASSPORT_AND_DRIVING_LICENCE_PAGE_F2F =
+            "ukPassportAndDrivingLicenceF2F";
     private static final String STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
             "stubUkPassportAndDrivingLicence";
 
@@ -323,6 +325,9 @@ public class SelectCriHandler extends JourneyRequestLambda {
     }
 
     private Optional<JourneyResponse> getMultipleDocCheckPage() {
+        if (configService.isEnabled(F2F_CRI)) {
+            return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE_F2F));
+        }
         if (configService.getActiveConnection(DRIVING_LICENCE_CRI).equals("stub")) {
             return Optional.of(getJourneyResponse(STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
         }

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
@@ -57,6 +57,8 @@ class SelectCriHandlerTest {
     private static final String UK_PASSPORT_JOURNEY = "/journey/ukPassport";
     private static final String UK_PASSPORT_AND_DRIVING_LICENCE_JOURNEY =
             "/journey/ukPassportAndDrivingLicence";
+    private static final String UK_PASSPORT_DRIVING_LICENCE_AND_F2F_JOURNEY =
+            "/journey/ukPassportAndDrivingLicenceF2F";
     private static final String ADDRESS_JOURNEY = "/journey/address";
     private static final String PYI_NO_MATCH_JOURNEY = "/journey/pyi-no-match";
     private static final String FRAUD_JOURNEY = "/journey/fraud";
@@ -126,6 +128,32 @@ class SelectCriHandlerTest {
         JourneyResponse response = handleRequest(input, context);
 
         assertEquals(UK_PASSPORT_AND_DRIVING_LICENCE_JOURNEY, response.getJourney());
+    }
+
+    @Test
+    void shouldReturnPassportDrivingLicenceAndF2FCriJourneyResponseWhenF2FCriEnabled()
+            throws Exception {
+        mockIpvSessionService();
+
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(createCriConfig(CLAIMED_IDENTITY_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(createCriConfig(PASSPORT_CRI_ISS));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
+                .thenReturn(createCriConfig(DRIVING_LICENCE_CRI));
+        List<VisitedCredentialIssuerDetailsDto> visitedCredentialIssuerDetails =
+                List.of(new VisitedCredentialIssuerDetailsDto(CLAIMED_IDENTITY_CRI, true, null));
+        when(mockIpvSessionItem.getVisitedCredentialIssuerDetails())
+                .thenReturn(Collections.emptyList());
+        when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(false);
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(true);
+        when(mockConfigService.isEnabled(F2F_CRI)).thenReturn(true);
+
+        JourneyRequest input = createRequestEvent();
+
+        JourneyResponse response = handleRequest(input, context);
+
+        assertEquals(UK_PASSPORT_DRIVING_LICENCE_AND_F2F_JOURNEY, response.getJourney());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

* Updated the `select-cri` handler to select the `/journey/ukPassportAndDrivingLicenceF2F` route when the user needs to choose how to select their identity and F2F is enabled.
* Added the `ukPassportAndDrivingLicenceF2F` event to the `process-journey-step`.

### Why did it change

Updated `select-cri` and `process-journey-step` to send the user through the F2F journey when F2F is enabled and the existing journey when F2F is disabled.

### Issue tracking

- [PYIC-2834](https://govukverify.atlassian.net/browse/PYIC-2834)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2834]: https://govukverify.atlassian.net/browse/PYIC-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ