### PR TITLE
PYIC-3326 Implement GPG45 logic to calculate required scores

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
  */
 public class Gpg45Scores implements Comparable<Gpg45Scores> {
 
+    public static final Evidence EV_00 = new Gpg45Scores.Evidence(0, 0);
     public static final Evidence EV_11 = new Gpg45Scores.Evidence(1, 1);
     public static final Evidence EV_22 = new Gpg45Scores.Evidence(2, 2);
     public static final Evidence EV_32 = new Gpg45Scores.Evidence(3, 2);
@@ -140,6 +141,31 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
                             targetEvidence.getValidity() - sourceEvidence.getValidity()));
         }
         return evidenceDiff;
+    }
+
+    public Gpg45Scores calculateRequiredScores(Gpg45Profile target) {
+        Gpg45Scores targetScores = target.getScores();
+        Gpg45Scores diff = difference(targetScores);
+        return new Gpg45Scores(
+                calculateRequiredEvidences(diff.getEvidences(), targetScores.getEvidences()),
+                diff.getActivity() > 0 ? targetScores.getActivity() : 0,
+                diff.getFraud() > 0 ? targetScores.getFraud() : 0,
+                diff.getVerification() > 0 ? targetScores.getVerification() : 0);
+    }
+
+    private List<Gpg45Scores.Evidence> calculateRequiredEvidences(
+            List<Gpg45Scores.Evidence> diffEvidences, List<Gpg45Scores.Evidence> targetEvidences) {
+        var requiredEvidences = new ArrayList<Evidence>();
+        var maxEvidence = Math.max(diffEvidences.size(), targetEvidences.size());
+        for (int i = 0; i < maxEvidence; i++) {
+            var diff = diffEvidences.get(i);
+            if (diff.getStrength() > 0 || diff.getValidity() > 0) {
+                requiredEvidences.add(targetEvidences.get(i));
+            } else {
+                requiredEvidences.add(EV_00);
+            }
+        }
+        return requiredEvidences;
     }
 
     @Override

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
@@ -7,8 +7,14 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.H2D;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.M1A;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.M1B;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.V2A;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_00;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_32;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_33;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_42;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_43;
 
 class Gpg45ScoresTest {
 
@@ -51,6 +57,25 @@ class Gpg45ScoresTest {
     void getEvidenceShouldReturnEvidenceWithZeroScoresWhenNoEvidences() {
         Gpg45Scores gpg45Scores = new Gpg45Scores(List.of(), 0, 1, 3);
         assertEquals(new Gpg45Scores.Evidence(0, 0), gpg45Scores.getEvidence(1));
+    }
+
+    @Test
+    void calculateRequiredScoresShouldReturnScoresRequiredToMeetGivenProfile() {
+        assertEquals(
+                new Gpg45Scores(EV_42, 0, 0, 2),
+                new Gpg45Scores(0, 0, 0, 1, 0).calculateRequiredScores(M1A));
+        assertEquals(
+                new Gpg45Scores(EV_42, 0, 0, 2),
+                new Gpg45Scores(0, 0, 0, 2, 0).calculateRequiredScores(M1A));
+        assertEquals(
+                new Gpg45Scores(EV_32, 1, 2, 2),
+                new Gpg45Scores(0, 0, 0, 1, 0).calculateRequiredScores(M1B));
+        assertEquals(
+                new Gpg45Scores(EV_32, 1, 0, 2),
+                new Gpg45Scores(0, 0, 0, 2, 0).calculateRequiredScores(M1B));
+        assertEquals(
+                new Gpg45Scores(List.of(EV_33, EV_00), 3, 0, 3),
+                new Gpg45Scores(List.of(EV_00, EV_43), 0, 2, 0).calculateRequiredScores(V2A));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Implement generic logic to calculate scores required to meet a given GPG45 profile based on the scores already attained. If a score eg. activity history has already been met/exceeded 0 will be output for that component, otherwise the target score required by the profile. See test cases for examples.

### Why did it change

We want to store this information in the session and use it pass the required strength score to F2F CRI

### Issue tracking
- [PYIC-3326](https://govukverify.atlassian.net/browse/PYIC-3326)



[PYIC-3326]: https://govukverify.atlassian.net/browse/PYIC-3326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ