### PR TITLE
PYIC-2930: Migrate process-journey-step F2F configuration to integration, staging and production

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -174,6 +174,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicenceF2F:
+      type: basic
+      name: ukPassportAndDrivingLicenceF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address
@@ -188,6 +195,20 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/fraud
+    claimedIdentity:
+      type: basic
+      name: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
+    f2f:
+      type: basic
+      name: f2f
+      targetState: CRI_F2F
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/f2f
     kbv:
       type: basic
       name: kbv
@@ -280,6 +301,22 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_CLAIMED_IDENTITY:
+  name: CRI_CLAIMED_IDENTITY
+  parent: CRI_STATE
+CRI_F2F:
+  name: CRI_F2F
+  parent: CRI_STATE
+  events:
+    pending:
+      type: basic
+      name: pending
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
+F2F_HANDOFF_PAGE:
+  name: F2F_HANDOFF_PAGE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE
@@ -351,6 +388,38 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
+MULTIPLE_DOC_CHECK_PAGE_F2F:
+  name: MULTIPLE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    ukPassport:
+      type: basic
+      name: ukPassport
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: drivingLicence
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -167,6 +167,20 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
+    stubUkPassportAndDrivingLicence:
+      type: basic
+      name: stubUkPassportAndDrivingLicence
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicenceF2F:
+      type: basic
+      name: ukPassportAndDrivingLicenceF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address
@@ -181,6 +195,20 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/fraud
+    claimedIdentity:
+      type: basic
+      name: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
+    f2f:
+      type: basic
+      name: f2f
+      targetState: CRI_F2F
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/f2f
     kbv:
       type: basic
       name: kbv
@@ -273,6 +301,22 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_CLAIMED_IDENTITY:
+  name: CRI_CLAIMED_IDENTITY
+  parent: CRI_STATE
+CRI_F2F:
+  name: CRI_F2F
+  parent: CRI_STATE
+  events:
+    pending:
+      type: basic
+      name: pending
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
+F2F_HANDOFF_PAGE:
+  name: F2F_HANDOFF_PAGE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE
@@ -344,6 +388,38 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
+MULTIPLE_DOC_CHECK_PAGE_F2F:
+  name: MULTIPLE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    ukPassport:
+      type: basic
+      name: ukPassport
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: drivingLicence
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -174,6 +174,13 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicenceF2F:
+      type: basic
+      name: ukPassportAndDrivingLicenceF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address
@@ -188,6 +195,20 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/fraud
+    claimedIdentity:
+      type: basic
+      name: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
+    f2f:
+      type: basic
+      name: f2f
+      targetState: CRI_F2F
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/f2f
     kbv:
       type: basic
       name: kbv
@@ -280,6 +301,22 @@ CRI_ADDRESS:
 CRI_FRAUD:
   name: CRI_FRAUD
   parent: CRI_STATE
+CRI_CLAIMED_IDENTITY:
+  name: CRI_CLAIMED_IDENTITY
+  parent: CRI_STATE
+CRI_F2F:
+  name: CRI_F2F
+  parent: CRI_STATE
+  events:
+    pending:
+      type: basic
+      name: pending
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
+F2F_HANDOFF_PAGE:
+  name: F2F_HANDOFF_PAGE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE
@@ -351,6 +388,38 @@ MULTIPLE_DOC_CHECK_PAGE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
+MULTIPLE_DOC_CHECK_PAGE_F2F:
+  name: MULTIPLE_DOC_CHECK_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    ukPassport:
+      type: basic
+      name: ukPassport
+      targetState: CRI_UK_PASSPORT
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/ukPassport
+    drivingLicence:
+      type: basic
+      name: drivingLicence
+      targetState: CRI_DRIVING_LICENCE
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/drivingLicence
+    end:
+      type: basic
+      name: end
+      targetState: CRI_CLAIMED_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/cri/build-oauth-request/claimedIdentity
 PRE_KBV_TRANSITION_PAGE:
   name: PRE_KBV_TRANSITION_PAGE
   parent: ATTEMPT_RECOVERY_STATE


### PR DESCRIPTION
## Proposed changes

### What changed

Added F2F and Claimed Identity journey configuration to process-journey-step for integration, staging and production

### Why did it change

Enable F2F and Claimed Identity journey on integration, staging and production

### Issue tracking

- [PYIC-2930](https://govukverify.atlassian.net/browse/PYIC-2930)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2930]: https://govukverify.atlassian.net/browse/PYIC-2930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ