### PR TITLE
PYIC-2972 Update journey back from oauth error back from dcmaw journey.

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -461,6 +461,13 @@ CRI_DCMAW:
       response:
         type: page
         pageId: page-multiple-doc-check
+    access-denied-multi-f2f-doc:
+      type: basic
+      name: access-denied-multi-f2f-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
     access-denied:
       type: basic
       name: access-denied

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -454,6 +454,13 @@ CRI_DCMAW:
       response:
         type: page
         pageId: page-multiple-doc-check
+    access-denied-multi-f2f-doc:
+      type: basic
+      name: access-denied-multi-f2f-doc
+      targetState: MULTIPLE_DOC_CHECK_PAGE_F2F
+      response:
+        type: page
+        pageId: page-multiple-doc-check
     access-denied:
       type: basic
       name: access-denied

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DRIVING_LICENCE_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CLIENT_OAUTH_SESSION_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
@@ -56,6 +57,8 @@ public class ValidateOAuthCallbackHandler
             Map.of(JOURNEY, "/journey/access-denied");
     private static final Map<String, Object> JOURNEY_ACCESS_DENIED_MULTI =
             Map.of(JOURNEY, "/journey/access-denied-multi-doc");
+    private static final Map<String, Object> JOURNEY_ACCESS_DENIED_MULTI_WITH_F2F =
+            Map.of(JOURNEY, "/journey/access-denied-multi-f2f-doc");
     private static final Map<String, Object> JOURNEY_TEMPORARILY_UNAVAILABLE =
             Map.of(JOURNEY, "/journey/temporarily-unavailable");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
@@ -263,7 +266,7 @@ public class ValidateOAuthCallbackHandler
         if (OAuth2Error.ACCESS_DENIED_CODE.equals(error)) {
             if (configService.isEnabled(PASSPORT_CRI)
                     && configService.isEnabled(DRIVING_LICENCE_CRI)) {
-                return JOURNEY_ACCESS_DENIED_MULTI;
+                return getMultipleDocCheckPage();
             }
             return JOURNEY_ACCESS_DENIED;
         } else if (OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE.equals(error)) {
@@ -309,6 +312,13 @@ public class ValidateOAuthCallbackHandler
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
         }
+    }
+
+    private Map<String, Object> getMultipleDocCheckPage() {
+        if (configService.isEnabled(F2F_CRI)) {
+            return JOURNEY_ACCESS_DENIED_MULTI_WITH_F2F;
+        }
+        return JOURNEY_ACCESS_DENIED_MULTI;
     }
 
     @Tracing

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DRIVING_LICENCE_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 
 @ExtendWith(MockitoExtension.class)
@@ -379,6 +380,30 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
 
         assertEquals("/journey/access-denied-multi-doc", output.get("journey"));
+        verify(mockCriOAuthSessionService, times(1)).getCriOauthSessionItem(any());
+    }
+
+    @Test
+    void
+            shouldReceiveAccessDeniedMultiJourneyResponseWhenOauthErrorAccessDeniedAndBothPassportDLicenceF2FEnabled()
+                    throws URISyntaxException {
+        CriCallbackRequest criCallbackRequestWithAccessDenied = validCriCallbackRequest();
+        criCallbackRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
+        criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockCriOAuthSessionService.getCriOauthSessionItem(any()))
+                .thenReturn(criOAuthSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockConfigService.isEnabled(PASSPORT_CRI)).thenReturn(true);
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(true);
+        when(mockConfigService.isEnabled(F2F_CRI)).thenReturn(true);
+
+        Map<String, Object> output =
+                underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
+
+        assertEquals("/journey/access-denied-multi-f2f-doc", output.get("journey"));
         verify(mockCriOAuthSessionService, times(1)).getCriOauthSessionItem(any());
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
When return back from dcmaw journey with “access_denied“ oauth error,  getting error when clicked “Prove your identity another way” on multiple-doc-check page.
Should return to f2f multi-doc journey instead of just multi-doc journey.

### What changed
Update journey config to add new journey event (access-denied-multi-f2f-doc) to be used when back with access_denied  oauth error back from dcmaw journey and when f2f is enabled.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
