### PR TITLE
PROBLEM-54: Handle error event from check existing identity

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -17,7 +17,7 @@ CRI_STATE:
     error:
       type: basic
       name: error
-      targetState: CRI_ERROR
+      targetState: ERROR
       response:
         type: error
         pageId: pyi-technical
@@ -166,6 +166,14 @@ CHECK_EXISTING_IDENTITY:
       response:
         type: page
         pageId: pyi-kbv-fail
+    error:
+      type: basic
+      name: error
+      targetState: ERROR
+      response:
+        type: error
+        pageId: pyi-technical
+        statusCode: 500
     attempt-recovery:
       type: basic
       name: attempt-recovery
@@ -352,14 +360,14 @@ PYI_ESCAPE:
       response:
         type: journey
         journeyStepId: /journey/build-client-oauth-response
-CRI_ERROR:
-  name: CRI_ERROR
+ERROR:
+  name: ERROR
   parent: END_JOURNEY
   events:
     attempt-recovery:
       type: basic
       name: error
-      targetState: CRI_ERROR
+      targetState: ERROR
       response:
         type: error
         pageId: pyi-technical


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handle error event from check existing identity

### Why did it change

The check-existing-identity lambda can emit an `error` event for a range or reasons. Currently we don't handle it gracefully and the process-journey-step lambda throws an error. Ultimately the user will see the same page but we should handle it properly.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PROBLEM-54](https://govukverify.atlassian.net/browse/PROBLEM-54)


[PROBLEM-54]: https://govukverify.atlassian.net/browse/PROBLEM-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ