### PR TITLE
PYIC-3309 Update evaluate-gpg45-scores to stash required scores in session

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.Gpg45ScoresDto;
 import uk.gov.di.ipv.core.library.dto.RequiredGpg45ScoresDto;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
@@ -331,7 +332,9 @@ public class EvaluateGpg45ScoresHandler
                                     profile ->
                                             new RequiredGpg45ScoresDto(
                                                     profile,
-                                                    gpg45Scores.calculateRequiredScores(profile)))
+                                                    Gpg45ScoresDto.fromGpg45Scores(
+                                                            gpg45Scores.calculateRequiredScores(
+                                                                    profile))))
                             .collect(Collectors.toList());
             ipvSessionItem.setRequiredGpg45Scores(requiredGpg45Scores);
             ipvSessionService.updateIpvSession(ipvSessionItem);

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.RequiredGpg45ScoresDto;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
@@ -53,6 +54,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
@@ -323,6 +325,16 @@ public class EvaluateGpg45ScoresHandler
                     .with("journeyResponse", JOURNEY_END);
             return JOURNEY_END;
         } else {
+            List<RequiredGpg45ScoresDto> requiredGpg45Scores =
+                    ACCEPTED_PROFILES.stream()
+                            .map(
+                                    profile ->
+                                            new RequiredGpg45ScoresDto(
+                                                    profile,
+                                                    gpg45Scores.calculateRequiredScores(profile)))
+                            .collect(Collectors.toList());
+            ipvSessionItem.setRequiredGpg45Scores(requiredGpg45Scores);
+            ipvSessionService.updateIpvSession(ipvSessionItem);
 
             message.with("lambdaResult", "No GPG45 profiles have been met")
                     .with("journeyResponse", JOURNEY_NEXT);

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -27,6 +27,8 @@ import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.EvidenceDto;
+import uk.gov.di.ipv.core.library.dto.Gpg45ScoresDto;
 import uk.gov.di.ipv.core.library.dto.RequiredGpg45ScoresDto;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
@@ -304,9 +306,11 @@ class EvaluateGpg45ScoresHandlerTest {
         assertEquals(
                 List.of(
                         new RequiredGpg45ScoresDto(
-                                Gpg45Profile.M1A, new Gpg45Scores(4, 2, 0, 0, 2)),
+                                Gpg45Profile.M1A,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(4, 2)), 0, 0, 2)),
                         new RequiredGpg45ScoresDto(
-                                Gpg45Profile.M1B, new Gpg45Scores(3, 2, 1, 0, 2))),
+                                Gpg45Profile.M1B,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(3, 2)), 1, 0, 2))),
                 updatedSessionItem.getRequiredGpg45Scores());
     }
 

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -27,6 +27,7 @@ import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.RequiredGpg45ScoresDto;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 import uk.gov.di.ipv.core.library.exceptions.CiRetrievalException;
@@ -258,6 +259,8 @@ class EvaluateGpg45ScoresHandlerTest {
         mockCiJourneyResponse(useContraIndicatorVC, Optional.empty());
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.buildScore(any()))
+                .thenReturn(new Gpg45Scores(Gpg45Scores.EV_42, 0, 0, 0));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(any(), any()))
@@ -273,6 +276,38 @@ class EvaluateGpg45ScoresHandlerTest {
         assertEquals(JOURNEY_NEXT.getJourney(), response.getJourney());
         verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+    }
+
+    @Test
+    void shouldStoreRequiredScoresInSessionIfGpg45ProfileNotMatched() throws Exception {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
+        when(configService.enabled(USE_CONTRA_INDICATOR_VC)).thenReturn(true);
+        mockCiJourneyResponse(true, Optional.empty());
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
+                .thenReturn(Optional.empty());
+        when(gpg45ProfileEvaluator.buildScore(any()))
+                .thenReturn(new Gpg45Scores(Gpg45Scores.EV_00, 0, 2, 0));
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(any(), any()))
+                .thenReturn(true);
+        when(userIdentityService.checkBirthDateCorrelationInCredentials(any(), any()))
+                .thenReturn(true);
+
+        evaluateGpg45ScoresHandler.handleRequest(request, context);
+
+        ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(IpvSessionItem.class);
+        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+        IpvSessionItem updatedSessionItem = ipvSessionItemArgumentCaptor.getValue();
+        assertEquals(
+                List.of(
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1A, new Gpg45Scores(4, 2, 0, 0, 2)),
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1B, new Gpg45Scores(3, 2, 1, 0, 2))),
+                updatedSessionItem.getRequiredGpg45Scores());
     }
 
     @Test
@@ -384,6 +419,8 @@ class EvaluateGpg45ScoresHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(any(), any()))
                 .thenThrow(new NoVcStatusForIssuerException("Bad"));
+        when(gpg45ProfileEvaluator.buildScore(any()))
+                .thenReturn(new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2));
 
         JourneyErrorResponse response =
                 toResponseClass(
@@ -431,6 +468,8 @@ class EvaluateGpg45ScoresHandlerTest {
         when(configService.enabled(USE_CONTRA_INDICATOR_VC)).thenReturn(useContraIndicatorVC);
         mockCiJourneyResponse(useContraIndicatorVC, Optional.empty());
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
+        when(gpg45ProfileEvaluator.buildScore(any()))
+                .thenReturn(new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(configService.getCredentialIssuerActiveConnectionConfig(any()))
@@ -470,6 +509,8 @@ class EvaluateGpg45ScoresHandlerTest {
         when(configService.enabled(USE_CONTRA_INDICATOR_VC)).thenReturn(useContraIndicatorVC);
         mockCiJourneyResponse(useContraIndicatorVC, Optional.empty());
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
+        when(gpg45ProfileEvaluator.buildScore(any()))
+                .thenReturn(new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -555,6 +596,8 @@ class EvaluateGpg45ScoresHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(any(), any()))
                 .thenReturn(false);
+        when(gpg45ProfileEvaluator.buildScore(any()))
+                .thenReturn(new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2));
 
         JourneyResponse response =
                 toResponseClass(
@@ -578,6 +621,8 @@ class EvaluateGpg45ScoresHandlerTest {
                 .thenReturn(true);
         when(userIdentityService.checkBirthDateCorrelationInCredentials(any(), any()))
                 .thenReturn(false);
+        when(gpg45ProfileEvaluator.buildScore(any()))
+                .thenReturn(new Gpg45Scores(Gpg45Scores.EV_42, 0, 1, 2));
 
         JourneyResponse response =
                 toResponseClass(

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/EvidenceDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/EvidenceDto.java
@@ -5,14 +5,18 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
 
 @ExcludeFromGeneratedCoverageReport
 @DynamoDbBean
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class RequiredGpg45ScoresDto {
-    private Gpg45Profile profile;
-    private Gpg45ScoresDto requiredScores;
+public class EvidenceDto {
+    public static EvidenceDto fromEvidence(Gpg45Scores.Evidence evidence) {
+        return new EvidenceDto(evidence.getStrength(), evidence.getValidity());
+    }
+
+    private int strength;
+    private int validity;
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/Gpg45ScoresDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/Gpg45ScoresDto.java
@@ -1,0 +1,33 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ExcludeFromGeneratedCoverageReport
+@DynamoDbBean
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Gpg45ScoresDto {
+    public static Gpg45ScoresDto fromGpg45Scores(Gpg45Scores scores) {
+        return new Gpg45ScoresDto(
+                scores.getEvidences().stream()
+                        .map(EvidenceDto::fromEvidence)
+                        .collect(Collectors.toList()),
+                scores.getActivity(),
+                scores.getFraud(),
+                scores.getVerification());
+    }
+
+    private List<EvidenceDto> evidences;
+    private int activity;
+    private int fraud;
+    private int verification;
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/dto/RequiredGpg45ScoresDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/dto/RequiredGpg45ScoresDto.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores;
+
+@ExcludeFromGeneratedCoverageReport
+@DynamoDbBean
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequiredGpg45ScoresDto {
+    private Gpg45Profile profile;
+    private Gpg45Scores requiredScores;
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -9,6 +9,7 @@ import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.dto.ContraIndicatorMitigationDetailsDto;
+import uk.gov.di.ipv.core.library.dto.RequiredGpg45ScoresDto;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.dto.VisitedCredentialIssuerDetailsDto;
 
@@ -38,6 +39,7 @@ public class IpvSessionItem implements DynamodbItem {
     private IpvJourneyTypes journeyType;
     private List<ContraIndicatorMitigationDetailsDto> contraIndicatorMitigationDetails;
     private String emailAddress;
+    private List<RequiredGpg45ScoresDto> requiredGpg45Scores;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {


### PR DESCRIPTION
## Proposed changes

### What changed

If a profile isn't matched, store the scores required to meet the profile in the user's session - one entry for each accepted profile

### Why did it change

We're storing the required GPG45 scores in the session so we can use this information later to pass requested evidence to a CRI

### Issue tracking
- [PYIC-3309](https://govukverify.atlassian.net/browse/PYIC-3309)


[PYIC-3309]: https://govukverify.atlassian.net/browse/PYIC-3309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ