### PR TITLE
PYIC-3112 Handle F2F start page options

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -87,6 +87,28 @@ IPV_IDENTITY_START_PAGE:
         type: page
         pageId: page-ipv-identity-start
 
+F2F_START_PAGE:
+  name: F2F_START_PAGE
+  events:
+    next:
+      type: cri
+      criId: claimedIdentity
+      targetState: CRI_CLAIMED_IDENTITY_J4
+    end:
+      type: basic
+      name: end
+      targetState: PYI_ESCAPE
+      response:
+        type: page
+        pageId: pyi-escape
+    attempt-recovery:
+      type: basic
+      name: attempt-recovery
+      targetState: F2F_START_PAGE
+      response:
+        type: page
+        pageId: page-ipv-identity-postoffice-start
+
 CHECK_EXISTING_IDENTITY:
   name: CHECK_EXISTING_IDENTITY
   events:


### PR DESCRIPTION
## Proposed changes

### What changed

Handle F2F start page options:
Yes (next) → start F2F journey (claimed identity CRI)
No (end) → escape page

### Why did it change

To stage out the changes this just sets up the new state ready to be wired up

### Issue tracking
- [PYIC-3112](https://govukverify.atlassian.net/browse/PYIC-3112)



[PYIC-3112]: https://govukverify.atlassian.net/browse/PYIC-3112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ