### PR TITLE
PYIC-3179 Rewire F2F escape to go to new doc start page

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -157,17 +157,12 @@ RESET_IDENTITY:
   name: RESET_IDENTITY
   events:
     next:
-      type: cri
-      criId: dcmaw
-      targetState: CRI_DCMAW
-      checkIfDisabled:
-        dcmaw:
-          type: basic
-          name: dcmaw-cri-disabled
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-          response:
-            type: page
-            pageId: page-multiple-doc-check
+      type: basic
+      name: next
+      targetState: IPV_IDENTITY_START_PAGE
+      response:
+        type: page
+        pageId: page-ipv-identity-document-start
     attempt-recovery:
       type: basic
       name: attempt-recovery


### PR DESCRIPTION
## Proposed changes

### What changed

Rewire F2F escape to go to new doc start page

### Why did it change

Now we have the new document start page the 'start' of the journey is no longer DCMAW/doc check page. A returning user who doesn't match a profile and a user who restarts on the F2F escape page will be routed via RESET_IDENTITY and now be taken to the new document start page.

### Issue tracking

- [PYIC-3179](https://govukverify.atlassian.net/browse/PYIC-3179)


[PYIC-3179]: https://govukverify.atlassian.net/browse/PYIC-3179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ