### PR TITLE
BAU: Log on null, but without field

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -71,11 +71,11 @@ public class DataStore<T extends DynamodbItem> {
 
     public T getItem(String partitionValue, String sortValue) {
         var key = Key.builder().partitionValue(partitionValue).sortValue(sortValue).build();
-        return getItemByKey(key, false);
+        return getItemByKey(key, true);
     }
 
     public T getItem(String partitionValue) {
-        return getItem(partitionValue, false);
+        return getItem(partitionValue, true);
     }
 
     public T getItem(String partitionValue, boolean warnOnNull) {
@@ -157,8 +157,7 @@ public class DataStore<T extends DynamodbItem> {
             var message =
                     new StringMapMessage()
                             .with("datastore", "Null result retrieved from DynamoDB")
-                            .with("table", table.describeTable().table().tableName())
-                            .with("field", key.partitionKeyValue().toString());
+                            .with("table", table.describeTable().table().tableName());
             LOGGER.warn(message);
         }
         return result;

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.DescribeTableEnhancedResponse;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
@@ -102,6 +103,11 @@ class DataStoreTest {
                 TableDescription.builder().tableName("test-table").build();
         DescribeTableResponse describeTableResponse =
                 DescribeTableResponse.builder().table(tableDescription).build();
+        when(mockDynamoDbTable.describeTable())
+                .thenReturn(
+                        new DescribeTableEnhancedResponse.Builder()
+                                .response(describeTableResponse)
+                                .build());
 
         dataStore.getItem("partition-key-12345", "sort-key-12345");
 
@@ -122,6 +128,11 @@ class DataStoreTest {
                 TableDescription.builder().tableName("test-table").build();
         DescribeTableResponse describeTableResponse =
                 DescribeTableResponse.builder().table(tableDescription).build();
+        when(mockDynamoDbTable.describeTable())
+                .thenReturn(
+                        new DescribeTableEnhancedResponse.Builder()
+                                .response(describeTableResponse)
+                                .build());
 
         dataStore.getItem("partition-key-12345");
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Log on null, but without field

### Why did it change

This adds back the logging so we know if we received null from Dynamo, but won't log the field value.
