### PR TITLE
PYIC-3407: Detect separate session in CI Scoring lambda

### DIFF
--- a/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
+++ b/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
@@ -38,6 +38,7 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PA
 
 public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
+    private static final String USER_STATE_INITIAL_CI_SCORING = "INITIAL_CI_SCORING";
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse(JOURNEY_NEXT_PATH);
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final CiMitService ciMitService;
@@ -90,7 +91,10 @@ public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<Stri
 
             final Optional<JourneyResponse> contraIndicatorErrorJourneyResponse =
                     getContraIndicatorJourneyResponse(
-                            ipAddress, clientOAuthSessionItem.getUserId(), govukSigninJourneyId);
+                            USER_STATE_INITIAL_CI_SCORING.equals(ipvSessionItem.getUserState()),
+                            ipAddress,
+                            clientOAuthSessionItem.getUserId(),
+                            govukSigninJourneyId);
 
             if (contraIndicatorErrorJourneyResponse.isPresent()) {
                 StringMapMessage message = new StringMapMessage();
@@ -133,12 +137,12 @@ public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<Stri
     }
 
     private Optional<JourneyResponse> getContraIndicatorJourneyResponse(
-            String ipAddress, String userId, String govukSigninJourneyId)
+            boolean initialCiScoring, String ipAddress, String userId, String govukSigninJourneyId)
             throws ConfigException, UnrecognisedCiException, CiRetrievalException {
         return configService.enabled(CoreFeatureFlag.USE_CONTRA_INDICATOR_VC)
                 ? gpg45ProfileEvaluator.getJourneyResponseForStoredContraIndicators(
                         ciMitService.getContraIndicatorsVC(userId, govukSigninJourneyId, ipAddress),
-                        false)
+                        initialCiScoring)
                 : gpg45ProfileEvaluator.getJourneyResponseForStoredCis(
                         ciMitService.getCIs(userId, govukSigninJourneyId, ipAddress));
     }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -23,7 +23,7 @@ CRI_STATE:
 INITIAL_IPV_JOURNEY:
   events:
     next:
-      targetState: CI_SCORING
+      targetState: INITIAL_CI_SCORING
 
 F2F_START_PAGE:
   response:
@@ -35,7 +35,7 @@ F2F_START_PAGE:
     end:
       targetState: PYI_ESCAPE
 
-CI_SCORING:
+INITIAL_CI_SCORING:
   response:
     type: journey
     journeyStepId: /journey/ci-scoring


### PR DESCRIPTION
## Proposed changes

### What changed
CI Scoring needs to distinguish separate and same session treatment for CI-breaching scores: Hence, we distinguish CI Scoring invocations at journey-commencement from those within a journey.

### Why did it change
Distinguishing same and separate session treatment for breaching CI scores.

### Issue tracking
- [PYIC-3407](https://govukverify.atlassian.net/browse/PYIC-3407)

## Checklists

### Environment variables or secrets
- No environment variables or secrets were added or changed

### Other considerations


[PYIC-3407]: https://govukverify.atlassian.net/browse/PYIC-3407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ