### PR TITLE
BAU: Handle fraud credentials containing an activity score

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -164,20 +164,11 @@ public class Gpg45ProfileEvaluator {
         List<CredentialEvidenceItem> evidenceItems = evidenceMap.get(evidenceType);
         for (CredentialEvidenceItem evidenceItem : evidenceItems) {
             List<CredentialEvidenceItem> gpg45EvidenceItems =
-                    convertEvidenceToGpg45EvidenceItem(evidenceItem);
-
+                    convertEvidenceItemToGpg45EvidenceItems(evidenceItem);
             for (CredentialEvidenceItem gpg45EvidenceItem : gpg45EvidenceItems) {
                 evidenceMap.get(gpg45EvidenceItem.getType()).add(gpg45EvidenceItem);
             }
         }
-    }
-
-    private List<CredentialEvidenceItem> convertEvidenceToGpg45EvidenceItem(
-            CredentialEvidenceItem evidenceItem) throws UnknownEvidenceTypeException {
-        if (isRelevantEvidence(evidenceItem)) {
-            return convertEvidenceItemToGpg45EvidenceItems(evidenceItem);
-        }
-        return Collections.emptyList();
     }
 
     public List<SignedJWT> parseCredentials(List<String> credentials) throws ParseException {
@@ -231,6 +222,9 @@ public class Gpg45ProfileEvaluator {
 
     private List<CredentialEvidenceItem> convertEvidenceItemToGpg45EvidenceItems(
             CredentialEvidenceItem evidenceItem) throws UnknownEvidenceTypeException {
+        if (!isRelevantEvidence(evidenceItem)) {
+            return Collections.emptyList();
+        }
         List<CredentialEvidenceItem> gpg45CredentialItems = new ArrayList<>();
 
         gpg45CredentialItems.add(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -117,6 +117,7 @@ public class Gpg45ProfileEvaluator {
         var evidenceMap = parseGpg45ScoresFromCredentials(credentials);
         processEvidenceItems(evidenceMap, CredentialEvidenceItem.EvidenceType.DCMAW);
         processEvidenceItems(evidenceMap, CredentialEvidenceItem.EvidenceType.F2F);
+        processFraudWithActivityItems(evidenceMap);
 
         return Gpg45Scores.builder()
                 .withActivity(
@@ -133,6 +134,27 @@ public class Gpg45ProfileEvaluator {
                                 .map(CredentialEvidenceItem::getEvidenceScore)
                                 .collect(Collectors.toList()))
                 .build();
+    }
+
+    private void processFraudWithActivityItems(
+            Map<CredentialEvidenceItem.EvidenceType, List<CredentialEvidenceItem>> evidenceMap) {
+        for (CredentialEvidenceItem evidenceItem :
+                evidenceMap.get(CredentialEvidenceItem.EvidenceType.FRAUD_WITH_ACTIVITY)) {
+            evidenceMap
+                    .get(CredentialEvidenceItem.EvidenceType.ACTIVITY)
+                    .add(
+                            new CredentialEvidenceItem(
+                                    CredentialEvidenceItem.EvidenceType.ACTIVITY,
+                                    evidenceItem.getActivityHistoryScore(),
+                                    Collections.emptyList()));
+            evidenceMap
+                    .get(CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD)
+                    .add(
+                            new CredentialEvidenceItem(
+                                    CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD,
+                                    evidenceItem.getIdentityFraudScore(),
+                                    Collections.emptyList()));
+        }
     }
 
     private void processEvidenceItems(
@@ -271,7 +293,8 @@ public class Gpg45ProfileEvaluator {
                         CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD, new ArrayList<>(),
                         CredentialEvidenceItem.EvidenceType.VERIFICATION, new ArrayList<>(),
                         CredentialEvidenceItem.EvidenceType.DCMAW, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.F2F, new ArrayList<>());
+                        CredentialEvidenceItem.EvidenceType.F2F, new ArrayList<>(),
+                        CredentialEvidenceItem.EvidenceType.FRAUD_WITH_ACTIVITY, new ArrayList<>());
 
         for (SignedJWT signedJWT : credentials) {
             List<CredentialEvidenceItem> credentialEvidenceList =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
@@ -74,6 +74,8 @@ public class CredentialEvidenceItem {
             return EvidenceType.DCMAW;
         } else if (isF2F()) {
             return EvidenceType.F2F;
+        } else if (isFraudWithActivity()) {
+            return EvidenceType.FRAUD_WITH_ACTIVITY;
         } else {
             throw new UnknownEvidenceTypeException();
         }
@@ -105,6 +107,14 @@ public class CredentialEvidenceItem {
     private boolean isIdentityFraud() {
         return identityFraudScore != null
                 && activityHistoryScore == null
+                && strengthScore == null
+                && validityScore == null
+                && verificationScore == null;
+    }
+
+    private boolean isFraudWithActivity() {
+        return identityFraudScore != null
+                && activityHistoryScore != null
                 && strengthScore == null
                 && validityScore == null
                 && verificationScore == null;
@@ -157,7 +167,8 @@ public class CredentialEvidenceItem {
                 generateComparator(CredentialEvidenceItem::getVerificationScore),
                 CredentialEvidenceItem::getVerificationScore),
         DCMAW(null, null),
-        F2F(null, null);
+        F2F(null, null),
+        FRAUD_WITH_ACTIVITY(null, null);
 
         public final Comparator<CredentialEvidenceItem> comparator;
         public final Function<CredentialEvidenceItem, Integer> scoreGetter;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
@@ -9,7 +9,6 @@ import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeExce
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
-import java.util.function.ToIntFunction;
 
 @AllArgsConstructor
 @Builder
@@ -89,13 +88,6 @@ public class CredentialEvidenceItem {
         return ci != null && !ci.isEmpty();
     }
 
-    private int numberOfContraIndicators() {
-        if (ci != null) {
-            return ci.size();
-        }
-        return 0;
-    }
-
     private boolean isActivityHistory() {
         return activityHistoryScore != null
                 && identityFraudScore == null
@@ -157,14 +149,14 @@ public class CredentialEvidenceItem {
     @Getter
     public enum EvidenceType {
         ACTIVITY(
-                generateComparator(CredentialEvidenceItem::getActivityHistoryScore),
+                Comparator.comparingInt(CredentialEvidenceItem::getActivityHistoryScore),
                 CredentialEvidenceItem::getActivityHistoryScore),
         IDENTITY_FRAUD(
-                generateComparator(CredentialEvidenceItem::getIdentityFraudScore),
+                Comparator.comparingInt(CredentialEvidenceItem::getIdentityFraudScore),
                 CredentialEvidenceItem::getIdentityFraudScore),
         EVIDENCE(null, null),
         VERIFICATION(
-                generateComparator(CredentialEvidenceItem::getVerificationScore),
+                Comparator.comparingInt(CredentialEvidenceItem::getVerificationScore),
                 CredentialEvidenceItem::getVerificationScore),
         DCMAW(null, null),
         F2F(null, null),
@@ -178,15 +170,6 @@ public class CredentialEvidenceItem {
                 Function<CredentialEvidenceItem, Integer> scoreGetter) {
             this.comparator = comparator;
             this.scoreGetter = scoreGetter;
-        }
-
-        private static Comparator<CredentialEvidenceItem> generateComparator(
-                ToIntFunction<CredentialEvidenceItem> keyExtractor) {
-            return Comparator.comparingInt(keyExtractor)
-                    .thenComparing(
-                            Comparator.comparingInt(
-                                            CredentialEvidenceItem::numberOfContraIndicators)
-                                    .reversed());
         }
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -44,6 +44,8 @@ class Gpg45ProfileEvaluatorTest {
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWEuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3MjAsImV4cCI6MTY1ODgzNjkyMCwidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIkFkZHJlc3NDcmVkZW50aWFsIl0sIkBjb250ZXh0IjpbImh0dHBzOlwvXC93d3cudzMub3JnXC8yMDE4XC9jcmVkZW50aWFsc1wvdjEiLCJodHRwczpcL1wvdm9jYWIubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsXC9jb250ZXh0c1wvaWRlbnRpdHktdjEuanNvbmxkIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImFkZHJlc3MiOlt7InVwcm4iOjEwMDEyMDAxMjA3NywiYnVpbGRpbmdOdW1iZXIiOiI4IiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwiYWRkcmVzc0xvY2FsaXR5IjoiQkFUSCIsInBvc3RhbENvZGUiOiJCQTIgNUFBIiwiYWRkcmVzc0NvdW50cnkiOiJHQiIsInZhbGlkRnJvbSI6IjIwMDAtMDEtMDEifV19fX0.MEQCIDGSdiAuPOEQGRlU_SGRWkVYt28oCVAVIuVWkAseN_RCAiBsdf5qS5BIsAoaebo8L60yaUuZjxU9mYloBa24IFWYsw";
     private final String M1A_FRAUD_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWYuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk3NTgsImV4cCI6MTY1ODgzNjk1OCwidmMiOnsiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XSwiYWRkcmVzcyI6W3siYWRkcmVzc0NvdW50cnkiOiJHQiIsImJ1aWxkaW5nTmFtZSI6IiIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImlkIjpudWxsLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwic3ViQnVpbGRpbmdOYW1lIjpudWxsfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTU5LTA4LTIzIn1dfSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eXBlIjoiSWRlbnRpdHlDaGVjayIsInR4biI6IlJCMDAwMTAzNDkwMDg3IiwiaWRlbnRpdHlGcmF1ZFNjb3JlIjoxLCJjaSI6W119XX19.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
+    private final String M1B_FRAUD_WITH_ACTIVITY_VC =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jldmlldy1mLmludGVncmF0aW9uLmFjY291bnQuZ292LnVrIiwic3ViIjoidXJuOnV1aWQ6ZTZlMmUzMjQtNWI2Ni00YWQ2LTgzMzgtODNmOWY4MzdlMzQ1IiwibmJmIjoxNjU4ODI5NzU4LCJleHAiOjE2NTg4MzY5NTgsInZjIjp7ImNyZWRlbnRpYWxTdWJqZWN0Ijp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidHlwZSI6IkdpdmVuTmFtZSIsInZhbHVlIjoiS0VOTkVUSCJ9LHsidHlwZSI6IkZhbWlseU5hbWUiLCJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIn1dfV0sImFkZHJlc3MiOlt7ImFkZHJlc3NDb3VudHJ5IjoiR0IiLCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZUk9BRCIsInBvQm94TnVtYmVyIjpudWxsLCJwb3N0YWxDb2RlIjoiQkEyNUFBIiwiYnVpbGRpbmdOdW1iZXIiOiI4IiwiaWQiOm51bGwsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJzdWJCdWlsZGluZ05hbWUiOm51bGx9XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5NTktMDgtMjMifV19LCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiSWRlbnRpdHlDaGVja0NyZWRlbnRpYWwiXSwiZXZpZGVuY2UiOlt7InR5cGUiOiJJZGVudGl0eUNoZWNrIiwidHhuIjoiUkIwMDAxMDM0OTAwODciLCJpZGVudGl0eUZyYXVkU2NvcmUiOjEsImFjdGl2aXR5SGlzdG9yeVNjb3JlIjoxLCJjaSI6W119XX19.MEUCIHoe7TsSTTORaj2X5cpv7Fpg1gVenFwEhYL4tf6zt3eJAiEAiwqUTOROjTB-Gyxt-IEwUQNndj_L43dMAnrPRaWnzNE";
     private final String M1A_KBV_VC =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczpcL1wvcmV2aWV3LWsuaW50ZWdyYXRpb24uYWNjb3VudC5nb3YudWsiLCJzdWIiOiJ1cm46dXVpZDplNmUyZTMyNC01YjY2LTRhZDYtODMzOC04M2Y5ZjgzN2UzNDUiLCJuYmYiOjE2NTg4Mjk5MTcsImV4cCI6MTY1ODgzNzExNywidmMiOnsidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIklkZW50aXR5Q2hlY2tDcmVkZW50aWFsIl0sImV2aWRlbmNlIjpbeyJ0eG4iOiI3TEFLUlRBN0ZTIiwidmVyaWZpY2F0aW9uU2NvcmUiOjIsInR5cGUiOiJJZGVudGl0eUNoZWNrIn1dLCJjcmVkZW50aWFsU3ViamVjdCI6eyJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dLCJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIn0seyJhZGRyZXNzQ291bnRyeSI6IkdCIiwidXBybiI6MTAwMTIwMDEyMDc3LCJidWlsZGluZ05hbWUiOiIiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsImJ1aWxkaW5nTnVtYmVyIjoiOCIsImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJ2YWxpZEZyb20iOiIyMDAwLTAxLTAxIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk1OS0wOC0yMyJ9XX19fQ.MEUCIAD3CkUQctCBxPIonRsYylmAsWsodyzpLlRzSTKvJBxHAiEAsewH-Ke7x8R3879-KQCwGAcYPt_14Wq7a6bvsb5tH_8";
     private final String M1B_DCMAW_VC =
@@ -205,6 +207,21 @@ class Gpg45ProfileEvaluatorTest {
                                 SignedJWT.parse(M1A_ADDRESS_VC),
                                 SignedJWT.parse(M1A_FRAUD_VC)));
         Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 0);
+
+        assertEquals(expectedScores, builtScores);
+    }
+
+    @Test
+    void buildScoreShouldReturnCorrectScoreForPassportAndAddressAndFraudWithActivityCredentials()
+            throws Exception {
+
+        Gpg45Scores builtScores =
+                evaluator.buildScore(
+                        List.of(
+                                SignedJWT.parse(M1A_PASSPORT_VC),
+                                SignedJWT.parse(M1A_ADDRESS_VC),
+                                SignedJWT.parse(M1B_FRAUD_WITH_ACTIVITY_VC)));
+        Gpg45Scores expectedScores = new Gpg45Scores(Gpg45Scores.EV_42, 1, 1, 0);
 
         assertEquals(expectedScores, builtScores);
     }

--- a/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
+++ b/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
@@ -75,16 +75,18 @@ public class VcHelper {
                 if (shouldCheckContraIndicators && item.hasContraIndicators()) {
                     return false;
                 }
-                if (item.getType().equals(CredentialEvidenceItem.EvidenceType.EVIDENCE)) {
-                    return Gpg45EvidenceValidator.isSuccessful(item);
-                } else if (item.getType()
-                        .equals(CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD)) {
-                    return Gpg45FraudValidator.isSuccessful(item);
-                } else if (item.getType()
-                        .equals(CredentialEvidenceItem.EvidenceType.VERIFICATION)) {
-                    return Gpg45VerificationValidator.isSuccessful(item);
-                } else if (item.getType().equals(CredentialEvidenceItem.EvidenceType.DCMAW)) {
-                    return Gpg45DcmawValidator.isSuccessful(item);
+                CredentialEvidenceItem.EvidenceType evidenceType = item.getType();
+
+                switch (evidenceType) {
+                    case EVIDENCE:
+                        return Gpg45EvidenceValidator.isSuccessful(item);
+                    case IDENTITY_FRAUD:
+                    case FRAUD_WITH_ACTIVITY:
+                        return Gpg45FraudValidator.isSuccessful(item);
+                    case VERIFICATION:
+                        return Gpg45VerificationValidator.isSuccessful(item);
+                    case DCMAW:
+                        return Gpg45DcmawValidator.isSuccessful(item);
                 }
             }
             return false;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handle fraud credentials containing an activity score

### Why did it change

[BAU: Handle fraud credentials containing activity](https://github.com/alphagov/di-ipv-core-back/pull/888/commits/ccacd0fd22c1c1a3e61ce0ba5401685b2f6c1af2) 
VC's received from the fraud CRI may start to include an activity score
as well as a fraud score. This change allows the GPG 45 evaluator to
handle both versions.

A credential that contains both fraud and activity scores is split into
two so the different scores can be compared with other scores of the
same type. We do a similar thing for DCMAW and f2f credentials.
  
[BAU: Simplify GPG45 score comparators](https://github.com/alphagov/di-ipv-core-back/pull/888/commits/7821930a231552981cd1d7e993f1183f5becb2ca) 
The comparators were comparing scores based on the score and then by the
number of CIs a VC contained. CI checking is handled separately now so
this is no longer required. It also doesn't make sense where we have VCs
containing multiple scores. If a VC had a fraud score and an activity
history score, which score would the CI apply to?

[BAU: Remove unnecessary wrapper method](https://github.com/alphagov/di-ipv-core-back/pull/888/commits/1b9a05622b28f02509fef1ffe9f0a2c8d39dd201) 
One method was wrapping another adding complexity. We can just move the
guard condition to the top of the method with the actual logic in.


This has now been validated to be working in a running dev set up. Original
fraud VCs work as well as new fraud VCs with activityHistory. See the screen
shots below. I've also run a journey and manually provided scores to hit an M1B
profile, using the activity score from the new fraud format. This also worked.

Original fraud VC format
![Screenshot 2023-06-08 at 15 49 34](https://github.com/alphagov/di-ipv-core-back/assets/13836290/9b2a74ea-8d0a-46d8-9930-f2f9c8bca3e4)

New fraud VC format with activity history
![Screenshot 2023-06-08 at 15 52 01](https://github.com/alphagov/di-ipv-core-back/assets/13836290/cd61c1eb-54da-43ce-b790-41cd86e6a84f)



