### PR TITLE
BAU: Conditionally turn off step function logging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -60,6 +60,13 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+  TurnOffCriReturnStepFunctionLogging: !Equals
+    - !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, criReturnStepFunctionLogLevel ]
+    - OFF
+  TurnOffJourneyEngineStepFunctionLogging: !Equals
+    - !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, journeyEngineStepFunctionLogLevel ]
+    - OFF
+
 
 # The AWS Account Id is used in the following mapping section because we have
 # multiple developer environments and it is undesirable to have to keep this
@@ -71,6 +78,7 @@ Mappings:
       ciStorageAccountId: 322814139578 # di-ipv-cri-dev
       environment: dev
       criReturnStepFunctionLogLevel: ALL
+      journeyEngineStepFunctionLogLevel: ALL
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
       asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:616199614141:stubQueue_F2FQueueOldDev"
@@ -83,6 +91,7 @@ Mappings:
       ciStorageAccountId: 158853307826 # new CIMIT dev
       environment: dev
       criReturnStepFunctionLogLevel: ALL
+      journeyEngineStepFunctionLogLevel: ALL
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
       asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:616199614141:stubQueue_F2FQueue"
@@ -93,6 +102,7 @@ Mappings:
       ciStorageAccountId: 755415363251 # di-ipv-contra-indicators-build
       environment: build
       criReturnStepFunctionLogLevel: ALL
+      journeyEngineStepFunctionLogLevel: ALL
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
       asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:616199614141:stubQueue_F2FQueue_build"
@@ -103,6 +113,7 @@ Mappings:
       ciStorageAccountId: 265689800486 # di-ipv-contra-indicators-staging
       environment: staging
       criReturnStepFunctionLogLevel: ALL
+      journeyEngineStepFunctionLogLevel: ALL
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
       asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:616199614141:stubQueue_F2FQueue_staging"
@@ -113,6 +124,7 @@ Mappings:
       ciStorageAccountId: 697519714716 # di-ipv-contra-indicators-integration
       environment: integration
       criReturnStepFunctionLogLevel: OFF
+      journeyEngineStepFunctionLogLevel: OFF
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
       asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:616199614141:stubQueue_F2FQueue_integration"
@@ -123,6 +135,7 @@ Mappings:
       ciStorageAccountId: 442136572379 # di-ipv-contra-indicators-prod
       environment: production
       criReturnStepFunctionLogLevel: OFF
+      journeyEngineStepFunctionLogLevel: OFF
       pgw500ErrorLimit: 20
       egw500ErrorLimit: 2
       asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:616199614141:stubQueue_F2FQueue_production"
@@ -1342,12 +1355,14 @@ Resources:
               Ref: IPVCorePrivateAPI
             Path: /journey/cri/callback
             Method: POST
-      Logging:
-        Destinations:
-          - CloudWatchLogsLogGroup:
-              LogGroupArn: !GetAtt CriReturnStepFunctionLogGroup.Arn
-        IncludeExecutionData: true
-        Level: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, criReturnStepFunctionLogLevel ]
+      Logging: !If
+        - TurnOffCriReturnStepFunctionLogging
+        - Ref: AWS::NoValue
+        - Destinations:
+            - CloudWatchLogsLogGroup:
+                LogGroupArn: !GetAtt CriReturnStepFunctionLogGroup.Arn
+          IncludeExecutionData: true
+          Level: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, criReturnStepFunctionLogLevel ]
       Policies:
         - LambdaInvokePolicy:
             FunctionName: !Ref IPVProcessJourneyStepFunction
@@ -1441,12 +1456,14 @@ Resources:
               Ref: IPVCorePrivateAPI
             Path: /journey/{journeyStep}
             Method: POST
-      Logging:
-        Destinations:
-          - CloudWatchLogsLogGroup:
-              LogGroupArn: !GetAtt JourneyEngineStepFunctionLogGroup.Arn
-        IncludeExecutionData: true
-        Level: ALL
+      Logging: !If
+        - TurnOffJourneyEngineStepFunctionLogging
+        - Ref: AWS::NoValue
+        - Destinations:
+            - CloudWatchLogsLogGroup:
+                LogGroupArn: !GetAtt JourneyEngineStepFunctionLogGroup.Arn
+          IncludeExecutionData: true
+          Level: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, journeyEngineStepFunctionLogLevel ]
       Policies:
         - LambdaInvokePolicy:
             FunctionName: !Ref IPVProcessJourneyStepFunction


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Conditionally turn off step function logging

### Why did it change

This is to address an unexpected issue that is preventing our CloudFormation deploying to integration and production.

We need to stop the step functions from logging. Updating their logging configuration to `OFF` in the template caused an error to be thrown when deploying the step function in the stack:

```
Resource handler returned message: "Model validation failed
(#/LoggingConfiguration/Level: #: only 1 subschema matches out of
2) #/LoggingConfiguration/Level: failed validation constraint for
keyword [enum] (#/LoggingConfiguration/Level)"
```

Changing the logging level to anything else works - ERROR for example - however we need to stop it completely.

Setting the level to OFF and removing all the other logging properties (Destination and IncludeExecutionData), also fails to deploy.

Removing the `Logging` property completely will deploy. The docs suggest that this should then default to logging being off. However after a deploy with no `Logging` property, the actual logging level, checked through the console, remains unaffected. It stays on whatever level was previously set.

Given all the above I suggest we make this change. It will check if the logging level is set to off in the env map, and if it is, remove the logging sections from the step functions completely. This won't actually change the logging level due to the issue mentioned above, but we can manually change it to off while we work out what on earth is happening. We won't have to worry about it being turned back on by a subsequent deploy. We've actually already manually turned them off. This will allow us to make releases and unblock people.
