### PR TITLE
PYIC-2991

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -19,6 +19,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.SharedClaimsResponse;
+import uk.gov.di.ipv.core.library.domain.SharedClaimsResponseDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -77,7 +78,16 @@ public class AuthorizationRequestHelper {
                         .claim("govuk_signin_journey_id", govukSigninJourneyId);
 
         if (Objects.nonNull(sharedClaims)) {
-            claimsSetBuilder.claim(SHARED_CLAIMS, sharedClaims);
+            if (sharedClaims.getEmailAddress() != null) {
+                claimsSetBuilder.claim(SHARED_CLAIMS, sharedClaims);
+            } else {
+                SharedClaimsResponseDto response =
+                        new SharedClaimsResponseDto(
+                                sharedClaims.getName(),
+                                sharedClaims.getBirthDate(),
+                                sharedClaims.getAddress());
+                claimsSetBuilder.claim(SHARED_CLAIMS, response);
+            }
         }
 
         SignedJWT signedJWT = new SignedJWT(header, claimsSetBuilder.build());

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -571,7 +571,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(TEST_USER_ID, signedJWT.getJWTClaimsSet().getSubject());
         assertEquals(CRI_AUDIENCE, signedJWT.getJWTClaimsSet().getAudience().get(0));
 
-        assertEquals(4, claimsSet.get(TEST_SHARED_CLAIMS).size());
+        assertEquals(3, claimsSet.get(TEST_SHARED_CLAIMS).size());
         JsonNode vcAttributes = claimsSet.get(TEST_SHARED_CLAIMS);
 
         JsonNode address = vcAttributes.get("address");
@@ -974,7 +974,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(3, sharedClaims.get("name").size());
         assertEquals(2, sharedClaims.get("birthDate").size());
         assertEquals(1, sharedClaims.get("address").size());
-        assertTrue(sharedClaims.get("email").isNull());
+        assertFalse(sharedClaims.has("emailAddress"));
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
     }
 
@@ -1037,7 +1037,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(3, sharedClaims.get("name").size());
         assertEquals(2, sharedClaims.get("birthDate").size());
         assertEquals(1, sharedClaims.get("address").size());
-        assertEquals(TEST_EMAIL_ADDRESS, sharedClaims.get("email").asText());
+        assertEquals(TEST_EMAIL_ADDRESS, sharedClaims.get("emailAddress").asText());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -8,7 +9,7 @@ import org.apache.logging.log4j.message.StringMapMessage;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-@JsonPropertyOrder({"name", "birthDate", "address", "email"})
+@JsonPropertyOrder({"name", "birthDate", "address", "emailAddress"})
 public class SharedClaimsResponse {
 
     private static final Logger LOGGER = LogManager.getLogger();
@@ -16,14 +17,14 @@ public class SharedClaimsResponse {
     private final Set<Name> name;
     private final Set<BirthDate> birthDate;
     private final Set<Address> address;
-    private final String email;
+    private final String emailAddress;
 
     public SharedClaimsResponse(
-            Set<Name> name, Set<BirthDate> birthDate, Set<Address> address, String email) {
+            Set<Name> name, Set<BirthDate> birthDate, Set<Address> address, String emailAddress) {
         this.name = name;
         this.birthDate = birthDate;
         this.address = address;
-        this.email = email;
+        this.emailAddress = emailAddress;
     }
 
     public Set<Name> getName() {
@@ -38,11 +39,13 @@ public class SharedClaimsResponse {
         return address;
     }
 
-    public String getEmail() {
-        return email;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getEmailAddress() {
+        return emailAddress;
     }
 
-    public static SharedClaimsResponse from(Set<SharedClaims> sharedAttributes, String email) {
+    public static SharedClaimsResponse from(
+            Set<SharedClaims> sharedAttributes, String emailAddress) {
         Set<Name> nameSet = new LinkedHashSet<>();
         Set<BirthDate> birthDateSet = new LinkedHashSet<>();
         Set<Address> addressSet = new LinkedHashSet<>();
@@ -62,6 +65,6 @@ public class SharedClaimsResponse {
                         .with("addresses", addressSet.size());
         LOGGER.info(message);
 
-        return new SharedClaimsResponse(nameSet, birthDateSet, addressSet, email);
+        return new SharedClaimsResponse(nameSet, birthDateSet, addressSet, emailAddress);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseDto.java
@@ -1,0 +1,35 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.Set;
+
+@ExcludeFromGeneratedCoverageReport
+@JsonPropertyOrder({"name", "birthDate", "address"})
+public class SharedClaimsResponseDto {
+
+    private final Set<Name> name;
+    private final Set<BirthDate> birthDate;
+    private final Set<Address> address;
+
+    public SharedClaimsResponseDto(Set<Name> name, Set<BirthDate> birthDate, Set<Address> address) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.address = address;
+    }
+
+    public Set<Name> getName() {
+        return name;
+    }
+
+    public Set<BirthDate> getBirthDate() {
+        return birthDate;
+    }
+
+    public Set<Address> getAddress() {
+        return address;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseDto.java
@@ -1,8 +1,6 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.Set;

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseTest.java
@@ -58,6 +58,6 @@ class SharedClaimsResponseTest {
         assertEquals(2, sharedClaimsResponse.getName().size());
         assertEquals(2, sharedClaimsResponse.getAddress().size());
         assertEquals(2, sharedClaimsResponse.getBirthDate().size());
-        assertEquals(TEST_EMAIL_ADDRESS, sharedClaimsResponse.getEmail());
+        assertEquals(TEST_EMAIL_ADDRESS, sharedClaimsResponse.getEmailAddress());
     }
 }


### PR DESCRIPTION
to exclude the email property from ClaimSet when it is null and rename the property to 'emailAddress'

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

to exclude the email property from ClaimSet when it is null and rename the property to 'emailAddress'

### Why did it change

Address CRI doesn't expectation email and null value.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2991](https://govukverify.atlassian.net/browse/PYIC-2991)



[PYIC-2991]: https://govukverify.atlassian.net/browse/PYIC-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ