### PR TITLE
PYIC-3207: Add CiScoring function to CRI return flow

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -46,7 +46,7 @@
         "featureSet.$": "$.featureSet"
       },
       "ResultPath": "$.lambdaResult",
-      "Next": "EvaluateGpg45Scores"
+      "Next": "RouteJourneyResponse"
     },
     "EvaluateGpg45Scores": {
       "Type": "Task",
@@ -87,8 +87,13 @@
         },
         {
           "Variable": "$.lambdaResult.journey",
-          "StringEquals": "/journey/evaluate",
+          "StringEquals": "/journey/ci-scoring",
           "Next": "CiScoring"
+        },
+        {
+          "Variable": "$.lambdaResult.journey",
+          "StringEquals": "/journey/evaluate",
+          "Next": "EvaluateGpg45Scores"
         }
       ],
       "Default": "ReturnToFrontend"

--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -37,6 +37,17 @@
       "ResultPath": "$.lambdaResult",
       "Next": "RouteJourneyResponse"
     },
+    "CiScoring": {
+      "Type": "Task",
+      "Resource": "${CiScoringFunctionArn}",
+      "Parameters": {
+        "ipvSessionId.$": "$.ipvSessionId",
+        "ipAddress.$": "$.ipAddress",
+        "featureSet.$": "$.featureSet"
+      },
+      "ResultPath": "$.lambdaResult",
+      "Next": "EvaluateGpg45Scores"
+    },
     "EvaluateGpg45Scores": {
       "Type": "Task",
       "Resource": "${EvaluateGpg45ScoresFunctionArn}",
@@ -77,7 +88,7 @@
         {
           "Variable": "$.lambdaResult.journey",
           "StringEquals": "/journey/evaluate",
-          "Next": "EvaluateGpg45Scores"
+          "Next": "CiScoring"
         }
       ],
       "Default": "ReturnToFrontend"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2426,14 +2426,10 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
-        - DynamoDBWritePolicy:
-            TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
-        - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
         - Statement:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2380,6 +2380,40 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub reset-identity-${Environment}
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
+          CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
+          CI_STORAGE_GET_LAMBDA_ARN: !Sub
+            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
+            - contra_indicator_storage_account_id: !If
+                - UseIndividualCiMitStubs
+                - !Ref AWS::AccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref AWS::AccountId
+                  - ciStorageAccountId
+              env: !If
+                - UseIndividualCiMitStubs
+                - !Sub ${Environment}
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref AWS::AccountId
+                  - environment
+          CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN: !Sub
+            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicatorCredential-${env}"
+            - contra_indicator_storage_account_id: !If
+                - UseIndividualCiMitStubs
+                - !Ref AWS::AccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref AWS::AccountId
+                  - ciStorageAccountId
+              env: !If
+                - UseIndividualCiMitStubs
+                - !Sub ${Environment}
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref AWS::AccountId
+                  - environment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2388,18 +2422,76 @@ Resources:
           - !GetAtt LambdaSecurityGroup.GroupId
       Policies:
         - VPCAccessPolicy: { }
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoDBKmsKey
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionsTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionsTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref UserIssuedCredentialsV2Table
+        - DynamoDBReadPolicy:
+            TableName: !Ref ClientOAuthSessionsTable
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub ${Environment}/core/*
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
         - Statement:
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+          - Sid: EnforceStayinSpecificVpc
+            Effect: Allow
+            Action:
+              - 'lambda:CreateFunction'
+              - 'lambda:UpdateFunctionConfiguration'
+            Resource:
+              - "*"
+            Condition:
+              StringEquals:
+                "lambda:VpcIds":
+                  - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+          - Sid: invokeGetCiFunction
+            Effect: Allow
+            Action:
+              - 'lambda:InvokeFunction'
+            Resource:
+              - !Sub
+                - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
+                - contra_indicator_storage_account_id: !If
+                    - UseIndividualCiMitStubs
+                    - !Ref AWS::AccountId
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - ciStorageAccountId
+                  env: !If
+                    - UseIndividualCiMitStubs
+                    - !Sub ${Environment}
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - environment
+          - Sid: invokeGetContraIndicatorCredentialFunction
+            Effect: Allow
+            Action:
+              - 'lambda:InvokeFunction'
+            Resource:
+              - !Sub
+                - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicatorCredential-${env}"
+                - contra_indicator_storage_account_id: !If
+                    - UseIndividualCiMitStubs
+                    - !Ref AWS::AccountId
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - ciStorageAccountId
+                  env: !If
+                    - UseIndividualCiMitStubs
+                    - !Sub ${Environment}
+                    - !FindInMap
+                      - EnvironmentConfiguration
+                      - !Ref AWS::AccountId
+                      - environment
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1265,6 +1265,7 @@ Resources:
         RetrieveCriOauthAccessTokenFunctionArn: !GetAtt RetrieveCriOauthAccessTokenFunction.Arn
         ValidateOAuthCallbackFunctionArn: !GetAtt ValidateOAuthCallbackFunction.Arn
         EvaluateGpg45ScoresFunctionArn: !GetAtt EvaluateGpg45ScoresFunction.Arn
+        CiScoringFunctionArn: !GetAtt CiScoringFunction.Arn
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1290,6 +1291,8 @@ Resources:
             FunctionName: !Ref ValidateOAuthCallbackFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref EvaluateGpg45ScoresFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref CiScoringFunction
         - Statement:
             - Sid: CloudWatchLogsAccess
               Effect: Allow

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2429,8 +2429,6 @@ Resources:
         - DynamoDBWritePolicy:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
-            TableName: !Ref UserIssuedCredentialsV2Table
-        - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*

--- a/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
+++ b/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
@@ -34,11 +34,12 @@ import java.util.Optional;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_JOURNEY_RESPONSE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_EVALUATE_PATH;
 
 public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse(JOURNEY_NEXT_PATH);
+    private static final JourneyResponse JOURNEY_EVALUATE =
+            new JourneyResponse(JOURNEY_EVALUATE_PATH);
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final CiMitService ciMitService;
     private final ConfigService configService;
@@ -102,7 +103,7 @@ public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<Stri
                 return contraIndicatorErrorJourneyResponse.get().toObjectMap();
             }
 
-            return JOURNEY_NEXT.toObjectMap();
+            return JOURNEY_EVALUATE.toObjectMap();
         } catch (HttpResponseExceptionWithErrorBody e) {
             LOGGER.error("Received HTTP response exception", e);
             return new JourneyErrorResponse(

--- a/lambdas/ci-scoring/src/test/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandlerTest.java
+++ b/lambdas/ci-scoring/src/test/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandlerTest.java
@@ -49,7 +49,8 @@ class CiScoringHandlerTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String JOURNEY_ERROR = "/journey/error";
-    private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
+    private static final JourneyResponse JOURNEY_EVALUATE =
+            new JourneyResponse("/journey/evaluate");
     private static final String JOURNEY_PYI_NO_MATCH = "/journey/pyi-no-match";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     private static final ObjectMapper mapper = new ObjectMapper();
@@ -113,7 +114,7 @@ class CiScoringHandlerTest {
                 toResponseClass(
                         ciScoringHandler.handleRequest(request, context), JourneyResponse.class);
 
-        assertEquals(JOURNEY_NEXT.getJourney(), response.getJourney());
+        assertEquals(JOURNEY_EVALUATE.getJourney(), response.getJourney());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -60,8 +60,8 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_VALIDATE
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_CI_SCORING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_EVALUATE_PATH;
 
 public class RetrieveCriCredentialHandler
         implements RequestHandler<Map<String, String>, Map<String, Object>> {
@@ -69,8 +69,8 @@ public class RetrieveCriCredentialHandler
     private static final String JOURNEY = "journey";
     private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final Map<String, Object> JOURNEY_EVALUATE =
-            Map.of(JOURNEY, JOURNEY_EVALUATE_PATH);
+    private static final Map<String, Object> JOURNEY_CI_SCORING =
+            Map.of(JOURNEY, JOURNEY_CI_SCORING_PATH);
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, JOURNEY_ERROR_PATH);
 
     private final VerifiableCredentialService verifiableCredentialService;
@@ -191,7 +191,7 @@ public class RetrieveCriCredentialHandler
                         ipvSessionItem);
             }
 
-            return JOURNEY_EVALUATE;
+            return JOURNEY_CI_SCORING;
 
         } catch (VerifiableCredentialException
                 | VerifiableCredentialResponseException

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -70,6 +70,8 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATORS;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_VC_1;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_CI_SCORING_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 
 @ExtendWith(MockitoExtension.class)
 class RetrieveCriCredentialHandlerTest {
@@ -202,7 +204,7 @@ class RetrieveCriCredentialHandlerTest {
         verify(verifiableCredentialJwtValidator)
                 .validate(any(SignedJWT.class), eq(testPassportIssuer), eq(TEST_USER_ID));
 
-        assertEquals("/journey/ci-scoring", output.get("journey"));
+        assertEquals(JOURNEY_CI_SCORING_PATH, output.get("journey"));
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
     }
 
@@ -275,7 +277,7 @@ class RetrieveCriCredentialHandlerTest {
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
-        assertEquals("/journey/error", output.get("journey"));
+        assertEquals(JOURNEY_ERROR_PATH, output.get("journey"));
     }
 
     @Test
@@ -301,7 +303,7 @@ class RetrieveCriCredentialHandlerTest {
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
-        assertEquals("/journey/error", output.get("journey"));
+        assertEquals(JOURNEY_ERROR_PATH, output.get("journey"));
     }
 
     @Test
@@ -331,7 +333,7 @@ class RetrieveCriCredentialHandlerTest {
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
-        assertEquals("/journey/error", output.get("journey"));
+        assertEquals(JOURNEY_ERROR_PATH, output.get("journey"));
     }
 
     @Test
@@ -632,7 +634,7 @@ class RetrieveCriCredentialHandlerTest {
                         testCriNotRequiringApiKey,
                         null,
                         CREDENTIAL_ISSUER_ID);
-        assertEquals("/journey/ci-scoring", output.get("journey"));
+        assertEquals(JOURNEY_CI_SCORING_PATH, output.get("journey"));
     }
 
     @Test
@@ -658,7 +660,7 @@ class RetrieveCriCredentialHandlerTest {
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
-        assertEquals("/journey/ci-scoring", output.get("journey"));
+        assertEquals(JOURNEY_CI_SCORING_PATH, output.get("journey"));
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
 
         verifyPersistedCriResponse(
@@ -684,7 +686,7 @@ class RetrieveCriCredentialHandlerTest {
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
-        assertEquals("/journey/error", output.get("journey"));
+        assertEquals(JOURNEY_ERROR_PATH, output.get("journey"));
 
         verify(criResponseService, times(0)).persistCriResponse(any(), any(), any(), any(), any());
 

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -202,7 +202,7 @@ class RetrieveCriCredentialHandlerTest {
         verify(verifiableCredentialJwtValidator)
                 .validate(any(SignedJWT.class), eq(testPassportIssuer), eq(TEST_USER_ID));
 
-        assertEquals("/journey/evaluate", output.get("journey"));
+        assertEquals("/journey/ci-scoring", output.get("journey"));
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
     }
 
@@ -632,7 +632,7 @@ class RetrieveCriCredentialHandlerTest {
                         testCriNotRequiringApiKey,
                         null,
                         CREDENTIAL_ISSUER_ID);
-        assertEquals("/journey/evaluate", output.get("journey"));
+        assertEquals("/journey/ci-scoring", output.get("journey"));
     }
 
     @Test
@@ -658,7 +658,7 @@ class RetrieveCriCredentialHandlerTest {
 
         Map<String, Object> output = handler.handleRequest(testInput, context);
 
-        assertEquals("/journey/evaluate", output.get("journey"));
+        assertEquals("/journey/ci-scoring", output.get("journey"));
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
 
         verifyPersistedCriResponse(

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -11,6 +11,7 @@ public class JourneyUris {
     public static final String JOURNEY_END_PATH = "/journey/end";
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
     public static final String JOURNEY_EVALUATE_PATH = "/journey/evaluate";
+    public static final String JOURNEY_CI_SCORING_PATH = "/journey/ci-scoring";
     public static final String JOURNEY_FAIL_PATH = "/journey/fail";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
     public static final String JOURNEY_NEXT_PATH = "/journey/next";


### PR DESCRIPTION
Adds new CiScoring function to the CriReturnStepFunction to perform CiScoring prior to evaluate gpg45

## Proposed changes

Run the new lambda as part of the CRI return flow, before the evaluate-gpg45-scores lambda itself. At this point it’s ok if the CI scoring is done twice, once by the new lambda and once by the evaluate-gpg45-scores lambda.

If a user has breaching CIs the new lambda should handle that. If the user doesn’t it should allow the flow to move to the evaluate-gpg45-scores.

### What changed

- Adds CiScoring function prior to evaluate gpg45
- Adds in relevant permissions and lambda env vars required to run

Example flow with no breaching CIs:
![image](https://github.com/alphagov/di-ipv-core-back/assets/55875065/757fccc1-a1dc-4d0d-bb14-41a5ffd9bda4)


Example flow with breaching CIs:
![image](https://github.com/alphagov/di-ipv-core-back/assets/55875065/d7c2fc1b-dea7-4cad-b5c3-e16b01c57e26)


### Why did it change

Only run evaluategpg45 scoring when required - exit journey early if breaching CIs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3207](https://govukverify.atlassian.net/browse/PYIC-3207)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3207]: https://govukverify.atlassian.net/browse/PYIC-3207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ