### PR TITLE
PYIC-3013: Test statemachine classes

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/State.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/State.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.processjourneystep.statemachine;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.events.Event;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
@@ -12,7 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-@ExcludeFromGeneratedCoverageReport
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineInitializer.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.processjourneystep.statemachine;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 
 import java.io.File;
@@ -11,7 +10,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-@ExcludeFromGeneratedCoverageReport
 public class StateMachineInitializer {
     private static final String PRODUCTION_CONFIG_FILE_PATH =
             "statemachine/production/ipv-core-main-journey.yaml";

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEvent.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEvent.java
@@ -1,13 +1,11 @@
 package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
 
 import lombok.Data;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.State;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineResult;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyStepResponse;
 
-@ExcludeFromGeneratedCoverageReport
 @Data
 public class BasicEvent implements Event {
 

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyContext.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyContext.java
@@ -1,10 +1,8 @@
 package uk.gov.di.ipv.core.processjourneystep.statemachine.responses;
 
 import lombok.Data;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @Data
-@ExcludeFromGeneratedCoverageReport
 public class JourneyContext {
     private String featureSet;
 

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyResponse.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyResponse.java
@@ -3,12 +3,10 @@ package uk.gov.di.ipv.core.processjourneystep.statemachine.responses;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.util.Map;
 
-@ExcludeFromGeneratedCoverageReport
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/PageResponse.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/PageResponse.java
@@ -3,12 +3,10 @@ package uk.gov.di.ipv.core.processjourneystep.statemachine.responses;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.util.Map;
 
-@ExcludeFromGeneratedCoverageReport
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineTest.java
@@ -1,0 +1,52 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownStateException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyResponse;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StateMachineTest {
+
+    @Test
+    void transitionShouldReturnStateMachineResultFromAppropriateState() throws Exception {
+        JourneyContext journeyContext = JourneyContext.emptyContext();
+        StateMachineResult expectedStateMachineResult =
+                new StateMachineResult(new State("END_STATE"), new JourneyResponse());
+
+        State startingState = mock(State.class);
+        when(startingState.transition("event", journeyContext))
+                .thenReturn(expectedStateMachineResult);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("START_STATE", startingState));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertEquals(
+                expectedStateMachineResult,
+                stateMachine.transition("START_STATE", "event", journeyContext));
+    }
+
+    @Test
+    void transitionShouldThrowIfGivenAnUnknownState() throws Exception {
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("START_STATE", new State("START_STATE")));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertThrows(
+                UnknownStateException.class,
+                () ->
+                        stateMachine.transition(
+                                "UNKNOWN_STATE", "event", JourneyContext.emptyContext()));
+    }
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateTest.java
@@ -1,0 +1,45 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.events.BasicEvent;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyResponse;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class StateTest {
+
+    public static final State CURRENT_STATE = new State("CURRENT_STATE");
+    private static final State TARGET_STATE = new State("TARGET_STATE");
+    private static final JourneyResponse JOURNEY_RESPONSE = new JourneyResponse("stepId");
+    private static final BasicEvent CURRENT_TO_TARGET_EVENT = new BasicEvent();
+    ;
+
+    @BeforeAll
+    private static void beforeAll() {
+        CURRENT_TO_TARGET_EVENT.setName("eventName");
+        CURRENT_TO_TARGET_EVENT.setTargetState(TARGET_STATE);
+        CURRENT_TO_TARGET_EVENT.setResponse(JOURNEY_RESPONSE);
+        CURRENT_STATE.setEvents(Map.of("next", CURRENT_TO_TARGET_EVENT));
+    }
+
+    @Test
+    void transitionShouldReturnAStateMachineResult() throws Exception {
+        StateMachineResult stateMachineResult =
+                CURRENT_STATE.transition("next", JourneyContext.emptyContext());
+
+        assertEquals(TARGET_STATE, stateMachineResult.getState());
+    }
+
+    @Test
+    void transitionShouldThrowIfEventNotFound() {
+        assertThrows(
+                UnknownEventException.class,
+                () -> CURRENT_STATE.transition("unknown-event", JourneyContext.emptyContext()));
+    }
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEventTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEventTest.java
@@ -1,0 +1,27 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.State;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineResult;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BasicEventTest {
+    @Test
+    void resolveShouldReturnAStateMachineResult() {
+        State targetState = new State("TARGET_STATE");
+        JourneyResponse journeyResponse = new JourneyResponse();
+
+        BasicEvent basicEvent = new BasicEvent();
+        basicEvent.setName("eventName");
+        basicEvent.setTargetState(targetState);
+        basicEvent.setResponse(journeyResponse);
+
+        StateMachineResult result = basicEvent.resolve(JourneyContext.emptyContext());
+
+        assertEquals(targetState, result.getState());
+        assertEquals(journeyResponse, result.getJourneyStepResponse());
+    }
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/ErrorResponseTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/ErrorResponseTest.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.responses;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class ErrorResponseTest {
+
+    public static final ErrorResponse ERROR_RESPONSE = new ErrorResponse("aPageId", "500");
+
+    @Test
+    void valueWithStringReturnsCorrectResponse() {
+        assertEquals(
+                Map.of("type", "error", "page", "overriddenPageId", "statusCode", 500),
+                ERROR_RESPONSE.value("overriddenPageId"));
+    }
+
+    @Test
+    void valueWithConfigServiceReturnsCorrectResponse() {
+        assertEquals(
+                Map.of("type", "error", "page", "aPageId", "statusCode", 500),
+                ERROR_RESPONSE.value(mock(ConfigService.class)));
+    }
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyContextTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyContextTest.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.responses;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JourneyContextTest {
+    @Test
+    void emptyContextReturnsAnEmptyJourneyContext() {
+        assertNull(JourneyContext.emptyContext().getFeatureSet());
+    }
+
+    @Test
+    void withFeatureSetReturnsJourneyContextWithFeatureSet() {
+        assertEquals(
+                "someFeatureSet", JourneyContext.withFeatureSet("someFeatureSet").getFeatureSet());
+    }
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyResponseTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/JourneyResponseTest.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.responses;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class JourneyResponseTest {
+
+    public static final JourneyResponse JOURNEY_RESPONSE = new JourneyResponse("aJourneyStepId");
+
+    @Test
+    void valueWithConfigServiceReturnsCorrectJourneyResponse() {
+        assertEquals(
+                Map.of("journey", "aJourneyStepId"),
+                JOURNEY_RESPONSE.value(mock(ConfigService.class)));
+    }
+
+    @Test
+    void valueWithStringReturnsCorrectJourneyResponse() {
+        assertEquals(
+                Map.of("journey", "overriddenJourneyStepId"),
+                JOURNEY_RESPONSE.value("overriddenJourneyStepId"));
+    }
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/PageResponseTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/responses/PageResponseTest.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.responses;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class PageResponseTest {
+
+    public static final PageResponse PAGE_RESPONSE = new PageResponse("aPageId");
+
+    @Test
+    void valueWithConfigServiceReturnsCorrectPageResponse() {
+        assertEquals(Map.of("page", "aPageId"), PAGE_RESPONSE.value(mock(ConfigService.class)));
+    }
+
+    @Test
+    void valueWithStringReturnsCorrectPageResponse() {
+        assertEquals(Map.of("page", "overriddenPageId"), PAGE_RESPONSE.value("overriddenPageId"));
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Test statemachine classes

### Why did it change

We've previously taken an approach of not testing directly the classes we use to build and operate the statemachine, but instead testing them implicitly by testing all the steps in the statemachine file. You can see these tests in ProcessJourneyStepHandlerTest. This file is currently 795 lines long.

Maintaining this testing strategy is not sustainable. There are too many tests, and they're prone to not being updated. Rather than trying to test the statemachine file here, we should instead unit test the "building blocks" of the statemachine system, and then allow the journeys themselves to be tested with the functional test suite. This will result in more maintainable tests that are easier to reason about and hopefully more useful.

Once we've moved over to using the refactored journey statemachine file, I propose we get rid of the majority of tests in
ProcessJourneyStepHandlerTest.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3013](https://govukverify.atlassian.net/browse/PYIC-3013)


[PYIC-3013]: https://govukverify.atlassian.net/browse/PYIC-3013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ