### PR TITLE
PYIC-3162: Remove next event from pending-page

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -212,13 +212,6 @@ IPV_IDENTITY_REUSE_PAGE:
 IPV_IDENTITY_PENDING_PAGE:
   name: IPV_IDENTITY_PENDING_PAGE
   events:
-    next:
-      type: basic
-      name: continue
-      targetState: PYI_ESCAPE
-      response:
-        type: page
-        pageId: pyi-escape
     attempt-recovery:
       type: basic
       name: attempt-recovery


### PR DESCRIPTION
We no longer will have a form on the page for a user to progress

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed the next event from the pending page

### Why did it change

Due to content changes we no longer have a button/form on the pending page

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3162](https://govukverify.atlassian.net/browse/PYIC-3162)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3162]: https://govukverify.atlassian.net/browse/PYIC-3162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ