### PR TITLE
PYIC-3010: Load statemachines and select from session

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/exceptions/StateMachineNotFoundException.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/exceptions/StateMachineNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions;
+
+public class StateMachineNotFoundException extends Exception {
+    public StateMachineNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
@@ -1,7 +1,8 @@
 package uk.gov.di.ipv.core.library.domain;
 
 public enum IpvJourneyTypes {
-    IPV_CORE_MAIN_JOURNEY("ipv-core-main-journey");
+    IPV_CORE_MAIN_JOURNEY("ipv-core-main-journey"),
+    IPV_CORE_REFACTOR_JOURNEY("ipv-core-refactor-journey");
 
     private final String value;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -52,7 +52,8 @@ public class LogHelper {
         LOG_PAYLOAD("payload"),
         LOG_STATUS_CODE("statusCode"),
         LOG_PARAMETER_PATH("parameterPath"),
-        LOG_FEATURE_SET("featureSet");
+        LOG_FEATURE_SET("featureSet"),
+        LOG_JOURNEY_TYPE("journeyType");
         private final String fieldName;
 
         LogField(String fieldName) {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Load statemachines and select from session

### Why did it change

This adds logic to the process-journey-step state machine to load statemachine files for the journey types that we care about. This is now the main journey that users are currently running, as well as the refactor journey that we're building.

The lambda will then use the state machine for the correct journey type, set in their session when it was initialized. If a matching state machine can't be found (which shouldn't ever happen), we log it and throw an error.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3010](https://govukverify.atlassian.net/browse/PYIC-3010)


[PYIC-3010]: https://govukverify.atlassian.net/browse/PYIC-3010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ