### PR TITLE
PYIC-2936: Clean up process-journey-step state machine removing unused stub events

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -167,23 +167,16 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
       type: basic
-      name: ukPassportAndDrivingLicence
+      name: multipleDocCheck
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    multipleDocCheckWithF2FPage:
       type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
+      name: multipleDocCheckWithF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
       response:
         type: page

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -160,23 +160,16 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
       type: basic
-      name: ukPassportAndDrivingLicence
+      name: multipleDocCheck
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    multipleDocCheckWithF2FPage:
       type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
+      name: multipleDocCheckWithF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
       response:
         type: page

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -160,23 +160,16 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
       type: basic
-      name: ukPassportAndDrivingLicence
+      name: multipleDocCheck
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    multipleDocCheckWithF2FPage:
       type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
+      name: multipleDocCheckWithF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
       response:
         type: page

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -160,23 +160,16 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
       type: basic
-      name: ukPassportAndDrivingLicence
+      name: multipleDocCheck
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    multipleDocCheckWithF2FPage:
       type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
+      name: multipleDocCheckWithF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
       response:
         type: page

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -160,23 +160,16 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
       type: basic
-      name: ukPassportAndDrivingLicence
+      name: multipleDocCheck
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    multipleDocCheckWithF2FPage:
       type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
+      name: multipleDocCheckWithF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
       response:
         type: page

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -53,10 +53,8 @@ public class SelectCriHandler extends JourneyRequestLambda {
     private static final String JOURNEY_FAIL = "/journey/fail";
     private static final String DCMAW_SUCCESS_PAGE = "dcmaw-success";
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
-    private static final String MULTIPLE_DOC_CHECK_PAGE =
-            "multipleDocCheckPage";
-    private static final String MULTIPLE_DOC_CHECK_WITH_F2F_PAGE =
-            "multipleDocCheckWithF2FPage";
+    private static final String MULTIPLE_DOC_CHECK_PAGE = "multipleDocCheckPage";
+    private static final String MULTIPLE_DOC_CHECK_WITH_F2F_PAGE = "multipleDocCheckWithF2FPage";
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -53,12 +53,10 @@ public class SelectCriHandler extends JourneyRequestLambda {
     private static final String JOURNEY_FAIL = "/journey/fail";
     private static final String DCMAW_SUCCESS_PAGE = "dcmaw-success";
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
-    private static final String UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
-            "ukPassportAndDrivingLicence";
-    private static final String UK_PASSPORT_AND_DRIVING_LICENCE_PAGE_F2F =
-            "ukPassportAndDrivingLicenceF2F";
-    private static final String STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE =
-            "stubUkPassportAndDrivingLicence";
+    private static final String MULTIPLE_DOC_CHECK_PAGE =
+            "multipleDocCheckPage";
+    private static final String MULTIPLE_DOC_CHECK_WITH_F2F_PAGE =
+            "multipleDocCheckWithF2FPage";
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
@@ -326,12 +324,9 @@ public class SelectCriHandler extends JourneyRequestLambda {
 
     private Optional<JourneyResponse> getMultipleDocCheckPage() {
         if (configService.isEnabled(F2F_CRI)) {
-            return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE_F2F));
+            return Optional.of(getJourneyResponse(MULTIPLE_DOC_CHECK_WITH_F2F_PAGE));
         }
-        if (configService.getActiveConnection(DRIVING_LICENCE_CRI).equals("stub")) {
-            return Optional.of(getJourneyResponse(STUB_UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
-        }
-        return Optional.of(getJourneyResponse(UK_PASSPORT_AND_DRIVING_LICENCE_PAGE));
+        return Optional.of(getJourneyResponse(MULTIPLE_DOC_CHECK_PAGE));
     }
 
     private boolean hasPassportVc(List<VcStatusDto> currentVcStatuses) {

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
@@ -55,10 +55,10 @@ class SelectCriHandlerTest {
     private static final String CLAIMED_IDENTITY_CRI_ISS = "test-claimed-identity-iss";
     private static final String F2F_CRI_ISS = "test-f2f-iss";
     private static final String UK_PASSPORT_JOURNEY = "/journey/ukPassport";
-    private static final String UK_PASSPORT_AND_DRIVING_LICENCE_JOURNEY =
-            "/journey/ukPassportAndDrivingLicence";
-    private static final String UK_PASSPORT_DRIVING_LICENCE_AND_F2F_JOURNEY =
-            "/journey/ukPassportAndDrivingLicenceF2F";
+    private static final String MULTIPLE_DOC_CHECK_PAGE_JOURNEY =
+            "/journey/multipleDocCheckPage";
+    private static final String MULTIPLE_DOC_CHECK_WITH_F2F_PAGE_JOURNEY =
+            "/journey/multipleDocCheckWithF2FPage";
     private static final String ADDRESS_JOURNEY = "/journey/address";
     private static final String PYI_NO_MATCH_JOURNEY = "/journey/pyi-no-match";
     private static final String FRAUD_JOURNEY = "/journey/fraud";
@@ -119,7 +119,6 @@ class SelectCriHandlerTest {
                 .thenReturn(Collections.emptyList());
         when(mockConfigService.getCredentialIssuerActiveConnectionConfig(DRIVING_LICENCE_CRI))
                 .thenReturn(createCriConfig(DRIVING_LICENCE_CRI));
-        when(mockConfigService.getActiveConnection(DRIVING_LICENCE_CRI)).thenReturn("main");
         when(mockConfigService.isEnabled(DCMAW_CRI)).thenReturn(false);
         when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(true);
 
@@ -127,7 +126,7 @@ class SelectCriHandlerTest {
 
         JourneyResponse response = handleRequest(input, context);
 
-        assertEquals(UK_PASSPORT_AND_DRIVING_LICENCE_JOURNEY, response.getJourney());
+        assertEquals(MULTIPLE_DOC_CHECK_PAGE_JOURNEY, response.getJourney());
     }
 
     @Test
@@ -153,7 +152,7 @@ class SelectCriHandlerTest {
 
         JourneyResponse response = handleRequest(input, context);
 
-        assertEquals(UK_PASSPORT_DRIVING_LICENCE_AND_F2F_JOURNEY, response.getJourney());
+        assertEquals(MULTIPLE_DOC_CHECK_WITH_F2F_PAGE_JOURNEY, response.getJourney());
     }
 
     @Test

--- a/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
+++ b/lambdas/select-cri/src/test/java/uk/gov/di/ipv/core/selectcri/SelectCriHandlerTest.java
@@ -55,8 +55,7 @@ class SelectCriHandlerTest {
     private static final String CLAIMED_IDENTITY_CRI_ISS = "test-claimed-identity-iss";
     private static final String F2F_CRI_ISS = "test-f2f-iss";
     private static final String UK_PASSPORT_JOURNEY = "/journey/ukPassport";
-    private static final String MULTIPLE_DOC_CHECK_PAGE_JOURNEY =
-            "/journey/multipleDocCheckPage";
+    private static final String MULTIPLE_DOC_CHECK_PAGE_JOURNEY = "/journey/multipleDocCheckPage";
     private static final String MULTIPLE_DOC_CHECK_WITH_F2F_PAGE_JOURNEY =
             "/journey/multipleDocCheckWithF2FPage";
     private static final String ADDRESS_JOURNEY = "/journey/address";


### PR DESCRIPTION
## Proposed changes

### What changed

* Removed unused events in `process-journey-step` and `select-cri`
* Renamed `ukPassportAndDrivingLicence` and `ukPassportAndDrivingLicenceF2F` to `multipleDocCheckPage` and `multipleDocCheckPageF2F` respectively

### Why did it change

Remove redundant code and make existing code cleaner.

### Issue tracking

- [PYIC-2936](https://govukverify.atlassian.net/browse/PYIC-2936)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2936]: https://govukverify.atlassian.net/browse/PYIC-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ