### PR TITLE
PYIC-3325: Feature flag enabling of mitigated ci scores

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MITIGATION_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.KBV_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
@@ -64,7 +65,8 @@ public class Gpg45ProfileEvaluator {
                                 contraIndications.getContraIndicators().size()));
         final int ciScore =
                 contraIndications.getContraIndicatorScore(
-                        configService.getContraIndicatorScoresMap(), false);
+                        configService.getContraIndicatorScoresMap(),
+                        configService.enabled(MITIGATION_ENABLED));
         LOGGER.info(
                 new StringMapMessage()
                         .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "Calculated user's CI score.")


### PR DESCRIPTION
## Proposed changes

### What changed
Include mitigations in CI scoring when enabled by feature flag

### Why did it change
Prep for introduction of CI mitigation

### Issue tracking
- [PYIC-3325](https://govukverify.atlassian.net/browse/PYIC-3325)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed


### Other considerations


[PYIC-3325]: https://govukverify.atlassian.net/browse/PYIC-3325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ