### PR TITLE
Add email address from IPV Session into Shared Attributes when CRI is…

### DIFF
--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -68,13 +68,15 @@ class AuthorizationRequestHelperTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String TEST_SHARED_CLAIMS = "shared_claims";
+    private static final String TEST_EMAIL_ADDRESS = "test@hotmail.com";
     private static final String OAUTH_STATE = SecureTokenHelper.generate();
 
     private final SharedClaimsResponse sharedClaims =
             new SharedClaimsResponse(
                     Set.of(new Name(List.of(new NameParts("Dan", "first_name")))),
                     Set.of(new BirthDate("2011-01-01")),
-                    Set.of(new Address()));
+                    Set.of(new Address()),
+                    TEST_EMAIL_ADDRESS);
 
     private ECDSASigner signer;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponse.java
@@ -8,7 +8,7 @@ import org.apache.logging.log4j.message.StringMapMessage;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-@JsonPropertyOrder({"name", "birthDate", "address"})
+@JsonPropertyOrder({"name", "birthDate", "address", "email"})
 public class SharedClaimsResponse {
 
     private static final Logger LOGGER = LogManager.getLogger();
@@ -16,11 +16,14 @@ public class SharedClaimsResponse {
     private final Set<Name> name;
     private final Set<BirthDate> birthDate;
     private final Set<Address> address;
+    private final String email;
 
-    public SharedClaimsResponse(Set<Name> name, Set<BirthDate> birthDate, Set<Address> address) {
+    public SharedClaimsResponse(
+            Set<Name> name, Set<BirthDate> birthDate, Set<Address> address, String email) {
         this.name = name;
         this.birthDate = birthDate;
         this.address = address;
+        this.email = email;
     }
 
     public Set<Name> getName() {
@@ -35,7 +38,11 @@ public class SharedClaimsResponse {
         return address;
     }
 
-    public static SharedClaimsResponse from(Set<SharedClaims> sharedAttributes) {
+    public String getEmail() {
+        return email;
+    }
+
+    public static SharedClaimsResponse from(Set<SharedClaims> sharedAttributes, String email) {
         Set<Name> nameSet = new LinkedHashSet<>();
         Set<BirthDate> birthDateSet = new LinkedHashSet<>();
         Set<Address> addressSet = new LinkedHashSet<>();
@@ -55,6 +62,6 @@ public class SharedClaimsResponse {
                         .with("addresses", addressSet.size());
         LOGGER.info(message);
 
-        return new SharedClaimsResponse(nameSet, birthDateSet, addressSet);
+        return new SharedClaimsResponse(nameSet, birthDateSet, addressSet, email);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -37,6 +37,7 @@ public class IpvSessionItem implements DynamodbItem {
     private long ttl;
     private IpvJourneyTypes journeyType;
     private List<ContraIndicatorMitigationDetailsDto> contraIndicatorMitigationDetails;
+    private String email;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseTest.java
@@ -13,6 +13,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.ADDRESS_JSON_2;
 
 class SharedClaimsResponseTest {
 
+    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
@@ -51,10 +52,12 @@ class SharedClaimsResponseTest {
 
         Set<SharedClaims> sharedAttributes = Set.of(sharedClaims1, sharedClaims2);
 
-        SharedClaimsResponse sharedClaimsResponse = SharedClaimsResponse.from(sharedAttributes);
+        SharedClaimsResponse sharedClaimsResponse =
+                SharedClaimsResponse.from(sharedAttributes, TEST_EMAIL_ADDRESS);
 
         assertEquals(2, sharedClaimsResponse.getName().size());
         assertEquals(2, sharedClaimsResponse.getAddress().size());
         assertEquals(2, sharedClaimsResponse.getBirthDate().size());
+        assertEquals(TEST_EMAIL_ADDRESS, sharedClaimsResponse.getEmail());
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/JwtHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/JwtHelperTest.java
@@ -53,7 +53,8 @@ class JwtHelperTest {
         SharedClaims sharedClaims =
                 new SharedClaims.Builder().setName(nameSet).setBirthDate(birthDaySet).build();
 
-        SharedClaimsResponse sharedClaimsResponse = SharedClaimsResponse.from(Set.of(sharedClaims));
+        SharedClaimsResponse sharedClaimsResponse =
+                SharedClaimsResponse.from(Set.of(sharedClaims), null);
 
         SignedJWT signedJWT = JwtHelper.createSignedJwtFromObject(sharedClaimsResponse, signer);
         JWTClaimsSet generatedClaims = signedJWT.getJWTClaimsSet();


### PR DESCRIPTION
Add email address from IPV Session into Shared Attributes when CRI is configured to for email.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add email address from IPV Session into Shared Attributes when CRI is configured to for email.

### Why did it change

to passing email to orchestration 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2985](https://govukverify.atlassian.net/browse/PYIC-2985)


[PYIC-2985]: https://govukverify.atlassian.net/browse/PYIC-2985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ