### PR TITLE
Spike logic for GPG45 scores min required given fraud value

### DIFF
--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.H2D;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.M1A;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.M1B;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_32;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_33;
 
@@ -75,5 +77,21 @@ class Gpg45ScoresTest {
         Gpg45Scores score2 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
 
         assertEquals(0, score1.compareTo(score2));
+    }
+
+    @Test
+    void shouldFindMinimumRequiredScoresToMeetOneOfProfilesGivenFraudScoreOf1() {
+        Gpg45Scores scores = new Gpg45Scores(0, 0, 0, 1, 2);
+        assertEquals(
+                new Gpg45Scores(4, 2, 0, 0, 0),
+                scores.minimumRequiredToMeetProfileGivenCurrentFraudScore(List.of(M1A, M1B)));
+    }
+
+    @Test
+    void shouldFindMinimumRequiredScoresToMeetOneOfProfilesGivenFraudScoreOf2() {
+        Gpg45Scores scores = new Gpg45Scores(0, 0, 0, 2, 2);
+        assertEquals(
+                new Gpg45Scores(3, 2, 1, 0, 0),
+                scores.minimumRequiredToMeetProfileGivenCurrentFraudScore(List.of(M1A, M1B)));
     }
 }


### PR DESCRIPTION
Method to find the minimum remaining scores required to reach a profile given the current fraud score and a list of profiles. If the fraud score for a given profile is already reached, we know the profile can be met and so the remaining 'diff' to reach that profile is added to the set of 'compatible' scores. Taking the min of all the compatible scores gives us the minimum remaining scores required to reach one of the profiles

https://govukverify.atlassian.net/browse/PYIC-3293