### PR TITLE
PROBLEM-59: Handle errors thrown in build-cri-oauth-request lambda by VcStatus weirdness

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -312,6 +312,13 @@ public class BuildCriOauthRequestHandler extends JourneyRequestLambda {
                 SignedJWT signedJWT = SignedJWT.parse(credential);
                 String credentialIss = signedJWT.getJWTClaimsSet().getIssuer();
 
+                if (currentVcStatuses == null) {
+                    throw new NoVcStatusForIssuerException(
+                            String.format(
+                                    "User has credential from issuer '%s' but currentVcStatuses is null",
+                                    credentialIss));
+                }
+
                 if (getVcStatus(currentVcStatuses, credentialIss)
                         .getIsSuccessfulVc()
                         .equals(Boolean.TRUE)) {
@@ -346,8 +353,7 @@ public class BuildCriOauthRequestHandler extends JourneyRequestLambda {
                 throw new HttpResponseExceptionWithErrorBody(
                         500, ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
             } catch (NoVcStatusForIssuerException e) {
-                LogHelper.logErrorMessage(
-                        "Failed to match VC issuer with VC status", e.getMessage());
+                LogHelper.logErrorMessage("Error getting VC status", e.getMessage());
                 throw new HttpResponseExceptionWithErrorBody(
                         500, ErrorResponse.NO_VC_STATUS_FOR_CREDENTIAL_ISSUER);
             }

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -35,6 +35,7 @@ import uk.gov.di.ipv.core.library.domain.SharedClaimsResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
@@ -201,7 +202,7 @@ public class BuildCriOauthRequestHandler extends JourneyRequestLambda {
                 return new JourneyErrorResponse(
                         JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse());
             }
-            LogHelper.logErrorMessage("Failed to create cri JAR", e.getMessage());
+            LogHelper.logErrorMessage("Failed to create cri JAR", e.getErrorReason());
             return new JourneyErrorResponse(
                     JOURNEY_ERROR_PATH, HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getErrorResponse());
         } catch (SqsException e) {
@@ -311,15 +312,9 @@ public class BuildCriOauthRequestHandler extends JourneyRequestLambda {
                 SignedJWT signedJWT = SignedJWT.parse(credential);
                 String credentialIss = signedJWT.getJWTClaimsSet().getIssuer();
 
-                VcStatusDto vcStatus =
-                        currentVcStatuses.stream()
-                                .filter(
-                                        vcStatusDto ->
-                                                vcStatusDto.getCriIss().equals(credentialIss))
-                                .findFirst()
-                                .orElseThrow();
-
-                if (vcStatus.getIsSuccessfulVc().equals(Boolean.TRUE)) {
+                if (getVcStatus(currentVcStatuses, credentialIss)
+                        .getIsSuccessfulVc()
+                        .equals(Boolean.TRUE)) {
                     JsonNode credentialSubject =
                             mapper.readTree(signedJWT.getPayload().toString())
                                     .path(VC_CLAIM)
@@ -350,6 +345,11 @@ public class BuildCriOauthRequestHandler extends JourneyRequestLambda {
                 LogHelper.logErrorMessage("Failed to parse issued credentials.", e.getMessage());
                 throw new HttpResponseExceptionWithErrorBody(
                         500, ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
+            } catch (NoVcStatusForIssuerException e) {
+                LogHelper.logErrorMessage(
+                        "Failed to match VC issuer with VC status", e.getMessage());
+                throw new HttpResponseExceptionWithErrorBody(
+                        500, ErrorResponse.NO_VC_STATUS_FOR_CREDENTIAL_ISSUER);
             }
         }
         return SharedClaimsResponse.from(
@@ -397,5 +397,23 @@ public class BuildCriOauthRequestHandler extends JourneyRequestLambda {
     private void persistCriOauthState(
             String oauthState, String criId, String clientOAuthSessionId) {
         criOAuthSessionService.persistCriOAuthSession(oauthState, criId, clientOAuthSessionId);
+    }
+
+    @Tracing
+    private VcStatusDto getVcStatus(List<VcStatusDto> currentVcStatuses, String credentialIss)
+            throws NoVcStatusForIssuerException {
+        return currentVcStatuses.stream()
+                .filter(vcStatusDto -> vcStatusDto.getCriIss().equals(credentialIss))
+                .findFirst()
+                .orElseThrow(
+                        () -> {
+                            StringJoiner stringJoiner = new StringJoiner(", ");
+                            currentVcStatuses.forEach(
+                                    (vcStatusDto -> stringJoiner.add(vcStatusDto.getCriIss())));
+                            return new NoVcStatusForIssuerException(
+                                    String.format(
+                                            "CRI issuer '%s' not found in current VC statuses: '%s'",
+                                            credentialIss, stringJoiner));
+                        });
     }
 }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -548,6 +548,46 @@ class BuildCriOauthRequestHandlerTest {
     }
 
     @Test
+    void shouldReturn500ResponseIfNoVcStatusFoundForVcIssuer() throws Exception {
+        when(configService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
+                .thenReturn(dcmawCredentialIssuerConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig);
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
+        when(mockIpvSessionItem.getCurrentVcStatuses())
+                .thenReturn(
+                        List.of(
+                                new VcStatusDto("a bad issuer", true),
+                                new VcStatusDto("another bad issuer", true)));
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                generateVerifiableCredential(
+                                        vcClaim(CREDENTIAL_ATTRIBUTES_1), IPV_ISSUER),
+                                generateVerifiableCredential(
+                                        vcClaim(CREDENTIAL_ATTRIBUTES_2), IPV_ISSUER)));
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        JourneyRequest input =
+                JourneyRequest.builder()
+                        .ipvSessionId(SESSION_ID)
+                        .ipAddress(TEST_IP_ADDRESS)
+                        .journey(DCMAW_CRI)
+                        .build();
+
+        JourneyErrorResponse response =
+                objectMapper.readValue(handleRequest(input, context), JourneyErrorResponse.class);
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.NO_VC_STATUS_FOR_CREDENTIAL_ISSUER.getCode(), response.getCode());
+        assertEquals(
+                ErrorResponse.NO_VC_STATUS_FOR_CREDENTIAL_ISSUER.getMessage(),
+                response.getMessage());
+    }
+
+    @Test
     void shouldReturn400IfSessionIdIsNull() throws JsonProcessingException {
         JourneyRequest input = JourneyRequest.builder().journey(CRI_ID).build();
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -588,6 +588,42 @@ class BuildCriOauthRequestHandlerTest {
     }
 
     @Test
+    void shouldReturn500ResponseIfUserHasCredentialButVcStatuesIsNull() throws Exception {
+        when(configService.getCredentialIssuerActiveConnectionConfig(DCMAW_CRI))
+                .thenReturn(dcmawCredentialIssuerConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig);
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
+        when(mockIpvSessionItem.getCurrentVcStatuses()).thenReturn(null);
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                generateVerifiableCredential(
+                                        vcClaim(CREDENTIAL_ATTRIBUTES_1), IPV_ISSUER),
+                                generateVerifiableCredential(
+                                        vcClaim(CREDENTIAL_ATTRIBUTES_2), IPV_ISSUER)));
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        JourneyRequest input =
+                JourneyRequest.builder()
+                        .ipvSessionId(SESSION_ID)
+                        .ipAddress(TEST_IP_ADDRESS)
+                        .journey(DCMAW_CRI)
+                        .build();
+
+        JourneyErrorResponse response =
+                objectMapper.readValue(handleRequest(input, context), JourneyErrorResponse.class);
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.NO_VC_STATUS_FOR_CREDENTIAL_ISSUER.getCode(), response.getCode());
+        assertEquals(
+                ErrorResponse.NO_VC_STATUS_FOR_CREDENTIAL_ISSUER.getMessage(),
+                response.getMessage());
+    }
+
+    @Test
     void shouldReturn400IfSessionIdIsNull() throws JsonProcessingException {
         JourneyRequest input = JourneyRequest.builder().journey(CRI_ID).build();
 

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -383,7 +383,7 @@ public class EvaluateGpg45ScoresHandler extends JourneyRequestLambda {
 
     @Tracing
     private Optional<JourneyResponse> getJourneyResponseForFailWithNoCi(
-            IpvSessionItem ipvSessionItem) {
+            IpvSessionItem ipvSessionItem) throws NoVisitedCriFoundException {
         VisitedCredentialIssuerDetailsDto lastVisitedCri =
                 ipvSessionItem.getVisitedCredentialIssuerDetails().stream()
                         .reduce((first, second) -> second)

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/NoVisitedCriFoundException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/exceptions/NoVisitedCriFoundException.java
@@ -1,3 +1,3 @@
 package uk.gov.di.ipv.core.library.exceptions;
 
-public class NoVisitedCriFoundException extends RuntimeException {}
+public class NoVisitedCriFoundException extends Exception {}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handle errors thrown in build-cri-oauth-request lambda by VcStatus weirdness

### Why did it change

[PROBLEM-59: Handle no VC status in build-cri-oauth](https://github.com/alphagov/di-ipv-core-back/commit/74c248379484380a1aa262b2c39ccaacc5c7de5a) 

We've been throwing unhandled `NoSuchElementException` in the
build-cri-oauth-request lambda. This happens when we try to get the
VC status for an issued VC and can't find it.

This change handles the exception and logs some hopefully useful
information.

I've followed a user journey that encountered this issue in the logs. It
looked completely normal. Hopefully this logging will help to work out
what's going on.

[PROBLEM-59: Handle VcStatues being null](https://github.com/alphagov/di-ipv-core-back/commit/b78f24e5bb4fc1000ea6e28819d516da9662e028) 

We have been throwing NPE's in the build-cri-oauth-request lambda when
a user has at least one credential but their VcStatues from their
session is null.

A user should never be in this state. This catches the NPE and logs some
info that might help us determine what's happening.

For the VcStatues to be null, they will never have been set. We only set
them in two places - the check-existing-identity lambda if the user has
a matched profile (for some reason), and in the eval-gpg45-scores lambda
once a user has a credential.

So, for a user to have a credential their VcStatues to be null should
not be possible. I'm guessing something to do with running two tabs with
the same session cookie.

Either way, we should handle the error and work out what's going on, and
if we can fix it.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PROBLEM-59](https://govukverify.atlassian.net/browse/PROBLEM-59)


[PROBLEM-59]: https://govukverify.atlassian.net/browse/PROBLEM-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ