### PR TITLE
PYIC-2961 Update select-cri to handle F2F attempt recovery

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -209,6 +209,13 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/f2f
+    pending:
+      type: basic
+      name: pending
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
     kbv:
       type: basic
       name: kbv

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -202,6 +202,13 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/f2f
+    pending:
+      type: basic
+      name: pending
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
     kbv:
       type: basic
       name: kbv

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -202,6 +202,13 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/f2f
+    pending:
+      type: basic
+      name: pending
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
     kbv:
       type: basic
       name: kbv

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -202,6 +202,13 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/f2f
+    pending:
+      type: basic
+      name: pending
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
     kbv:
       type: basic
       name: kbv

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -202,6 +202,13 @@ SELECT_CRI:
       response:
         type: journey
         journeyStepId: /journey/cri/build-oauth-request/f2f
+    pending:
+      type: basic
+      name: pending
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
     kbv:
       type: basic
       name: kbv

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -51,6 +51,7 @@ public class SelectCriHandler extends JourneyRequestLambda {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String CRI_START_JOURNEY = "/journey/%s";
     private static final String JOURNEY_FAIL = "/journey/fail";
+    private static final String JOURNEY_PENDING = "/journey/pending";
     private static final String DCMAW_SUCCESS_PAGE = "dcmaw-success";
     private static final String APP_JOURNEY_USER_ID_PREFIX = "urn:uuid:app-journey-user-";
     private static final String MULTIPLE_DOC_CHECK_PAGE = "multipleDocCheckPage";
@@ -284,6 +285,11 @@ public class SelectCriHandler extends JourneyRequestLambda {
 
                 return Optional.of(getJourneyResponse(journeyId));
             }
+
+            if (criId.equals(F2F_CRI)) {
+                return Optional.of(new JourneyResponse(JOURNEY_PENDING));
+            }
+
             var message =
                     new StringMapMessage()
                             .with(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When the F2F CRI has already been visited but there's no VC, return F2F 'pending' journey response to get the user back to the F2F handoff page.

### Why did it change

Back button 'attempt recovery' needed special handling in this case so the user isn't just taken to the pyi-no-match page because of a missing VC.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2961](https://govukverify.atlassian.net/browse/PYIC-2961)


[PYIC-2961]: https://govukverify.atlassian.net/browse/PYIC-2961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ