### PR TITLE
PYIC-3011: Move evaluate-gpg45-scores lambda to criReturn step function

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -35,6 +35,17 @@
         "featureSet.$": "$.featureSet"
       },
       "ResultPath": "$.lambdaResult",
+      "Next": "RunEvaluateGpg45ScoresForRefactorJourney"
+    },
+    "EvaluateGpg45Scores": {
+      "Type": "Task",
+      "Resource": "${EvaluateGpg45ScoresFunctionArn}",
+      "Parameters": {
+        "ipvSessionId.$": "$.ipvSessionId",
+        "ipAddress.$": "$.ipAddress",
+        "featureSet.$": "$.featureSet"
+      },
+      "ResultPath": "$.lambdaResult",
       "Next": "ReturnToFrontend"
     },
     "RetrieveCriOAuthAccessTokenError": {
@@ -62,6 +73,17 @@
           "Variable": "$.lambdaResult.journey",
           "StringEquals": "/journey/cri/access-token",
           "Next": "RetrieveCriOauthAccessToken"
+        }
+      ],
+      "Default": "ReturnToFrontend"
+    },
+    "RunEvaluateGpg45ScoresForRefactorJourney": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.lambdaResult.journeyType",
+          "StringEquals": "ipv-core-refactor-journey",
+          "Next": "EvaluateGpg45Scores"
         }
       ],
       "Default": "ReturnToFrontend"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1308,6 +1308,7 @@ Resources:
         RetrieveCriCredentialFunctionArn: !GetAtt RetrieveCriCredentialFunction.Arn
         RetrieveCriOauthAccessTokenFunctionArn: !GetAtt RetrieveCriOauthAccessTokenFunction.Arn
         ValidateOAuthCallbackFunctionArn: !GetAtt ValidateOAuthCallbackFunction.Arn
+        EvaluateGpg45ScoresFunctionArn: !GetAtt EvaluateGpg45ScoresFunction.Arn
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1331,6 +1332,8 @@ Resources:
             FunctionName: !Ref RetrieveCriOauthAccessTokenFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref ValidateOAuthCallbackFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref EvaluateGpg45ScoresFunction
         - Statement:
             - Sid: CloudWatchLogsAccess
               Effect: Allow

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -49,6 +49,7 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredent
 import uk.gov.di.ipv.core.library.verifiablecredential.validation.VerifiableCredentialJwtValidator;
 
 import java.text.ParseException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,6 +70,7 @@ public class RetrieveCriCredentialHandler
     private static final Map<String, Object> JOURNEY_NEXT = Map.of(JOURNEY, "/journey/next");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
     private static final Map<String, Object> JOURNEY_PENDING = Map.of(JOURNEY, "/journey/pending");
+    public static final String JOURNEY_TYPE_KEY = "journeyType";
 
     private final VerifiableCredentialService verifiableCredentialService;
     private final IpvSessionService ipvSessionService;
@@ -244,7 +246,13 @@ public class RetrieveCriCredentialHandler
                                 LOG_LAMBDA_RESULT.getFieldName(),
                                 "Successfully processed CRI pending response.")
                         .with(LOG_CRI_ID.getFieldName(), credentialIssuerId));
-        return JOURNEY_PENDING;
+
+        // Add journey type to the response to allow temporary flow control in step function while
+        // refactoring journey
+        HashMap<String, Object> pendingLambdaResult = new HashMap<>(JOURNEY_PENDING);
+        pendingLambdaResult.put(JOURNEY_TYPE_KEY, ipvSessionItem.getJourneyType().getValue());
+
+        return pendingLambdaResult;
     }
 
     private Map<String, Object> processVerifiableCredentials(
@@ -290,7 +298,12 @@ public class RetrieveCriCredentialHandler
                                 "Successfully retrieved CRI credential.")
                         .with(LOG_CRI_ID.getFieldName(), credentialIssuerId));
 
-        return JOURNEY_NEXT;
+        // Add journey type to the response to allow temporary flow control in step function while
+        // refactoring journey
+        HashMap<String, Object> nextLambdaResult = new HashMap<>(JOURNEY_NEXT);
+        nextLambdaResult.put(JOURNEY_TYPE_KEY, ipvSessionItem.getJourneyType().getValue());
+
+        return nextLambdaResult;
     }
 
     @Tracing


### PR DESCRIPTION



<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This adds the evaluate-gpg45-scores lambda into the criReturn step function, and runs it after the retrieve-cri-credential lambda IF the user is on an 'ipv-core-refactor-journey' type journey.

### Why did it change

This change allows us to refactor the journey state machine files without affecting the current main user journey.

The retrieve-cri-credential lambda has had its output instruments with the users journey type from their session. This is the used in the step function to decide if it should run the evaluate-gpg45-scores lambda. This instrumentation and logic will be removed once the refactor work has been completed.

This change has been deployed to my dev account, and tested with each type of user journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3011](https://govukverify.atlassian.net/browse/PYIC-3011)

[PYIC-3011]: https://govukverify.atlassian.net/browse/PYIC-3011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ