### PR TITLE
Add missing attempt-recovery parent state to F2F handoff page for build

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -317,6 +317,7 @@ CRI_F2F:
         pageId: page-face-to-face-handoff
 F2F_HANDOFF_PAGE:
   name: F2F_HANDOFF_PAGE
+  parent: ATTEMPT_RECOVERY_STATE
 CRI_KBV:
   name: CRI_KBV
   parent: CRI_STATE


### PR DESCRIPTION
What changed
Add missing attempt-recovery parent state to F2F handoff page for build env

Why did it change
Attempt recovery wasn't working for the F2F handoff page due to the state machine not finding the event for it

Issue tracking
[PYIC-2952](https://govukverify.atlassian.net/browse/PYIC-2952)


[PYIC-2952]: https://govukverify.atlassian.net/browse/PYIC-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ