### PR TITLE
PYIC-3106 Handle escape page options

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/build/ipv-core-main-journey.yaml
@@ -513,6 +513,23 @@ PYI_KBV_FAIL:
 PYI_KBV_THIN_FILE:
   name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
+PYI_ESCAPE:
+  name: PYI_ESCAPE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/dev/ipv-core-main-journey.yaml
@@ -508,6 +508,21 @@ PYI_KBV_THIN_FILE:
   parent: END_JOURNEY
 PYI_ESCAPE:
   name: PYI_ESCAPE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/integration/ipv-core-main-journey.yaml
@@ -508,6 +508,21 @@ PYI_KBV_THIN_FILE:
   parent: END_JOURNEY
 PYI_ESCAPE:
   name: PYI_ESCAPE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
@@ -295,6 +295,20 @@ PYI_ESCAPE:
       response:
         type: page
         pageId: pyi-escape
+    next:
+      type: basic
+      name: next
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/production/ipv-core-main-journey.yaml
@@ -508,6 +508,21 @@ PYI_KBV_THIN_FILE:
   parent: END_JOURNEY
 PYI_ESCAPE:
   name: PYI_ESCAPE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY

--- a/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/staging/ipv-core-main-journey.yaml
@@ -508,6 +508,21 @@ PYI_KBV_THIN_FILE:
   parent: END_JOURNEY
 PYI_ESCAPE:
   name: PYI_ESCAPE
+  events:
+    next:
+      type: basic
+      name: next
+      targetState: RESET_IDENTITY
+      response:
+        type: journey
+        journeyStepId: /journey/reset-identity
+    end:
+      type: basic
+      name: end
+      targetState: END
+      response:
+        type: journey
+        journeyStepId: /journey/build-client-oauth-response
 CRI_ERROR:
   name: CRI_ERROR
   parent: END_JOURNEY


### PR DESCRIPTION
## Proposed changes

### What changed

Handle new escape page options - next goes to `RESET-IDENTITY` and end goes to `END`. Includes missing definition for `PYI_ESCAPE` event in build

### Why did it change

New escape page gives users the option to go back to the RP to PYI another way or to 'restart' and try again online

### Issue tracking
- [PYIC-3106](https://govukverify.atlassian.net/browse/PYIC-3106)



[PYIC-3106]: https://govukverify.atlassian.net/browse/PYIC-3106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ