### PR TITLE
Revert "PYIC-3013: Remove redundant code from validate OAuth callback"

### DIFF
--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditExtensionErrorParams;
 import uk.gov.di.ipv.core.library.auditing.AuditExtensions;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -39,6 +40,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.domain.CriConstants.DRIVING_LICENCE_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CLIENT_OAUTH_SESSION_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
@@ -52,6 +56,10 @@ public class ValidateOAuthCallbackHandler
             Map.of(JOURNEY, "/journey/cri/access-token");
     private static final Map<String, Object> JOURNEY_ACCESS_DENIED =
             Map.of(JOURNEY, "/journey/access-denied");
+    private static final Map<String, Object> JOURNEY_ACCESS_DENIED_MULTI =
+            Map.of(JOURNEY, "/journey/access-denied-multi-doc");
+    private static final Map<String, Object> JOURNEY_ACCESS_DENIED_MULTI_WITH_F2F =
+            Map.of(JOURNEY, "/journey/access-denied-multi-f2f-doc");
     private static final Map<String, Object> JOURNEY_TEMPORARILY_UNAVAILABLE =
             Map.of(JOURNEY, "/journey/temporarily-unavailable");
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, "/journey/error");
@@ -257,6 +265,12 @@ public class ValidateOAuthCallbackHandler
         LogHelper.logOauthError("OAuth error received from CRI", error, errorDescription);
 
         if (OAuth2Error.ACCESS_DENIED_CODE.equals(error)) {
+            if (configService.isEnabled(PASSPORT_CRI)
+                    && configService.isEnabled(DRIVING_LICENCE_CRI)
+                    && ipvSessionItem.getJourneyType() == IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY) {
+                // This branch should be removed after we move the newly refactored journey
+                return getMultipleDocCheckPage();
+            }
             return JOURNEY_ACCESS_DENIED;
         } else if (OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE.equals(error)) {
             return JOURNEY_TEMPORARILY_UNAVAILABLE;
@@ -301,6 +315,13 @@ public class ValidateOAuthCallbackHandler
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
         }
+    }
+
+    private Map<String, Object> getMultipleDocCheckPage() {
+        if (configService.isEnabled(F2F_CRI)) {
+            return JOURNEY_ACCESS_DENIED_MULTI_WITH_F2F;
+        }
+        return JOURNEY_ACCESS_DENIED_MULTI;
     }
 
     @Tracing

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -40,6 +40,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.DRIVING_LICENCE_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 
 @ExtendWith(MockitoExtension.class)
 class ValidateOAuthCallbackHandlerHandlerTest {
@@ -338,7 +341,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     }
 
     @Test
-    void shouldReceiveAccessDeniedJourneyResponseWhenAccessDeniedOAuthErrorReceived() {
+    void shouldReceiveAccessDeniedJourneyResponseWhenRunningRefactorJourney() {
         CriCallbackRequest criCallbackRequestWithAccessDenied = validCriCallbackRequest();
         criCallbackRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
         criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
@@ -350,11 +353,82 @@ class ValidateOAuthCallbackHandlerHandlerTest {
                 .thenReturn(criOAuthSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
+        when(mockConfigService.isEnabled(PASSPORT_CRI)).thenReturn(true);
+
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(true);
 
         Map<String, Object> output =
                 underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
 
         assertEquals("/journey/access-denied", output.get("journey"));
+        verify(mockCriOAuthSessionService, times(1)).getCriOauthSessionItem(any());
+    }
+
+    @Test
+    void shouldReceiveAccessDeniedJourneyResponseWhenOauthErrorAccessDeniedAndOnlyPassportEnabled()
+            throws URISyntaxException {
+        CriCallbackRequest criCallbackRequestWithAccessDenied = validCriCallbackRequest();
+        criCallbackRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
+        criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockCriOAuthSessionService.getCriOauthSessionItem(any()))
+                .thenReturn(criOAuthSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockConfigService.isEnabled(PASSPORT_CRI)).thenReturn(true);
+
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(false);
+        Map<String, Object> output =
+                underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
+
+        assertEquals("/journey/access-denied", output.get("journey"));
+    }
+
+    @Test
+    void
+            shouldReceiveAccessDeniedMultiJourneyResponseWhenOauthErrorAccessDeniedAndBothPassportAndDrivingLicenceEnabled() {
+        CriCallbackRequest criCallbackRequestWithAccessDenied = validCriCallbackRequest();
+        criCallbackRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
+        criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockCriOAuthSessionService.getCriOauthSessionItem(any()))
+                .thenReturn(criOAuthSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockConfigService.isEnabled(PASSPORT_CRI)).thenReturn(true);
+
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(true);
+
+        Map<String, Object> output =
+                underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
+
+        assertEquals("/journey/access-denied-multi-doc", output.get("journey"));
+        verify(mockCriOAuthSessionService, times(1)).getCriOauthSessionItem(any());
+    }
+
+    @Test
+    void
+            shouldReceiveAccessDeniedMultiJourneyResponseWhenOauthErrorAccessDeniedAndBothPassportDLicenceF2FEnabled()
+                    throws URISyntaxException {
+        CriCallbackRequest criCallbackRequestWithAccessDenied = validCriCallbackRequest();
+        criCallbackRequestWithAccessDenied.setError(TEST_OAUTH_ACCESS_DENIED_ERROR);
+        criCallbackRequestWithAccessDenied.setErrorDescription(TEST_ERROR_DESCRIPTION);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockCriOAuthSessionService.getCriOauthSessionItem(any()))
+                .thenReturn(criOAuthSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockConfigService.isEnabled(PASSPORT_CRI)).thenReturn(true);
+        when(mockConfigService.isEnabled(DRIVING_LICENCE_CRI)).thenReturn(true);
+        when(mockConfigService.isEnabled(F2F_CRI)).thenReturn(true);
+
+        Map<String, Object> output =
+                underTest.handleRequest(criCallbackRequestWithAccessDenied, context);
+
+        assertEquals("/journey/access-denied-multi-f2f-doc", output.get("journey"));
         verify(mockCriOAuthSessionService, times(1)).getCriOauthSessionItem(any());
     }
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Revert "PYIC-3013: Remove redundant code from validate OAuth callback"

### Why did it change

This reverts commit 6b797431824e4913516f56efb9690231d5ff187b.

For some reason this failed the tests in staging, and is blocking the pipeline.
