### PR TITLE
BAU: Only check for fail with no ci's if on refactor journey

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -172,10 +172,12 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
 
             updateSuccessfulVcStatuses(ipvSessionItem, credentials);
 
-            Optional<JourneyResponse> journeyResponseForFailWithNoCi =
-                    getJourneyResponseForFailWithNoCi(ipvSessionItem);
-            if (journeyResponseForFailWithNoCi.isPresent()) {
-                return journeyResponseForFailWithNoCi.get();
+            if (ipvSessionItem.getJourneyType() == IpvJourneyTypes.IPV_CORE_REFACTOR_JOURNEY) {
+                Optional<JourneyResponse> journeyResponseForFailWithNoCi =
+                        getJourneyResponseForFailWithNoCi(ipvSessionItem);
+                if (journeyResponseForFailWithNoCi.isPresent()) {
+                    return journeyResponseForFailWithNoCi.get();
+                }
             }
 
             if (!checkCorrelation(userId, ipvSessionItem.getCurrentVcStatuses())) {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Only check for fail with no ci's if on refactor journey

### Why did it change

The main journey calls the evaluate-gpg45-scores lambda before we've hit any CRIs. This causes an error and the journey stops.

We can conditionally run this for now and remove the condition once we've switched.
