### PR TITLE
PYIC-2915: Correct F2F handoff state naming (dev and build)

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -318,13 +318,12 @@ CRI_F2F:
     pending:
       type: basic
       name: pending
-      targetState: CRI_F2F_HANDOFF
+      targetState: F2F_HANDOFF_PAGE
       response:
         type: page
         pageId: page-face-to-face-handoff
-CRI_F2F_HANDOFF:
-  name: CRI_F2F_HANDOFF
-  parent: CRI_F2F
+F2F_HANDOFF_PAGE:
+  name: F2F_HANDOFF_PAGE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -311,13 +311,12 @@ CRI_F2F:
     pending:
       type: basic
       name: pending
-      targetState: CRI_F2F_HANDOFF
+      targetState: F2F_HANDOFF_PAGE
       response:
         type: page
         pageId: page-face-to-face-handoff
-CRI_F2F_HANDOFF:
-  name: CRI_F2F_HANDOFF
-  parent: CRI_F2F
+F2F_HANDOFF_PAGE:
+  name: F2F_HANDOFF_PAGE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE


### PR DESCRIPTION
## Proposed changes

### What changed
Correct F2F handoff state naming (dev and build)

### Why did it change
Name change suggested by Tech Lead

### Issue tracking

- [PYIC-2915](https://govukverify.atlassian.net/browse/PYIC-2915)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed


### Other considerations


[PYIC-2915]: https://govukverify.atlassian.net/browse/PYIC-2915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ