### PR TITLE
PYIC-2941 Correct F2F pending response to use CRI oauth state

### DIFF
--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -141,6 +141,7 @@ public class RetrieveCriCredentialHandler
         CriOAuthSessionItem criOAuthSessionItem =
                 criOAuthSessionService.getCriOauthSessionItem(
                         ipvSessionItem.getCriOAuthSessionId());
+        String criOAuthState = criOAuthSessionItem.getCriOAuthSessionId();
         String credentialIssuerId = criOAuthSessionItem.getCriId();
         try {
             ClientOAuthSessionItem clientOAuthSessionItem =
@@ -174,7 +175,7 @@ public class RetrieveCriCredentialHandler
                         userId,
                         credentialIssuerId,
                         verifiableCredentialResponse,
-                        clientOAuthSessionItem,
+                        criOAuthState,
                         ipvSessionItem);
             } else {
                 return processVerifiableCredentials(
@@ -213,7 +214,7 @@ public class RetrieveCriCredentialHandler
             String userId,
             String credentialIssuerId,
             VerifiableCredentialResponse verifiableCredentialResponse,
-            ClientOAuthSessionItem clientOAuthSessionItem,
+            String criOAuthState,
             IpvSessionItem ipvSessionItem)
             throws JsonProcessingException {
         // Validate the response
@@ -233,7 +234,7 @@ public class RetrieveCriCredentialHandler
                 userId,
                 credentialIssuerId,
                 OBJECT_MAPPER.writeValueAsString(verifiableCredentialResponseDto),
-                clientOAuthSessionItem.getState());
+                criOAuthState);
         // Update session to indicate no VC, but no error
         updateVisitedCredentials(ipvSessionItem, credentialIssuerId, false, null);
         // Audit

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -72,7 +72,8 @@ class RetrieveCriCredentialHandlerTest {
     private static final String ACCESS_TOKEN = "Bearer dGVzdAo=";
     private static final String CREDENTIAL_ISSUER_ID = "PassportIssuer";
     private static final String TEST_USER_ID = "test-user-id";
-    private static final String TEST_STATE = "test-state";
+    private static final String TEST_CLIENT_OAUTH_STATE = "test-client-oauth-state";
+    private static final String TEST_CRI_OAUTH_STATE = "test-cri-oauth-state";
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
     private static final String CODE = "code";
     private static final String MESSAGE = "message";
@@ -154,7 +155,7 @@ class RetrieveCriCredentialHandlerTest {
 
         criOAuthSessionItem =
                 CriOAuthSessionItem.builder()
-                        .criOAuthSessionId(TEST_STATE)
+                        .criOAuthSessionId(TEST_CRI_OAUTH_STATE)
                         .criId(CREDENTIAL_ISSUER_ID)
                         .accessToken(ACCESS_TOKEN)
                         .build();
@@ -523,7 +524,7 @@ class RetrieveCriCredentialHandlerTest {
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
 
         verifyPersistedCriResponse(
-                TEST_USER_ID, CREDENTIAL_ISSUER_ID, expectedIssuerResponse, TEST_STATE);
+                TEST_USER_ID, CREDENTIAL_ISSUER_ID, expectedIssuerResponse, TEST_CRI_OAUTH_STATE);
 
         verifyPersistedVisitedCredentialIssuerDetails(CREDENTIAL_ISSUER_ID, false, null);
     }
@@ -584,7 +585,7 @@ class RetrieveCriCredentialHandlerTest {
         return ClientOAuthSessionItem.builder()
                 .clientOAuthSessionId(SecureTokenHelper.generate())
                 .responseType("code")
-                .state(TEST_STATE)
+                .state(TEST_CLIENT_OAUTH_STATE)
                 .redirectUri("https://example.com/redirect")
                 .govukSigninJourneyId("test-journey-id")
                 .userId("test-user-id")


### PR DESCRIPTION
## Proposed changes

### What changed

Store the CRI oauth state in the F2F pending response, not the client oauth state

### Why did it change

We were using the wrong state

### Issue tracking
- [PYIC-2941](https://govukverify.atlassian.net/browse/PYIC-2941)



[PYIC-2941]: https://govukverify.atlassian.net/browse/PYIC-2941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ