### PR TITLE
PYIC-3180: Handle escape from F2F CRI

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -342,6 +342,8 @@ CRI_F2F_J4:
   events:
     next:
       targetState: F2F_HANDOFF_PAGE_J4
+    access-denied:
+      targetState: PYI_NO_MATCH
 
 F2F_HANDOFF_PAGE_J4:
   response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handle access denied response from F2F CRI to redirect user to page pyi-another-way 

### Why did it change

If the user selects to ‘escape’ F2F CRI to prove their identity another way, we’ll get back an Access Denied oauth error from F2F. We should handle this by showing the page pyi-another-way

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3180](https://govukverify.atlassian.net/browse/PYIC-3180)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3180]: https://govukverify.atlassian.net/browse/PYIC-3180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ