### PR TITLE
PYIC-3032: Add CI scoring to ContraIndications domain object

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
@@ -12,6 +12,15 @@ import java.util.Optional;
 public class ContraIndications {
     private final Map<String, ContraIndicator> contraIndicators;
 
+    public Integer getContraIndicatorScores(
+            final Map<String, ContraIndicatorScore> contraIndicatorScores) {
+        return contraIndicators.keySet().stream()
+                .map(
+                        contraIndicatorCode ->
+                                contraIndicatorScores.get(contraIndicatorCode).getDetectedScore())
+                .reduce(0, Integer::sum);
+    }
+
     public Optional<ContraIndicator> getLatestContraIndicator() {
         return contraIndicators.values().stream()
                 .max(Comparator.comparing(ContraIndicator::getIssuanceDate));

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
@@ -2,13 +2,26 @@ package uk.gov.di.ipv.core.library.domain;
 
 import lombok.Builder;
 import lombok.Getter;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
-import java.util.Map;
+import java.util.*;
 
 @Getter
-@Builder
-@ExcludeFromGeneratedCoverageReport
+@Builder(toBuilder = true)
 public class ContraIndications {
     private final Map<String, ContraIndicator> contraIndicators;
+
+    private final Map<String, ContraIndicatorScore> contraIndicatorScores;
+
+    public Integer getContraIndicatorScores() {
+        return contraIndicators.keySet().stream()
+                .map(
+                        contraIndicatorCode ->
+                                contraIndicatorScores.get(contraIndicatorCode).getDetectedScore())
+                .reduce(0, Integer::sum);
+    }
+
+    public Optional<ContraIndicator> getLatestContraIndicator() {
+        return contraIndicators.values().stream()
+                .max(Comparator.comparing(ContraIndicator::getIssuanceDate));
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
@@ -3,22 +3,14 @@ package uk.gov.di.ipv.core.library.domain;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
 
 @Getter
 @Builder(toBuilder = true)
 public class ContraIndications {
     private final Map<String, ContraIndicator> contraIndicators;
-
-    private final Map<String, ContraIndicatorScore> contraIndicatorScores;
-
-    public Integer getContraIndicatorScores() {
-        return contraIndicators.keySet().stream()
-                .map(
-                        contraIndicatorCode ->
-                                contraIndicatorScores.get(contraIndicatorCode).getDetectedScore())
-                .reduce(0, Integer::sum);
-    }
 
     public Optional<ContraIndicator> getLatestContraIndicator() {
         return contraIndicators.values().stream()

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicator.java
@@ -2,14 +2,12 @@ package uk.gov.di.ipv.core.library.domain;
 
 import lombok.Builder;
 import lombok.Getter;
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.time.Instant;
 import java.util.List;
 
 @Getter
 @Builder(toBuilder = true)
-@ExcludeFromGeneratedCoverageReport
 public class ContraIndicator implements Comparable<ContraIndicator> {
     private final String code;
     private final Instant issuanceDate;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicator.java
@@ -8,13 +8,18 @@ import java.time.Instant;
 import java.util.List;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @ExcludeFromGeneratedCoverageReport
-public class ContraIndicator {
+public class ContraIndicator implements Comparable<ContraIndicator> {
     private final String code;
     private final Instant issuanceDate;
     private final String documentId;
     private final List<String> transactionIds;
     private final List<Mitigation> mitigations;
     private final List<Mitigation> incompleteMitigations;
+
+    @Override
+    public int compareTo(ContraIndicator other) {
+        return this.issuanceDate.compareTo(other.issuanceDate);
+    }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicator.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.time.Instant;
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @Builder(toBuilder = true)
+@EqualsAndHashCode
 public class ContraIndicator implements Comparable<ContraIndicator> {
     private final String code;
     private final Instant issuanceDate;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicator.java
@@ -1,25 +1,18 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.time.Instant;
 import java.util.List;
 
 @Getter
-@Builder(toBuilder = true)
-@EqualsAndHashCode
-public class ContraIndicator implements Comparable<ContraIndicator> {
+@Builder
+public class ContraIndicator {
     private final String code;
     private final Instant issuanceDate;
     private final String documentId;
     private final List<String> transactionIds;
     private final List<Mitigation> mitigations;
     private final List<Mitigation> incompleteMitigations;
-
-    @Override
-    public int compareTo(ContraIndicator other) {
-        return this.issuanceDate.compareTo(other.issuanceDate);
-    }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
@@ -1,0 +1,74 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ContraIndicationsTest {
+    private ContraIndications contraIndications;
+    private static final String TEST_CI1 = "CI1";
+    private static final String TEST_CI2 = "CI2";
+    private static final String TEST_CI3 = "CI3";
+    private static final Instant BASE_TIME = Instant.now();
+    private static final Map<String, ContraIndicatorScore> CONTRA_INDICATOR_SCORE_MAP =
+            Map.of(
+                    TEST_CI1,
+                    new ContraIndicatorScore(TEST_CI1, 4, -3, null, null),
+                    TEST_CI2,
+                    new ContraIndicatorScore(TEST_CI2, 3, -3, null, null),
+                    TEST_CI3,
+                    new ContraIndicatorScore(TEST_CI3, 2, -1, null, null));
+
+    @BeforeEach
+    void setup() {
+        contraIndications =
+                ContraIndications.builder()
+                        .contraIndicatorScores(CONTRA_INDICATOR_SCORE_MAP)
+                        .contraIndicators(Map.of())
+                        .build();
+    }
+
+    @Test
+    void shouldReturnZeroScoreForEmptyContraIndications() {
+        assertEquals(0, contraIndications.getContraIndicatorScores());
+    }
+
+    @Test
+    void shouldCalculateContraIndicatorScore() {
+        addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1));
+        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2));
+        assertEquals(7, contraIndications.getContraIndicatorScores());
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalForLatestContraIndicatorFromEmptyContraIndications() {
+        assertFalse(contraIndications.getLatestContraIndicator().isPresent());
+    }
+
+    @Test
+    void shouldIdentifyLatestContraIndicator() {
+        addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1));
+        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2));
+        addContraIndicators(TEST_CI3, BASE_TIME.plusSeconds(3));
+        Optional<ContraIndicator> latestContraIndicator =
+                contraIndications.getLatestContraIndicator();
+        assertTrue(latestContraIndicator.isPresent());
+        assertEquals(TEST_CI3, latestContraIndicator.get().getCode());
+    }
+
+    private void addContraIndicators(final String code, Instant issuanceDate) {
+        ContraIndicator contraIndicator =
+                ContraIndicator.builder().code(code).issuanceDate(issuanceDate).build();
+        Map<String, ContraIndicator> updatedContraIndicators =
+                new HashMap<>(contraIndications.getContraIndicators());
+        updatedContraIndicators.put(code, contraIndicator);
+        contraIndications =
+                contraIndications.toBuilder().contraIndicators(updatedContraIndicators).build();
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
@@ -36,6 +36,19 @@ class ContraIndicationsTest {
     }
 
     @Test
+    void shouldReturnZeroScoreForEmptyContraIndications() {
+        assertEquals(0, contraIndications.getContraIndicatorScores(CONTRA_INDICATOR_SCORE_MAP));
+    }
+
+    @Test
+    void shouldCalculateContraIndicatorScore() {
+        addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1));
+        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2));
+        assertEquals(7, contraIndications.getContraIndicatorScores(CONTRA_INDICATOR_SCORE_MAP));
+        contraIndications = ContraIndications.builder().contraIndicators(Map.of()).build();
+    }
+
+    @Test
     void shouldIdentifyLatestContraIndicator() {
         addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1));
         addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2));

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
@@ -27,23 +27,7 @@ class ContraIndicationsTest {
 
     @BeforeEach
     void setup() {
-        contraIndications =
-                ContraIndications.builder()
-                        .contraIndicatorScores(CONTRA_INDICATOR_SCORE_MAP)
-                        .contraIndicators(Map.of())
-                        .build();
-    }
-
-    @Test
-    void shouldReturnZeroScoreForEmptyContraIndications() {
-        assertEquals(0, contraIndications.getContraIndicatorScores());
-    }
-
-    @Test
-    void shouldCalculateContraIndicatorScore() {
-        addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1));
-        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2));
-        assertEquals(7, contraIndications.getContraIndicatorScores());
+        contraIndications = ContraIndications.builder().contraIndicators(Map.of()).build();
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.library.domain;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,33 +42,5 @@ class ContraIndicatorTest {
         assertEquals(TRANSACTIONS, CI.getTransactionIds());
         assertEquals(MITIGATIONS, CI.getMitigations());
         assertTrue(CI.getIncompleteMitigations().isEmpty());
-    }
-
-    @Test
-    void shouldBeCompareAccordingIssuanceDate() {
-        ContraIndicator contraIndicator1 =
-                CI.toBuilder().issuanceDate(CURRENT_TIME.plusSeconds(20)).build();
-        ContraIndicator contraIndicator2 = CI.toBuilder().issuanceDate(CURRENT_TIME).build();
-        ContraIndicator contraIndicator3 =
-                CI.toBuilder().issuanceDate(CURRENT_TIME.minusSeconds(10)).build();
-        ContraIndicator contraIndicator4 = CI.toBuilder().issuanceDate(CURRENT_TIME).build();
-
-        assertEquals(0, contraIndicator2.compareTo(contraIndicator4));
-        assertTrue(contraIndicator2.compareTo(contraIndicator1) < 0);
-        assertTrue(contraIndicator2.compareTo(contraIndicator3) > 0);
-        assertTrue(contraIndicator3.compareTo(contraIndicator1) < 0);
-        assertTrue(contraIndicator3.compareTo(contraIndicator2) < 0);
-
-        List<ContraIndicator> contraIndicators =
-                new ArrayList<>(
-                        List.of(
-                                contraIndicator1,
-                                contraIndicator2,
-                                contraIndicator3,
-                                contraIndicator4));
-        Collections.sort(contraIndicators);
-        assertEquals(
-                List.of(contraIndicator3, contraIndicator2, contraIndicator4, contraIndicator1),
-                contraIndicators);
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ContraIndicatorTest {
+class ContraIndicatorTest {
 
     private static final Instant CURRENT_TIME = Instant.now();
 
@@ -36,7 +36,7 @@ public class ContraIndicatorTest {
                     .build();
 
     @Test
-    public void checkGetterMethods() {
+    void checkGetterMethods() {
         assertEquals(CODE, CI.getCode());
         assertEquals(CURRENT_TIME, CI.getIssuanceDate());
         assertEquals(DOCUMENT_ID, CI.getDocumentId());
@@ -46,7 +46,7 @@ public class ContraIndicatorTest {
     }
 
     @Test
-    public void shouldBeCompareAccordingIssuanceDate() {
+    void shouldBeCompareAccordingIssuanceDate() {
         ContraIndicator contraIndicator1 =
                 CI.toBuilder().issuanceDate(CURRENT_TIME.plusSeconds(20)).build();
         ContraIndicator contraIndicator2 = CI.toBuilder().issuanceDate(CURRENT_TIME).build();

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorTest.java
@@ -1,0 +1,75 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ContraIndicatorTest {
+
+    private static final Instant CURRENT_TIME = Instant.now();
+
+    private static final String CODE = "CODE1";
+    private static final String DOCUMENT_ID = "DOCID-123";
+
+    private static final List<String> TRANSACTIONS =
+            List.of("TRANS1", "TRANS2", "TRANS3", "TRANS4");
+
+    private static final List<Mitigation> MITIGATIONS =
+            List.of(
+                    Mitigation.builder().code("MTG1").build(),
+                    Mitigation.builder().code("MTG2").build());
+
+    private static final ContraIndicator CI =
+            ContraIndicator.builder()
+                    .code(CODE)
+                    .issuanceDate(CURRENT_TIME)
+                    .documentId(DOCUMENT_ID)
+                    .transactionIds(TRANSACTIONS)
+                    .mitigations(MITIGATIONS)
+                    .incompleteMitigations(Collections.emptyList())
+                    .build();
+
+    @Test
+    public void checkGetterMethods() {
+        assertEquals(CODE, CI.getCode());
+        assertEquals(CURRENT_TIME, CI.getIssuanceDate());
+        assertEquals(DOCUMENT_ID, CI.getDocumentId());
+        assertEquals(TRANSACTIONS, CI.getTransactionIds());
+        assertEquals(MITIGATIONS, CI.getMitigations());
+        assertTrue(CI.getIncompleteMitigations().isEmpty());
+    }
+
+    @Test
+    public void shouldBeCompareAccordingIssuanceDate() {
+        ContraIndicator contraIndicator1 =
+                CI.toBuilder().issuanceDate(CURRENT_TIME.plusSeconds(20)).build();
+        ContraIndicator contraIndicator2 = CI.toBuilder().issuanceDate(CURRENT_TIME).build();
+        ContraIndicator contraIndicator3 =
+                CI.toBuilder().issuanceDate(CURRENT_TIME.minusSeconds(10)).build();
+        ContraIndicator contraIndicator4 = CI.toBuilder().issuanceDate(CURRENT_TIME).build();
+
+        assertEquals(0, contraIndicator2.compareTo(contraIndicator4));
+        assertTrue(contraIndicator2.compareTo(contraIndicator1) < 0);
+        assertTrue(contraIndicator2.compareTo(contraIndicator3) > 0);
+        assertTrue(contraIndicator3.compareTo(contraIndicator1) < 0);
+        assertTrue(contraIndicator3.compareTo(contraIndicator2) < 0);
+
+        List<ContraIndicator> contraIndicators =
+                new ArrayList<>(
+                        List.of(
+                                contraIndicator1,
+                                contraIndicator2,
+                                contraIndicator3,
+                                contraIndicator4));
+        Collections.sort(contraIndicators);
+        assertEquals(
+                List.of(contraIndicator3, contraIndicator2, contraIndicator4, contraIndicator1),
+                contraIndicators);
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add CI scoring to ContraIndications domain object

### Why did it change

Add a new getContraIndicatorScore method which will

Fetch/cache? the contra indicators score map

Return the sum over the CI detected scores

Add getLatestContraIndicator method to return most recent ContraIndicator.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3032](https://govukverify.atlassian.net/browse/PYIC-3032)



[PYIC-3032]: https://govukverify.atlassian.net/browse/PYIC-3032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ