### PR TITLE
PYIC-3212: handle multiple doc page when f2f is enabled, redirect to f2f multi doc page

### DIFF
--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -83,17 +83,14 @@ IPV_IDENTITY_START_PAGE:
       targetState: CRI_DCMAW
       checkIfDisabled:
         dcmaw:
-
           targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
           checkIfDisabled:
-
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
     end:
       targetState: F2F_START_PAGE
       checkIfDisabled:
         f2f:
-
           targetState: PYI_ANOTHER_WAY
 
 PYI_ANOTHER_WAY:
@@ -113,19 +110,16 @@ CRI_DCMAW:
     access-denied:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
       checkIfDisabled:
-
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
     temporarily-unavailable:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
       checkIfDisabled:
-
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
     fail-with-no-ci:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
       checkIfDisabled:
-
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
 
@@ -142,7 +136,6 @@ MULTIPLE_DOC_CHECK_PAGE:
       targetState: CRI_CLAIMED_IDENTITY_J4
       checkIfDisabled:
         f2f:
-
           targetState: END
 
 MULTIPLE_DOC_F2F_CHECK_PAGE:
@@ -158,7 +151,6 @@ MULTIPLE_DOC_F2F_CHECK_PAGE:
       targetState: CRI_CLAIMED_IDENTITY_J4
       checkIfDisabled:
         f2f:
-
           targetState: END
 
 PYI_NO_MATCH:
@@ -252,7 +244,6 @@ CRI_UK_PASSPORT_J2:
     access-denied:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
       checkIfDisabled:
-
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
 
@@ -305,7 +296,6 @@ CRI_DRIVING_LICENCE_J3:
     access-denied:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
       checkIfDisabled:
-
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
 

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -84,7 +84,11 @@ IPV_IDENTITY_START_PAGE:
       checkIfDisabled:
         dcmaw:
 
-          targetState: MULTIPLE_DOC_CHECK_PAGE
+          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+          checkIfDisabled:
+
+            f2f:
+              targetState: MULTIPLE_DOC_CHECK_PAGE
     end:
       targetState: F2F_START_PAGE
       checkIfDisabled:
@@ -107,16 +111,44 @@ CRI_DCMAW:
     next:
       targetState: POST_DCMAW_SUCCESS_PAGE
     access-denied:
-      targetState: MULTIPLE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
     temporarily-unavailable:
-      targetState: MULTIPLE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
     fail-with-no-ci:
-      targetState: MULTIPLE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
 
 MULTIPLE_DOC_CHECK_PAGE:
   response:
     type: page
     pageId: page-multiple-doc-check
+  events:
+    ukPassport:
+      targetState: CRI_UK_PASSPORT_J2
+    drivingLicence:
+      targetState: CRI_DRIVING_LICENCE_J3
+    end:
+      targetState: CRI_CLAIMED_IDENTITY_J4
+      checkIfDisabled:
+        f2f:
+
+          targetState: END
+
+MULTIPLE_DOC_F2F_CHECK_PAGE:
+  response:
+    type: page
+    pageId: page-f2f-multiple-doc-check
   events:
     ukPassport:
       targetState: CRI_UK_PASSPORT_J2
@@ -218,7 +250,11 @@ CRI_UK_PASSPORT_J2:
     next:
       targetState: CRI_ADDRESS_J2
     access-denied:
-      targetState: MULTIPLE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
 
 CRI_ADDRESS_J2:
   response:
@@ -267,7 +303,11 @@ CRI_DRIVING_LICENCE_J3:
     next:
       targetState: CRI_ADDRESS_J3
     access-denied:
-      targetState: MULTIPLE_DOC_CHECK_PAGE
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
 
 CRI_ADDRESS_J3:
   response:

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -133,10 +133,7 @@ MULTIPLE_DOC_CHECK_PAGE:
     drivingLicence:
       targetState: CRI_DRIVING_LICENCE_J3
     end:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-      checkIfDisabled:
-        f2f:
-          targetState: END
+      targetState: END
 
 MULTIPLE_DOC_F2F_CHECK_PAGE:
   response:
@@ -149,9 +146,6 @@ MULTIPLE_DOC_F2F_CHECK_PAGE:
       targetState: CRI_DRIVING_LICENCE_J3
     end:
       targetState: CRI_CLAIMED_IDENTITY_J4
-      checkIfDisabled:
-        f2f:
-          targetState: END
 
 PYI_NO_MATCH:
   response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Redirect user to f2f multiple doc page when f2f is enabled.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3212](https://govukverify.atlassian.net/browse/PYIC-3212)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3212]: https://govukverify.atlassian.net/browse/PYIC-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ