### PR TITLE
PYIC-3013: Add new journeys to dev statemachine file

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -141,7 +141,7 @@ public class ProcessJourneyStepHandler
                     stateMachine.transition(
                             ipvSessionItem.getUserState(),
                             journeyStep,
-                            JourneyContext.emptyContext());
+                            JourneyContext.withFeatureSet(configService.getFeatureSet()));
 
             updateUserState(
                     ipvSessionItem.getUserState(),
@@ -157,14 +157,14 @@ public class ProcessJourneyStepHandler
         } catch (UnknownStateException e) {
             LOGGER.error(
                     new StringMapMessage()
-                            .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "Unknown journey state.")
+                            .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), e.getMessage())
                             .with(LOG_USER_STATE.getFieldName(), ipvSessionItem.getUserState()));
             throw new JourneyEngineException(
                     "Invalid journey state encountered, failed to execute journey engine step.");
         } catch (UnknownEventException e) {
             LOGGER.error(
                     new StringMapMessage()
-                            .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "Unknown journey event.")
+                            .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), e.getMessage())
                             .with(LOG_JOURNEY_STEP.getFieldName(), journeyStep));
             throw new JourneyEngineException(
                     "Invalid journey event provided, failed to execute journey engine step.");

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/CriEvent.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/CriEvent.java
@@ -33,6 +33,7 @@ public class CriEvent implements Event {
 
     @Override
     public StateMachineResult resolve(JourneyContext journeyContext) {
+        configService.setFeatureSet(journeyContext.getFeatureSet());
         if (checkIfDisabled != null) {
             Optional<String> firstDisabledCri =
                     checkIfDisabled.keySet().stream()
@@ -40,7 +41,7 @@ public class CriEvent implements Event {
                             .findFirst();
             if (firstDisabledCri.isPresent()) {
                 String disabledCriId = firstDisabledCri.get();
-                LOGGER.info("CRI with ID '{}' is disabled. Using alternative event", criId);
+                LOGGER.info("CRI with ID '{}' is disabled. Using alternative event", disabledCriId);
                 return checkIfDisabled.get(disabledCriId).resolve(journeyContext);
             }
         }

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyContext.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyContext.java
@@ -1,12 +1,22 @@
 package uk.gov.di.ipv.core.processjourneystep.statemachine.responses;
 
+import lombok.Data;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+@Data
 @ExcludeFromGeneratedCoverageReport
 public class JourneyContext {
+    private String featureSet;
+
     private JourneyContext() {}
 
     public static JourneyContext emptyContext() {
         return new JourneyContext();
+    }
+
+    public static JourneyContext withFeatureSet(String featureSet) {
+        JourneyContext journeyContext = new JourneyContext();
+        journeyContext.setFeatureSet(featureSet);
+        return journeyContext;
     }
 }

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-refactor-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-refactor-journey.yaml
@@ -1,3 +1,64 @@
+# parent states
+END_JOURNEY:
+  name: END_JOURNEY
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
+
+CRI_STATE:
+  name: CRI_STATE
+  parent: ATTEMPT_RECOVERY_STATE
+  events:
+    error:
+      type: basic
+      name: error
+      targetState: CRI_ERROR
+      response:
+        type: error
+        pageId: pyi-technical
+        statusCode: 500
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    end:
+      type: basic
+      name: end
+      targetState: IPV_SUCCESS_PAGE
+      response:
+        type: page
+        pageId: page-ipv-success
+    pyi-no-match:
+      type: basic
+      name: pyi-no-match
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    pyi-kbv-fail:
+      type: basic
+      name: pyi-kbv-fail
+      targetState: PYI_KBV_FAIL
+      response:
+        type: page
+        pageId: pyi-kbv-fail
+
+# Shared states
 INITIAL_IPV_JOURNEY:
   name: INIT
   events:
@@ -18,3 +79,492 @@ IPV_IDENTITY_START_PAGE:
       response:
         type: journey
         journeyStepId: /journey/check-existing-identity
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: IPV_IDENTITY_START_PAGE
+      response:
+        type: page
+        pageId: page-ipv-identity-start
+
+CHECK_EXISTING_IDENTITY:
+  name: CHECK_EXISTING_IDENTITY
+  events:
+    next:
+      type: cri
+      criId: dcmaw
+      targetState: CRI_DCMAW
+      checkIfDisabled:
+        dcmaw:
+          type: basic
+          name: dcmaw-cri-disabled
+          targetState: MULTIPLE_DOC_CHECK_PAGE
+          response:
+            type: page
+            pageId: page-multiple-doc-check
+    reuse:
+      type: basic
+      name: reuse
+      targetState: IPV_IDENTITY_REUSE_PAGE
+      response:
+        type: page
+        pageId: page-ipv-reuse
+    pending:
+      type: basic
+      name: pending
+      targetState: IPV_IDENTITY_PENDING_PAGE
+      response:
+        type: page
+        pageId: page-ipv-pending
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: CHECK_EXISTING_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/check-existing-identity
+
+IPV_IDENTITY_REUSE_PAGE:
+  name: IPV_IDENTITY_REUSE_PAGE
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: IPV_IDENTITY_REUSE_PAGE
+      response:
+        type: page
+        pageId: page-ipv-reuse
+
+IPV_IDENTITY_PENDING_PAGE:
+  name: IPV_IDENTITY_PENDING_PAGE
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: IPV_IDENTITY_PENDING_PAGE
+      response:
+        type: page
+        pageId: page-ipv-pending
+
+CRI_DCMAW:
+  name: CRI_DCMAW
+  parent: CRI_STATE
+  events:
+    next:
+      type: basic
+      name: dcmaw-success
+      targetState: POST_DCMAW_SUCCESS_PAGE
+      response:
+        type: page
+        pageId: page-dcmaw-success
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    temporarily-unavailable:
+      type: basic
+      name: temporarily-unavailable
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    attempt-recovery:
+      type: cri
+      criId: dcmaw
+      targetState: CRI_DCMAW
+
+MULTIPLE_DOC_CHECK_PAGE:
+  name: MULTIPLE_DOC_CHECK_PAGE
+  events:
+    ukPassport:
+      type: cri
+      criId: ukPassport
+      targetState: CRI_UK_PASSPORT_J2
+    drivingLicence:
+      type: cri
+      criId: drivingLicence
+      targetState: CRI_DRIVING_LICENCE_J3
+    end:
+      type: cri
+      criId: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY_J4
+      checkIfDisabled:
+        f2f:
+          type: basic
+          name: end
+          targetState: END
+          response:
+            type: journey
+            journeyStepId: /journey/build-client-oauth-response
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+
+PYI_NO_MATCH:
+  name: PYI_NO_MATCH
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+PYI_KBV_FAIL:
+  name: PYI_KBV_FAIL
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: PYI_KBV_FAIL
+      response:
+        type: page
+        pageId: pyi-kbv-fail
+PYI_KBV_THIN_FILE:
+  name: PYI_KBV_THIN_FILE
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: PYI_KBV_THIN_FILE
+      response:
+        type: page
+        pageId: pyi-kbv-thin-file
+CRI_ERROR:
+  name: CRI_ERROR
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: error
+      targetState: CRI_ERROR
+      response:
+        type: error
+        pageId: pyi-technical
+        statusCode: 500
+CORE_SESSION_TIMEOUT:
+  name: CORE_SESSION_TIMEOUT
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: CORE_SESSION_TIMEOUT
+      response:
+        type: page
+        pageId: pyi-timeout-unrecoverable
+
+# DCMAW journey (J1)
+POST_DCMAW_SUCCESS_PAGE:
+  name: POST_DCMAW_SUCCESS_PAGE
+  events:
+    next:
+      type: cri
+      criId: address
+      targetState: CRI_ADDRESS_J1
+
+CRI_ADDRESS_J1:
+  name: CRI_ADDRESS_J1
+  parent: CRI_STATE
+  events:
+    next:
+      type: cri
+      criId: fraud
+      targetState: CRI_FRAUD_J1
+    attempt-recovery:
+      type: cri
+      criId: address
+      targetState: CRI_ADDRESS_J1
+
+CRI_FRAUD_J1:
+  name: CRI_FRAUD_J1
+  parent: CRI_STATE
+  events:
+    end:
+      type: basic
+      name: end
+      targetState: IPV_SUCCESS_PAGE_J1
+      response:
+        type: page
+        pageId: page-ipv-success
+    attempt-recovery:
+      type: cri
+      criId: fraud
+      targetState: CRI_FRAUD_J1
+
+IPV_SUCCESS_PAGE_J1:
+  name: IPV_SUCCESS_PAGE_J1
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: IPV_SUCCESS_PAGE
+      response:
+        type: page
+        pageId: page-ipv-success
+
+# Passport journey (J2)
+CRI_UK_PASSPORT_J2:
+  name: CRI_UK_PASSPORT_J2
+  parent: CRI_STATE
+  events:
+    next:
+      type: cri
+      criId: address
+      targetState: CRI_ADDRESS_J2
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    attempt-recovery:
+      type: cri
+      criId: ukPassport
+      targetState: CRI_UK_PASSPORT_J2
+
+CRI_ADDRESS_J2:
+  name: CRI_ADDRESS_J2
+  parent: CRI_STATE
+  events:
+    next:
+      type: cri
+      criId: fraud
+      targetState: CRI_FRAUD_J2
+    attempt-recovery:
+      type: cri
+      criId: address
+      targetState: CRI_ADDRESS_J2
+
+CRI_FRAUD_J2:
+  name: CRI_FRAUD_J2
+  parent: CRI_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: PRE_KBV_TRANSITION_PAGE_J2
+      response:
+        type: page
+        pageId: page-pre-kbv-transition
+    attempt-recovery:
+      type: cri
+      criId: fraud
+      targetState: CRI_FRAUD_J2
+
+PRE_KBV_TRANSITION_PAGE_J2:
+  name: PRE_KBV_TRANSITION_PAGEJ2
+  events:
+    next:
+      type: cri
+      criId: kbv
+      targetState: CRI_KBV_J2
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: PRE_KBV_TRANSITION_PAGE_J2
+      response:
+        type: page
+        pageId: page-pre-kbv-transition
+
+CRI_KBV_J2:
+  name: CRI_KBV_J2
+  parent: CRI_STATE
+  events:
+    end:
+      type: basic
+      name: end
+      targetState: IPV_SUCCESS_PAGE_J2
+      response:
+        type: page
+        pageId: page-ipv-success
+    attempt-recovery:
+      type: cri
+      criId: kbv
+      targetState: CRI_KBV_J2
+
+IPV_SUCCESS_PAGE_J2:
+  name: IPV_SUCCESS_PAGE_J2
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: IPV_SUCCESS_PAGE_J2
+      response:
+        type: page
+        pageId: page-ipv-success
+
+# Driving licence journey (J3)
+CRI_DRIVING_LICENCE_J3:
+  name: CRI_DRIVING_LICENCE_J3
+  parent: CRI_STATE
+  events:
+    next:
+      type: cri
+      criId: address
+      targetState: CRI_ADDRESS_J3
+    access-denied:
+      type: basic
+      name: access-denied
+      targetState: MULTIPLE_DOC_CHECK_PAGE
+      response:
+        type: page
+        pageId: page-multiple-doc-check
+    attempt-recovery:
+      type: cri
+      criId: drivingLicence
+      targetState: CRI_DRIVING_LICENCE_J3
+
+CRI_ADDRESS_J3:
+  name: CRI_ADDRESS_J3
+  parent: CRI_STATE
+  events:
+    next:
+      type: cri
+      criId: fraud
+      targetState: CRI_FRAUD_J3
+    attempt-recovery:
+      type: cri
+      criId: address
+      targetState: CRI_ADDRESS_J3
+
+CRI_FRAUD_J3:
+  name: CRI_FRAUD_J3
+  parent: CRI_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: PRE_KBV_TRANSITION_PAGE_J3
+      response:
+        type: page
+        pageId: page-pre-kbv-transition
+    attempt-recovery:
+      type: cri
+      criId: fraud
+      targetState: CRI_FRAUD_J3
+
+PRE_KBV_TRANSITION_PAGE_J3:
+  name: PRE_KBV_TRANSITION_PAGE_J3
+  events:
+    next:
+      type: cri
+      criId: kbv
+      targetState: CRI_KBV_J3
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: PRE_KBV_TRANSITION_PAGE_J3
+      response:
+        type: page
+        pageId: page-pre-kbv-transition
+
+CRI_KBV_J3:
+  name: CRI_KBV_J3
+  parent: CRI_STATE
+  events:
+    end:
+      type: basic
+      name: end
+      targetState: IPV_SUCCESS_PAGE_J3
+      response:
+        type: page
+        pageId: page-ipv-success
+    attempt-recovery:
+      type: cri
+      criId: kbv
+      targetState: CRI_KBV_J3
+
+IPV_SUCCESS_PAGE_J3:
+  name: IPV_SUCCESS_PAGE_J3
+  parent: END_JOURNEY
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: IPV_SUCCESS_PAGE_J3
+      response:
+        type: page
+        pageId: page-ipv-success
+
+# F2F journey (J4)
+CRI_CLAIMED_IDENTITY_J4:
+  name: CRI_CLAIMED_IDENTITY_J4
+  parent: CRI_STATE
+  events:
+    next:
+      type: cri
+      criId: address
+      targetState: CRI_ADDRESS_J4
+    attempt-recovery:
+      type: cri
+      criId: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY_J4
+
+CRI_ADDRESS_J4:
+  name: CRI_ADDRESS_J4
+  parent: CRI_STATE
+  events:
+    next:
+      type: cri
+      criId: fraud
+      targetState: CRI_FRAUD_J4
+    attempt-recovery:
+      type: cri
+      criId: address
+      targetState: CRI_ADDRESS_J4
+
+CRI_FRAUD_J4:
+  name: CRI_FRAUD_J4
+  parent: CRI_STATE
+  events:
+    next:
+      type: cri
+      criId: f2f
+      targetState: CRI_F2F_J4
+    attempt-recovery:
+      type: cri
+      criId: fraud
+      targetState: CRI_FRAUD_J4
+
+CRI_F2F_J4:
+  name: CRI_F2F_J4
+  parent: CRI_STATE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: F2F_HANDOFF_PAGE_J4
+      response:
+        type: page
+        pageId: page-face-to-face-handoff
+    attempt-recovery:
+      type: cri
+      criId: f2f
+      targetState: CRI_F2F_J4
+
+F2F_HANDOFF_PAGE_J4:
+  name: F2F_HANDOFF_PAGE_J4
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: F2F_HANDOFF_PAGE_J4
+      response:
+        type: page
+        pageId: page-face-to-face-handoff

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditExtensionErrorParams;
 import uk.gov.di.ipv.core.library.auditing.AuditExtensions;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -265,7 +266,9 @@ public class ValidateOAuthCallbackHandler
 
         if (OAuth2Error.ACCESS_DENIED_CODE.equals(error)) {
             if (configService.isEnabled(PASSPORT_CRI)
-                    && configService.isEnabled(DRIVING_LICENCE_CRI)) {
+                    && configService.isEnabled(DRIVING_LICENCE_CRI)
+                    && ipvSessionItem.getJourneyType() == IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY) {
+                // This branch should be removed after we move the newly refactored journey
                 return getMultipleDocCheckPage();
             }
             return JOURNEY_ACCESS_DENIED;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This change has been deployed to my development env and the build environments functional test suite run against it, both for the new refactored journey and the existing journey. Both are fulling passing.

### What changed

Add new journeys to dev statemachine file and fix up logic to ensure both original and new journeys can be run.

### Why did it change

[PYIC-3013: Add journeys to ipv-core-refactor-journey statemachine](https://github.com/alphagov/di-ipv-core-back/commit/3974bd93bec57ddd48771fee6f39db6b6670a850) 

We have four main journeys through the system. This maps them out in the
new state file, which will allow the removal of select-cri.

The states are split into sections. Parent states are the states that
contain common events used by other states. Shared states are the states
used by more than one journey. And then the journeys that have their own
states (DCMAW, passport, driving licence and f2f). This may not be the
best way to organise them, but we can play with that when we understand
the best way to lay them out.

All the states now contain an attempt-recovery event. This is due to
losing the ATTEMPT_RECOVERY parent state. This state just routed
everything back to the evaluate-gpg45-scores lambda which we are no
longer calling directly. Instead, the event now needs to call back to
the state it's defined on. We've identified this as a piece of tech-debt
that it would be nice to fix up so we no longer need to define it. This
will reduce the size of this file substantially.


[PYIC-3013: Pass featureSet to criEvent](https://github.com/alphagov/di-ipv-core-back/commit/2854d7b46d8c1857a2de48ad09b5b6b55d877471) 

The criEvent has a config service. It uses this to determine if CRIs are
enabled or disabled.

The pattern we use for featureSets and the config service is to set
any featureSet being used on the config service itself. As the criEvent
is creating an entirely new config service, it doesn't know about the
the featureSet. So we need to pass it in and set it on it.

An alternative to this would be to use a singleton pattern for the
config service, so that all subsequently instantiated services have that
featureSet info. I have a PR for this.


[PYIC-3013: Remove routing from validate-oauth-callback lambda](https://github.com/alphagov/di-ipv-core-back/commit/74a867f8131dee9b19317124d9371fb6b722ae15) 

The validate-oauth-callback lambda had logic in it for deciding what
event to send in to the process-journey-step lambda. This was to do with
what version of the multidoc page we should show, if at all.

We've made an assumption that the passport and driving licence CRIs will
always be on. So we can now assume that receiving an `access_denied`
oauth response from DCMAW should always result in showing the multidoc
page. We've also moved the handling of what the "prove your identity
another way" button does to the statemachine.

This all means we can remove the logic and journeys from the lambda.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3013](https://govukverify.atlassian.net/browse/PYIC-3013)


[PYIC-3013]: https://govukverify.atlassian.net/browse/PYIC-3013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ