### PR TITLE
BAU Set govuk_signin_journey_id in ValidateOAuthCallback

### DIFF
--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -115,6 +115,11 @@ public class ValidateOAuthCallbackHandler
 
             if (!StringUtils.isBlank(ipvSessionId)) {
                 ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
+                clientOAuthSessionItem =
+                        clientOAuthSessionDetailsService.getClientOAuthSession(
+                                ipvSessionItem.getClientOAuthSessionId());
+                LogHelper.attachGovukSigninJourneyIdToLogs(
+                        clientOAuthSessionItem.getGovukSigninJourneyId());
             } else if (!StringUtils.isBlank(criOAuthSessionId)) {
                 criOAuthSessionItem =
                         criOAuthSessionService.getCriOauthSessionItem(criOAuthSessionId);
@@ -148,9 +153,6 @@ public class ValidateOAuthCallbackHandler
                         criOAuthSessionService.getCriOauthSessionItem(
                                 ipvSessionItem.getCriOAuthSessionId());
             }
-            clientOAuthSessionItem =
-                    clientOAuthSessionDetailsService.getClientOAuthSession(
-                            ipvSessionItem.getClientOAuthSessionId());
 
             if (callbackRequest.getError() != null) {
                 return sendOauthErrorJourneyResponse(


### PR DESCRIPTION
## Proposed changes

### What changed

Attach `govuk_signin_journey_id` for the logging from ValidateOAuthCallback

### Why did it change

Debugging a support issue I noticed this was missing from this lambda's logs making it harder to trace a user's full journey
