### PR TITLE
PYIC-3266 Rename classes which extend JourneyStepResponse to also inc…

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -28,7 +28,7 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEve
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownStateException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
-import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageResponse;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageStepResponse;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -119,7 +119,7 @@ public class ProcessJourneyEventHandler
         String currentUserState = ipvSessionItem.getUserState();
         if (sessionIsNewlyExpired(ipvSessionItem)) {
             updateUserSessionForTimeout(currentUserState, ipvSessionItem);
-            return new PageResponse(PYIC_TIMEOUT_UNRECOVERABLE_ID).value();
+            return new PageStepResponse(PYIC_TIMEOUT_UNRECOVERABLE_ID).value();
         }
 
         try {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -11,7 +11,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public class CriResponse implements JourneyStepResponse {
+public class CriStepResponse implements JourneyStepResponse {
 
     public static final String CRI_JOURNEY_TEMPLATE = "/journey/cri/build-oauth-request/%s";
 

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponse.java
@@ -9,7 +9,7 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ErrorResponse implements JourneyStepResponse {
+public class ErrorStepResponse implements JourneyStepResponse {
 
     private static final String ERROR = "error";
     private String pageId;

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/JourneyStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/JourneyStepResponse.java
@@ -8,9 +8,9 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = JourneyResponse.class, name = "journey"),
-    @JsonSubTypes.Type(value = PageResponse.class, name = "page"),
-    @JsonSubTypes.Type(value = ErrorResponse.class, name = "error"),
-    @JsonSubTypes.Type(value = CriResponse.class, name = "cri")
+    @JsonSubTypes.Type(value = PageStepResponse.class, name = "page"),
+    @JsonSubTypes.Type(value = ErrorStepResponse.class, name = "error"),
+    @JsonSubTypes.Type(value = CriStepResponse.class, name = "cri")
 })
 public interface JourneyStepResponse {
     Map<String, Object> value();

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
@@ -9,7 +9,7 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class PageResponse implements JourneyStepResponse {
+public class PageStepResponse implements JourneyStepResponse {
 
     private String pageId;
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -6,9 +6,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CriResponseTest {
+public class CriStepResponseTest {
 
-    public static final CriResponse CRI_RESPONSE = new CriResponse("aCriId");
+    public static final CriStepResponse CRI_RESPONSE = new CriStepResponse("aCriId");
 
     @Test
     void valueReturnsCorrectJourneyResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponseTest.java
@@ -6,9 +6,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ErrorResponseTest {
+public class ErrorStepResponseTest {
 
-    public static final ErrorResponse ERROR_RESPONSE = new ErrorResponse("aPageId", "500");
+    public static final ErrorStepResponse ERROR_RESPONSE = new ErrorStepResponse("aPageId", "500");
 
     @Test
     void valueReturnsCorrectResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
@@ -6,9 +6,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class PageResponseTest {
+public class PageStepResponseTest {
 
-    public static final PageResponse PAGE_RESPONSE = new PageResponse("aPageId");
+    public static final PageStepResponse PAGE_RESPONSE = new PageStepResponse("aPageId");
 
     @Test
     void valueReturnsCorrectPageResponse() {


### PR DESCRIPTION
…lude "Step" in their name to align with docs/journey-engine-concepts.md

The possible responses from the process-journey-event lambda are defined in `uk.gov.di.ipv.core.processjourneystep.statemachine.stepresponses`. The name of their interface and the classes themselves clashes with the concept of a Journey Response, which we’ve defined as the JSON that gets returned to the frontend. See docs/journey-engine-concepts.md for more detail on how these things are different. 

## Proposed changes

The JourneyStepResponse interface should become StepResponse.

The concrete response classes should change from <type>Response to <type>StepResponse. For example CriResponse should become CriStepResponse.

JourneyContext can stay as it is.

### What changed

The follow classes and respective tests have been renamed as follows:
- CriResponse -> CriStepResponse
- ErrorResponse -> ErrorStepResponse
- PageResponse -> PageStepResponse

### Why did it change

Renamed to be clearer of what each class actually does.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3266](https://govukverify.atlassian.net/browse/PYIC-3266)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3266]: https://govukverify.atlassian.net/browse/PYIC-3266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ