### PR TITLE
PROBLEM-58: Handle no status matching VC issuer

### DIFF
--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.ipv.core.library.domain.Name;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -131,13 +132,20 @@ public class BuildProvenUserIdentityDetailsHandler extends JourneyRequestLambda 
                     JOURNEY_ERROR_PATH,
                     HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_GENERATE_PROVEN_USER_IDENTITY_DETAILS);
+        } catch (NoVcStatusForIssuerException e) {
+            LOGGER.error("No VC status found for issuer", e);
+            return new JourneyErrorResponse(
+                    JOURNEY_ERROR_PATH,
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.NO_VC_STATUS_FOR_CREDENTIAL_ISSUER);
         }
     }
 
     @Tracing
     private NameAndDateOfBirth getProvenIdentityNameAndDateOfBirth(
             List<VcStoreItem> credentialIssuerItems, List<VcStatusDto> currentVcStatuses)
-            throws ParseException, JsonProcessingException, ProvenUserIdentityDetailsException {
+            throws ParseException, JsonProcessingException, ProvenUserIdentityDetailsException,
+                    NoVcStatusForIssuerException {
         for (VcStoreItem item : credentialIssuerItems) {
             CredentialIssuerConfig credentialIssuerConfig =
                     configService.getCredentialIssuerActiveConnectionConfig(
@@ -183,7 +191,8 @@ public class BuildProvenUserIdentityDetailsHandler extends JourneyRequestLambda 
     @Tracing
     private List<Address> getProvenIdentityAddresses(
             List<VcStoreItem> credentialIssuerItems, List<VcStatusDto> currentVcStatuses)
-            throws ParseException, JsonProcessingException, ProvenUserIdentityDetailsException {
+            throws ParseException, JsonProcessingException, ProvenUserIdentityDetailsException,
+                    NoVcStatusForIssuerException {
         for (VcStoreItem item : credentialIssuerItems) {
             CredentialIssuerConfig credentialIssuerConfig =
                     configService.getCredentialIssuerActiveConnectionConfig(

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -31,6 +31,7 @@ import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.NoVisitedCriFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
@@ -225,11 +226,17 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
                     JOURNEY_ERROR_PATH,
                     HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ErrorResponse.UNRECOGNISED_CI_CODE);
+        } catch (NoVcStatusForIssuerException e) {
+            LOGGER.error("No VC status found for CRI issuer", e);
+            return new JourneyErrorResponse(
+                    JOURNEY_ERROR_PATH,
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.NO_VC_STATUS_FOR_CREDENTIAL_ISSUER);
         }
     }
 
     private boolean checkCorrelation(String userId, List<VcStatusDto> currentVcStatuses)
-            throws HttpResponseExceptionWithErrorBody {
+            throws HttpResponseExceptionWithErrorBody, NoVcStatusForIssuerException {
         if (!userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(
                 userId, currentVcStatuses)) {
             var message = new StringMapMessage();

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -63,7 +63,8 @@ public enum ErrorResponse {
             1051, "Failed to validate verifiable credential response"),
     FAILED_TO_FIND_VISITED_CRI(1052, "Failed to find a visited CRI"),
     FAILED_TO_PARSE_CIMIT_SIGNING_KEY(1053, "Failed to parse CIMIT signing key"),
-    UNRECOGNISED_CI_CODE(1054, "Unrecognised CI code");
+    UNRECOGNISED_CI_CODE(1054, "Unrecognised CI code"),
+    NO_VC_STATUS_FOR_CREDENTIAL_ISSUER(1055, "No VC status found for issuer");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/NoVcStatusForIssuerException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/NoVcStatusForIssuerException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+public class NoVcStatusForIssuerException extends Exception {
+    public NoVcStatusForIssuerException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handle no status matching VC issuer

### Why did it change

We've seen some unhandled errors in the logs. These are generated by a call to `isVcSuccessful` in the UserIdentityServive. This method will run through the list of generated VC statuses, and pull out the one that matches with an CRI issuer value from the users VCs. In theory we should always have one that matches. Turns out we sometimes don't. When we don't, the method just calls `orElseThrow` which is unhandled.

This updates it to thrown a specific exception which is then handled.

It's hard to determine how a user gets into this state. I've followed one affected users journey through the logs. It was a very confused journey. It looks like they might have had multiple journeys running in the same session, maybe in different tabs. Also they've hit the back button at least once as there is an attempt recover in there.

More work might be needed to identify how this happens, but in the mean time we should be handling the error.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PROBLEM-58](https://govukverify.atlassian.net/browse/PROBLEM-58)


[PROBLEM-58]: https://govukverify.atlassian.net/browse/PROBLEM-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ