### PR TITLE
PROBLEM-54: Validate CI codes when retrieving VCs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -881,6 +881,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/*
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/*/api-key-*
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -2042,6 +2044,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
         - Statement:
             - Sid: kmsSigningKeyPermission
               Effect: Allow

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -83,7 +83,7 @@ public class ProcessAsyncCriCredentialHandler
     @ExcludeFromGeneratedCoverageReport
     public ProcessAsyncCriCredentialHandler() {
         this.configService = new ConfigService();
-        this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator();
+        this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator(configService);
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
         this.ciStorageService = new CiStorageService(configService);

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -111,7 +111,7 @@ public class RetrieveCriCredentialHandler
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
-        this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator();
+        this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator(configService);
         this.ciStorageService = new CiStorageService(configService);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiStorageService.java
@@ -71,7 +71,7 @@ public class CiStorageService {
     public CiStorageService(ConfigService configService) {
         this.lambdaClient = AWSLambdaClientBuilder.defaultClient();
         this.configService = configService;
-        this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator();
+        this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator(configService);
     }
 
     public CiStorageService(


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Validate CI codes when retrieving VCs

### Why did it change

We recently encountered an issue where a CRI was returning an unrecognised CI code. We should not be accepting these VCs.

This adds a check in the VC validator to compare all the CI codes in the VC against our known list. If any CI is not recognised the VC fails validation.

We're not logging the bad CI code to prevent leaks of sensitive information.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PROBLEM-54](https://govukverify.atlassian.net/browse/PROBLEM-54)


[PROBLEM-54]: https://govukverify.atlassian.net/browse/PROBLEM-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ