### PR TITLE
BAU: Ignore template written by dev-deploy tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ build
 
 # Ignore node/TS output
 node_modules
+
+# Ignore template written by dev-deploy tool
+deploy/core-back-*.yaml


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Ignore template written by dev-deploy tool

### Why did it change

The dev-deploy tool makes a copy of the CF template that is uses to deploy a devs core-back. This can be ignored to save accidental commital.
