### PR TITLE
PYIC-2936: Added new replacement journey steps multipleDocCheckPage and multipleDocCheckWithF2FPage

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -167,21 +167,35 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
+      type: basic
+      name: multipleDocCheck
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    multipleDocCheckWithF2FPage:
+      type: basic
+      name: multipleDocCheckWithF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: stubUkPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
+    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicenceF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -160,21 +160,35 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
+      type: basic
+      name: multipleDocCheck
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    multipleDocCheckWithF2FPage:
+      type: basic
+      name: multipleDocCheckWithF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: stubUkPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
+    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicenceF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -160,21 +160,35 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
+      type: basic
+      name: multipleDocCheck
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    multipleDocCheckWithF2FPage:
+      type: basic
+      name: multipleDocCheckWithF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: stubUkPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
+    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicenceF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -160,21 +160,35 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
+      type: basic
+      name: multipleDocCheck
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    multipleDocCheckWithF2FPage:
+      type: basic
+      name: multipleDocCheckWithF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: stubUkPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
+    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicenceF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -160,21 +160,35 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-driving-licence-doc-check
-    ukPassportAndDrivingLicence:
+    multipleDocCheckPage:
+      type: basic
+      name: multipleDocCheck
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    multipleDocCheckWithF2FPage:
+      type: basic
+      name: multipleDocCheckWithF2F
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence:
+    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
       type: basic
       name: stubUkPassportAndDrivingLicence
       targetState: MULTIPLE_DOC_CHECK_PAGE
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F:
+    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
       type: basic
       name: ukPassportAndDrivingLicenceF2F
       targetState: MULTIPLE_DOC_CHECK_PAGE_F2F


### PR DESCRIPTION
## Proposed changes

### What changed

Added multipleDocCheckPage and multipleDocCheckPageF2F which will replace ukPassportAndDrivingLicence and ukPassportAndDrivingLicenceF2F respectively in a later pull request.

### Why did it change

Remove redundant code and make existing code cleaner.

### Issue tracking

- [PYIC-2936](https://govukverify.atlassian.net/browse/PYIC-2936)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2936]: https://govukverify.atlassian.net/browse/PYIC-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ