### PR TITLE
BAU: Add spotless check to pre-commit

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonarqube
+        run: ./gradlew sonar
 
   sam-build:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,28 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-    -   id: check-json
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: detect-aws-credentials
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: detect-aws-credentials
         args: [ --allow-missing-credentials ]
-    -   id: detect-private-key
--   repo: https://github.com/awslabs/cfn-python-lint
+      - id: detect-private-key
+
+  - repo: https://github.com/awslabs/cfn-python-lint
     rev: v0.77.5 # The version of cfn-lint to use
     hooks:
-    -   id: cfn-python-lint
+      - id: cfn-python-lint
         files: .template\.yaml$
-- repo: https://github.com/bridgecrewio/checkov.git
-  rev: '2.3.245'
-  hooks:
-  - id: checkov
-    verbose: true
-    args: [--soft-fail]
+
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: '2.3.245'
+    hooks:
+      - id: checkov
+        verbose: true
+        args: [--soft-fail]
+
+  - repo: https://github.com/Wynndow/spotless-pre-commit.git
+    rev: 'v0.2.0'
+    hooks:
+      - id: spotlessCheck

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id "java"
-	id "org.sonarqube" version "4.2.0.3129"
+	id "org.sonarqube" version "4.2.1.3168"
 	id "com.diffplug.spotless" version "6.19.0"
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add spotless check to pre-commit

### Why did it change

[BAU: Add spotless check to pre-commit](https://github.com/alphagov/di-ipv-core-back/pull/1008/commits/76c59498cd9192d8dd01740f215ed6aae55a8460)

It can be very annoying if you forget to run Spotless, only to find out when your PR checks fail.

This adds a `spotlessCheck` to pre-commit. It will only check, not fix for you, so you'd still have to manually run `spotlessApply`. This can be changed if people think it's better for it to make the changes for you.

The plugin being used is one I wrote and is a repo in my personal GitHub. If people think doing this is a good idea we should transfer it to alphagov, in case I go under a bus.

[BAU: Bump sonarqube and use non deprecated gradle task](https://github.com/alphagov/di-ipv-core-back/pull/1008/commits/7bef169d7a3bac19ae1f7d702aced14dd353a541) 
When running the sonarqube task in GHA we get a deprecation warning that
we should be `sonarqube` task is deprecated and we should use `sonar`
instead. This also bumps the plugin to the latest version.

This is mostly being done in an attempt to fix an issue where the GHA is
failing when running that task:

```
Execution failed for task ':sonarqube'.
> Failed to upload report - An unexpected error occurred. Please try again later.
```

Who knows if this will fix that. Lets find out.
