### PR TITLE
PYIC-3198: Remove name and type from states and events

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineInitializer.java
@@ -24,6 +24,7 @@ public class StateMachineInitializer {
 
         states.forEach(
                 (stateName, state) -> {
+                    state.setName(stateName);
                     if (state.getParent() != null) {
                         state.setParent(states.get(state.getParent().getName()));
                     }

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEvent.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/BasicEvent.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 public class BasicEvent implements Event {
     private static final Logger LOGGER = LogManager.getLogger();
     @JsonIgnore private ConfigService configService;
-    private String name;
     private State targetState;
     private LinkedHashMap<String, Event> checkIfDisabled;
 

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/Event.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/Event.java
@@ -7,8 +7,8 @@ import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyConte
 
 import java.util.Map;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonSubTypes({@JsonSubTypes.Type(value = BasicEvent.class, name = "basic")})
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({@JsonSubTypes.Type(value = BasicEvent.class)})
 public interface Event {
     State resolve(JourneyContext journeyContext);
 

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -3,29 +3,22 @@ END_JOURNEY:
   name: END_JOURNEY
   events:
     next:
-      name: next
       targetState: END
 
 CRI_STATE:
   name: CRI_STATE
   events:
     error:
-      name: error
       targetState: ERROR
     access-denied:
-      name: access-denied
       targetState: PYI_NO_MATCH
     temporarily-unavailable:
-      name: temporarily-unavailable
       targetState: PYI_NO_MATCH
     end:
-      name: end
       targetState: IPV_SUCCESS_PAGE
     pyi-no-match:
-      name: pyi-no-match
       targetState: PYI_NO_MATCH
     pyi-kbv-fail:
-      name: pyi-kbv-fail
       targetState: PYI_KBV_FAIL
 
 # Shared states
@@ -33,7 +26,6 @@ INITIAL_IPV_JOURNEY:
   name: INIT
   events:
     next:
-      name: next
       targetState: CHECK_EXISTING_IDENTITY
 
 F2F_START_PAGE:
@@ -43,10 +35,8 @@ F2F_START_PAGE:
   name: F2F_START_PAGE
   events:
     next:
-      name: next
       targetState: CRI_CLAIMED_IDENTITY_J4
     end:
-      name: end
       targetState: PYI_ESCAPE
 
 CHECK_EXISTING_IDENTITY:
@@ -56,25 +46,18 @@ CHECK_EXISTING_IDENTITY:
   name: CHECK_EXISTING_IDENTITY
   events:
     next:
-      name: next
       targetState: IPV_IDENTITY_START_PAGE
     reset-identity:
-      name: next
       targetState: RESET_IDENTITY
     reuse:
-      name: reuse
       targetState: IPV_IDENTITY_REUSE_PAGE
     pending:
-      name: pending
       targetState: IPV_IDENTITY_PENDING_PAGE
     pyi-no-match:
-      name: pyi-no-match
       targetState: PYI_NO_MATCH
     pyi-kbv-fail:
-      name: pyi-kbv-fail
       targetState: PYI_KBV_FAIL
     error:
-      name: error
       targetState: ERROR
 
 RESET_IDENTITY:
@@ -84,7 +67,6 @@ RESET_IDENTITY:
   name: RESET_IDENTITY
   events:
     next:
-      name: next
       targetState: IPV_IDENTITY_START_PAGE
 
 IPV_IDENTITY_REUSE_PAGE:
@@ -107,18 +89,16 @@ IPV_IDENTITY_START_PAGE:
   name: IPV_IDENTITY_START_PAGE
   events:
     next:
-      name: next
       targetState: CRI_DCMAW
       checkIfDisabled:
         dcmaw:
-          name: dcmaw-cri-disabled
+
           targetState: MULTIPLE_DOC_CHECK_PAGE
     end:
-      name: end
       targetState: F2F_START_PAGE
       checkIfDisabled:
         f2f:
-          name: f2f-cri-disabled
+
           targetState: PYI_ANOTHER_WAY
 
 PYI_ANOTHER_WAY:
@@ -136,16 +116,12 @@ CRI_DCMAW:
   parent: CRI_STATE
   events:
     next:
-      name: dcmaw-success
       targetState: POST_DCMAW_SUCCESS_PAGE
     access-denied:
-      name: access-denied
       targetState: MULTIPLE_DOC_CHECK_PAGE
     temporarily-unavailable:
-      name: temporarily-unavailable
       targetState: MULTIPLE_DOC_CHECK_PAGE
     fail-with-no-ci:
-      name: fail-with-no-ci
       targetState: MULTIPLE_DOC_CHECK_PAGE
 
 MULTIPLE_DOC_CHECK_PAGE:
@@ -155,17 +131,14 @@ MULTIPLE_DOC_CHECK_PAGE:
   name: MULTIPLE_DOC_CHECK_PAGE
   events:
     ukPassport:
-      name: ukPassport
       targetState: CRI_UK_PASSPORT_J2
     drivingLicence:
-      name: drivingLicence
       targetState: CRI_DRIVING_LICENCE_J3
     end:
-      name: claimedIdentity
       targetState: CRI_CLAIMED_IDENTITY_J4
       checkIfDisabled:
         f2f:
-          name: end
+
           targetState: END
 
 PYI_NO_MATCH:
@@ -196,10 +169,8 @@ PYI_ESCAPE:
   name: PYI_ESCAPE
   events:
     next:
-      name: next
       targetState: RESET_IDENTITY
     end:
-      name: end
       targetState: END
 
 ERROR:
@@ -238,7 +209,6 @@ POST_DCMAW_SUCCESS_PAGE:
   name: POST_DCMAW_SUCCESS_PAGE
   events:
     next:
-      name: address
       targetState: CRI_ADDRESS_J1
 
 CRI_ADDRESS_J1:
@@ -249,7 +219,6 @@ CRI_ADDRESS_J1:
   parent: CRI_STATE
   events:
     next:
-      name: fraud
       targetState: CRI_FRAUD_J1
 
 CRI_FRAUD_J1:
@@ -260,7 +229,6 @@ CRI_FRAUD_J1:
   parent: CRI_STATE
   events:
     end:
-      name: end
       targetState: IPV_SUCCESS_PAGE
 
 # Passport journey (J2)
@@ -272,10 +240,8 @@ CRI_UK_PASSPORT_J2:
   parent: CRI_STATE
   events:
     next:
-      name: address
       targetState: CRI_ADDRESS_J2
     access-denied:
-      name: access-denied
       targetState: MULTIPLE_DOC_CHECK_PAGE
 
 CRI_ADDRESS_J2:
@@ -286,7 +252,6 @@ CRI_ADDRESS_J2:
   parent: CRI_STATE
   events:
     next:
-      name: fraud
       targetState: CRI_FRAUD_J2
 
 CRI_FRAUD_J2:
@@ -297,7 +262,6 @@ CRI_FRAUD_J2:
   parent: CRI_STATE
   events:
     next:
-      name: next
       targetState: PRE_KBV_TRANSITION_PAGE_J2
 
 PRE_KBV_TRANSITION_PAGE_J2:
@@ -307,7 +271,6 @@ PRE_KBV_TRANSITION_PAGE_J2:
   name: PRE_KBV_TRANSITION_PAGE_J2
   events:
     next:
-      name: kbv
       targetState: CRI_KBV_J2
 
 CRI_KBV_J2:
@@ -318,10 +281,8 @@ CRI_KBV_J2:
   parent: CRI_STATE
   events:
     end:
-      name: end
       targetState: IPV_SUCCESS_PAGE
     fail-with-no-ci:
-      name: fail-with-no-ci
       targetState: PYI_KBV_THIN_FILE
 
 # Driving licence journey (J3)
@@ -333,10 +294,8 @@ CRI_DRIVING_LICENCE_J3:
   parent: CRI_STATE
   events:
     next:
-      name: address
       targetState: CRI_ADDRESS_J3
     access-denied:
-      name: access-denied
       targetState: MULTIPLE_DOC_CHECK_PAGE
 
 CRI_ADDRESS_J3:
@@ -347,7 +306,6 @@ CRI_ADDRESS_J3:
   parent: CRI_STATE
   events:
     next:
-      name: fraud
       targetState: CRI_FRAUD_J3
 
 CRI_FRAUD_J3:
@@ -358,7 +316,6 @@ CRI_FRAUD_J3:
   parent: CRI_STATE
   events:
     next:
-      name: next
       targetState: PRE_KBV_TRANSITION_PAGE_J3
 
 PRE_KBV_TRANSITION_PAGE_J3:
@@ -368,7 +325,6 @@ PRE_KBV_TRANSITION_PAGE_J3:
   name: PRE_KBV_TRANSITION_PAGE_J3
   events:
     next:
-      name: kbv
       targetState: CRI_KBV_J3
 
 CRI_KBV_J3:
@@ -379,10 +335,8 @@ CRI_KBV_J3:
   parent: CRI_STATE
   events:
     end:
-      name: end
       targetState: IPV_SUCCESS_PAGE
     fail-with-no-ci:
-      name: fail-with-no-ci
       targetState: PYI_KBV_THIN_FILE
 
 # F2F journey (J4)
@@ -394,7 +348,6 @@ CRI_CLAIMED_IDENTITY_J4:
   parent: CRI_STATE
   events:
     next:
-      name: address
       targetState: CRI_ADDRESS_J4
 
 CRI_ADDRESS_J4:
@@ -405,7 +358,6 @@ CRI_ADDRESS_J4:
   parent: CRI_STATE
   events:
     next:
-      name: fraud
       targetState: CRI_FRAUD_J4
 
 CRI_FRAUD_J4:
@@ -416,7 +368,6 @@ CRI_FRAUD_J4:
   parent: CRI_STATE
   events:
     next:
-      name: f2f
       targetState: CRI_F2F_J4
 
 CRI_F2F_J4:
@@ -427,7 +378,6 @@ CRI_F2F_J4:
   parent: CRI_STATE
   events:
     next:
-      name: next
       targetState: F2F_HANDOFF_PAGE_J4
 
 F2F_HANDOFF_PAGE_J4:

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -3,7 +3,6 @@ END_JOURNEY:
   name: END_JOURNEY
   events:
     next:
-      type: basic
       name: next
       targetState: END
 
@@ -11,27 +10,21 @@ CRI_STATE:
   name: CRI_STATE
   events:
     error:
-      type: basic
       name: error
       targetState: ERROR
     access-denied:
-      type: basic
       name: access-denied
       targetState: PYI_NO_MATCH
     temporarily-unavailable:
-      type: basic
       name: temporarily-unavailable
       targetState: PYI_NO_MATCH
     end:
-      type: basic
       name: end
       targetState: IPV_SUCCESS_PAGE
     pyi-no-match:
-      type: basic
       name: pyi-no-match
       targetState: PYI_NO_MATCH
     pyi-kbv-fail:
-      type: basic
       name: pyi-kbv-fail
       targetState: PYI_KBV_FAIL
 
@@ -40,7 +33,6 @@ INITIAL_IPV_JOURNEY:
   name: INIT
   events:
     next:
-      type: basic
       name: next
       targetState: CHECK_EXISTING_IDENTITY
 
@@ -51,11 +43,9 @@ F2F_START_PAGE:
   name: F2F_START_PAGE
   events:
     next:
-      type: basic
       name: next
       targetState: CRI_CLAIMED_IDENTITY_J4
     end:
-      type: basic
       name: end
       targetState: PYI_ESCAPE
 
@@ -66,31 +56,24 @@ CHECK_EXISTING_IDENTITY:
   name: CHECK_EXISTING_IDENTITY
   events:
     next:
-      type: basic
       name: next
       targetState: IPV_IDENTITY_START_PAGE
     reset-identity:
-      type: basic
       name: next
       targetState: RESET_IDENTITY
     reuse:
-      type: basic
       name: reuse
       targetState: IPV_IDENTITY_REUSE_PAGE
     pending:
-      type: basic
       name: pending
       targetState: IPV_IDENTITY_PENDING_PAGE
     pyi-no-match:
-      type: basic
       name: pyi-no-match
       targetState: PYI_NO_MATCH
     pyi-kbv-fail:
-      type: basic
       name: pyi-kbv-fail
       targetState: PYI_KBV_FAIL
     error:
-      type: basic
       name: error
       targetState: ERROR
 
@@ -101,7 +84,6 @@ RESET_IDENTITY:
   name: RESET_IDENTITY
   events:
     next:
-      type: basic
       name: next
       targetState: IPV_IDENTITY_START_PAGE
 
@@ -125,21 +107,17 @@ IPV_IDENTITY_START_PAGE:
   name: IPV_IDENTITY_START_PAGE
   events:
     next:
-      type: basic
       name: next
       targetState: CRI_DCMAW
       checkIfDisabled:
         dcmaw:
-          type: basic
           name: dcmaw-cri-disabled
           targetState: MULTIPLE_DOC_CHECK_PAGE
     end:
-      type: basic
       name: end
       targetState: F2F_START_PAGE
       checkIfDisabled:
         f2f:
-          type: basic
           name: f2f-cri-disabled
           targetState: PYI_ANOTHER_WAY
 
@@ -158,19 +136,15 @@ CRI_DCMAW:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: dcmaw-success
       targetState: POST_DCMAW_SUCCESS_PAGE
     access-denied:
-      type: basic
       name: access-denied
       targetState: MULTIPLE_DOC_CHECK_PAGE
     temporarily-unavailable:
-      type: basic
       name: temporarily-unavailable
       targetState: MULTIPLE_DOC_CHECK_PAGE
     fail-with-no-ci:
-      type: basic
       name: fail-with-no-ci
       targetState: MULTIPLE_DOC_CHECK_PAGE
 
@@ -181,20 +155,16 @@ MULTIPLE_DOC_CHECK_PAGE:
   name: MULTIPLE_DOC_CHECK_PAGE
   events:
     ukPassport:
-      type: basic
       name: ukPassport
       targetState: CRI_UK_PASSPORT_J2
     drivingLicence:
-      type: basic
       name: drivingLicence
       targetState: CRI_DRIVING_LICENCE_J3
     end:
-      type: basic
       name: claimedIdentity
       targetState: CRI_CLAIMED_IDENTITY_J4
       checkIfDisabled:
         f2f:
-          type: basic
           name: end
           targetState: END
 
@@ -226,11 +196,9 @@ PYI_ESCAPE:
   name: PYI_ESCAPE
   events:
     next:
-      type: basic
       name: next
       targetState: RESET_IDENTITY
     end:
-      type: basic
       name: end
       targetState: END
 
@@ -270,7 +238,6 @@ POST_DCMAW_SUCCESS_PAGE:
   name: POST_DCMAW_SUCCESS_PAGE
   events:
     next:
-      type: basic
       name: address
       targetState: CRI_ADDRESS_J1
 
@@ -282,7 +249,6 @@ CRI_ADDRESS_J1:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: fraud
       targetState: CRI_FRAUD_J1
 
@@ -294,7 +260,6 @@ CRI_FRAUD_J1:
   parent: CRI_STATE
   events:
     end:
-      type: basic
       name: end
       targetState: IPV_SUCCESS_PAGE
 
@@ -307,11 +272,9 @@ CRI_UK_PASSPORT_J2:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: address
       targetState: CRI_ADDRESS_J2
     access-denied:
-      type: basic
       name: access-denied
       targetState: MULTIPLE_DOC_CHECK_PAGE
 
@@ -323,7 +286,6 @@ CRI_ADDRESS_J2:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: fraud
       targetState: CRI_FRAUD_J2
 
@@ -335,7 +297,6 @@ CRI_FRAUD_J2:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: next
       targetState: PRE_KBV_TRANSITION_PAGE_J2
 
@@ -346,7 +307,6 @@ PRE_KBV_TRANSITION_PAGE_J2:
   name: PRE_KBV_TRANSITION_PAGE_J2
   events:
     next:
-      type: basic
       name: kbv
       targetState: CRI_KBV_J2
 
@@ -358,11 +318,9 @@ CRI_KBV_J2:
   parent: CRI_STATE
   events:
     end:
-      type: basic
       name: end
       targetState: IPV_SUCCESS_PAGE
     fail-with-no-ci:
-      type: basic
       name: fail-with-no-ci
       targetState: PYI_KBV_THIN_FILE
 
@@ -375,11 +333,9 @@ CRI_DRIVING_LICENCE_J3:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: address
       targetState: CRI_ADDRESS_J3
     access-denied:
-      type: basic
       name: access-denied
       targetState: MULTIPLE_DOC_CHECK_PAGE
 
@@ -391,7 +347,6 @@ CRI_ADDRESS_J3:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: fraud
       targetState: CRI_FRAUD_J3
 
@@ -403,7 +358,6 @@ CRI_FRAUD_J3:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: next
       targetState: PRE_KBV_TRANSITION_PAGE_J3
 
@@ -414,7 +368,6 @@ PRE_KBV_TRANSITION_PAGE_J3:
   name: PRE_KBV_TRANSITION_PAGE_J3
   events:
     next:
-      type: basic
       name: kbv
       targetState: CRI_KBV_J3
 
@@ -426,11 +379,9 @@ CRI_KBV_J3:
   parent: CRI_STATE
   events:
     end:
-      type: basic
       name: end
       targetState: IPV_SUCCESS_PAGE
     fail-with-no-ci:
-      type: basic
       name: fail-with-no-ci
       targetState: PYI_KBV_THIN_FILE
 
@@ -443,7 +394,6 @@ CRI_CLAIMED_IDENTITY_J4:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: address
       targetState: CRI_ADDRESS_J4
 
@@ -455,7 +405,6 @@ CRI_ADDRESS_J4:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: fraud
       targetState: CRI_FRAUD_J4
 
@@ -467,7 +416,6 @@ CRI_FRAUD_J4:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: f2f
       targetState: CRI_F2F_J4
 
@@ -479,7 +427,6 @@ CRI_F2F_J4:
   parent: CRI_STATE
   events:
     next:
-      type: basic
       name: next
       targetState: F2F_HANDOFF_PAGE_J4
 

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -1,12 +1,10 @@
 # parent states
 END_JOURNEY:
-  name: END_JOURNEY
   events:
     next:
       targetState: END
 
 CRI_STATE:
-  name: CRI_STATE
   events:
     error:
       targetState: ERROR
@@ -23,7 +21,6 @@ CRI_STATE:
 
 # Shared states
 INITIAL_IPV_JOURNEY:
-  name: INIT
   events:
     next:
       targetState: CHECK_EXISTING_IDENTITY
@@ -32,7 +29,6 @@ F2F_START_PAGE:
   response:
     type: page
     pageId: page-ipv-identity-postoffice-start
-  name: F2F_START_PAGE
   events:
     next:
       targetState: CRI_CLAIMED_IDENTITY_J4
@@ -43,7 +39,6 @@ CHECK_EXISTING_IDENTITY:
   response:
     type: journey
     journeyStepId: /journey/check-existing-identity
-  name: CHECK_EXISTING_IDENTITY
   events:
     next:
       targetState: IPV_IDENTITY_START_PAGE
@@ -64,7 +59,6 @@ RESET_IDENTITY:
   response:
     type: journey
     journeyStepId: /journey/reset-identity
-  name: RESET_IDENTITY
   events:
     next:
       targetState: IPV_IDENTITY_START_PAGE
@@ -73,20 +67,17 @@ IPV_IDENTITY_REUSE_PAGE:
   response:
     type: page
     pageId: page-ipv-reuse
-  name: IPV_IDENTITY_REUSE_PAGE
   parent: END_JOURNEY
 
 IPV_IDENTITY_PENDING_PAGE:
   response:
     type: page
     pageId: page-ipv-pending
-  name: IPV_IDENTITY_PENDING_PAGE
 
 IPV_IDENTITY_START_PAGE:
   response:
     type: page
     pageId: page-ipv-identity-document-start
-  name: IPV_IDENTITY_START_PAGE
   events:
     next:
       targetState: CRI_DCMAW
@@ -105,14 +96,12 @@ PYI_ANOTHER_WAY:
   response:
     type: page
     pageId: pyi-another-way
-  name: PYI_ANOTHER_WAY
   parent: END_JOURNEY
 
 CRI_DCMAW:
   response:
     type: cri
     criId: dcmaw
-  name: CRI_DCMAW
   parent: CRI_STATE
   events:
     next:
@@ -128,7 +117,6 @@ MULTIPLE_DOC_CHECK_PAGE:
   response:
     type: page
     pageId: page-multiple-doc-check
-  name: MULTIPLE_DOC_CHECK_PAGE
   events:
     ukPassport:
       targetState: CRI_UK_PASSPORT_J2
@@ -145,28 +133,24 @@ PYI_NO_MATCH:
   response:
     type: page
     pageId: pyi-no-match
-  name: PYI_NO_MATCH
   parent: END_JOURNEY
 
 PYI_KBV_FAIL:
   response:
     type: page
     pageId: pyi-kbv-fail
-  name: PYI_KBV_FAIL
   parent: END_JOURNEY
 
 PYI_KBV_THIN_FILE:
   response:
     type: page
     pageId: pyi-kbv-thin-file
-  name: PYI_KBV_THIN_FILE
   parent: END_JOURNEY
 
 PYI_ESCAPE:
   response:
     type: page
     pageId: pyi-escape
-  name: PYI_ESCAPE
   events:
     next:
       targetState: RESET_IDENTITY
@@ -178,35 +162,30 @@ ERROR:
     type: error
     pageId: pyi-technical
     statusCode: 500
-  name: ERROR
   parent: END_JOURNEY
 
 CORE_SESSION_TIMEOUT:
   response:
     type: page
     pageId: pyi-timeout-unrecoverable
-  name: CORE_SESSION_TIMEOUT
   parent: END_JOURNEY
 
 IPV_SUCCESS_PAGE:
   response:
     type: page
     pageId: page-ipv-success
-  name: IPV_SUCCESS_PAGE
   parent: END_JOURNEY
 
 END:
   response:
     type: journey
     journeyStepId: /journey/build-client-oauth-response
-  name: END
 
 # DCMAW journey (J1)
 POST_DCMAW_SUCCESS_PAGE:
   response:
     type: page
     pageId: page-dcmaw-success
-  name: POST_DCMAW_SUCCESS_PAGE
   events:
     next:
       targetState: CRI_ADDRESS_J1
@@ -215,7 +194,6 @@ CRI_ADDRESS_J1:
   response:
     type: cri
     criId: address
-  name: CRI_ADDRESS_J1
   parent: CRI_STATE
   events:
     next:
@@ -225,7 +203,6 @@ CRI_FRAUD_J1:
   response:
     type: cri
     criId: fraud
-  name: CRI_FRAUD_J1
   parent: CRI_STATE
   events:
     end:
@@ -236,7 +213,6 @@ CRI_UK_PASSPORT_J2:
   response:
     type: cri
     criId: ukPassport
-  name: CRI_UK_PASSPORT_J2
   parent: CRI_STATE
   events:
     next:
@@ -248,7 +224,6 @@ CRI_ADDRESS_J2:
   response:
     type: cri
     criId: address
-  name: CRI_ADDRESS_J2
   parent: CRI_STATE
   events:
     next:
@@ -258,7 +233,6 @@ CRI_FRAUD_J2:
   response:
     type: cri
     criId: fraud
-  name: CRI_FRAUD_J2
   parent: CRI_STATE
   events:
     next:
@@ -268,7 +242,6 @@ PRE_KBV_TRANSITION_PAGE_J2:
   response:
     type: page
     pageId: page-pre-kbv-transition
-  name: PRE_KBV_TRANSITION_PAGE_J2
   events:
     next:
       targetState: CRI_KBV_J2
@@ -277,7 +250,6 @@ CRI_KBV_J2:
   response:
     type: cri
     criId: kbv
-  name: CRI_KBV_J2
   parent: CRI_STATE
   events:
     end:
@@ -290,7 +262,6 @@ CRI_DRIVING_LICENCE_J3:
   response:
     type: cri
     criId: drivingLicence
-  name: CRI_DRIVING_LICENCE_J3
   parent: CRI_STATE
   events:
     next:
@@ -302,7 +273,6 @@ CRI_ADDRESS_J3:
   response:
     type: cri
     criId: address
-  name: CRI_ADDRESS_J3
   parent: CRI_STATE
   events:
     next:
@@ -312,7 +282,6 @@ CRI_FRAUD_J3:
   response:
     type: cri
     criId: fraud
-  name: CRI_FRAUD_J3
   parent: CRI_STATE
   events:
     next:
@@ -322,7 +291,6 @@ PRE_KBV_TRANSITION_PAGE_J3:
   response:
     type: page
     pageId: page-pre-kbv-transition
-  name: PRE_KBV_TRANSITION_PAGE_J3
   events:
     next:
       targetState: CRI_KBV_J3
@@ -331,7 +299,6 @@ CRI_KBV_J3:
   response:
     type: cri
     criId: kbv
-  name: CRI_KBV_J3
   parent: CRI_STATE
   events:
     end:
@@ -344,7 +311,6 @@ CRI_CLAIMED_IDENTITY_J4:
   response:
     type: cri
     criId: claimedIdentity
-  name: CRI_CLAIMED_IDENTITY_J4
   parent: CRI_STATE
   events:
     next:
@@ -354,7 +320,6 @@ CRI_ADDRESS_J4:
   response:
     type: cri
     criId: address
-  name: CRI_ADDRESS_J4
   parent: CRI_STATE
   events:
     next:
@@ -364,7 +329,6 @@ CRI_FRAUD_J4:
   response:
     type: cri
     criId: fraud
-  name: CRI_FRAUD_J4
   parent: CRI_STATE
   events:
     next:
@@ -374,7 +338,6 @@ CRI_F2F_J4:
   response:
     type: cri
     criId: f2f
-  name: CRI_F2F_J4
   parent: CRI_STATE
   events:
     next:
@@ -384,4 +347,3 @@ F2F_HANDOFF_PAGE_J4:
   response:
     type: page
     pageId: page-face-to-face-handoff
-  name: F2F_HANDOFF_PAGE_J4


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove name and type from states and events 

### Why did it change

[PYIC-3198: Remove type from events](https://github.com/alphagov/di-ipv-core-back/pull/1029/commits/ac8c90799470f8a820ac42046c74a20f0120ba4b) 
We can use the `DEDUCTION` method of deserializing events, rather than
having to use a property in the YAML. This tells the objectmapper to
look at the fields defined to determine what sub-type it should be
deserializing into.

We currently only have one event type, but we could add more if we
need to and this strategy should work.

[PYIC-3198: Remove name property from events](https://github.com/alphagov/di-ipv-core-back/pull/1029/commits/1aa974401d167ac79b447fa8f2e681f03ca6db0d) 
The `name` property is redundant. The events are all keyed in the YAML
under a descriptive name, and it's that key that is used when an event
is received.

[PYIC-3198: Remove name property from states](https://github.com/alphagov/di-ipv-core-back/pull/1029/commits/34bdc233bfd0192c569bc971ea07aa4445cc5797) 
The states do need to have a name property once deserialized - it's the
value that is stored and fetched from the users session as they move
through the system.

We don't need to duplicate it though. The states are organised in the
YAML under keys, with the key being the state name. We can use this to
populate the name property, rather than having to define it again the
state definition.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3198](https://govukverify.atlassian.net/browse/PYIC-3198)


[PYIC-3198]: https://govukverify.atlassian.net/browse/PYIC-3198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ