### PR TITLE
BAU Add 15-minute timeouts in GitHub workflow

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   test-node-delete-user-data:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambdas/delete-user-data
@@ -40,6 +41,7 @@ jobs:
 
   test-java:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write
       contents: read
@@ -81,6 +83,7 @@ jobs:
 
   sam-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/secure-post-merge-delete-account.yml
+++ b/.github/workflows/secure-post-merge-delete-account.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
       ENVIRONMENT: build

--- a/.github/workflows/secure-post-merge-notags.yml
+++ b/.github/workflows/secure-post-merge-notags.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
       ENVIRONMENT: build

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       AWS_REGION: eu-west-2
       ENVIRONMENT: build

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   RunCheckov:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,6 +27,7 @@ jobs:
 
   RunSamValidate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Set GitHub action timeouts to 15 minutes.

## Proposed changes

### What changed

Set GitHub action timeouts to 15 minutes.

### Why did it change

E-mail from Alex Wilson entitled “GitHub Actions Storage/Duration Limits” on 15th August 2023 to the whole of DI requests that all projects should “Include job timeouts on all your GitHub workflows of 15m (or more if appropriate for longer build processes)“ in order to control costs of GitHub Actions.

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
