### PR TITLE
PROBLEM-54: Check CI codes from storage against known

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -30,6 +30,7 @@ import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -265,6 +266,12 @@ public class CheckExistingIdentityHandler extends JourneyRequestLambda {
                     JOURNEY_ERROR_PATH,
                     HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
+        } catch (UnrecognisedCiException e) {
+            LOGGER.error("Unrecognised CI code received", e);
+            return new JourneyErrorResponse(
+                    JOURNEY_ERROR_PATH,
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.UNRECOGNISED_CI_CODE);
         }
     }
 

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.NoVisitedCriFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -218,6 +219,12 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
                     JOURNEY_ERROR_PATH,
                     HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_FIND_VISITED_CRI);
+        } catch (UnrecognisedCiException e) {
+            LOGGER.error("Unrecognised CI code received", e);
+            return new JourneyErrorResponse(
+                    JOURNEY_ERROR_PATH,
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.UNRECOGNISED_CI_CODE);
         }
     }
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -62,7 +62,8 @@ public enum ErrorResponse {
     FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE(
             1051, "Failed to validate verifiable credential response"),
     FAILED_TO_FIND_VISITED_CRI(1052, "Failed to find a visited CRI"),
-    FAILED_TO_PARSE_CIMIT_SIGNING_KEY(1053, "Failed to parse CIMIT signing key");
+    FAILED_TO_PARSE_CIMIT_SIGNING_KEY(1053, "Failed to parse CIMIT signing key"),
+    UNRECOGNISED_CI_CODE(1054, "Unrecognised CI code");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.domain.CheckDetail;
 import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
+import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.text.ParseException;
@@ -50,7 +51,7 @@ public class Gpg45ProfileEvaluator {
     }
 
     public Optional<JourneyResponse> getJourneyResponseForStoredCis(
-            List<ContraIndicatorItem> ciItems) {
+            List<ContraIndicatorItem> ciItems) throws UnrecognisedCiException {
         List<ContraIndicatorItem> contraIndicatorItems = new ArrayList<>(ciItems);
         LOGGER.info(
                 new StringMapMessage()
@@ -67,6 +68,10 @@ public class Gpg45ProfileEvaluator {
 
         int ciScore = 0;
         for (String ci : ciSet) {
+            if (!contraIndicatorScoresMap.containsKey(ci)) {
+                throw new UnrecognisedCiException(
+                        "Unrecognised CI code received from CI storage system");
+            }
             ContraIndicatorScore scoresConfig = contraIndicatorScoresMap.get(ci);
             ciScore += scoresConfig.getDetectedScore();
         }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/UnrecognisedCiException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/UnrecognisedCiException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+public class UnrecognisedCiException extends Exception {
+    public UnrecognisedCiException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Check CI codes from storage against known

### Why did it change

We've had an issue where a CRI has issued incorrect CI codes. This resulted in a NPE being thrown in the check existing identity lambda when trying to check the users CI score.

This change will check the CI exists in the CI map, and if not throw an exception which is handled.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PROBLEM-54](https://govukverify.atlassian.net/browse/PROBLEM-54)


[PROBLEM-54]: https://govukverify.atlassian.net/browse/PROBLEM-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ