### PR TITLE
PYIC-3267: Implement nested journey maps

### DIFF
--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/ProcessJourneyStepHandler.java
@@ -21,7 +21,6 @@ import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.processjourneystep.exceptions.JourneyEngineException;
-import uk.gov.di.ipv.core.processjourneystep.statemachine.State;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachine;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.StateMachineInitializer;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.StateMachineNotFoundException;
@@ -29,6 +28,7 @@ import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEven
 import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownStateException;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.PageResponse;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.BasicState;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -134,11 +134,12 @@ public class ProcessJourneyStepHandler
                     "Found state machine for journey type: {}",
                     ipvSessionItem.getJourneyType().getValue());
 
-            State newState =
-                    stateMachine.transition(
-                            ipvSessionItem.getUserState(),
-                            journeyStep,
-                            JourneyContext.withFeatureSet(configService.getFeatureSet()));
+            BasicState newState =
+                    (BasicState)
+                            stateMachine.transition(
+                                    ipvSessionItem.getUserState(),
+                                    journeyStep,
+                                    JourneyContext.withFeatureSet(configService.getFeatureSet()));
 
             updateUserState(
                     ipvSessionItem.getUserState(), newState.getName(), journeyStep, ipvSessionItem);

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineInitializer.java
@@ -1,9 +1,17 @@
 package uk.gov.di.ipv.core.processjourneystep.statemachine;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.events.Event;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.events.ExitNestedJourneyEvent;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.JourneyMapDeserializationException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.BasicState;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.NestedJourneyDefinition;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.NestedJourneyInvokeState;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.State;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,37 +19,170 @@ import java.util.Map;
 import java.util.Objects;
 
 public class StateMachineInitializer {
-    private static final ObjectMapper om = new ObjectMapper(new YAMLFactory());
-    private final IpvJourneyTypes journeyType;
+    private static final ObjectMapper yamlOm = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper om = new ObjectMapper();
+    private Map<String, State> journeyStates;
+    private Map<String, NestedJourneyDefinition> nestedJourneyDefinitions;
+    private final StateMachineInitializerMode mode;
 
     public StateMachineInitializer(IpvJourneyTypes journeyType) {
-        this.journeyType = journeyType;
+        this(journeyType, StateMachineInitializerMode.STANDARD);
     }
+
+    public StateMachineInitializer(IpvJourneyTypes journeyType, StateMachineInitializerMode mode) {
+        this.journeyType = journeyType;
+        this.mode = mode;
+    }
+
+    private final IpvJourneyTypes journeyType;
 
     public Map<String, State> initialize() throws IOException {
-        File file = getConfigFile(journeyType);
-        Map<String, State> states = om.readValue(file, new TypeReference<>() {});
+        journeyStates =
+                yamlOm.readValue(getJourneyConfigFile(journeyType), new TypeReference<>() {});
+        nestedJourneyDefinitions =
+                yamlOm.readValue(getNestedJourneyDefinitionsConfigFile(), new TypeReference<>() {});
 
-        states.forEach(
-                (stateName, state) -> {
-                    state.setName(stateName);
-                    if (state.getParent() != null) {
-                        state.setParent(states.get(state.getParent().getName()));
-                    }
-                    state.getEvents()
-                            .forEach((eventName, event) -> event.initialize(eventName, states));
-                });
+        initializeJourneyStates();
 
-        return states;
+        return journeyStates;
     }
 
-    private File getConfigFile(IpvJourneyTypes journeyType) {
+    private void initializeJourneyStates() {
+        journeyStates.forEach(
+                (stateName, state) -> {
+                    if (state instanceof BasicState) {
+                        initializeBasicState((BasicState) state, stateName, journeyStates);
+                    }
+
+                    if (state instanceof NestedJourneyInvokeState) {
+                        initializeNestedJourneyInvokeState(
+                                (NestedJourneyInvokeState) state, stateName, journeyStates);
+                    }
+                });
+    }
+
+    void initializeBasicState(
+            BasicState state, String stateName, Map<String, State> eventTargetsStatesMap) {
+        initializeBasicState(state, stateName, eventTargetsStatesMap, null);
+    }
+
+    void initializeBasicState(
+            BasicState state,
+            String stateName,
+            Map<String, State> eventTargetsStatesMap,
+            Map<String, Event> nestedJourneyExitEvents) {
+        state.setName(stateName);
+        linkBasicStateParents(state, journeyStates);
+        initializeBasicStateEvents(state, eventTargetsStatesMap, nestedJourneyExitEvents);
+    }
+
+    private void linkBasicStateParents(BasicState state, Map<String, State> journeyStates) {
+        if (state.getParent() != null) {
+            state.setParentObj((BasicState) journeyStates.get(state.getParent()));
+        }
+    }
+
+    private void initializeBasicStateEvents(
+            BasicState state,
+            Map<String, State> eventStatesSource,
+            Map<String, Event> nestedJourneyExitEvents) {
+        initializeEvents(state.getEvents(), eventStatesSource, nestedJourneyExitEvents);
+    }
+
+    private void initializeEvents(
+            Map<String, Event> eventMap,
+            Map<String, State> eventStatesSource,
+            Map<String, Event> nestedJourneyExitEvents) {
+        eventMap.forEach(
+                (eventName, event) -> {
+                    if (event instanceof ExitNestedJourneyEvent) {
+                        ((ExitNestedJourneyEvent) event)
+                                .setNestedJourneyExitEvents(nestedJourneyExitEvents);
+                    } else {
+                        event.initialize(eventName, eventStatesSource);
+                    }
+                });
+    }
+
+    void initializeNestedJourneyInvokeState(
+            NestedJourneyInvokeState state, String stateName, Map<String, State> journeyStates) {
+        state.setName(stateName);
+        NestedJourneyDefinition nestedJourneyDefinition =
+                nestedJourneyDefinitions.get(state.getNestedJourney());
+        NestedJourneyDefinition nestedJourneyDefinitionCopy =
+                deepCopyNestedJourneyDefinition(nestedJourneyDefinition);
+        state.setNestedJourneyDefinition(
+                initializeNestedJourneyDefinition(state, nestedJourneyDefinitionCopy));
+        initializeExitStateEvents(state, journeyStates);
+    }
+
+    private NestedJourneyDefinition deepCopyNestedJourneyDefinition(
+            NestedJourneyDefinition toCopy) {
+        try {
+            return om.readValue(om.writeValueAsString(toCopy), NestedJourneyDefinition.class);
+        } catch (JsonProcessingException e) {
+            throw new JourneyMapDeserializationException(e);
+        }
+    }
+
+    private NestedJourneyDefinition initializeNestedJourneyDefinition(
+            NestedJourneyInvokeState nestedJourneyInvokeState,
+            NestedJourneyDefinition nestedJourneyDefinition) {
+
+        nestedJourneyDefinition
+                .getNestedJourneyStates()
+                .forEach(
+                        (nestedJourneyStateName, nestedJourneyState) -> {
+                            String name =
+                                    createNestedJourneyStateName(
+                                            nestedJourneyInvokeState, nestedJourneyStateName);
+                            if (nestedJourneyState instanceof BasicState) {
+                                initializeBasicState(
+                                        (BasicState) nestedJourneyState,
+                                        name,
+                                        nestedJourneyDefinition.getNestedJourneyStates(),
+                                        nestedJourneyInvokeState.getExitEvents());
+                            }
+                            if (nestedJourneyState instanceof NestedJourneyInvokeState) {
+                                initializeNestedJourneyInvokeState(
+                                        (NestedJourneyInvokeState) nestedJourneyState,
+                                        name,
+                                        nestedJourneyDefinition.getNestedJourneyStates());
+                            }
+                        });
+        initializeEvents(
+                nestedJourneyDefinition.getEntryEvents(),
+                nestedJourneyDefinition.getNestedJourneyStates(),
+                null);
+
+        return nestedJourneyDefinition;
+    }
+
+    private void initializeExitStateEvents(
+            NestedJourneyInvokeState state, Map<String, State> eventStatesSource) {
+        initializeEvents(state.getExitEvents(), eventStatesSource, null);
+    }
+
+    private String createNestedJourneyStateName(State state, String nestedJourneyStateName) {
+        return String.format("%s/%s", state.getName(), nestedJourneyStateName);
+    }
+
+    private File getJourneyConfigFile(IpvJourneyTypes journeyType) {
+        return getFile(journeyType.getValue());
+    }
+
+    private File getNestedJourneyDefinitionsConfigFile() {
+        return getFile("nested-journey-definitions");
+    }
+
+    private File getFile(String filename) {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         return new File(
                 Objects.requireNonNull(
                                 classLoader.getResource(
                                         String.format(
-                                                "statemachine/%s.yaml", journeyType.getValue())))
+                                                "statemachine/%s%s.yaml",
+                                                mode.getPathPart(), filename)))
                         .getFile());
     }
 }

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineInitializerMode.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineInitializerMode.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine;
+
+public enum StateMachineInitializerMode {
+    STANDARD(""),
+    TEST("test/");
+
+    private final String pathPart;
+
+    StateMachineInitializerMode(String pathPart) {
+        this.pathPart = pathPart;
+    }
+
+    public String getPathPart() {
+        return pathPart;
+    }
+}

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/Event.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/Event.java
@@ -2,15 +2,19 @@ package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import uk.gov.di.ipv.core.processjourneystep.statemachine.State;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.State;
 
 import java.util.Map;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-@JsonSubTypes({@JsonSubTypes.Type(value = BasicEvent.class)})
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = BasicEvent.class),
+    @JsonSubTypes.Type(value = ExitNestedJourneyEvent.class)
+})
 public interface Event {
-    State resolve(JourneyContext journeyContext);
+    State resolve(JourneyContext journeyContext) throws UnknownEventException;
 
     void initialize(String name, Map<String, State> states);
 }

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/ExitNestedJourneyEvent.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/ExitNestedJourneyEvent.java
@@ -1,0 +1,30 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
+
+import lombok.Data;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.State;
+
+import java.util.Map;
+
+@Data
+public class ExitNestedJourneyEvent implements Event {
+
+    private String exitEventToEmit;
+    private Map<String, Event> nestedJourneyExitEvents;
+
+    @Override
+    public State resolve(JourneyContext journeyContext) throws UnknownEventException {
+        Event event = nestedJourneyExitEvents.get(exitEventToEmit);
+        if (event == null) {
+            throw new UnknownEventException("Event '%s' not found in nested journey's exit events");
+        }
+        return event.resolve(journeyContext);
+    }
+
+    @Override
+    public void initialize(String name, Map<String, State> states) {
+        throw new UnsupportedOperationException(
+                "Initialize of ExitNestedJourneyEvent not supported");
+    }
+}

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/exceptions/JourneyMapDeserializationException.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/exceptions/JourneyMapDeserializationException.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions;
+
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class JourneyMapDeserializationException extends RuntimeException {
+    public JourneyMapDeserializationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/BasicState.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/BasicState.java
@@ -1,8 +1,10 @@
-package uk.gov.di.ipv.core.processjourneystep.statemachine;
+package uk.gov.di.ipv.core.processjourneystep.statemachine.states;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.events.Event;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
@@ -15,35 +17,36 @@ import java.util.Optional;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class State {
+public class BasicState implements State {
+    private static final Logger LOGGER = LogManager.getLogger();
     private static final String ATTEMPT_RECOVERY_EVENT = "attempt-recovery";
     private String name;
-    private State parent;
+    private String parent;
+    private BasicState parentObj;
     private JourneyStepResponse response;
     private Map<String, Event> events = new HashMap<>();
 
-    public State(String name) {
-        this.name = name;
-    }
-
-    public State transition(String eventName, JourneyContext journeyContext)
+    @Override
+    public State transition(String eventName, String startState, JourneyContext journeyContext)
             throws UnknownEventException {
         if (ATTEMPT_RECOVERY_EVENT.equals(eventName)) {
             return this;
         }
 
-        var event = getEvent(eventName);
-        if (event.isPresent()) {
-            return event.get().resolve(journeyContext);
-        }
-        throw new UnknownEventException(
-                String.format("Unknown event provided to '%s' state: '%s'", name, eventName));
+        return getEvent(eventName)
+                .orElseThrow(
+                        () ->
+                                new UnknownEventException(
+                                        String.format(
+                                                "Unknown event provided to '%s' state: '%s'",
+                                                name, eventName)))
+                .resolve(journeyContext);
     }
 
     private Optional<Event> getEvent(String eventName) {
         var event = events.get(eventName);
-        if (event == null && parent != null) {
-            return parent.getEvent(eventName);
+        if (event == null && parentObj != null) {
+            return parentObj.getEvent(eventName);
         }
         return Optional.ofNullable(event);
     }

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/NestedJourneyDefinition.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/NestedJourneyDefinition.java
@@ -1,0 +1,12 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.states;
+
+import lombok.Data;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.events.Event;
+
+import java.util.Map;
+
+@Data
+public class NestedJourneyDefinition {
+    private Map<String, Event> entryEvents;
+    private Map<String, State> nestedJourneyStates;
+}

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/NestedJourneyInvokeState.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/NestedJourneyInvokeState.java
@@ -1,0 +1,74 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.states;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.events.Event;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownStateException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NestedJourneyInvokeState implements State {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final String DELIMITER = "/";
+    private String nestedJourney;
+    private NestedJourneyDefinition nestedJourneyDefinition;
+    private Map<String, Event> exitEvents;
+    private String name;
+
+    public State transition(String eventName, String startState, JourneyContext journeyContext)
+            throws UnknownEventException, UnknownStateException {
+        Queue<String> stateNameParts = getStateNameParts(startState);
+
+        State nextState;
+        if (stateNameParts.size() == 1) { // We've not descended into the nested-states yet
+            Event event = nestedJourneyDefinition.getEntryEvents().get(eventName);
+            if (event == null) {
+                throw new UnknownEventException(
+                        String.format(
+                                "Unknown entry event '%s' for '%s' state nested journey definition",
+                                eventName, name));
+            }
+            nextState = event.resolve(journeyContext);
+        } else {
+            stateNameParts.remove();
+            State currentNestedState =
+                    nestedJourneyDefinition.getNestedJourneyStates().get(stateNameParts.peek());
+            if (currentNestedState == null) {
+                throw new UnknownStateException(
+                        String.format(
+                                "State '%s' not found in nested journey definition for `%s`",
+                                stateNameParts.peek(), name));
+            }
+            nextState =
+                    currentNestedState.transition(
+                            eventName, String.join(DELIMITER, stateNameParts), journeyContext);
+        }
+
+        if (nextState instanceof NestedJourneyInvokeState) {
+            return nextState.transition(
+                    eventName, String.join(DELIMITER, stateNameParts), journeyContext);
+        }
+
+        return nextState;
+    }
+
+    private Queue<String> getStateNameParts(String stateName) {
+        return new LinkedList<>(Arrays.asList(stateName.split(DELIMITER)));
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+}

--- a/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/State.java
+++ b/lambdas/process-journey-step/src/main/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/State.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.states;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownStateException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = BasicState.class),
+    @JsonSubTypes.Type(value = NestedJourneyInvokeState.class),
+})
+public interface State {
+    State transition(String eventName, String startState, JourneyContext journeyContext)
+            throws UnknownEventException, UnknownStateException;
+
+    String getName();
+
+    void setName(String name);
+}

--- a/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/ipv-core-main-journey.yaml
@@ -218,23 +218,11 @@ POST_DCMAW_SUCCESS_PAGE:
     pageId: page-dcmaw-success
   events:
     next:
-      targetState: CRI_ADDRESS_J1
+      targetState: ADDRESS_AND_FRAUD_J1
 
-CRI_ADDRESS_J1:
-  response:
-    type: cri
-    criId: address
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_FRAUD_J1
-
-CRI_FRAUD_J1:
-  response:
-    type: cri
-    criId: fraud
-  parent: CRI_STATE
-  events:
+ADDRESS_AND_FRAUD_J1:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
     end:
       targetState: IPV_SUCCESS_PAGE
     next:
@@ -248,28 +236,16 @@ CRI_UK_PASSPORT_J2:
   parent: CRI_STATE
   events:
     next:
-      targetState: CRI_ADDRESS_J2
+      targetState: ADDRESS_AND_FRAUD_J2
     access-denied:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
       checkIfDisabled:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
 
-CRI_ADDRESS_J2:
-  response:
-    type: cri
-    criId: address
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_FRAUD_J2
-
-CRI_FRAUD_J2:
-  response:
-    type: cri
-    criId: fraud
-  parent: CRI_STATE
-  events:
+ADDRESS_AND_FRAUD_J2:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
     next:
       targetState: PRE_KBV_TRANSITION_PAGE_J2
 
@@ -300,28 +276,16 @@ CRI_DRIVING_LICENCE_J3:
   parent: CRI_STATE
   events:
     next:
-      targetState: CRI_ADDRESS_J3
+      targetState: ADDRESS_AND_FRAUD_J3
     access-denied:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
       checkIfDisabled:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
 
-CRI_ADDRESS_J3:
-  response:
-    type: cri
-    criId: address
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_FRAUD_J3
-
-CRI_FRAUD_J3:
-  response:
-    type: cri
-    criId: fraud
-  parent: CRI_STATE
-  events:
+ADDRESS_AND_FRAUD_J3:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
     next:
       targetState: PRE_KBV_TRANSITION_PAGE_J3
 
@@ -354,23 +318,11 @@ CRI_CLAIMED_IDENTITY_J4:
   parent: CRI_STATE
   events:
     next:
-      targetState: CRI_ADDRESS_J4
+      targetState: ADDRESS_AND_FRAUD_J4
 
-CRI_ADDRESS_J4:
-  response:
-    type: cri
-    criId: address
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_FRAUD_J4
-
-CRI_FRAUD_J4:
-  response:
-    type: cri
-    criId: fraud
-  parent: CRI_STATE
-  events:
+ADDRESS_AND_FRAUD_J4:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
     next:
       targetState: CRI_F2F_J4
 
@@ -384,6 +336,7 @@ CRI_F2F_J4:
       targetState: F2F_HANDOFF_PAGE_J4
     access-denied:
       targetState: PYI_ANOTHER_WAY
+
 
 F2F_HANDOFF_PAGE_J4:
   response:

--- a/lambdas/process-journey-step/src/main/resources/statemachine/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/nested-journey-definitions.yaml
@@ -1,0 +1,23 @@
+ADDRESS_AND_FRAUD:
+  entryEvents:
+    next:
+      targetState: CRI_ADDRESS
+  nestedJourneyStates:
+    CRI_ADDRESS:
+      response:
+        type: cri
+        criId: address
+      parent: CRI_STATE
+      events:
+        next:
+          targetState: CRI_FRAUD
+    CRI_FRAUD:
+      response:
+        type: cri
+        criId: fraud
+      parent: CRI_STATE
+      events:
+        end:
+          exitEventToEmit: end
+        next:
+          exitEventToEmit: next

--- a/lambdas/process-journey-step/src/main/resources/statemachine/test/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/test/ipv-core-main-journey.yaml
@@ -1,0 +1,52 @@
+# This file is for simple config to easily test the state machine initializer
+PARENT_STATE:
+  events:
+    parentEvent:
+      targetState: CRI_STATE
+
+PAGE_STATE:
+  response:
+    type: page
+    pageId: page-id-for-some-page
+  parent: PARENT_STATE
+  events:
+    eventOne:
+      targetState: JOURNEY_STATE
+    eventTwo:
+      targetState: CRI_STATE
+      checkIfDisabled:
+        aCriId:
+          targetState: ERROR_STATE
+
+JOURNEY_STATE:
+  response:
+    type: journey
+    journeyStepId: /journey/letsgosomewhere
+  events:
+    eventOne:
+      targetState: CRI_STATE
+
+CRI_STATE:
+  response:
+    type: cri
+    criId: aCriId
+  events:
+    enterNestedJourneyAtStateOne:
+      targetState: NESTED_JOURNEY_INVOKE_STATE
+
+ERROR_STATE:
+  response:
+    type: error
+    pageId: page-error
+    statusCode: 500
+  events:
+    enterNestedJourneyAtStateTwo:
+      targetState: NESTED_JOURNEY_INVOKE_STATE
+
+NESTED_JOURNEY_INVOKE_STATE:
+  nestedJourney: NESTED_JOURNEY_DEFINITION
+  exitEvents:
+    exitEventFromNestedStateTwo:
+      targetState: JOURNEY_STATE
+    exitEventFromDoublyNestedInvokeState:
+      targetState: ERROR_STATE

--- a/lambdas/process-journey-step/src/main/resources/statemachine/test/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-step/src/main/resources/statemachine/test/nested-journey-definitions.yaml
@@ -1,0 +1,50 @@
+NESTED_JOURNEY_DEFINITION:
+  entryEvents:
+    enterNestedJourneyAtStateOne:
+      targetState: NESTED_STATE_ONE
+    enterNestedJourneyAtStateTwo:
+      targetState: NESTED_STATE_TWO
+  nestedJourneyStates:
+    NESTED_STATE_ONE:
+      response:
+        type: journey
+        journeyStepId: /journey/nestedStateOneJourneyStepId
+      parent: PARENT_STATE
+      events:
+        eventOne:
+          targetState: NESTED_STATE_TWO
+    NESTED_STATE_TWO:
+      response:
+        type: page
+        pageId: page-id-nested-state-two
+      events:
+        eventOne:
+          exitEventToEmit: exitEventFromNestedStateTwo
+        eventTwo:
+          targetState: DOUBLY_NESTED_INVOKE_STATE
+
+    DOUBLY_NESTED_INVOKE_STATE:
+      nestedJourney: DOUBLY_NESTED_DEFINITION
+      exitEvents:
+        exitEventFromDoublyNestedStateTwo:
+          exitEventToEmit: exitEventFromDoublyNestedInvokeState
+
+DOUBLY_NESTED_DEFINITION:
+  entryEvents:
+    eventTwo:
+      targetState: DOUBLY_NESTED_STATE_ONE
+  nestedJourneyStates:
+    DOUBLY_NESTED_STATE_ONE:
+      response:
+        type: journey
+        journeyStepId: /journey/doublyNestedStateOneJourneyStepId
+      events:
+        eventOne:
+          targetState: DOUBLY_NESTED_STATE_TWO
+    DOUBLY_NESTED_STATE_TWO:
+      response:
+        type: page
+        pageId: page-id-doubly-nested-state-two
+      events:
+        eventOne:
+          exitEventToEmit: exitEventFromDoublyNestedStateTwo

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/StateMachineTest.java
@@ -3,6 +3,9 @@ package uk.gov.di.ipv.core.processjourneystep.statemachine;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownStateException;
 import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.BasicState;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.NestedJourneyInvokeState;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.State;
 
 import java.util.Map;
 
@@ -16,10 +19,11 @@ class StateMachineTest {
     @Test
     void transitionShouldReturnAppropriateState() throws Exception {
         JourneyContext journeyContext = JourneyContext.emptyContext();
-        State endState = new State();
+        State expectedEndState = new BasicState();
 
-        State startingState = mock(State.class);
-        when(startingState.transition("event", journeyContext)).thenReturn(endState);
+        State startingState = mock(BasicState.class);
+        when(startingState.transition("event", "START_STATE", journeyContext))
+                .thenReturn(expectedEndState);
 
         StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
         when(mockStateMachineInitializer.initialize())
@@ -27,14 +31,16 @@ class StateMachineTest {
 
         StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
 
-        assertEquals(endState, stateMachine.transition("START_STATE", "event", journeyContext));
+        State transitionedState = stateMachine.transition("START_STATE", "event", journeyContext);
+
+        assertEquals(expectedEndState, transitionedState);
     }
 
     @Test
     void transitionShouldThrowIfGivenAnUnknownState() throws Exception {
         StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
         when(mockStateMachineInitializer.initialize())
-                .thenReturn(Map.of("START_STATE", new State()));
+                .thenReturn(Map.of("START_STATE", new BasicState()));
 
         StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
 
@@ -43,5 +49,49 @@ class StateMachineTest {
                 () ->
                         stateMachine.transition(
                                 "UNKNOWN_STATE", "event", JourneyContext.emptyContext()));
+    }
+
+    @Test
+    void transitionShouldTransitionIntoNestedJourneyInvokeState() throws Exception {
+        JourneyContext journeyContext = JourneyContext.emptyContext();
+        State expectedNestedEndState = new BasicState();
+        State nestedJourneyInvokeState = mock(NestedJourneyInvokeState.class);
+        when(nestedJourneyInvokeState.transition("event", "START_STATE", journeyContext))
+                .thenReturn(expectedNestedEndState);
+
+        State startingState = mock(BasicState.class);
+        when(startingState.transition("event", "START_STATE", journeyContext))
+                .thenReturn(nestedJourneyInvokeState);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("START_STATE", startingState));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        State transitionState = stateMachine.transition("START_STATE", "event", journeyContext);
+
+        assertEquals(expectedNestedEndState, transitionState);
+    }
+
+    @Test
+    void transitionShouldHandleNestedStateName() throws Exception {
+        JourneyContext journeyContext = JourneyContext.emptyContext();
+        State expectedEndState = new BasicState();
+
+        State startingState = mock(NestedJourneyInvokeState.class);
+        when(startingState.transition("event", "START_STATE/NESTED_JOURNEY", journeyContext))
+                .thenReturn(expectedEndState);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("START_STATE", startingState));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        State transitionedState =
+                stateMachine.transition("START_STATE/NESTED_JOURNEY", "event", journeyContext);
+
+        assertEquals(expectedEndState, transitionedState);
     }
 }

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/ExitNestedJourneyEventTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/events/ExitNestedJourneyEventTest.java
@@ -1,0 +1,53 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.events;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.BasicState;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.states.State;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ExitNestedJourneyEventTest {
+    @Test
+    void resolveShouldResolveEventFromNestedJourneyExitEvents() throws UnknownEventException {
+        BasicState expectedState = new BasicState();
+        BasicEvent nestedJourneyExitEvent = mock(BasicEvent.class);
+        when(nestedJourneyExitEvent.resolve(any(JourneyContext.class))).thenReturn(expectedState);
+
+        ExitNestedJourneyEvent exitNestedJourneyEvent = new ExitNestedJourneyEvent();
+        exitNestedJourneyEvent.setExitEventToEmit("exiting");
+        exitNestedJourneyEvent.setNestedJourneyExitEvents(
+                Map.of("exiting", nestedJourneyExitEvent));
+
+        assertEquals(expectedState, exitNestedJourneyEvent.resolve(JourneyContext.emptyContext()));
+    }
+
+    @Test
+    void resolveShouldThrowIfEventNotFoundInNestedJourneyExitEvents() {
+        ExitNestedJourneyEvent exitNestedJourneyEvent = new ExitNestedJourneyEvent();
+        exitNestedJourneyEvent.setNestedJourneyExitEvents(
+                Map.of("exiting", new BasicEvent(mock(ConfigService.class))));
+        exitNestedJourneyEvent.setExitEventToEmit("not-found");
+
+        assertThrows(
+                UnknownEventException.class,
+                () -> exitNestedJourneyEvent.resolve(JourneyContext.emptyContext()));
+    }
+
+    @Test
+    void initializeShouldThrowAnUnsupportedOperationException() {
+        ExitNestedJourneyEvent exitNestedJourneyEvent = new ExitNestedJourneyEvent();
+        Map<String, State> emptyMap = Map.of();
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> exitNestedJourneyEvent.initialize("name", emptyMap));
+    }
+}

--- a/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/NestedJourneyInvokeStateTest.java
+++ b/lambdas/process-journey-step/src/test/java/uk/gov/di/ipv/core/processjourneystep/statemachine/states/NestedJourneyInvokeStateTest.java
@@ -1,0 +1,126 @@
+package uk.gov.di.ipv.core.processjourneystep.statemachine.states;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.events.BasicEvent;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownEventException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.exceptions.UnknownStateException;
+import uk.gov.di.ipv.core.processjourneystep.statemachine.responses.JourneyContext;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NestedJourneyInvokeStateTest {
+    @Test
+    void transitionShouldUseEntryEventsWhenStartStateHasOnePart() throws Exception {
+        BasicState expectedEndState = new BasicState();
+        BasicEvent basicEvent = mock(BasicEvent.class);
+        when(basicEvent.resolve(any(JourneyContext.class))).thenReturn(expectedEndState);
+
+        NestedJourneyDefinition nestedJourneyDefinition = new NestedJourneyDefinition();
+        nestedJourneyDefinition.setEntryEvents(Map.of("next", basicEvent));
+
+        NestedJourneyInvokeState nestedJourneyInvokeState = new NestedJourneyInvokeState();
+        nestedJourneyInvokeState.setNestedJourneyDefinition(nestedJourneyDefinition);
+
+        State transitionedToState =
+                nestedJourneyInvokeState.transition(
+                        "next", "INVOKE_STATE", JourneyContext.emptyContext());
+
+        assertEquals(expectedEndState, transitionedToState);
+    }
+
+    @Test
+    void transitionShouldReturnStateFromNestedJourneyDefinitionIfStartStateHasMultipleParts()
+            throws Exception {
+        NestedJourneyDefinition nestedJourneyDefinition = new NestedJourneyDefinition();
+        BasicState currentNestedState = mock(BasicState.class);
+        nestedJourneyDefinition.setNestedJourneyStates(Map.of("NESTED_STATE", currentNestedState));
+
+        BasicState expectedEndState = new BasicState();
+        when(currentNestedState.transition(
+                        eq("next"), eq("NESTED_STATE"), any(JourneyContext.class)))
+                .thenReturn(expectedEndState);
+
+        NestedJourneyInvokeState nestedJourneyInvokeState = new NestedJourneyInvokeState();
+        nestedJourneyInvokeState.setNestedJourneyDefinition(nestedJourneyDefinition);
+
+        State transitionedToState =
+                nestedJourneyInvokeState.transition(
+                        "next", "INVOKE_STATE/NESTED_STATE", JourneyContext.emptyContext());
+
+        assertEquals(expectedEndState, transitionedToState);
+    }
+
+    @Test
+    void transitionShouldHandleANestedNestedJourneyInvokeState() throws Exception {
+        NestedJourneyDefinition nestedJourneyDefinition = new NestedJourneyDefinition();
+        BasicState currentNestedState = mock(BasicState.class);
+        nestedJourneyDefinition.setNestedJourneyStates(Map.of("NESTED_STATE", currentNestedState));
+
+        NestedJourneyInvokeState nestedJourneyInvokeState = new NestedJourneyInvokeState();
+        nestedJourneyInvokeState.setNestedJourneyDefinition(nestedJourneyDefinition);
+
+        NestedJourneyInvokeState nestedNestedJourneyInvokeState =
+                mock(NestedJourneyInvokeState.class);
+        BasicState expectedEndState = new BasicState();
+        when(nestedNestedJourneyInvokeState.transition(
+                        eq("next"), eq("NESTED_STATE"), any(JourneyContext.class)))
+                .thenReturn(expectedEndState);
+        when(currentNestedState.transition(
+                        eq("next"), eq("NESTED_STATE"), any(JourneyContext.class)))
+                .thenReturn(nestedNestedJourneyInvokeState);
+
+        State transitionedToState =
+                nestedJourneyInvokeState.transition(
+                        "next", "INVOKE_STATE/NESTED_STATE", JourneyContext.emptyContext());
+
+        assertEquals(expectedEndState, transitionedToState);
+    }
+
+    @Test
+    void transitionShouldThrowIfUnknownEntryEvent() {
+        NestedJourneyDefinition nestedJourneyDefinition = new NestedJourneyDefinition();
+        nestedJourneyDefinition.setEntryEvents(Map.of("next", mock(BasicEvent.class)));
+
+        NestedJourneyInvokeState nestedJourneyInvokeState = new NestedJourneyInvokeState();
+        nestedJourneyInvokeState.setNestedJourneyDefinition(nestedJourneyDefinition);
+
+        assertThrows(
+                UnknownEventException.class,
+                () ->
+                        nestedJourneyInvokeState.transition(
+                                "unknown", "INVOKE_STATE", JourneyContext.emptyContext()));
+    }
+
+    @Test
+    void transitionShouldThrowIfNestedStateNotFoundInDefinition() {
+        NestedJourneyDefinition nestedJourneyDefinition = new NestedJourneyDefinition();
+        BasicState currentNestedState = mock(BasicState.class);
+        nestedJourneyDefinition.setNestedJourneyStates(Map.of("NESTED_STATE", currentNestedState));
+
+        NestedJourneyInvokeState nestedJourneyInvokeState = new NestedJourneyInvokeState();
+        nestedJourneyInvokeState.setNestedJourneyDefinition(nestedJourneyDefinition);
+
+        assertThrows(
+                UnknownStateException.class,
+                () ->
+                        nestedJourneyInvokeState.transition(
+                                "unknown",
+                                "INVOKE_STATE/UNKNOWN_STATE",
+                                JourneyContext.emptyContext()));
+    }
+
+    @Test
+    void toStringShouldReturnStateName() {
+        NestedJourneyInvokeState nestedJourneyInvokeState = new NestedJourneyInvokeState();
+        nestedJourneyInvokeState.setName("Robert Paulsen");
+
+        assertEquals("Robert Paulsen", nestedJourneyInvokeState.getName());
+    }
+}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Implement nested journey maps

### Why did it change

This allows us to reuse chunks of journey map.

Initially the only real candidate for re-use is the address -> fraud CRIs journey which is used in a few places.

This changes makes the changes to the state machine initializer, and adds some supporting classes, to facilitate this. The journey map is then updated to reuse the new nested journey definition for address and fraud.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3259](https://govukverify.atlassian.net/browse/PYIC-3259)


[PYIC-3259]: https://govukverify.atlassian.net/browse/PYIC-3259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ