### PR TITLE
PYIC-3053: Remove criReturn switch for eval-gpg45-scores

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -35,7 +35,7 @@
         "featureSet.$": "$.featureSet"
       },
       "ResultPath": "$.lambdaResult",
-      "Next": "RunEvaluateGpg45ScoresForRefactorJourney"
+      "Next": "RouteJourneyResponse"
     },
     "EvaluateGpg45Scores": {
       "Type": "Task",
@@ -73,16 +73,10 @@
           "Variable": "$.lambdaResult.journey",
           "StringEquals": "/journey/cri/access-token",
           "Next": "RetrieveCriOauthAccessToken"
-        }
-      ],
-      "Default": "ReturnToFrontend"
-    },
-    "RunEvaluateGpg45ScoresForRefactorJourney": {
-      "Type": "Choice",
-      "Choices": [
+        },
         {
-          "Variable": "$.lambdaResult.journeyType",
-          "StringEquals": "ipv-core-refactor-journey",
+          "Variable": "$.lambdaResult.journey",
+          "StringEquals": "/journey/evaluate",
           "Next": "EvaluateGpg45Scores"
         }
       ],

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -49,7 +49,6 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredent
 import uk.gov.di.ipv.core.library.verifiablecredential.validation.VerifiableCredentialJwtValidator;
 
 import java.text.ParseException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -67,10 +66,9 @@ public class RetrieveCriCredentialHandler
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final Map<String, Object> JOURNEY_NEXT = Map.of(JOURNEY, "/journey/next");
+    private static final Map<String, Object> JOURNEY_EVALUATE =
+            Map.of(JOURNEY, "/journey/evaluate");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
-    private static final Map<String, Object> JOURNEY_PENDING = Map.of(JOURNEY, "/journey/pending");
-    public static final String JOURNEY_TYPE_KEY = "journeyType";
 
     private final VerifiableCredentialService verifiableCredentialService;
     private final IpvSessionService ipvSessionService;
@@ -173,14 +171,14 @@ public class RetrieveCriCredentialHandler
 
             if (VerifiableCredentialStatus.PENDING.equals(
                     verifiableCredentialResponse.getCredentialStatus())) {
-                return processPendingResponse(
+                processPendingResponse(
                         userId,
                         credentialIssuerId,
                         verifiableCredentialResponse,
                         criOAuthState,
                         ipvSessionItem);
             } else {
-                return processVerifiableCredentials(
+                processVerifiableCredentials(
                         userId,
                         credentialIssuerId,
                         credentialIssuerConfig,
@@ -189,6 +187,8 @@ public class RetrieveCriCredentialHandler
                         clientOAuthSessionItem,
                         ipvSessionItem);
             }
+
+            return JOURNEY_EVALUATE;
 
         } catch (VerifiableCredentialException
                 | VerifiableCredentialResponseException
@@ -212,7 +212,7 @@ public class RetrieveCriCredentialHandler
         }
     }
 
-    private Map<String, Object> processPendingResponse(
+    private void processPendingResponse(
             String userId,
             String credentialIssuerId,
             VerifiableCredentialResponse verifiableCredentialResponse,
@@ -246,16 +246,9 @@ public class RetrieveCriCredentialHandler
                                 LOG_LAMBDA_RESULT.getFieldName(),
                                 "Successfully processed CRI pending response.")
                         .with(LOG_CRI_ID.getFieldName(), credentialIssuerId));
-
-        // Add journey type to the response to allow temporary flow control in step function while
-        // refactoring journey
-        HashMap<String, Object> pendingLambdaResult = new HashMap<>(JOURNEY_PENDING);
-        pendingLambdaResult.put(JOURNEY_TYPE_KEY, ipvSessionItem.getJourneyType().getValue());
-
-        return pendingLambdaResult;
     }
 
-    private Map<String, Object> processVerifiableCredentials(
+    private void processVerifiableCredentials(
             String userId,
             String credentialIssuerId,
             CredentialIssuerConfig credentialIssuerConfig,
@@ -297,13 +290,6 @@ public class RetrieveCriCredentialHandler
                                 LOG_LAMBDA_RESULT.getFieldName(),
                                 "Successfully retrieved CRI credential.")
                         .with(LOG_CRI_ID.getFieldName(), credentialIssuerId));
-
-        // Add journey type to the response to allow temporary flow control in step function while
-        // refactoring journey
-        HashMap<String, Object> nextLambdaResult = new HashMap<>(JOURNEY_NEXT);
-        nextLambdaResult.put(JOURNEY_TYPE_KEY, ipvSessionItem.getJourneyType().getValue());
-
-        return nextLambdaResult;
     }
 
     @Tracing

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -180,7 +180,6 @@ class RetrieveCriCredentialHandlerTest {
                                 .build());
 
         mockServiceCallsAndSessionItem();
-        when(ipvSessionItem.getJourneyType()).thenReturn(IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY);
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
@@ -192,8 +191,7 @@ class RetrieveCriCredentialHandlerTest {
         verify(verifiableCredentialJwtValidator)
                 .validate(any(SignedJWT.class), eq(testPassportIssuer), eq(TEST_USER_ID));
 
-        assertEquals("/journey/next", output.get("journey"));
-        assertEquals("ipv-core-main-journey", output.get("journeyType"));
+        assertEquals("/journey/evaluate", output.get("journey"));
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
     }
 
@@ -342,7 +340,6 @@ class RetrieveCriCredentialHandlerTest {
                                         List.of(SignedJWT.parse(SIGNED_CONTRA_INDICATORS)))
                                 .build());
         mockServiceCallsAndSessionItem();
-        when(ipvSessionItem.getJourneyType()).thenReturn(IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY);
 
         handler.handleRequest(testInput, context);
 
@@ -383,7 +380,6 @@ class RetrieveCriCredentialHandlerTest {
         when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
                 .thenReturn(claimedIdentityConfig);
         mockServiceCallsAndSessionItem();
-        when(ipvSessionItem.getJourneyType()).thenReturn(IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY);
 
         handler.handleRequest(testInput, context);
 
@@ -483,7 +479,6 @@ class RetrieveCriCredentialHandlerTest {
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);
         when(ipvSessionItem.getIpvSessionId()).thenReturn(testSessionId);
-        when(ipvSessionItem.getJourneyType()).thenReturn(IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY);
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
                 .thenReturn(getClientOAuthSessionItem());
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -502,11 +497,11 @@ class RetrieveCriCredentialHandlerTest {
                         testCriNotRequiringApiKey,
                         null,
                         CREDENTIAL_ISSUER_ID);
-        assertEquals("/journey/next", output.get("journey"));
+        assertEquals("/journey/evaluate", output.get("journey"));
     }
 
     @Test
-    void shouldReturnJourneyPendingResponseOnSuccessfulPendingCriResponse() {
+    void shouldReturnJourneyEvaluateResponseOnSuccessfulPendingCriResponse() {
         final String expectedIssuerResponse =
                 "{\"sub\":\""
                         + TEST_USER_ID
@@ -524,13 +519,11 @@ class RetrieveCriCredentialHandlerTest {
                                 .build());
 
         IpvSessionItem testIpvSessionItem = makeTestIpvSessionItem(TEST_IPV_SESSION_ID);
-        testIpvSessionItem.setJourneyType(IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY);
         mockServiceCalls(testIpvSessionItem);
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
-        assertEquals("/journey/pending", output.get("journey"));
-        assertEquals("ipv-core-main-journey", output.get("journeyType"));
+        assertEquals("/journey/evaluate", output.get("journey"));
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
 
         verifyPersistedCriResponse(


### PR DESCRIPTION
**NOT TO BE MERGED UNTIL WE'VE SWITCHED TO THE REFACTORED JOURNEY**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Remove criReturn switch for eval-gpg45-scores

### Why did it change

We're now running the refactored journey, so all journey should move from the retrieve-cri-cred lambda to the eval-gpg45-scores lambda, regardless of journey type.

The retrieve-cri-cred lambda now returns `/journey/evaluate` instead of `/journey/next`. This makes the routing in the step function a little more obvious than using the overloaded `next` event.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3053](https://govukverify.atlassian.net/browse/PYIC-3053)


[PYIC-3053]: https://govukverify.atlassian.net/browse/PYIC-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ