### PR TITLE
PYIC-3042: RetrieveCriCredential to send VCs to CIMIT Post Mitigations when usePostMitigations feature flag set

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -827,6 +827,16 @@ Resources:
                 - EnvironmentConfiguration
                 - !Ref AWS::AccountId
                 - environment
+          CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN: !Sub
+            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:postMitigations-${env}"
+            - contra_indicator_storage_account_id: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - ciStorageAccountId
+              env: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - environment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -888,6 +898,21 @@ Resources:
               Resource:
                 - !Sub
                   - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraIndicators-${env}"
+                  - contra_indicator_storage_account_id: !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - ciStorageAccountId
+                    env: !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - environment
+            - Sid: invokePostCiMitigationFunction
+              Effect: Allow
+              Action:
+                - 'lambda:InvokeFunction'
+              Resource:
+                - !Sub
+                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:postMitigations-${env}"
                   - contra_indicator_storage_account_id: !FindInMap
                       - EnvironmentConfiguration
                       - !Ref AWS::AccountId

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
@@ -88,7 +88,7 @@ public class CiStorageService {
                                                 ipAddress,
                                                 verifiableCredentialList)));
 
-        LOGGER.info("Sending mitigating VC's to CI storage system.");
+        LOGGER.info("Sending mitigating VCs to CI storage system.");
         InvokeResult result = lambdaClient.invoke(request);
 
         if (lambdaExecutionFailed(result)) {


### PR DESCRIPTION
## Proposed changes

### What changed
`RetrieveCriCredentialHandler` updated to send all VCs to CIMIT postMitigations function when `usePostMitigations` feature flag is set true.

### Why did it change
Prerequisite for enabling mitigation of contraindicators

### Issue tracking

- [PYIC-3042](https://govukverify.atlassian.net/browse/PYIC-3042)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations



[PYIC-3042]: https://govukverify.atlassian.net/browse/PYIC-3042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ