### PR TITLE
PYIC-3053: Remove fail-with-no-ci scaffolding

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -19,7 +19,6 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.BaseResponse;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
@@ -172,12 +171,10 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
 
             updateSuccessfulVcStatuses(ipvSessionItem, credentials);
 
-            if (ipvSessionItem.getJourneyType() == IpvJourneyTypes.IPV_CORE_REFACTOR_JOURNEY) {
-                Optional<JourneyResponse> journeyResponseForFailWithNoCi =
-                        getJourneyResponseForFailWithNoCi(ipvSessionItem);
-                if (journeyResponseForFailWithNoCi.isPresent()) {
-                    return journeyResponseForFailWithNoCi.get();
-                }
+            Optional<JourneyResponse> journeyResponseForFailWithNoCi =
+                    getJourneyResponseForFailWithNoCi(ipvSessionItem);
+            if (journeyResponseForFailWithNoCi.isPresent()) {
+                return journeyResponseForFailWithNoCi.get();
             }
 
             if (!checkCorrelation(userId, ipvSessionItem.getCurrentVcStatuses())) {
@@ -384,8 +381,7 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
                         .findFirst();
 
         if (lastVisitedCriVcStatus.isPresent()
-                && Boolean.FALSE.equals(lastVisitedCriVcStatus.get().getIsSuccessfulVc())
-                && ipvSessionItem.getJourneyType() == IpvJourneyTypes.IPV_CORE_REFACTOR_JOURNEY) {
+                && Boolean.FALSE.equals(lastVisitedCriVcStatus.get().getIsSuccessfulVc())) {
             // Handle scenario where VCs without CIs should be redirected
             return Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_NO_CI));
         }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove fail-with-no-ci scaffolding

### Why did it change

The new logic to handle VCs that are "unsuccessful" but have no CIs only worked with the new refactored journey. Now that we've switched we can remove the scaffolding that allowed both journeys to run.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3053](https://govukverify.atlassian.net/browse/PYIC-3053)


[PYIC-3053]: https://govukverify.atlassian.net/browse/PYIC-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ