### PR TITLE
PYIC-2934: Include F2F VC as an evidence CRI type

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -39,6 +39,7 @@ import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.USER_ISSUED_
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DRIVING_LICENCE_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
@@ -52,7 +53,7 @@ public class UserIdentityService {
     private static final List<String> DRIVING_PERMIT_CRI_TYPES =
             List.of(DCMAW_CRI, DRIVING_LICENCE_CRI);
     public static final List<String> EVIDENCE_CRI_TYPES =
-            List.of(PASSPORT_CRI, DCMAW_CRI, DRIVING_LICENCE_CRI);
+            List.of(PASSPORT_CRI, DCMAW_CRI, DRIVING_LICENCE_CRI, F2F_CRI);
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String PASSPORT_PROPERTY_NAME = "passport";


### PR DESCRIPTION
## Proposed changes

### What changed
F2F CRI has been included as an evidence CRI type alongside PASSPORT, DCMAW, and DRIVING_LICENCE

### Why did it change
Integration of F2F MVP

### Issue tracking
- [PYIC-2934](https://govukverify.atlassian.net/browse/PYIC-2934)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations



[PYIC-2934]: https://govukverify.atlassian.net/browse/PYIC-2934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ