### PR TITLE
PYIC-3309 Follow-up: correct index bounds when getting evidence

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
@@ -90,7 +90,7 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
     }
 
     public Evidence getEvidence(int index) {
-        if (evidences.size() < index) {
+        if ((evidences.size() - 1) < index) {
             return new Gpg45Scores.Evidence(0, 0);
         }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
@@ -56,7 +56,7 @@ class Gpg45ScoresTest {
     @Test
     void getEvidenceShouldReturnEvidenceWithZeroScoresWhenNoEvidences() {
         Gpg45Scores gpg45Scores = new Gpg45Scores(List.of(), 0, 1, 3);
-        assertEquals(new Gpg45Scores.Evidence(0, 0), gpg45Scores.getEvidence(1));
+        assertEquals(new Gpg45Scores.Evidence(0, 0), gpg45Scores.getEvidence(0));
     }
 
     @Test
@@ -76,6 +76,9 @@ class Gpg45ScoresTest {
         assertEquals(
                 new Gpg45Scores(List.of(EV_33, EV_00), 3, 0, 3),
                 new Gpg45Scores(List.of(EV_00, EV_43), 0, 2, 0).calculateRequiredScores(V2A));
+        assertEquals(
+                new Gpg45Scores(EV_42, 0, 0, 2),
+                new Gpg45Scores(List.of(), 0, 1, 0).calculateRequiredScores(M1A));
     }
 
     @Test


### PR DESCRIPTION
When getting evidence scores to calculate the diff from a target profile the getEvidence method was throwing an index out of bounds exception when evidence is an empty list. This caused the F2F journey to fail as evidence is always empty. The bounds needed correcting so that an empty list returns a default evidence object {0,0} when trying to access the 0th evidence item.
