### PR TITLE
PYIC-2920: Cleaned up BuildProvenUserIdentityDetailsHandlerTest to make it more maintainable

### DIFF
--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -36,6 +36,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.FRAUD_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.KBV_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FAILED_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
@@ -51,6 +56,16 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final CredentialIssuerConfig ISSUER_CONFIG_ADDRESS =
+            createCredentialIssuerConfig("https://review-a.integration.account.gov.uk");
+    private static final CredentialIssuerConfig ISSUER_CONFIG_CLAIMED_IDENTITY =
+            createCredentialIssuerConfig("https://review-c.integration.account.gov.uk");
+    private static final CredentialIssuerConfig ISSUER_CONFIG_FRAUD =
+            createCredentialIssuerConfig("https://review-f.integration.account.gov.uk");
+    private static final CredentialIssuerConfig ISSUER_CONFIG_KBV =
+            createCredentialIssuerConfig("https://review-k.integration.account.gov.uk");
+    private static final CredentialIssuerConfig ISSUER_CONFIG_UK_PASSPORT =
+            createCredentialIssuerConfig("https://review-p.integration.account.gov.uk");
 
     @Mock private Context context;
     @Mock private ConfigService mockConfigService;
@@ -91,52 +106,20 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                 .thenReturn(
                         List.of(
                                 createVcStoreItem(
-                                        "user-id-1", "ukPassport", M1A_PASSPORT_VC, Instant.now()),
+                                        PASSPORT_CRI, M1A_PASSPORT_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "address", M1A_ADDRESS_VC, Instant.now()),
+                                        ADDRESS_CRI, M1A_ADDRESS_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
+                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-c.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS);
 
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -161,55 +144,22 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                 .thenReturn(
                         List.of(
                                 createVcStoreItem(
-                                        "user-id-1", "ukPassport", M1A_PASSPORT_VC, Instant.now()),
+                                        PASSPORT_CRI, M1A_PASSPORT_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1",
-                                        "address",
+                                        ADDRESS_CRI,
                                         M1A_MULTI_ADDRESS_VC,
                                         Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
+                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-c.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS);
 
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -239,55 +189,22 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                 .thenReturn(
                         List.of(
                                 createVcStoreItem(
-                                        "user-id-1", "ukPassport", M1A_PASSPORT_VC, Instant.now()),
+                                        PASSPORT_CRI, M1A_PASSPORT_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1",
-                                        "address",
+                                        ADDRESS_CRI,
                                         M1A_MULTI_ADDRESS_VC_WITHOUT_VALID_FROM_FIELD,
                                         Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
+                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-c.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -304,41 +221,21 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     @Test
     void shouldReceive400ResponseCodeWhenEvidenceVcIsMissing() throws Exception {
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-c.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS);
 
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
                         List.of(
                                 createVcStoreItem(
-                                        "user-id-1", "address", M1A_ADDRESS_VC, Instant.now()),
+                                        ADDRESS_CRI, M1A_ADDRESS_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
+                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -364,76 +261,23 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                 .thenReturn(
                         List.of(
                                 createVcStoreItem(
-                                        "user-id-1", "ukPassport", M1A_PASSPORT_VC, Instant.now()),
+                                        PASSPORT_CRI, M1A_PASSPORT_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
+                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-c.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
+                .thenReturn(ISSUER_CONFIG_FRAUD);
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("fraud"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-f.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("kbv"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-k.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(KBV_CRI))
+                .thenReturn(ISSUER_CONFIG_KBV);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -459,81 +303,27 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                 .thenReturn(
                         List.of(
                                 createVcStoreItem(
-                                        "user-id-1",
-                                        "ukPassport",
+                                        PASSPORT_CRI,
                                         M1A_FAILED_PASSPORT_VC,
                                         Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "address", M1A_ADDRESS_VC, Instant.now()),
+                                        ADDRESS_CRI, M1A_ADDRESS_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
+                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-c.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS);
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
+                .thenReturn(ISSUER_CONFIG_FRAUD);
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("ukPassport"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-p.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-a.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("fraud"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-f.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig("kbv"))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                URI.create("https://example.com/token"),
-                                URI.create("https://example.com/credential"),
-                                URI.create("https://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-jwk",
-                                "https://review-k.integration.account.gov.uk",
-                                URI.create("https://example.com/callback"),
-                                true));
+        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(KBV_CRI))
+                .thenReturn(ISSUER_CONFIG_KBV);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -571,16 +361,15 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                 .thenReturn(
                         List.of(
                                 createVcStoreItem(
-                                        "user-id-1",
-                                        "ukPassport",
+                                        PASSPORT_CRI,
                                         "invalid-credential",
                                         Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "address", M1A_ADDRESS_VC, Instant.now()),
+                                        ADDRESS_CRI, M1A_ADDRESS_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "fraud", M1A_FRAUD_VC, Instant.now()),
+                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
                                 createVcStoreItem(
-                                        "user-id-1", "kbv", M1A_VERIFICATION_VC, Instant.now())));
+                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
 
         JourneyRequest input = createRequestEvent();
         var errorResponse = makeRequest(input, context, JourneyErrorResponse.class);
@@ -599,9 +388,9 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     }
 
     private VcStoreItem createVcStoreItem(
-            String userId, String credentialIssuer, String credential, Instant dateCreated) {
+            String credentialIssuer, String credential, Instant dateCreated) {
         VcStoreItem vcStoreItem = new VcStoreItem();
-        vcStoreItem.setUserId(userId);
+        vcStoreItem.setUserId("user-id-1");
         vcStoreItem.setCredentialIssuer(credentialIssuer);
         vcStoreItem.setCredential(credential);
         vcStoreItem.setDateCreated(dateCreated);

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -105,14 +105,10 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
                         List.of(
-                                createVcStoreItem(
-                                        PASSPORT_CRI, M1A_PASSPORT_VC, Instant.now()),
-                                createVcStoreItem(
-                                        ADDRESS_CRI, M1A_ADDRESS_VC, Instant.now()),
-                                createVcStoreItem(
-                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
-                                createVcStoreItem(
-                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
+                                createVcStoreItem(PASSPORT_CRI, M1A_PASSPORT_VC),
+                                createVcStoreItem(ADDRESS_CRI, M1A_ADDRESS_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
@@ -143,16 +139,10 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
                         List.of(
-                                createVcStoreItem(
-                                        PASSPORT_CRI, M1A_PASSPORT_VC, Instant.now()),
-                                createVcStoreItem(
-                                        ADDRESS_CRI,
-                                        M1A_MULTI_ADDRESS_VC,
-                                        Instant.now()),
-                                createVcStoreItem(
-                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
-                                createVcStoreItem(
-                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
+                                createVcStoreItem(PASSPORT_CRI, M1A_PASSPORT_VC),
+                                createVcStoreItem(ADDRESS_CRI, M1A_MULTI_ADDRESS_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
@@ -188,16 +178,11 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
                         List.of(
+                                createVcStoreItem(PASSPORT_CRI, M1A_PASSPORT_VC),
                                 createVcStoreItem(
-                                        PASSPORT_CRI, M1A_PASSPORT_VC, Instant.now()),
-                                createVcStoreItem(
-                                        ADDRESS_CRI,
-                                        M1A_MULTI_ADDRESS_VC_WITHOUT_VALID_FROM_FIELD,
-                                        Instant.now()),
-                                createVcStoreItem(
-                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
-                                createVcStoreItem(
-                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
+                                        ADDRESS_CRI, M1A_MULTI_ADDRESS_VC_WITHOUT_VALID_FROM_FIELD),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
@@ -230,12 +215,9 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
                         List.of(
-                                createVcStoreItem(
-                                        ADDRESS_CRI, M1A_ADDRESS_VC, Instant.now()),
-                                createVcStoreItem(
-                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
-                                createVcStoreItem(
-                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
+                                createVcStoreItem(ADDRESS_CRI, M1A_ADDRESS_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -260,12 +242,9 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
                         List.of(
-                                createVcStoreItem(
-                                        PASSPORT_CRI, M1A_PASSPORT_VC, Instant.now()),
-                                createVcStoreItem(
-                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
-                                createVcStoreItem(
-                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
+                                createVcStoreItem(PASSPORT_CRI, M1A_PASSPORT_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
@@ -302,16 +281,10 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
                         List.of(
-                                createVcStoreItem(
-                                        PASSPORT_CRI,
-                                        M1A_FAILED_PASSPORT_VC,
-                                        Instant.now()),
-                                createVcStoreItem(
-                                        ADDRESS_CRI, M1A_ADDRESS_VC, Instant.now()),
-                                createVcStoreItem(
-                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
-                                createVcStoreItem(
-                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
+                                createVcStoreItem(PASSPORT_CRI, M1A_FAILED_PASSPORT_VC),
+                                createVcStoreItem(ADDRESS_CRI, M1A_ADDRESS_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
@@ -360,16 +333,10 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
                 .thenReturn(
                         List.of(
-                                createVcStoreItem(
-                                        PASSPORT_CRI,
-                                        "invalid-credential",
-                                        Instant.now()),
-                                createVcStoreItem(
-                                        ADDRESS_CRI, M1A_ADDRESS_VC, Instant.now()),
-                                createVcStoreItem(
-                                        FRAUD_CRI, M1A_FRAUD_VC, Instant.now()),
-                                createVcStoreItem(
-                                        KBV_CRI, M1A_VERIFICATION_VC, Instant.now())));
+                                createVcStoreItem(PASSPORT_CRI, "invalid-credential"),
+                                createVcStoreItem(ADDRESS_CRI, M1A_ADDRESS_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
         JourneyRequest input = createRequestEvent();
         var errorResponse = makeRequest(input, context, JourneyErrorResponse.class);
@@ -387,8 +354,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
         return JourneyRequest.builder().ipvSessionId(SESSION_ID).ipAddress("10.10.10.1").build();
     }
 
-    private VcStoreItem createVcStoreItem(
-            String credentialIssuer, String credential, Instant dateCreated) {
+    private VcStoreItem createVcStoreItem(String credentialIssuer, String credential) {
+        Instant dateCreated = Instant.now();
         VcStoreItem vcStoreItem = new VcStoreItem();
         vcStoreItem.setUserId("user-id-1");
         vcStoreItem.setCredentialIssuer(credentialIssuer);


### PR DESCRIPTION
## Proposed changes

### What changed

Updated BuildProvenUserIdentityDetailsHandlerTest to make it more maintainable by:
* Using constants for CRI names
* Using a generator function to create example data

### Why did it change

The BuildProvenUserIdentityDetailsHandlerTest was getting very difficult to maintain as it had a lot of repeated code.

### Issue tracking

- [PYIC-2920](https://govukverify.atlassian.net/browse/PYIC-2920)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2920]: https://govukverify.atlassian.net/browse/PYIC-2920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ