### PR TITLE
PYIC-3068: redirect to f2f postoffice page when f2f is enabled

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -217,7 +217,7 @@ IPV_IDENTITY_START_PAGE:
     end:
       type: basic
       name: end
-      targetState: IPV_IDENTITY_POSTOFFICE_START_PAGE
+      targetState: F2F_START_PAGE
       response:
         type: page
         pageId: page-ipv-identity-postoffice-start

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -217,10 +217,18 @@ IPV_IDENTITY_START_PAGE:
     end:
       type: basic
       name: end
-      targetState: PYI_ANOTHER_WAY
+      targetState: IPV_IDENTITY_POSTOFFICE_START_PAGE
       response:
         type: page
-        pageId: pyi-another-way
+        pageId: page-ipv-identity-postoffice-start
+      checkIfDisabled:
+        f2f:
+          type: basic
+          name: f2f-cri-disabled
+          targetState: PYI_ANOTHER_WAY
+          response:
+            type: page
+            pageId: pyi-another-way
     attempt-recovery:
       type: basic
       name: attempt-recovery


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- redirect to f2f postoffice page when f2f is enabled after start page.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3068](https://govukverify.atlassian.net/browse/PYIC-3068)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3068]: https://govukverify.atlassian.net/browse/PYIC-3068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ