### PR TITLE
PYIC-3077: Correct MitigatingCredential userId attribute to be id

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/MitigatingCredential.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/MitigatingCredential.java
@@ -13,5 +13,5 @@ public class MitigatingCredential {
     private final String issuer;
     private final Instant validFrom;
     private final String transactionId;
-    private final String userId;
+    private final String id;
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

As per  's comment on  , userId property on MitigatingCredential should be id

### Why did it change

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3077](https://govukverify.atlassian.net/browse/PYIC-3077)


[PYIC-3077]: https://govukverify.atlassian.net/browse/PYIC-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ