### PR TITLE
PYIC-3046 Handle F2F restart event to clear VCs and return user to start

### DIFF
--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -53,7 +53,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_F2F_VC;
@@ -72,16 +71,8 @@ class CheckExistingIdentityHandlerTest {
     private static final String TEST_FEATURE_SET = "test-feature-set";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
 
-    private static final String TEST_JOURNEY = DCMAW_CRI;
+    private static final String TEST_JOURNEY = "journey/check-existing-identity";
 
-    private static final JourneyRequest event =
-            JourneyRequest.builder()
-                    .ipvSessionId(TEST_SESSION_ID)
-                    .ipAddress(TEST_CLIENT_SOURCE_IP)
-                    .clientOAuthSessionId(TEST_CLIENT_SOURCE_IP)
-                    .journey(TEST_JOURNEY)
-                    .featureSet(TEST_FEATURE_SET)
-                    .build();
     private static final List<String> CREDENTIALS =
             List.of(
                     M1A_PASSPORT_VC,
@@ -144,6 +135,7 @@ class CheckExistingIdentityHandlerTest {
     @Mock private ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     @InjectMocks private CheckExistingIdentityHandler checkExistingIdentityHandler;
 
+    private JourneyRequest event;
     private IpvSessionItem ipvSessionItem;
     private ClientOAuthSessionItem clientOAuthSessionItem;
 
@@ -156,6 +148,15 @@ class CheckExistingIdentityHandlerTest {
 
     @BeforeEach
     void setUpEach() {
+        event =
+                JourneyRequest.builder()
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .ipAddress(TEST_CLIENT_SOURCE_IP)
+                        .clientOAuthSessionId(TEST_CLIENT_SOURCE_IP)
+                        .journey(TEST_JOURNEY)
+                        .featureSet(TEST_FEATURE_SET)
+                        .build();
+
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setIpvSessionId(TEST_SESSION_ID);

--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -142,6 +142,13 @@ IPV_IDENTITY_PENDING_PAGE:
       response:
         type: page
         pageId: page-face-to-face-handoff
+    restart:
+      type: basic
+      name: restart
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -135,6 +135,13 @@ IPV_IDENTITY_PENDING_PAGE:
       response:
         type: page
         pageId: page-face-to-face-handoff
+    restart:
+      type: basic
+      name: restart
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -135,6 +135,13 @@ IPV_IDENTITY_PENDING_PAGE:
       response:
         type: page
         pageId: page-face-to-face-handoff
+    restart:
+      type: basic
+      name: restart
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
@@ -147,6 +147,13 @@ IPV_IDENTITY_PENDING_PAGE:
       response:
         type: page
         pageId: page-ipv-pending
+    continue:
+      type: basic
+      name: continue
+      targetState: F2F_HANDOFF_PAGE
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
     restart:
       type: basic
       name: restart

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
@@ -147,6 +147,13 @@ IPV_IDENTITY_PENDING_PAGE:
       response:
         type: page
         pageId: page-ipv-pending
+    restart:
+      type: basic
+      name: restart
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
 
 CRI_DCMAW:
   name: CRI_DCMAW

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -135,6 +135,13 @@ IPV_IDENTITY_PENDING_PAGE:
       response:
         type: page
         pageId: page-face-to-face-handoff
+    restart:
+      type: basic
+      name: restart
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -135,6 +135,13 @@ IPV_IDENTITY_PENDING_PAGE:
       response:
         type: page
         pageId: page-face-to-face-handoff
+    restart:
+      type: basic
+      name: restart
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.statemachine.JourneyRequestLambda;
 
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 
 public class ResetIdentityHandler extends JourneyRequestLambda {
@@ -88,6 +89,7 @@ public class ResetIdentityHandler extends JourneyRequestLambda {
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
             userIdentityService.deleteVcStoreItems(userId);
+            criResponseService.deleteCriResponseItem(userId, F2F_CRI);
 
             return JOURNEY_NEXT;
         } catch (HttpResponseExceptionWithErrorBody e) {

--- a/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
+++ b/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 
 @ExtendWith(MockitoExtension.class)
 public class ResetIdentityHandlerTest {
@@ -81,6 +82,7 @@ public class ResetIdentityHandlerTest {
         var journeyResponse = resetIdentityHandler.handleRequest(event, context);
 
         verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID);
+        verify(criResponseService).deleteCriResponseItem(TEST_USER_ID, F2F_CRI);
         assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -58,4 +58,8 @@ public class CriResponseService {
         CriResponseItem userRequest = dataStore.getItem(userId, "f2f");
         return !Objects.isNull(userRequest);
     }
+
+    public void deleteCriResponseItem(String userId, String credentialIssuer) {
+        dataStore.delete(userId, credentialIssuer);
+    }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Add 'restart' event for the F2F pending page which points to the new reset-identity lambda, which clears the user's existing VCs and F2F CRI response item and returns next which takes them to the start of the journey (app eligibility/doc select page for now)

### Why did it change

When a returning user hits the F2F pending page they have the option to 'restart' and prove their identity another way. This handles the backend logic for that scenario

### Issue tracking
- [PYIC-3046](https://govukverify.atlassian.net/browse/PYIC-3046)


[PYIC-3046]: https://govukverify.atlassian.net/browse/PYIC-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ