### PR TITLE
BAU: Fix compile warnings

### DIFF
--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.buildcrioauthrequest;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -1039,11 +1038,6 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(1, sharedClaims.get("address").size());
         assertEquals(TEST_EMAIL_ADDRESS, sharedClaims.get("emailAddress").asText());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-    }
-
-    private Map<String, Map<String, String>> getResponseBodyAsMap(
-            APIGatewayProxyResponseEvent response) throws JsonProcessingException {
-        return objectMapper.readValue(response.getBody(), Map.class);
     }
 
     private void assertErrorResponse(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/JwtHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/JwtHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.helpers;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
@@ -37,8 +38,8 @@ public class JwtHelper {
     private static <T> JWTClaimsSet generateClaims(T claimInput) {
         var claimsBuilder = new JWTClaimsSet.Builder();
 
-        mapper.convertValue(claimInput, Map.class)
-                .forEach((key, value) -> claimsBuilder.claim((String) key, value));
+        mapper.convertValue(claimInput, new TypeReference<Map<String, Object>>() {})
+                .forEach(claimsBuilder::claim);
 
         return claimsBuilder.build();
     }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.CollectionType;
+import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -28,7 +29,6 @@ import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
 import java.text.Normalizer;
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -178,7 +178,13 @@ public class UserIdentityService {
             throw new HttpResponseExceptionWithErrorBody(
                     500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
         } else if (propertyNode.isMissingNode()) {
-            return (T) Collections.emptyList();
+            try {
+                return objectMapper.readValue(new JSONArray().toJSONString(), valueType);
+            } catch (JsonProcessingException e) {
+                LOGGER.error("Failed to generate empty list: {}", e.getMessage());
+                throw new HttpResponseExceptionWithErrorBody(
+                        500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
+            }
         }
         try {
             return objectMapper.treeToValue(propertyNode, valueType);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix compile warnings

### Why did it change

When we compile the lambdas with gradle (`./gradlew build`), we see warnings generated for a couple of the sub-projects.

```
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```

This makes a few small modifications to remove those warnings.
