### PR TITLE
BAU: Add f2f check validator

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/validation/Gpg45F2fValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/validation/Gpg45F2fValidator.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.core.library.domain.gpg45.validation;
+
+import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
+
+public class Gpg45F2fValidator {
+
+    private Gpg45F2fValidator() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static boolean isSuccessful(CredentialEvidenceItem item) {
+        if (item.getFailedCheckDetails() != null) {
+            return false;
+        }
+        return item.getValidityScore() != 0;
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/validation/Gpg45F2fValidatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/validation/Gpg45F2fValidatorTest.java
@@ -1,0 +1,58 @@
+package uk.gov.di.ipv.core.library.domain.gpg45.validation;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.domain.gpg45.domain.CheckDetail;
+import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Gpg45F2fValidatorTest {
+
+    @Test
+    void isSuccessfulShouldReturnTrueOnValidCredential() {
+        CredentialEvidenceItem credentialEvidenceItem =
+                new CredentialEvidenceItem(
+                        4,
+                        3,
+                        0,
+                        3,
+                        Collections.singletonList(new CheckDetail()),
+                        null,
+                        Collections.emptyList());
+
+        assertTrue(Gpg45F2fValidator.isSuccessful(credentialEvidenceItem));
+    }
+
+    @Test
+    void isSuccessfulShouldReturnFalseOnInValidCredentialWithFailedCheckDetails() {
+        CredentialEvidenceItem credentialEvidenceItem =
+                new CredentialEvidenceItem(
+                        4,
+                        3,
+                        0,
+                        3,
+                        null,
+                        Collections.singletonList(new CheckDetail()),
+                        Collections.emptyList());
+
+        assertFalse(Gpg45F2fValidator.isSuccessful(credentialEvidenceItem));
+    }
+
+    @Test
+    void isSuccessfulShouldReturnFalseOnInValidCredentialWithIncorrectValidityScoreValue() {
+        CredentialEvidenceItem credentialEvidenceItem =
+                new CredentialEvidenceItem(
+                        3,
+                        0,
+                        0,
+                        3,
+                        Collections.singletonList(new CheckDetail()),
+                        null,
+                        Collections.emptyList());
+
+        assertFalse(Gpg45F2fValidator.isSuccessful(credentialEvidenceItem));
+    }
+}

--- a/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
+++ b/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
@@ -11,6 +11,7 @@ import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45DcmawValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45EvidenceValidator;
+import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45F2fValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45FraudValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45VerificationValidator;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
@@ -87,6 +88,8 @@ public class VcHelper {
                         return Gpg45VerificationValidator.isSuccessful(item);
                     case DCMAW:
                         return Gpg45DcmawValidator.isSuccessful(item);
+                    case F2F:
+                        return Gpg45F2fValidator.isSuccessful(item);
                 }
             }
             return false;


### PR DESCRIPTION
We have logic to check if VC's are deemed "successful". This is used when deciding where to send a user, but also for deciding which VCs we should extract data from when constructing an identity.

We need this for the new f2f VC as it will be the only VC that contains the name and date of birth data.

