### PR TITLE
PYIC-2936: Removed unused states from process-journey-step

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -181,27 +181,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
-      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
-      response:
-        type: page
-        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -174,27 +174,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
-      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
-      response:
-        type: page
-        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -174,27 +174,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
-      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
-      response:
-        type: page
-        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -174,27 +174,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
-      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
-      response:
-        type: page
-        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -174,27 +174,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    stubUkPassportAndDrivingLicence: # Replaced with multipleDocCheckPage, will be deleted in next PR
-      type: basic
-      name: stubUkPassportAndDrivingLicence
-      targetState: MULTIPLE_DOC_CHECK_PAGE
-      response:
-        type: page
-        pageId: page-multiple-doc-check
-    ukPassportAndDrivingLicenceF2F: # Replaced with multipleDocCheckWithF2FPage, will be deleted in next PR
-      type: basic
-      name: ukPassportAndDrivingLicenceF2F
-      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
-      response:
-        type: page
-        pageId: page-multiple-doc-check
     address:
       type: basic
       name: address


### PR DESCRIPTION
## Proposed changes

### What changed

* Removed the states `ukPassportAndDrivingLicence` and `stubUkPassportAndDrivingLicence` which have been replaced with `multipleDocCheckPage`.
* Removed the state `ukPassportAndDrivingLicenceF2F` which has been replaced with `multipleDocCheckWithF2FPage`.

### Why did it change

Removed unused events from `process-journey-step`

### Issue tracking

- [PYIC-2936](https://govukverify.atlassian.net/browse/PYIC-2936)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

None

[PYIC-2936]: https://govukverify.atlassian.net/browse/PYIC-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ