### PR TITLE
PYIC-2839: Add missing CRI_RESPONSE_TABLE_NAME env var

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -762,6 +762,7 @@ Resources:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
+          CRI_RESPONSE_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt CRIResponseTable.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub retrieve-cri-credentials-${Environment}
@@ -803,6 +804,8 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBCrudPolicy:
             TableName: !Ref UserIssuedCredentialsV2Table
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CRIResponseTable
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:


### PR DESCRIPTION

## Proposed changes

### What changed
Add missing CRI_RESPONSE_TABLE_NAME env var

### Why did it change
Missing config for retrieve-cri-credential lambda

### Issue tracking

- [PYIC-2839](https://govukverify.atlassian.net/browse/PYIC-2839)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed


### Other considerations


[PYIC-2839]: https://govukverify.atlassian.net/browse/PYIC-2839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ