### PR TITLE
PYIC-3035: Account for Mitigations in Contra-indicator Scoring.

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import com.nimbusds.oauth2.sdk.util.CollectionUtils;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,25 +23,24 @@ public class ContraIndications {
     }
 
     private Integer calculateCheckedScore(
-            final Map<String, ContraIndicatorScore> contraIndicatorScoreMap) {
+            final Map<String, ContraIndicatorScore> contraIndicatorScores) {
         return contraIndicators.values().stream()
                 .filter(
                         contraIndicator ->
-                                (contraIndicator.getMitigations() != null)
-                                        && !contraIndicator.getMitigations().isEmpty())
+                                !CollectionUtils.isEmpty(contraIndicator.getMitigations()))
                 .map(
                         contraIndicator ->
-                                contraIndicatorScoreMap
+                                contraIndicatorScores
                                         .get(contraIndicator.getCode())
                                         .getCheckedScore())
                 .reduce(0, Integer::sum);
     }
 
     public Integer getContraIndicatorScore(
-            final Map<String, ContraIndicatorScore> contraIndicatorScoreMap,
+            final Map<String, ContraIndicatorScore> contraIndicatorScores,
             final boolean includeMitigation) {
-        return calculateDetectedScore(contraIndicatorScoreMap)
-                + (includeMitigation ? calculateCheckedScore(contraIndicatorScoreMap) : 0);
+        return calculateDetectedScore(contraIndicatorScores)
+                + (includeMitigation ? calculateCheckedScore(contraIndicatorScores) : 0);
     }
 
     public Optional<ContraIndicator> getLatestContraIndicator() {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndications.java
@@ -12,13 +12,35 @@ import java.util.Optional;
 public class ContraIndications {
     private final Map<String, ContraIndicator> contraIndicators;
 
-    public Integer getContraIndicatorScores(
+    private Integer calculateDetectedScore(
             final Map<String, ContraIndicatorScore> contraIndicatorScores) {
         return contraIndicators.keySet().stream()
                 .map(
                         contraIndicatorCode ->
                                 contraIndicatorScores.get(contraIndicatorCode).getDetectedScore())
                 .reduce(0, Integer::sum);
+    }
+
+    private Integer calculateCheckedScore(
+            final Map<String, ContraIndicatorScore> contraIndicatorScoreMap) {
+        return contraIndicators.values().stream()
+                .filter(
+                        contraIndicator ->
+                                (contraIndicator.getMitigations() != null)
+                                        && !contraIndicator.getMitigations().isEmpty())
+                .map(
+                        contraIndicator ->
+                                contraIndicatorScoreMap
+                                        .get(contraIndicator.getCode())
+                                        .getCheckedScore())
+                .reduce(0, Integer::sum);
+    }
+
+    public Integer getContraIndicatorScore(
+            final Map<String, ContraIndicatorScore> contraIndicatorScoreMap,
+            final boolean includeMitigation) {
+        return calculateDetectedScore(contraIndicatorScoreMap)
+                + (includeMitigation ? calculateCheckedScore(contraIndicatorScoreMap) : 0);
     }
 
     public Optional<ContraIndicator> getLatestContraIndicator() {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
@@ -4,10 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -68,7 +65,7 @@ class ContraIndicationsTest {
     void shouldCalculateContraIndicatorScoreIncludeMitigationAndSomeEmptyMitigations() {
         addContraIndicators(
                 TEST_CI1, BASE_TIME.minusSeconds(1), List.of(Mitigation.builder().build()));
-        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2), null);
+        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2), Collections.emptyList());
         addContraIndicators(TEST_CI3, BASE_TIME.minusSeconds(4), null);
         assertEquals(
                 6, contraIndications.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP, true));
@@ -78,7 +75,7 @@ class ContraIndicationsTest {
     @Test
     void shouldFindLatestContraIndicator() {
         addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1), null);
-        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2), null);
+        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2), Collections.emptyList());
         addContraIndicators(TEST_CI3, BASE_TIME.plusSeconds(3), null);
         Optional<ContraIndicator> latestContraIndicator =
                 contraIndications.getLatestContraIndicator();

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -31,37 +32,79 @@ class ContraIndicationsTest {
     }
 
     @Test
-    void shouldReturnEmptyOptionalForLatestContraIndicatorFromEmptyContraIndications() {
+    void shouldReturnEmptyOptionalWhenNoContraIndicatorExistInContraIndications() {
         assertFalse(contraIndications.getLatestContraIndicator().isPresent());
     }
 
     @Test
-    void shouldReturnZeroScoreForEmptyContraIndications() {
-        assertEquals(0, contraIndications.getContraIndicatorScores(CONTRA_INDICATOR_SCORE_MAP));
+    void shouldReturnZeroScoreWhenNoContraIndicatorExistInContraIndications() {
+        assertEquals(
+                0, contraIndications.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP, false));
     }
 
     @Test
-    void shouldCalculateContraIndicatorScore() {
-        addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1));
-        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2));
-        assertEquals(7, contraIndications.getContraIndicatorScores(CONTRA_INDICATOR_SCORE_MAP));
+    void shouldCalculateContraIndicatorScoreExcludeMitigation() {
+        addContraIndicators(
+                TEST_CI1, BASE_TIME.minusSeconds(1), List.of(Mitigation.builder().build()));
+        addContraIndicators(
+                TEST_CI2, BASE_TIME.minusSeconds(2), List.of(Mitigation.builder().build()));
+        assertEquals(
+                7, contraIndications.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP, false));
         contraIndications = ContraIndications.builder().contraIndicators(Map.of()).build();
     }
 
     @Test
-    void shouldIdentifyLatestContraIndicator() {
-        addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1));
-        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2));
-        addContraIndicators(TEST_CI3, BASE_TIME.plusSeconds(3));
+    void shouldCalculateContraIndicatorScoreIncludeMitigation() {
+        addContraIndicators(
+                TEST_CI1, BASE_TIME.minusSeconds(1), List.of(Mitigation.builder().build()));
+        addContraIndicators(
+                TEST_CI2, BASE_TIME.minusSeconds(2), List.of(Mitigation.builder().build()));
+        assertEquals(
+                1, contraIndications.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP, true));
+        contraIndications = ContraIndications.builder().contraIndicators(Map.of()).build();
+    }
+
+    @Test
+    void shouldCalculateContraIndicatorScoreIncludeMitigationAndSomeEmptyMitigations() {
+        addContraIndicators(
+                TEST_CI1, BASE_TIME.minusSeconds(1), List.of(Mitigation.builder().build()));
+        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2), null);
+        addContraIndicators(TEST_CI3, BASE_TIME.minusSeconds(4), null);
+        assertEquals(
+                6, contraIndications.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP, true));
+        contraIndications = ContraIndications.builder().contraIndicators(Map.of()).build();
+    }
+
+    @Test
+    void shouldFindLatestContraIndicator() {
+        addContraIndicators(TEST_CI1, BASE_TIME.minusSeconds(1), null);
+        addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2), null);
+        addContraIndicators(TEST_CI3, BASE_TIME.plusSeconds(3), null);
         Optional<ContraIndicator> latestContraIndicator =
                 contraIndications.getLatestContraIndicator();
         assertTrue(latestContraIndicator.isPresent());
         assertEquals(TEST_CI3, latestContraIndicator.get().getCode());
     }
 
-    private void addContraIndicators(final String code, Instant issuanceDate) {
+    @Test
+    void shouldFindLatestContraIndicatorWhenMultipleIndicatorsAtSameTime() {
+        addContraIndicators(TEST_CI1, BASE_TIME, null);
+        addContraIndicators(TEST_CI2, BASE_TIME, null);
+        addContraIndicators(TEST_CI3, BASE_TIME.minusSeconds(3), null);
+        Optional<ContraIndicator> latestContraIndicator =
+                contraIndications.getLatestContraIndicator();
+        assertTrue(latestContraIndicator.isPresent());
+        assertEquals(TEST_CI2, latestContraIndicator.get().getCode());
+    }
+
+    private void addContraIndicators(
+            final String code, Instant issuanceDate, List<Mitigation> mitigations) {
         ContraIndicator contraIndicator =
-                ContraIndicator.builder().code(code).issuanceDate(issuanceDate).build();
+                ContraIndicator.builder()
+                        .code(code)
+                        .issuanceDate(issuanceDate)
+                        .mitigations(mitigations)
+                        .build();
         Map<String, ContraIndicator> updatedContraIndicators =
                 new HashMap<>(contraIndications.getContraIndicators());
         updatedContraIndicators.put(code, contraIndicator);

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicationsTest.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Account for Mitigations in Contra-indicator Scoring.

### Why did it change

Update getContraIndicatorScore method to

Add the checked score into the Contra-indicator score for each CI which has a non-empty mitigations list. The checked scores are negative quantities so this has the effect of reducing the Contra-indicator score where at least one mitigation is present.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3035](https://govukverify.atlassian.net/browse/PYIC-3035)


[PYIC-3035]: https://govukverify.atlassian.net/browse/PYIC-3035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ