### PR TITLE
PYIC-3012: Create new CRI event type for state machine

### DIFF
--- a/lambdas/process-journey-step/build.gradle
+++ b/lambdas/process-journey-step/build.gradle
@@ -23,7 +23,8 @@ dependencies {
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.9.3",
-			"org.mockito:mockito-junit-jupiter:5.4.0"
+			"org.mockito:mockito-junit-jupiter:5.4.0",
+			"uk.org.webcompere:system-stubs-jupiter:2.0.2"
 }
 
 java {

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/CriEvent.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/CriEvent.java
@@ -1,0 +1,51 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.State;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineResult;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyResponse;
+
+import java.util.LinkedHashMap;
+import java.util.Optional;
+
+@Data
+public class CriEvent implements Event {
+    public static final String CRI_JOURNEY_TEMPLATE = "/journey/cri/build-oauth-request/%s";
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @JsonIgnore private ConfigService configService;
+    private State targetState;
+    private String criId;
+    private LinkedHashMap<String, Event> checkIfDisabled;
+
+    public CriEvent() {
+        this.configService = new ConfigService();
+    }
+
+    public CriEvent(ConfigService configService) {
+        this.configService = configService;
+    }
+
+    @Override
+    public StateMachineResult resolve(JourneyContext journeyContext) {
+        if (checkIfDisabled != null) {
+            Optional<String> firstDisabledCri =
+                    checkIfDisabled.keySet().stream()
+                            .filter(id -> !configService.isEnabled(id))
+                            .findFirst();
+            if (firstDisabledCri.isPresent()) {
+                String disabledCriId = firstDisabledCri.get();
+                LOGGER.info("CRI with ID '{}' is disabled. Using alternative event", criId);
+                return checkIfDisabled.get(disabledCriId).resolve(journeyContext);
+            }
+        }
+
+        return new StateMachineResult(
+                targetState, new JourneyResponse(String.format(CRI_JOURNEY_TEMPLATE, criId)));
+    }
+}

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/Event.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/Event.java
@@ -5,8 +5,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineResult;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@JsonSubTypes({@JsonSubTypes.Type(value = BasicEvent.class, name = "basic")})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = BasicEvent.class, name = "basic"),
+    @JsonSubTypes.Type(value = CriEvent.class, name = "cri")
+})
 public interface Event {
     StateMachineResult resolve(JourneyContext journeyContext);
 }

--- a/lambdas/process-journey-step/src/main/resources/test/statemachine/events/criEvent.yaml
+++ b/lambdas/process-journey-step/src/main/resources/test/statemachine/events/criEvent.yaml
@@ -1,0 +1,18 @@
+type: cri
+targetState: CRI_SAUSAGES
+criId: sausages
+checkIfDisabled:
+  first-cri-id-to-check:
+    type: basic
+    name: sorry-page
+    targetState: SORRY_NO_SAUSAGES_PAGE
+    response:
+      type: page
+      pageId: page-sorry-no-sausages-at-the-moment
+  second-cri-id-to-check:
+    type: basic
+    name: not-sorry-page
+    targetState: NOT_SORRY_STATE
+    response:
+      type: page
+      pageId: page-not-sorry-at-all

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/CriEventTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/CriEventTest.java
@@ -1,0 +1,171 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.State;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineResult;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyResponse;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.PageResponse;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class CriEventTest {
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @Mock private ConfigService mockConfigService;
+
+    @Test
+    void resolveShouldReturnAStateMachineResult() {
+        State state = new State("sausages");
+
+        CriEvent criEvent = new CriEvent(mockConfigService);
+        criEvent.setTargetState(state);
+        criEvent.setCriId("aCriId");
+
+        StateMachineResult result = criEvent.resolve(JourneyContext.emptyContext());
+
+        assertEquals(state, result.getState());
+        assertEquals(
+                "/journey/cri/build-oauth-request/aCriId",
+                result.getJourneyStepResponse().value(mockConfigService).get("journey"));
+    }
+
+    @Test
+    void resolveShouldReturnAlternativeResultIfACheckedCriIsDisabled() {
+        CriEvent criEventWithCheckIfDisabledConfigured = new CriEvent(mockConfigService);
+        criEventWithCheckIfDisabledConfigured.setTargetState(new State());
+        criEventWithCheckIfDisabledConfigured.setCriId("aCriId");
+
+        BasicEvent alternativeEvent = new BasicEvent();
+        State alternativeState = new State("THE_TARGET_STATE_FOR_THE_ALTERNATIVE_RESULT");
+        JourneyResponse alternativeJourneyResponse = new JourneyResponse();
+        alternativeJourneyResponse.setJourneyStepId("alternativeStepId");
+        alternativeEvent.setTargetState(alternativeState);
+        alternativeEvent.setResponse(alternativeJourneyResponse);
+
+        when(mockConfigService.isEnabled("anEnabledCri")).thenReturn(true);
+        when(mockConfigService.isEnabled("anotherEnabledCri")).thenReturn(true);
+        when(mockConfigService.isEnabled("aDisabledCri")).thenReturn(false);
+        LinkedHashMap<String, Event> checkIfDisabled = new LinkedHashMap<>();
+        checkIfDisabled.put("anEnabledCri", new BasicEvent());
+        checkIfDisabled.put("anotherEnabledCri", new BasicEvent());
+        checkIfDisabled.put("aDisabledCri", alternativeEvent);
+        criEventWithCheckIfDisabledConfigured.setCheckIfDisabled(checkIfDisabled);
+
+        StateMachineResult result =
+                criEventWithCheckIfDisabledConfigured.resolve(JourneyContext.emptyContext());
+
+        assertEquals(alternativeState, result.getState());
+        assertEquals(
+                "alternativeStepId",
+                result.getJourneyStepResponse().value(mockConfigService).get("journey"));
+    }
+
+    @Test
+    void resolveShouldReturnFirstAlternativeResultIfMultipleCheckedCrisAreDisabled() {
+        CriEvent criEventWithCheckIfDisabledConfigured = new CriEvent(mockConfigService);
+        criEventWithCheckIfDisabledConfigured.setTargetState(new State());
+        criEventWithCheckIfDisabledConfigured.setCriId("aCriId");
+
+        BasicEvent alternativeEvent = new BasicEvent();
+        State alternativeState = new State("THE_TARGET_STATE_FOR_THE_ALTERNATIVE_RESULT");
+        JourneyResponse alternativeJourneyResponse = new JourneyResponse();
+        alternativeJourneyResponse.setJourneyStepId("alternativeStepId");
+        alternativeEvent.setTargetState(alternativeState);
+        alternativeEvent.setResponse(alternativeJourneyResponse);
+
+        when(mockConfigService.isEnabled("anEnabledCri")).thenReturn(true);
+        when(mockConfigService.isEnabled("aDisabledCri")).thenReturn(false);
+        LinkedHashMap<String, Event> checkIfDisabled = new LinkedHashMap<>();
+        checkIfDisabled.put("anEnabledCri", new BasicEvent());
+        checkIfDisabled.put("aDisabledCri", alternativeEvent);
+        checkIfDisabled.put("anotherDisabledCri", new BasicEvent());
+        criEventWithCheckIfDisabledConfigured.setCheckIfDisabled(checkIfDisabled);
+
+        StateMachineResult result =
+                criEventWithCheckIfDisabledConfigured.resolve(JourneyContext.emptyContext());
+
+        assertEquals(alternativeState, result.getState());
+        assertEquals(
+                "alternativeStepId",
+                result.getJourneyStepResponse().value(mockConfigService).get("journey"));
+    }
+
+    @Test
+    void resolveShouldReturnCriResultIfAllCheckedCrisAreEnabled() {
+        State state = new State("THE_TARGET_STATE_FOR_THE_CRI_EVENT");
+
+        CriEvent criEventWithCheckIfDisabledConfigured = new CriEvent(mockConfigService);
+        criEventWithCheckIfDisabledConfigured.setTargetState(state);
+        criEventWithCheckIfDisabledConfigured.setCriId("aCriId");
+
+        when(mockConfigService.isEnabled("anEnabledCri")).thenReturn(true);
+        when(mockConfigService.isEnabled("anotherEnabledCri")).thenReturn(true);
+        when(mockConfigService.isEnabled("oneMoreEnabledCri")).thenReturn(true);
+        LinkedHashMap<String, Event> checkIfDisabled = new LinkedHashMap<>();
+        checkIfDisabled.put("anEnabledCri", new BasicEvent());
+        checkIfDisabled.put("anotherEnabledCri", new BasicEvent());
+        checkIfDisabled.put("oneMoreEnabledCri", new BasicEvent());
+        criEventWithCheckIfDisabledConfigured.setCheckIfDisabled(checkIfDisabled);
+
+        StateMachineResult result =
+                criEventWithCheckIfDisabledConfigured.resolve(JourneyContext.emptyContext());
+
+        assertEquals(state, result.getState());
+        assertEquals(
+                "/journey/cri/build-oauth-request/aCriId",
+                result.getJourneyStepResponse().value(mockConfigService).get("journey"));
+    }
+
+    @Test
+    void shouldBeDeserializableFromYaml() throws Exception {
+        environmentVariables.set("IS_LOCAL", "true");
+        ObjectMapper om = new ObjectMapper(new YAMLFactory());
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        File file =
+                new File(
+                        Objects.requireNonNull(
+                                        classLoader.getResource(
+                                                "test/statemachine/events/criEvent.yaml"))
+                                .getFile());
+
+        CriEvent criEvent = om.readValue(file, new TypeReference<>() {});
+        assertEquals("sausages", criEvent.getCriId());
+        assertEquals("CRI_SAUSAGES", criEvent.getTargetState().getName());
+
+        LinkedHashMap<String, Event> checkIfDisabledBlock = criEvent.getCheckIfDisabled();
+        assertEquals(2, checkIfDisabledBlock.entrySet().size());
+
+        BasicEvent firstAlternative =
+                (BasicEvent) checkIfDisabledBlock.get("first-cri-id-to-check");
+        assertEquals("sorry-page", firstAlternative.getName());
+        assertEquals("SORRY_NO_SAUSAGES_PAGE", firstAlternative.getTargetState().getName());
+        PageResponse firstAlternativeResponse = (PageResponse) firstAlternative.getResponse();
+        assertEquals("page-sorry-no-sausages-at-the-moment", firstAlternativeResponse.getPageId());
+
+        BasicEvent secondAlternative =
+                (BasicEvent) checkIfDisabledBlock.get("second-cri-id-to-check");
+        assertEquals("not-sorry-page", secondAlternative.getName());
+        assertEquals("NOT_SORRY_STATE", secondAlternative.getTargetState().getName());
+        PageResponse secondAlternativeResponse = (PageResponse) secondAlternative.getResponse();
+        assertEquals("page-not-sorry-at-all", secondAlternativeResponse.getPageId());
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Create new CRI event type for state machine

### Why did it change

This new event type does a couple of things.

First it adds a bit of sugar on creating the journey response for a CRI, to keep the statemachine file a bit cleaner.

Second, it adds a new `disabled` property which defines an event to use in the case the CRI is set as disabled.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3012](https://govukverify.atlassian.net/browse/PYIC-3012)


[PYIC-3012]: https://govukverify.atlassian.net/browse/PYIC-3012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ