### PR TITLE
PYIC-3304: Handle 404 response when retrieving credential from CRI

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -111,6 +111,11 @@ CRI_DCMAW:
   events:
     next:
       targetState: POST_DCMAW_SUCCESS_PAGE
+    not-found:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
     access-denied:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
       checkIfDisabled:

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -202,13 +202,11 @@ public class RetrieveCriCredentialHandler
                 | CiPostMitigationsException e) {
             updateVisitedCredentials(
                     ipvSessionItem, credentialIssuerId, null, false, OAuth2Error.SERVER_ERROR_CODE);
-            if (e instanceof VerifiableCredentialException) {
-                VerifiableCredentialException vce = (VerifiableCredentialException) e;
-                if (credentialIssuerId.equals(DCMAW_CRI)
-                        && vce.getHttpStatusCode() == HTTPResponse.SC_NOT_FOUND) {
-                    LOGGER.info("404 received from DCMAW CRI");
-                    return JOURNEY_NOT_FOUND;
-                }
+            if (credentialIssuerId.equals(DCMAW_CRI)
+                    && e instanceof VerifiableCredentialException vce
+                    && vce.getHttpStatusCode() == HTTPResponse.SC_NOT_FOUND) {
+                LOGGER.info("404 received from DCMAW CRI");
+                return JOURNEY_NOT_FOUND;
             }
             return JOURNEY_ERROR;
 

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -206,6 +206,7 @@ public class RetrieveCriCredentialHandler
                 VerifiableCredentialException vce = (VerifiableCredentialException) e;
                 if (credentialIssuerId.equals(DCMAW_CRI)
                         && vce.getHttpStatusCode() == HTTPResponse.SC_NOT_FOUND) {
+                    LOGGER.info("404 received from DCMAW CRI");
                     return JOURNEY_NOT_FOUND;
                 }
             }

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -205,7 +205,8 @@ public class RetrieveCriCredentialHandler
             if (credentialIssuerId.equals(DCMAW_CRI)
                     && e instanceof VerifiableCredentialException vce
                     && vce.getHttpStatusCode() == HTTPResponse.SC_NOT_FOUND) {
-                LOGGER.info("404 received from DCMAW CRI");
+                LogHelper.logErrorMessage(
+                        "404 received from DCMAW CRI", vce.getErrorResponse().getMessage());
                 return JOURNEY_NOT_FOUND;
             }
             return JOURNEY_ERROR;

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -56,12 +56,14 @@ import java.util.Map;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.USE_POST_MITIGATIONS;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_CI_SCORING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NOT_FOUND_PATH;
 
 public class RetrieveCriCredentialHandler
         implements RequestHandler<Map<String, String>, Map<String, Object>> {
@@ -72,7 +74,8 @@ public class RetrieveCriCredentialHandler
     private static final Map<String, Object> JOURNEY_CI_SCORING =
             Map.of(JOURNEY, JOURNEY_CI_SCORING_PATH);
     private static final Map<String, Object> JOURNEY_ERROR = Map.of(JOURNEY, JOURNEY_ERROR_PATH);
-
+    private static final Map<String, Object> JOURNEY_NOT_FOUND =
+            Map.of(JOURNEY, JOURNEY_NOT_FOUND_PATH);
     private final VerifiableCredentialService verifiableCredentialService;
     private final IpvSessionService ipvSessionService;
     private final ConfigService configService;
@@ -199,7 +202,15 @@ public class RetrieveCriCredentialHandler
                 | CiPostMitigationsException e) {
             updateVisitedCredentials(
                     ipvSessionItem, credentialIssuerId, null, false, OAuth2Error.SERVER_ERROR_CODE);
+            if (e instanceof VerifiableCredentialException) {
+                VerifiableCredentialException vce = (VerifiableCredentialException) e;
+                if (credentialIssuerId.equals(DCMAW_CRI)
+                        && vce.getHttpStatusCode() == HTTPResponse.SC_NOT_FOUND) {
+                    return JOURNEY_NOT_FOUND;
+                }
+            }
             return JOURNEY_ERROR;
+
         } catch (ParseException | JsonProcessingException | SqsException e) {
             LogHelper.logErrorMessage("Failed to send audit event to SQS queue.", e.getMessage());
             updateVisitedCredentials(

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -10,6 +10,7 @@ public class JourneyUris {
     public static final String JOURNEY_ACCESS_TOKEN_PATH = "/journey/cri/access-token";
     public static final String JOURNEY_END_PATH = "/journey/end";
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
+    public static final String JOURNEY_NOT_FOUND_PATH = "/journey/not-found";
     public static final String JOURNEY_EVALUATE_PATH = "/journey/evaluate";
     public static final String JOURNEY_CI_SCORING_PATH = "/journey/ci-scoring";
     public static final String JOURNEY_FAIL_PATH = "/journey/fail";

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_RESPONSE_CONTENT_TYPE;
@@ -94,6 +95,12 @@ public class VerifiableCredentialService {
                         "Error retrieving credential",
                         response.getStatusCode(),
                         response.getStatusMessage());
+                if (credentialIssuerId.equals(DCMAW_CRI)
+                        && response.getStatusCode() == HTTPResponse.SC_NOT_FOUND) {
+                    throw new VerifiableCredentialException(
+                            HTTPResponse.SC_NOT_FOUND,
+                            ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
+                }
                 throw new VerifiableCredentialException(
                         HTTPResponse.SC_SERVER_ERROR,
                         ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handle 404 response when retrieving credential from CRI.
When we retrieve a credential from DCMAW we should handle 404 error response and redirect the user to the doc check page for KBV route.

### Why did it change

On receipt of HTTP 404 response from /userinfo, IPV to redirect users to a page to prove their identity another way (KBV option). The behaviour is identical to what is expected in a user abort scenario.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3304](https://govukverify.atlassian.net/browse/PYIC-3304)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3304]: https://govukverify.atlassian.net/browse/PYIC-3304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ