### PR TITLE
Remove legacy mitigation states from process-journey-step state machine definitions

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -61,17 +61,6 @@ END_JOURNEY:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-MITIGATION_JOURNEY:
-  name: MITIGATION_JOURNEY
-  parent: ATTEMPT_RECOVERY_STATE
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -247,20 +236,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-dcmaw-success
-    end-mj01:
-      type: basic
-      name: end-mj01
-      targetState: END_MJ01
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ01
-    end-mj02:
-      type: basic
-      name: end-mj02
-      targetState: END_MJ02
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ02
     fail:
       type: basic
       name: fail
@@ -500,12 +475,6 @@ CRI_DCMAW:
         type: error
         pageId: pyi-technical
         statusCode: 500
-END_MJ01:
-  name: END_MJ01
-  parent: MITIGATION_JOURNEY
-END_MJ02:
-  name: END_MJ02
-  parent: MITIGATION_JOURNEY
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -54,17 +54,6 @@ END_JOURNEY:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-MITIGATION_JOURNEY:
-  name: MITIGATION_JOURNEY
-  parent: ATTEMPT_RECOVERY_STATE
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -240,20 +229,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-dcmaw-success
-    end-mj01:
-      type: basic
-      name: end-mj01
-      targetState: END_MJ01
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ01
-    end-mj02:
-      type: basic
-      name: end-mj02
-      targetState: END_MJ02
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ02
     fail:
       type: basic
       name: fail
@@ -493,12 +468,6 @@ CRI_DCMAW:
         type: error
         pageId: pyi-technical
         statusCode: 500
-END_MJ01:
-  name: END_MJ01
-  parent: MITIGATION_JOURNEY
-END_MJ02:
-  name: END_MJ02
-  parent: MITIGATION_JOURNEY
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -54,17 +54,6 @@ END_JOURNEY:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-MITIGATION_JOURNEY:
-  name: MITIGATION_JOURNEY
-  parent: ATTEMPT_RECOVERY_STATE
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -240,20 +229,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-dcmaw-success
-    end-mj01:
-      type: basic
-      name: end-mj01
-      targetState: END_MJ01
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ01
-    end-mj02:
-      type: basic
-      name: end-mj02
-      targetState: END_MJ02
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ02
     fail:
       type: basic
       name: fail
@@ -493,12 +468,6 @@ CRI_DCMAW:
         type: error
         pageId: pyi-technical
         statusCode: 500
-END_MJ01:
-  name: END_MJ01
-  parent: MITIGATION_JOURNEY
-END_MJ02:
-  name: END_MJ02
-  parent: MITIGATION_JOURNEY
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -54,17 +54,6 @@ END_JOURNEY:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-MITIGATION_JOURNEY:
-  name: MITIGATION_JOURNEY
-  parent: ATTEMPT_RECOVERY_STATE
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -240,20 +229,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-dcmaw-success
-    end-mj01:
-      type: basic
-      name: end-mj01
-      targetState: END_MJ01
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ01
-    end-mj02:
-      type: basic
-      name: end-mj02
-      targetState: END_MJ02
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ02
     fail:
       type: basic
       name: fail
@@ -493,12 +468,6 @@ CRI_DCMAW:
         type: error
         pageId: pyi-technical
         statusCode: 500
-END_MJ01:
-  name: END_MJ01
-  parent: MITIGATION_JOURNEY
-END_MJ02:
-  name: END_MJ02
-  parent: MITIGATION_JOURNEY
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -54,17 +54,6 @@ END_JOURNEY:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-MITIGATION_JOURNEY:
-  name: MITIGATION_JOURNEY
-  parent: ATTEMPT_RECOVERY_STATE
-  events:
-    next:
-      type: basic
-      name: next
-      targetState: EVALUATE_GPG45_SCORES
-      response:
-        type: journey
-        journeyStepId: /journey/evaluate-gpg45-scores
 
 #child states
 INITIAL_IPV_JOURNEY:
@@ -240,20 +229,6 @@ SELECT_CRI:
       response:
         type: page
         pageId: page-dcmaw-success
-    end-mj01:
-      type: basic
-      name: end-mj01
-      targetState: END_MJ01
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ01
-    end-mj02:
-      type: basic
-      name: end-mj02
-      targetState: END_MJ02
-      response:
-        type: journey
-        journeyStepId: /journey/end-mitigation-journey/MJ02
     fail:
       type: basic
       name: fail
@@ -493,12 +468,6 @@ CRI_DCMAW:
         type: error
         pageId: pyi-technical
         statusCode: 500
-END_MJ01:
-  name: END_MJ01
-  parent: MITIGATION_JOURNEY
-END_MJ02:
-  name: END_MJ02
-  parent: MITIGATION_JOURNEY
 IPV_SUCCESS_PAGE:
   name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY


### PR DESCRIPTION
PYIC-3023 Remove legacy mitigation states from process-journey-step state machine definitions

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Remove legacy mitigation states from process-journey-step state machine definitions

### Why did it change

We need to ‘clean house’ prior to undertaking the V03 mitigation work.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3023](https://govukverify.atlassian.net/browse/PYIC-3023)



[PYIC-3023]: https://govukverify.atlassian.net/browse/PYIC-3023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ