### PR TITLE
BAU: Stop logging warnings if null received from Dynamo

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -71,11 +71,11 @@ public class DataStore<T extends DynamodbItem> {
 
     public T getItem(String partitionValue, String sortValue) {
         var key = Key.builder().partitionValue(partitionValue).sortValue(sortValue).build();
-        return getItemByKey(key, true);
+        return getItemByKey(key, false);
     }
 
     public T getItem(String partitionValue) {
-        return getItem(partitionValue, true);
+        return getItem(partitionValue, false);
     }
 
     public T getItem(String partitionValue, boolean warnOnNull) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
@@ -14,7 +14,6 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
-import software.amazon.awssdk.enhanced.dynamodb.model.DescribeTableEnhancedResponse;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
@@ -103,11 +102,6 @@ class DataStoreTest {
                 TableDescription.builder().tableName("test-table").build();
         DescribeTableResponse describeTableResponse =
                 DescribeTableResponse.builder().table(tableDescription).build();
-        when(mockDynamoDbTable.describeTable())
-                .thenReturn(
-                        new DescribeTableEnhancedResponse.Builder()
-                                .response(describeTableResponse)
-                                .build());
 
         dataStore.getItem("partition-key-12345", "sort-key-12345");
 
@@ -128,11 +122,6 @@ class DataStoreTest {
                 TableDescription.builder().tableName("test-table").build();
         DescribeTableResponse describeTableResponse =
                 DescribeTableResponse.builder().table(tableDescription).build();
-        when(mockDynamoDbTable.describeTable())
-                .thenReturn(
-                        new DescribeTableEnhancedResponse.Builder()
-                                .response(describeTableResponse)
-                                .build());
 
         dataStore.getItem("partition-key-12345");
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Stop logging warnings if null received from Dynamo

### Why did it change

The warning can contain sensitive information. We should stop logging it.
