### PR TITLE
PYIC-2952 Add missing attempt-recovery parent state to F2F handoff page

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -310,6 +310,7 @@ CRI_F2F:
         pageId: page-face-to-face-handoff
 F2F_HANDOFF_PAGE:
   name: F2F_HANDOFF_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -310,6 +310,7 @@ CRI_F2F:
         pageId: page-face-to-face-handoff
 F2F_HANDOFF_PAGE:
   name: F2F_HANDOFF_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -310,6 +310,7 @@ CRI_F2F:
         pageId: page-face-to-face-handoff
 F2F_HANDOFF_PAGE:
   name: F2F_HANDOFF_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -310,6 +310,7 @@ CRI_F2F:
         pageId: page-face-to-face-handoff
 F2F_HANDOFF_PAGE:
   name: F2F_HANDOFF_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add missing attempt-recovery parent state to F2F handoff page

### Why did it change

Attempt recovery wasn't working for the F2F handoff page due to the state machine not finding the event for it

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2952](https://govukverify.atlassian.net/browse/PYIC-2952)


[PYIC-2952]: https://govukverify.atlassian.net/browse/PYIC-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ