### PR TITLE
PYIC-3375 Update F2F thin file logic

### DIFF
--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -29,11 +29,8 @@ import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
-import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile;
+import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
-import uk.gov.di.ipv.core.library.dto.EvidenceDto;
-import uk.gov.di.ipv.core.library.dto.Gpg45ScoresDto;
-import uk.gov.di.ipv.core.library.dto.RequiredGpg45ScoresDto;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -118,6 +115,7 @@ class BuildCriOauthRequestHandlerTest {
     @Mock private IpvSessionItem mockIpvSessionItem;
     @Mock private CriOAuthSessionService mockCriOAuthSessionService;
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionDetailsService;
+    @Mock private Gpg45ProfileEvaluator mockGpg45ProfileEvaluator;
 
     private CredentialIssuerConfig credentialIssuerConfig;
     private CredentialIssuerConfig addressCredentialIssuerConfig;
@@ -142,7 +140,8 @@ class BuildCriOauthRequestHandlerTest {
                         mockAuditService,
                         mockIpvSessionService,
                         mockCriOAuthSessionService,
-                        mockClientOAuthSessionDetailsService);
+                        mockClientOAuthSessionDetailsService,
+                        mockGpg45ProfileEvaluator);
         credentialIssuerConfig =
                 new CredentialIssuerConfig(
                         new URI(CRI_TOKEN_URL),
@@ -1091,22 +1090,8 @@ class BuildCriOauthRequestHandlerTest {
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockIpvSessionItem.getRequiredGpg45Scores())
-                .thenReturn(
-                        List.of(
-                                new RequiredGpg45ScoresDto(
-                                        Gpg45Profile.M1A,
-                                        new Gpg45ScoresDto(
-                                                List.of(new EvidenceDto(4, 2)), 0, 0, 2)),
-                                new RequiredGpg45ScoresDto(
-                                        Gpg45Profile.M1B,
-                                        new Gpg45ScoresDto(
-                                                List.of(new EvidenceDto(2, 2)), 0, 1, 2)),
-                                new RequiredGpg45ScoresDto(
-                                        Gpg45Profile.M1C,
-                                        new Gpg45ScoresDto(
-                                                List.of(new EvidenceDto(3, 2)), 1, 0, 2))));
         when(configService.enabled(EVIDENCE_REQUEST_ENABLED)).thenReturn(true);
+        when(mockGpg45ProfileEvaluator.calculateF2FRequiredStrengthScore(any())).thenReturn(3);
 
         JourneyRequest input =
                 JourneyRequest.builder()

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -16,6 +16,9 @@ import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.gpg45.domain.CheckDetail;
 import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
 import uk.gov.di.ipv.core.library.domain.gpg45.exception.UnknownEvidenceTypeException;
+import uk.gov.di.ipv.core.library.dto.EvidenceDto;
+import uk.gov.di.ipv.core.library.dto.Gpg45ScoresDto;
+import uk.gov.di.ipv.core.library.dto.RequiredGpg45ScoresDto;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -245,6 +248,22 @@ public class Gpg45ProfileEvaluator {
             }
         }
         return Optional.empty();
+    }
+
+    public int calculateF2FRequiredStrengthScore(List<RequiredGpg45ScoresDto> requiredGpg45Scores) {
+        int strengthScore = 0;
+        for (RequiredGpg45ScoresDto gpg45Score : requiredGpg45Scores) {
+            Gpg45ScoresDto requiredScores = gpg45Score.getRequiredScores();
+            if (requiredScores.getFraud() > 0 || requiredScores.getActivity() > 0) {
+                continue;
+            }
+            List<EvidenceDto> evidences = requiredScores.getEvidences();
+            if (evidences.size() > 0
+                    && (strengthScore == 0 || evidences.get(0).getStrength() < strengthScore)) {
+                strengthScore = evidences.get(0).getStrength();
+            }
+        }
+        return strengthScore;
     }
 
     private boolean isRelevantEvidence(CredentialEvidenceItem evidenceItem)

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -19,6 +19,9 @@ import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.Mitigation;
 import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
+import uk.gov.di.ipv.core.library.dto.EvidenceDto;
+import uk.gov.di.ipv.core.library.dto.Gpg45ScoresDto;
+import uk.gov.di.ipv.core.library.dto.RequiredGpg45ScoresDto;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -412,6 +415,62 @@ class Gpg45ProfileEvaluatorTest {
                         parsedCredentials, CredentialEvidenceItem.EvidenceType.IDENTITY_FRAUD);
 
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void calculateF2FRequiredStrengthScoreShouldReturn3ForUserWithActivityScore1FraudScore2() {
+        List<RequiredGpg45ScoresDto> requiredScores =
+                List.of(
+                        // User who has Fraud VC with activity score 1, fraud score 2
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1A,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(4, 2)), 0, 0, 2)),
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1B,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(3, 2)), 0, 0, 2)));
+        assertEquals(3, evaluator.calculateF2FRequiredStrengthScore(requiredScores));
+    }
+
+    @Test
+    void calculateF2FRequiredStrengthScoreShouldReturn4ForUserWithActivityScore0FraudScore2() {
+        List<RequiredGpg45ScoresDto> requiredScores =
+                List.of(
+                        // User who has Fraud VC with activity score 0, fraud score 2 (thin file)
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1A,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(4, 2)), 0, 0, 2)),
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1B,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(3, 2)), 1, 0, 2)));
+        assertEquals(4, evaluator.calculateF2FRequiredStrengthScore(requiredScores));
+    }
+
+    @Test
+    void calculateF2FRequiredStrengthScoreShouldReturn4ForUserWithActivityScore1FraudScore1() {
+        List<RequiredGpg45ScoresDto> requiredScores =
+                List.of(
+                        // User who has Fraud VC with activity score 1, fraud score 1 (thin file)
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1A,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(4, 2)), 0, 0, 2)),
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1B,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(3, 2)), 0, 2, 2)));
+        assertEquals(4, evaluator.calculateF2FRequiredStrengthScore(requiredScores));
+    }
+
+    @Test
+    void calculateF2FRequiredStrengthScoreShouldReturn4ForUserWithActivityScore0FraudScore1() {
+        List<RequiredGpg45ScoresDto> requiredScores =
+                List.of(
+                        // User who has Fraud VC with activity score 0, fraud score 1 (thin file)
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1A,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(4, 2)), 0, 0, 2)),
+                        new RequiredGpg45ScoresDto(
+                                Gpg45Profile.M1B,
+                                new Gpg45ScoresDto(List.of(new EvidenceDto(3, 2)), 1, 2, 2)));
+        assertEquals(4, evaluator.calculateF2FRequiredStrengthScore(requiredScores));
     }
 
     private void setupMockContraIndicatorScoringConfig() {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
@@ -79,6 +79,12 @@ class Gpg45ScoresTest {
         assertEquals(
                 new Gpg45Scores(EV_42, 0, 0, 2),
                 new Gpg45Scores(List.of(), 0, 1, 0).calculateRequiredScores(M1A));
+        assertEquals(
+                new Gpg45Scores(EV_42, 0, 0, 2),
+                new Gpg45Scores(List.of(), 1, 2, 0).calculateRequiredScores(M1A));
+        assertEquals(
+                new Gpg45Scores(EV_32, 0, 0, 2),
+                new Gpg45Scores(List.of(), 1, 2, 0).calculateRequiredScores(M1B));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

The only small change to the logic is to check if we require an outstanding activity history score (or fraud score as before) in which case we skip the profile as the user won't be able to meet it. The logic has been moved into Gpg45ProfileEvaluator so the different combinations of scores can be properly unit tested. Some additional test cases have been added for the required scores logic.

### Why did it change

We need to check the activity history score as well as fraud score as a 'thin file' user may have insufficient activity history.

### Issue tracking

- [PYIC-3375](https://govukverify.atlassian.net/browse/PYIC-3375)



[PYIC-3375]: https://govukverify.atlassian.net/browse/PYIC-3375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ