### PR TITLE
PYIC-3167 Handle CRI disabled switch for basic state machine event

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEvent.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEvent.java
@@ -1,19 +1,48 @@
 package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.State;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineResult;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyStepResponse;
 
+import java.util.LinkedHashMap;
+import java.util.Optional;
+
 @Data
 public class BasicEvent implements Event {
-
+    private static final Logger LOGGER = LogManager.getLogger();
+    @JsonIgnore private ConfigService configService;
     private String name;
     private State targetState;
     private JourneyStepResponse response;
+    private LinkedHashMap<String, Event> checkIfDisabled;
+
+    public BasicEvent() {
+        this.configService = new ConfigService();
+    }
+
+    public BasicEvent(ConfigService configService) {
+        this.configService = configService;
+    }
 
     public StateMachineResult resolve(JourneyContext journeyContext) {
+        configService.setFeatureSet(journeyContext.getFeatureSet());
+        if (checkIfDisabled != null) {
+            Optional<String> firstDisabledCri =
+                    checkIfDisabled.keySet().stream()
+                            .filter(id -> !configService.isEnabled(id))
+                            .findFirst();
+            if (firstDisabledCri.isPresent()) {
+                String disabledCriId = firstDisabledCri.get();
+                LOGGER.info("CRI with ID '{}' is disabled. Using alternative event", disabledCriId);
+                return checkIfDisabled.get(disabledCriId).resolve(journeyContext);
+            }
+        }
         return new StateMachineResult(targetState, response);
     }
 }

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateTest.java
@@ -1,27 +1,33 @@
 package uk.gov.di.ipv.core.processjourneystep.statemachine;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.events.BasicEvent;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyResponse;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 public class StateTest {
-
+    @Mock private static ConfigService mockConfigService;
     public static final State CURRENT_STATE = new State("CURRENT_STATE");
     private static final State TARGET_STATE = new State("TARGET_STATE");
     private static final JourneyResponse JOURNEY_RESPONSE = new JourneyResponse("stepId");
-    private static final BasicEvent CURRENT_TO_TARGET_EVENT = new BasicEvent();
-    ;
 
-    @BeforeAll
-    private static void beforeAll() {
+    @BeforeEach
+    private void beforeEach() {
+        BasicEvent CURRENT_TO_TARGET_EVENT = new BasicEvent(mockConfigService);
         CURRENT_TO_TARGET_EVENT.setName("eventName");
         CURRENT_TO_TARGET_EVENT.setTargetState(TARGET_STATE);
         CURRENT_TO_TARGET_EVENT.setResponse(JOURNEY_RESPONSE);

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEventTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEventTest.java
@@ -1,20 +1,33 @@
 package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.State;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineResult;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyResponse;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.PageResponse;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 class BasicEventTest {
+    @Mock private ConfigService mockConfigService;
+
     @Test
     void resolveShouldReturnAStateMachineResult() {
         State targetState = new State("TARGET_STATE");
         JourneyResponse journeyResponse = new JourneyResponse();
 
-        BasicEvent basicEvent = new BasicEvent();
+        BasicEvent basicEvent = new BasicEvent(mockConfigService);
         basicEvent.setName("eventName");
         basicEvent.setTargetState(targetState);
         basicEvent.setResponse(journeyResponse);
@@ -23,5 +36,35 @@ class BasicEventTest {
 
         assertEquals(targetState, result.getState());
         assertEquals(journeyResponse, result.getJourneyStepResponse());
+    }
+
+    @Test
+    void resolveShouldReturnAlternativeResultIfACheckedCriIsDisabled() {
+        BasicEvent basicEventWithCheckIfDisabledConfigured = new BasicEvent(mockConfigService);
+        basicEventWithCheckIfDisabledConfigured.setName("eventName");
+        basicEventWithCheckIfDisabledConfigured.setTargetState(new State());
+        basicEventWithCheckIfDisabledConfigured.setResponse(new PageResponse());
+
+        BasicEvent alternativeEvent = new BasicEvent(mockConfigService);
+        State alternativeState = new State("THE_TARGET_STATE_FOR_THE_ALTERNATIVE_RESULT");
+        PageResponse alternativePageResponse = new PageResponse();
+        alternativePageResponse.setPageId("alternativePageId");
+        alternativeEvent.setTargetState(alternativeState);
+        alternativeEvent.setResponse(alternativePageResponse);
+
+        when(mockConfigService.isEnabled("anEnabledCri")).thenReturn(true);
+        when(mockConfigService.isEnabled("aDisabledCri")).thenReturn(false);
+        LinkedHashMap<String, Event> checkIfDisabled = new LinkedHashMap<>();
+        checkIfDisabled.put("anEnabledCri", new BasicEvent(mockConfigService));
+        checkIfDisabled.put("aDisabledCri", alternativeEvent);
+        basicEventWithCheckIfDisabledConfigured.setCheckIfDisabled(checkIfDisabled);
+
+        StateMachineResult result =
+                basicEventWithCheckIfDisabledConfigured.resolve(JourneyContext.emptyContext());
+
+        assertEquals(alternativeState, result.getState());
+        assertEquals(
+                "alternativePageId",
+                result.getJourneyStepResponse().value(mockConfigService).get("page"));
     }
 }

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/CriEventTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/CriEventTest.java
@@ -54,7 +54,7 @@ class CriEventTest {
         criEventWithCheckIfDisabledConfigured.setTargetState(new State());
         criEventWithCheckIfDisabledConfigured.setCriId("aCriId");
 
-        BasicEvent alternativeEvent = new BasicEvent();
+        BasicEvent alternativeEvent = new BasicEvent(mockConfigService);
         State alternativeState = new State("THE_TARGET_STATE_FOR_THE_ALTERNATIVE_RESULT");
         JourneyResponse alternativeJourneyResponse = new JourneyResponse();
         alternativeJourneyResponse.setJourneyStepId("alternativeStepId");
@@ -65,8 +65,8 @@ class CriEventTest {
         when(mockConfigService.isEnabled("anotherEnabledCri")).thenReturn(true);
         when(mockConfigService.isEnabled("aDisabledCri")).thenReturn(false);
         LinkedHashMap<String, Event> checkIfDisabled = new LinkedHashMap<>();
-        checkIfDisabled.put("anEnabledCri", new BasicEvent());
-        checkIfDisabled.put("anotherEnabledCri", new BasicEvent());
+        checkIfDisabled.put("anEnabledCri", new BasicEvent(mockConfigService));
+        checkIfDisabled.put("anotherEnabledCri", new BasicEvent(mockConfigService));
         checkIfDisabled.put("aDisabledCri", alternativeEvent);
         criEventWithCheckIfDisabledConfigured.setCheckIfDisabled(checkIfDisabled);
 
@@ -85,7 +85,7 @@ class CriEventTest {
         criEventWithCheckIfDisabledConfigured.setTargetState(new State());
         criEventWithCheckIfDisabledConfigured.setCriId("aCriId");
 
-        BasicEvent alternativeEvent = new BasicEvent();
+        BasicEvent alternativeEvent = new BasicEvent(mockConfigService);
         State alternativeState = new State("THE_TARGET_STATE_FOR_THE_ALTERNATIVE_RESULT");
         JourneyResponse alternativeJourneyResponse = new JourneyResponse();
         alternativeJourneyResponse.setJourneyStepId("alternativeStepId");
@@ -95,9 +95,9 @@ class CriEventTest {
         when(mockConfigService.isEnabled("anEnabledCri")).thenReturn(true);
         when(mockConfigService.isEnabled("aDisabledCri")).thenReturn(false);
         LinkedHashMap<String, Event> checkIfDisabled = new LinkedHashMap<>();
-        checkIfDisabled.put("anEnabledCri", new BasicEvent());
+        checkIfDisabled.put("anEnabledCri", new BasicEvent(mockConfigService));
         checkIfDisabled.put("aDisabledCri", alternativeEvent);
-        checkIfDisabled.put("anotherDisabledCri", new BasicEvent());
+        checkIfDisabled.put("anotherDisabledCri", new BasicEvent(mockConfigService));
         criEventWithCheckIfDisabledConfigured.setCheckIfDisabled(checkIfDisabled);
 
         StateMachineResult result =
@@ -121,9 +121,9 @@ class CriEventTest {
         when(mockConfigService.isEnabled("anotherEnabledCri")).thenReturn(true);
         when(mockConfigService.isEnabled("oneMoreEnabledCri")).thenReturn(true);
         LinkedHashMap<String, Event> checkIfDisabled = new LinkedHashMap<>();
-        checkIfDisabled.put("anEnabledCri", new BasicEvent());
-        checkIfDisabled.put("anotherEnabledCri", new BasicEvent());
-        checkIfDisabled.put("oneMoreEnabledCri", new BasicEvent());
+        checkIfDisabled.put("anEnabledCri", new BasicEvent(mockConfigService));
+        checkIfDisabled.put("anotherEnabledCri", new BasicEvent(mockConfigService));
+        checkIfDisabled.put("oneMoreEnabledCri", new BasicEvent(mockConfigService));
         criEventWithCheckIfDisabledConfigured.setCheckIfDisabled(checkIfDisabled);
 
         StateMachineResult result =


### PR DESCRIPTION
## Proposed changes

### What changed

Handle CRI disabled switch for basic state machine event

### Why did it change

We only had the `checkIfDisabled` state machine flag working for CriEvents, but we want to be able to use this for BasicEvents with page responses specifically for the new F2F entry route

### Issue tracking
- [PYIC-3167](https://govukverify.atlassian.net/browse/PYIC-3167)



[PYIC-3167]: https://govukverify.atlassian.net/browse/PYIC-3167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ