### PR TITLE
PYIC-3105 Update pending route to lead to new escape page

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -133,22 +133,15 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 IPV_IDENTITY_PENDING_PAGE:
   name: IPV_IDENTITY_PENDING_PAGE
-  parent: END_JOURNEY
+  parent: ATTEMPT_RECOVERY_STATE
   events:
-    continue:
+    next:
       type: basic
-      name: continue
-      targetState: F2F_HANDOFF_PAGE
+      name: next
+      targetState: PYI_ESCAPE
       response:
         type: page
-        pageId: page-face-to-face-handoff
-    restart:
-      type: basic
-      name: restart
-      targetState: RESET_IDENTITY
-      response:
-        type: journey
-        journeyStepId: /journey/reset-identity
+        pageId: pyi-escape
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -126,22 +126,15 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 IPV_IDENTITY_PENDING_PAGE:
   name: IPV_IDENTITY_PENDING_PAGE
-  parent: END_JOURNEY
+  parent: ATTEMPT_RECOVERY_STATE
   events:
-    continue:
+    next:
       type: basic
-      name: continue
-      targetState: F2F_HANDOFF_PAGE
+      name: next
+      targetState: PYI_ESCAPE
       response:
         type: page
-        pageId: page-face-to-face-handoff
-    restart:
-      type: basic
-      name: restart
-      targetState: RESET_IDENTITY
-      response:
-        type: journey
-        journeyStepId: /journey/reset-identity
+        pageId: pyi-escape
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE
@@ -513,6 +506,8 @@ PYI_KBV_FAIL:
 PYI_KBV_THIN_FILE:
   name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
+PYI_ESCAPE:
+  name: PYI_ESCAPE
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -126,22 +126,15 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 IPV_IDENTITY_PENDING_PAGE:
   name: IPV_IDENTITY_PENDING_PAGE
-  parent: END_JOURNEY
+  parent: ATTEMPT_RECOVERY_STATE
   events:
-    continue:
+    next:
       type: basic
-      name: continue
-      targetState: F2F_HANDOFF_PAGE
+      name: next
+      targetState: PYI_ESCAPE
       response:
         type: page
-        pageId: page-face-to-face-handoff
-    restart:
-      type: basic
-      name: restart
-      targetState: RESET_IDENTITY
-      response:
-        type: journey
-        journeyStepId: /journey/reset-identity
+        pageId: pyi-escape
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE
@@ -513,6 +506,8 @@ PYI_KBV_FAIL:
 PYI_KBV_THIN_FILE:
   name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
+PYI_ESCAPE:
+  name: PYI_ESCAPE
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
@@ -168,22 +168,14 @@ IPV_IDENTITY_REUSE_PAGE:
 
 IPV_IDENTITY_PENDING_PAGE:
   name: IPV_IDENTITY_PENDING_PAGE
-  parent: END_JOURNEY
   events:
-    continue:
+    next:
       type: basic
       name: continue
-      targetState: F2F_HANDOFF_PAGE_J4
+      targetState: PYI_ESCAPE
       response:
         type: page
-        pageId: page-face-to-face-handoff
-    restart:
-      type: basic
-      name: restart
-      targetState: RESET_IDENTITY
-      response:
-        type: journey
-        journeyStepId: /journey/reset-identity
+        pageId: pyi-escape
     attempt-recovery:
       type: basic
       name: attempt-recovery
@@ -293,6 +285,16 @@ PYI_KBV_THIN_FILE:
       response:
         type: page
         pageId: pyi-kbv-thin-file
+PYI_ESCAPE:
+  name: PYI_ESCAPE
+  events:
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: PYI_ESCAPE
+      response:
+        type: page
+        pageId: pyi-escape
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -126,22 +126,15 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 IPV_IDENTITY_PENDING_PAGE:
   name: IPV_IDENTITY_PENDING_PAGE
-  parent: END_JOURNEY
+  parent: ATTEMPT_RECOVERY_STATE
   events:
-    continue:
+    next:
       type: basic
-      name: continue
-      targetState: F2F_HANDOFF_PAGE
+      name: next
+      targetState: PYI_ESCAPE
       response:
         type: page
-        pageId: page-face-to-face-handoff
-    restart:
-      type: basic
-      name: restart
-      targetState: RESET_IDENTITY
-      response:
-        type: journey
-        journeyStepId: /journey/reset-identity
+        pageId: pyi-escape
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE
@@ -513,6 +506,8 @@ PYI_KBV_FAIL:
 PYI_KBV_THIN_FILE:
   name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
+PYI_ESCAPE:
+  name: PYI_ESCAPE
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -126,22 +126,15 @@ IPV_IDENTITY_REUSE_PAGE:
   parent: END_JOURNEY
 IPV_IDENTITY_PENDING_PAGE:
   name: IPV_IDENTITY_PENDING_PAGE
-  parent: END_JOURNEY
+  parent: ATTEMPT_RECOVERY_STATE
   events:
-    continue:
+    next:
       type: basic
-      name: continue
-      targetState: F2F_HANDOFF_PAGE
+      name: next
+      targetState: PYI_ESCAPE
       response:
         type: page
-        pageId: page-face-to-face-handoff
-    restart:
-      type: basic
-      name: restart
-      targetState: RESET_IDENTITY
-      response:
-        type: journey
-        journeyStepId: /journey/reset-identity
+        pageId: pyi-escape
 EVALUATE_GPG45_SCORES:
   name: EVALUATE_GPG45_SCORES
   parent: ATTEMPT_RECOVERY_STATE
@@ -513,6 +506,8 @@ PYI_KBV_FAIL:
 PYI_KBV_THIN_FILE:
   name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
+PYI_ESCAPE:
+  name: PYI_ESCAPE
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY


### PR DESCRIPTION
## Proposed changes

### What changed

Update pending route to lead to new escape page.

### Why did it change

The pending page has a new design - it now just has a link to "prove your identity another way". This emits a 'next' event which we want to route to the new escape page.

### Issue tracking
- [PYIC-3105](https://govukverify.atlassian.net/browse/PYIC-3105)


[PYIC-3105]: https://govukverify.atlassian.net/browse/PYIC-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ