### PR TITLE
PYIC-2938: Handle f2f failure result

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -52,6 +52,8 @@ CHECK_EXISTING_IDENTITY:
       targetState: PYI_NO_MATCH
     pyi-kbv-fail:
       targetState: PYI_KBV_FAIL
+    fail:
+      targetState: ERROR
     error:
       targetState: ERROR
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handled the scenario where a user has an unsuccessful F2F VC (but no CI) and doesn’t match a GPG45 profile.

***Until the necessary error page has been made we are redirecting to pyi-technical***

### Why did it change

We need to handle a failure response scenario.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3243](https://govukverify.atlassian.net/browse/PYIC-3243)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-2938]: https://govukverify.atlassian.net/browse/PYIC-2938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PYIC-3243]: https://govukverify.atlassian.net/browse/PYIC-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ