### PR TITLE
BAU: Apply singleton pattern to ConfigService

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -55,7 +55,7 @@ public class DataStoreIpvSessionIT {
                     "The environment variable 'IPV_SESSIONS_TABLE_NAME' must be provided to run this test");
         }
 
-        ConfigService configService = new ConfigService();
+        ConfigService configService = ConfigService.getInstance();
 
         ipvSessionItemDataStore =
                 new DataStore<>(

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -64,7 +64,7 @@ public class BuildClientOauthResponseHandler extends JourneyRequestLambda {
 
     @ExcludeFromGeneratedCoverageReport
     public BuildClientOauthResponseHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.sessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.authRequestValidator = new AuthRequestValidator(configService);

--- a/lambdas/build-debug-credential-data/src/main/java/uk/gov/di/ipv/core/builddebugcredentialdata/BuildDebugCredentialDataHandler.java
+++ b/lambdas/build-debug-credential-data/src/main/java/uk/gov/di/ipv/core/builddebugcredentialdata/BuildDebugCredentialDataHandler.java
@@ -55,7 +55,7 @@ public class BuildDebugCredentialDataHandler
 
     @ExcludeFromGeneratedCoverageReport
     public BuildDebugCredentialDataHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -74,7 +74,7 @@ public class BuildProvenUserIdentityDetailsHandler extends JourneyRequestLambda 
 
     @ExcludeFromGeneratedCoverageReport
     public BuildProvenUserIdentityDetailsHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.ipvSessionService = new IpvSessionService(configService);
         this.userIdentityService = new UserIdentityService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -70,7 +70,7 @@ public class BuildUserIdentityHandler
 
     @ExcludeFromGeneratedCoverageReport
     public BuildUserIdentityHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -107,7 +107,7 @@ public class CheckExistingIdentityHandler extends JourneyRequestLambda {
     @SuppressWarnings("unused") // Used through dependency injection
     @ExcludeFromGeneratedCoverageReport
     public CheckExistingIdentityHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService);

--- a/lambdas/end-mitigation-journey/src/main/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandler.java
+++ b/lambdas/end-mitigation-journey/src/main/java/uk/gov/di/ipv/core/endmitigationjourney/EndMitigationJourneyHandler.java
@@ -73,7 +73,7 @@ public class EndMitigationJourneyHandler
 
     @ExcludeFromGeneratedCoverageReport
     public EndMitigationJourneyHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.ciStorageService = new CiStorageService(configService);

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -106,7 +106,7 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
     @SuppressWarnings("unused") // Used by AWS
     @ExcludeFromGeneratedCoverageReport
     public EvaluateGpg45ScoresHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService);

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -67,7 +67,7 @@ public class InitialiseIpvSessionHandler
 
     @ExcludeFromGeneratedCoverageReport
     public InitialiseIpvSessionHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.kmsRsaDecrypter =

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -69,7 +69,7 @@ public class IssueClientAccessTokenHandler
 
     @ExcludeFromGeneratedCoverageReport
     public IssueClientAccessTokenHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.accessTokenService = new AccessTokenService(configService);
         this.sessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -80,7 +80,7 @@ public class ProcessAsyncCriCredentialHandler
 
     @ExcludeFromGeneratedCoverageReport
     public ProcessAsyncCriCredentialHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator();
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -68,7 +68,7 @@ public class ProcessJourneyStepHandler
 
     @ExcludeFromGeneratedCoverageReport
     public ProcessJourneyStepHandler() throws IOException {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.stateMachine =

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -105,7 +105,7 @@ public class RetrieveCriCredentialHandler
 
     @ExcludeFromGeneratedCoverageReport
     public RetrieveCriCredentialHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -67,7 +67,7 @@ public class RetrieveCriOauthAccessTokenHandler
 
     @ExcludeFromGeneratedCoverageReport
     public RetrieveCriOauthAccessTokenHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.authCodeToAccessTokenService =
                 new AuthCodeToAccessTokenService(
                         configService, new KmsEs256Signer(configService.getSigningKeyId()));

--- a/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
+++ b/lambdas/select-cri/src/main/java/uk/gov/di/ipv/core/selectcri/SelectCriHandler.java
@@ -73,7 +73,7 @@ public class SelectCriHandler extends JourneyRequestLambda {
     @SuppressWarnings("unused") // Used by AWS Lambda
     @ExcludeFromGeneratedCoverageReport
     public SelectCriHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
     }

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -96,7 +96,7 @@ public class ValidateOAuthCallbackHandler
 
     @ExcludeFromGeneratedCoverageReport
     public ValidateOAuthCallbackHandler() {
-        this.configService = new ConfigService();
+        this.configService = ConfigService.getInstance();
         this.ipvSessionService = new IpvSessionService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
         this.componentId = this.configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -52,11 +52,19 @@ public class ConfigService {
     private static final String API_KEY = "apiKey";
     private static final String CORE_BASE_PATH = "/%s/core/";
     private static final Logger LOGGER = LogManager.getLogger();
+    private static ConfigService instance;
     private final SSMProvider ssmProvider;
     private final SecretsProvider secretsProvider;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private String featureSet;
+
+    public static ConfigService getInstance() {
+        if (instance == null) {
+            instance = new ConfigService();
+        }
+        return instance;
+    }
 
     public ConfigService(
             SSMProvider ssmProvider, SecretsProvider secretsProvider, String featureSet) {
@@ -69,7 +77,7 @@ public class ConfigService {
         this(ssmProvider, secretsProvider, null);
     }
 
-    public ConfigService(String featureSet) {
+    protected ConfigService() {
         if (isRunningLocally()) {
             this.ssmProvider =
                     ParamManager.getSsmProvider(
@@ -101,11 +109,6 @@ public class ConfigService {
                                             .build())
                             .defaultMaxAge(3, MINUTES);
         }
-        setFeatureSet(featureSet);
-    }
-
-    public ConfigService() {
-        this(null);
     }
 
     public SSMProvider getSsmProvider() {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -87,7 +87,7 @@ class ConfigServiceTest {
                 "software.amazon.awssdk.http.service.impl",
                 "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
 
-        SSMProvider ssmProvider = new ConfigService().getSsmProvider();
+        SSMProvider ssmProvider = ConfigService.getInstance().getSsmProvider();
         assertThrows(NullPointerException.class, () -> ssmProvider.get("any-old-thing"));
 
         HashMap requestBody =


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Apply singleton pattern to ConfigService

### Why did it change

It might be useful for certain classes to have direct access to a ConfigService without it having to be passed down through a chain of method calls, and without having to instantiate a whole new instance of it for themselves.

Applying the singleton pattern like this would allow some class in the depths of the system to use an already existing config service. This would hopefully help with performance of the lambda, and also benefit from the parameter caching we're already doing.

There can be issues with this pattern when in a multithreaded environment, but I don't think this is an issue when running in the context of a lambda.
