### PR TITLE
BAU: Return no match if returning user has CIs

### DIFF
--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -263,7 +263,7 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnJourneyResetIdentityResponseIfVcsFailCiScoreCheck()
+    void shouldReturnPyiNoMatchIfVcsFailCiScoreCheck()
             throws ParseException, SqsException, IOException {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
@@ -275,14 +275,8 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
 
         var journeyResponse = handleRequest(event, context, JourneyResponse.class);
-        assertEquals("/journey/reset-identity", journeyResponse.getJourney());
+        assertEquals("/journey/pyi-no-match", journeyResponse.getJourney());
 
-        ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
-                ArgumentCaptor.forClass(AuditEvent.class);
-        verify(auditService).sendAuditEvent(auditEventArgumentCaptor.capture());
-        assertEquals(
-                AuditEventTypes.IPV_IDENTITY_REUSE_RESET,
-                auditEventArgumentCaptor.getValue().getEventName());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-refactor-journey.yaml
@@ -123,6 +123,20 @@ CHECK_EXISTING_IDENTITY:
       response:
         type: page
         pageId: page-ipv-pending
+    pyi-no-match:
+      type: basic
+      name: pyi-no-match
+      targetState: PYI_NO_MATCH
+      response:
+        type: page
+        pageId: pyi-no-match
+    pyi-kbv-fail:
+      type: basic
+      name: pyi-kbv-fail
+      targetState: PYI_KBV_FAIL
+      response:
+        type: page
+        pageId: pyi-kbv-fail
     attempt-recovery:
       type: basic
       name: attempt-recovery


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return no match if returning user has CIs
### Why did it change

If a user has CIs stored in the CI storage service, and they fail the check on their scores, they should receive a no match response.

The recent changes to the journey engine meant that the gpg45-eval lambda wasn't being called after a user reset, called from the check-existing-identity lambda. This meant that a user with CIs could come back into the system and reach the first CRI, before getting a no match response due to their existing CIs.

This change slightly updates the logic in the check-existing-identity lambda to return a fail response if necessary, and maintains existing behaviour beyond that.
