### PR TITLE
PYIC-3043: ProcessAsyncCredentialHandler to send VCs to postMitigations

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2239,6 +2239,16 @@ Resources:
                 - EnvironmentConfiguration
                 - !Ref AWS::AccountId
                 - environment
+          CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN: !Sub
+            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:postMitigations-${env}"
+            - contra_indicator_storage_account_id: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - ciStorageAccountId
+              env: !FindInMap
+                - EnvironmentConfiguration
+                - !Ref AWS::AccountId
+                - environment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2298,7 +2308,21 @@ Resources:
                       - EnvironmentConfiguration
                       - !Ref AWS::AccountId
                       - environment
-
+            - Sid: invokePostCiMitigationFunction
+              Effect: Allow
+              Action:
+                - 'lambda:InvokeFunction'
+              Resource:
+                - !Sub
+                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:postMitigations-${env}"
+                  - contra_indicator_storage_account_id: !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - ciStorageAccountId
+                    env: !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - environment
             - Sid: asyncCriResponseQueuePermission
               Effect: Allow
               Action:


### PR DESCRIPTION
## Proposed changes

### What changed
`ProcessAsyncCredentialHandler` to send VCs to CIMIT `postMitigations` if feature flag enabled

### Why did it change
Introduction of mitigations, part 1

### Issue tracking

- [PYIC-3043](https://govukverify.atlassian.net/browse/PYIC-3043)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations


[PYIC-3043]: https://govukverify.atlassian.net/browse/PYIC-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ