### PR TITLE
PYIC-3038 Return F2F pending page if pending response and no VC

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -71,6 +71,7 @@ public class CheckExistingIdentityHandler extends JourneyRequestLambda {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
+    private static final JourneyResponse JOURNEY_PENDING = new JourneyResponse("/journey/pending");
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
 
     private final ConfigService configService;
@@ -151,6 +152,7 @@ public class CheckExistingIdentityHandler extends JourneyRequestLambda {
                                         LOG_MESSAGE_DESCRIPTION.getFieldName(),
                                         "F2F cri pending verification.");
                 LOGGER.info(message);
+                return JOURNEY_PENDING;
             }
 
             List<SignedJWT> credentials =

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -98,6 +98,7 @@ class CheckExistingIdentityHandlerTest {
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
     private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
+    private static final JourneyResponse JOURNEY_PENDING = new JourneyResponse("/journey/pending");
     private static final ObjectMapper mapper = new ObjectMapper();
 
     static {
@@ -324,24 +325,16 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnNextDeleteVcIfFaceToFaceVerificationIsPending() throws Exception {
+    void shouldReturnPendingResponseIfFaceToFaceVerificationIsPending() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(userIdentityService.getVcStoreItem(TEST_USER_ID, F2F_CRI)).thenReturn(null);
         when(criResponseService.userHasFaceToFaceRequest(TEST_USER_ID)).thenReturn(true);
-        when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
-                .thenReturn(Optional.empty());
-        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
-                .thenReturn(Optional.empty());
-        when(gpg45ProfileEvaluator.parseCredentials(any())).thenCallRealMethod();
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
         var journeyResponse = handleRequest(event, context, JourneyResponse.class);
-        assertEquals(JOURNEY_NEXT, journeyResponse);
-
-        verify(userIdentityService, times(1)).deleteVcStoreItems(TEST_USER_ID);
-        verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+        assertEquals(JOURNEY_PENDING, journeyResponse);
+        verify(userIdentityService, times(0)).deleteVcStoreItems(TEST_USER_ID);
     }
 
     @Test

--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -114,8 +114,18 @@ CHECK_EXISTING_IDENTITY:
       response:
         type: page
         pageId: page-ipv-reuse
+    pending:
+      type: basic
+      name: pending
+      targetState: IPV_IDENTITY_PENDING_PAGE
+      response:
+        type: page
+        pageId: page-ipv-pending
 IPV_IDENTITY_REUSE_PAGE:
   name: IPV_IDENTITY_REUSE_PAGE
+  parent: END_JOURNEY
+IPV_IDENTITY_PENDING_PAGE:
+  name: IPV_IDENTITY_PENDING_PAGE
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -107,8 +107,18 @@ CHECK_EXISTING_IDENTITY:
       response:
         type: page
         pageId: page-ipv-reuse
+    pending:
+      type: basic
+      name: pending
+      targetState: IPV_IDENTITY_PENDING_PAGE
+      response:
+        type: page
+        pageId: page-ipv-pending
 IPV_IDENTITY_REUSE_PAGE:
   name: IPV_IDENTITY_REUSE_PAGE
+  parent: END_JOURNEY
+IPV_IDENTITY_PENDING_PAGE:
+  name: IPV_IDENTITY_PENDING_PAGE
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -107,8 +107,18 @@ CHECK_EXISTING_IDENTITY:
       response:
         type: page
         pageId: page-ipv-reuse
+    pending:
+      type: basic
+      name: pending
+      targetState: IPV_IDENTITY_PENDING_PAGE
+      response:
+        type: page
+        pageId: page-ipv-pending
 IPV_IDENTITY_REUSE_PAGE:
   name: IPV_IDENTITY_REUSE_PAGE
+  parent: END_JOURNEY
+IPV_IDENTITY_PENDING_PAGE:
+  name: IPV_IDENTITY_PENDING_PAGE
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -107,8 +107,18 @@ CHECK_EXISTING_IDENTITY:
       response:
         type: page
         pageId: page-ipv-reuse
+    pending:
+      type: basic
+      name: pending
+      targetState: IPV_IDENTITY_PENDING_PAGE
+      response:
+        type: page
+        pageId: page-ipv-pending
 IPV_IDENTITY_REUSE_PAGE:
   name: IPV_IDENTITY_REUSE_PAGE
+  parent: END_JOURNEY
+IPV_IDENTITY_PENDING_PAGE:
+  name: IPV_IDENTITY_PENDING_PAGE
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -107,8 +107,18 @@ CHECK_EXISTING_IDENTITY:
       response:
         type: page
         pageId: page-ipv-reuse
+    pending:
+      type: basic
+      name: pending
+      targetState: IPV_IDENTITY_PENDING_PAGE
+      response:
+        type: page
+        pageId: page-ipv-pending
 IPV_IDENTITY_REUSE_PAGE:
   name: IPV_IDENTITY_REUSE_PAGE
+  parent: END_JOURNEY
+IPV_IDENTITY_PENDING_PAGE:
+  name: IPV_IDENTITY_PENDING_PAGE
   parent: END_JOURNEY
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES


### PR DESCRIPTION
## Proposed changes

### What changed

Send the user to a new 'pending' page if they have a pending F2F response but no VC yet. The content on the page is subject to change and for now the 'continue' button just ends the journey and returns the user to the RP.

### Why did it change

To make a start on handling the user's return to IPV Core in the 'pending' scenario, when they return before we've received a result from the Post Office.

### Issue tracking
- [PYIC-3038](https://govukverify.atlassian.net/browse/PYIC-3038)



[PYIC-3038]: https://govukverify.atlassian.net/browse/PYIC-3038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ