### PR TITLE
PYIC-3187: Update `BuildUserIdentityDetails` to fetch and return CIMIT VC alongside the CRI VCs

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.Setter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -55,7 +56,7 @@ public class UserIdentity {
             @JsonProperty(value = "sub", required = true) String sub,
             @JsonProperty(value = "vot", required = true) String vot,
             @JsonProperty(value = "vtm", required = true) String vtm) {
-        this.vcs = vcs;
+        this.vcs = new ArrayList<>(vcs);
         this.identityClaim = identityClaim;
         this.addressClaim = addressClaim;
         this.passportClaim = passportClaim;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -149,6 +149,23 @@ public class CiMitService {
     public ContraIndications getContraIndicatorsVC(
             String userId, String govukSigninJourneyId, String ipAddress)
             throws CiRetrievalException {
+        SignedJWT ciSignedJWT = getContraIndicatorsJWT(userId, govukSigninJourneyId, ipAddress);
+        ContraIndicatorEvidenceDto contraIndicatorEvidence =
+                parseContraIndicatorEvidence(ciSignedJWT);
+
+        return mapToContraIndications(contraIndicatorEvidence);
+    }
+
+    public String getContraIndicatorsVcAsJwtString(
+            String userId, String govukSigninJourneyId, String ipAddress)
+            throws CiRetrievalException {
+        SignedJWT ciSignedJWT = getContraIndicatorsJWT(userId, govukSigninJourneyId, ipAddress);
+        return ciSignedJWT.serialize();
+    }
+
+    private SignedJWT getContraIndicatorsJWT(
+            String userId, String govukSigninJourneyId, String ipAddress)
+            throws CiRetrievalException {
         InvokeResult result =
                 invokeClientToGetCIResult(
                         CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN,
@@ -160,12 +177,7 @@ public class CiMitService {
                 gson.fromJson(
                         new String(result.getPayload().array(), StandardCharsets.UTF_8),
                         ContraIndicatorCredentialDto.class);
-        SignedJWT ciSignedJWT =
-                extractAndValidateContraIndicatorsJwt(contraIndicatorCredential.getVc(), userId);
-        ContraIndicatorEvidenceDto contraIndicatorEvidence =
-                parseContraIndicatorEvidence(ciSignedJWT);
-
-        return mapToContraIndications(contraIndicatorEvidence);
+        return extractAndValidateContraIndicatorsJwt(contraIndicatorCredential.getVc(), userId);
     }
 
     private InvokeResult invokeClientToGetCIResult(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -149,21 +149,14 @@ public class CiMitService {
     public ContraIndications getContraIndicatorsVC(
             String userId, String govukSigninJourneyId, String ipAddress)
             throws CiRetrievalException {
-        SignedJWT ciSignedJWT = getContraIndicatorsJWT(userId, govukSigninJourneyId, ipAddress);
+        SignedJWT ciSignedJWT = getContraIndicatorsVCJwt(userId, govukSigninJourneyId, ipAddress);
         ContraIndicatorEvidenceDto contraIndicatorEvidence =
                 parseContraIndicatorEvidence(ciSignedJWT);
 
         return mapToContraIndications(contraIndicatorEvidence);
     }
 
-    public String getContraIndicatorsVcAsJwtString(
-            String userId, String govukSigninJourneyId, String ipAddress)
-            throws CiRetrievalException {
-        SignedJWT ciSignedJWT = getContraIndicatorsJWT(userId, govukSigninJourneyId, ipAddress);
-        return ciSignedJWT.serialize();
-    }
-
-    private SignedJWT getContraIndicatorsJWT(
+    public SignedJWT getContraIndicatorsVCJwt(
             String userId, String govukSigninJourneyId, String ipAddress)
             throws CiRetrievalException {
         InvokeResult result =

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiMitServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/CiMitServiceTest.java
@@ -430,7 +430,7 @@ class CiMitServiceTest {
     }
 
     @Test
-    void getContraIndicatorsVcAsJwtStringValidJWT()
+    void getContraIndicatorsVCJwtWhenValidJWT()
             throws CiRetrievalException, JsonProcessingException {
         when(configService.getEnvironmentVariable(CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN))
                 .thenReturn(THE_ARN_OF_CIMIT_GET_CI_LAMBDA);
@@ -444,10 +444,9 @@ class CiMitServiceTest {
                                 .withStatusCode(200)
                                 .withPayload(makeCiMitVCPayload(SIGNED_CONTRA_INDICATOR_VC)));
 
-        String jwtString =
-                ciMitService.getContraIndicatorsVcAsJwtString(
+        SignedJWT contraIndicatorsVCJwt =
+                ciMitService.getContraIndicatorsVCJwt(
                         TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP);
-
         verify(verifiableCredentialJwtValidator)
                 .validateSignatureAndClaims(
                         any(SignedJWT.class),
@@ -463,11 +462,11 @@ class CiMitServiceTest {
                         GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP, TEST_USER_ID),
                 new String(request.getPayload().array(), StandardCharsets.UTF_8));
 
-        assertEquals(SIGNED_CONTRA_INDICATOR_VC, jwtString);
+        assertEquals(SIGNED_CONTRA_INDICATOR_VC, contraIndicatorsVCJwt.serialize());
     }
 
     @Test
-    void getContraIndicatorsVcAsJwtStringInvalidJWT() throws JsonProcessingException {
+    void getContraIndicatorsVCJwtWhenInvalidJWT() throws JsonProcessingException {
         when(configService.getEnvironmentVariable(CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN))
                 .thenReturn(THE_ARN_OF_CIMIT_GET_CI_LAMBDA);
         when(lambdaClient.invoke(any()))
@@ -479,12 +478,12 @@ class CiMitServiceTest {
         assertThrows(
                 CiRetrievalException.class,
                 () ->
-                        ciMitService.getContraIndicatorsVcAsJwtString(
+                        ciMitService.getContraIndicatorsVCJwt(
                                 TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
     }
 
     @Test
-    void getContraIndicatorsVcAsJwtStringAWSLambdaClientInvocationFailed() {
+    void getContraIndicatorsVCJwtWhenAWSLambdaClientInvocationFailed() {
         when(configService.getEnvironmentVariable(CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN))
                 .thenReturn(THE_ARN_OF_CIMIT_GET_CI_LAMBDA);
         doThrow(new AWSLambdaException("AWSLambda client invocation failed"))
@@ -499,7 +498,7 @@ class CiMitServiceTest {
     }
 
     @Test
-    void getContraIndicatorsVcAsJwtStringVcValidationFails() throws JsonProcessingException {
+    void getContraIndicatorsVCJwtWhenVcValidationFails() throws JsonProcessingException {
         when(configService.getEnvironmentVariable(CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN))
                 .thenReturn(THE_ARN_OF_CIMIT_GET_CI_LAMBDA);
         when(configService.getSsmParameter(ConfigurationVariable.CIMIT_COMPONENT_ID))
@@ -525,7 +524,7 @@ class CiMitServiceTest {
         assertThrows(
                 CiRetrievalException.class,
                 () ->
-                        ciMitService.getContraIndicatorsVcAsJwtString(
+                        ciMitService.getContraIndicatorsVCJwt(
                                 TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
     }
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update `BuildUserIdentityDetails` to fetch and return CIMIT VC alongside the CRI VCs

### Why did it change

added the CiMit's VC to the UserIdentity's VC list

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3187](https://govukverify.atlassian.net/browse/PYIC-3187)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3187]: https://govukverify.atlassian.net/browse/PYIC-3187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ