### PR TITLE
BAU: Subscription Filter cannot be added to Dev Accounts

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -50,7 +50,7 @@ Conditions:
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
   IsProduction: !Equals [ !Ref Environment, "production"]
   IsNotProduction: !Not [!Equals [ !Ref Environment, "production"]]
-  IsNotProdOrDev: !Or
+  IsNotProdOrDev: !And
     - !Not [!Equals [ !Ref Environment, "production"]]
     - !Not [ !Condition IsDevelopment ]
   UseCodeSigning:


### PR DESCRIPTION
## Proposed changes

### What changed
The ProcessAsyncCriCredential subscription filter should be applied to neither Prod (temporarily) nor Dev (ever).

### Why did it change
Correct the condition

### Issue tracking

## Checklists

### Environment variables or secrets

### Other considerations

