### PR TITLE
PYIC-3409 Implement new checkFeatureFlag journey mechanism

### DIFF
--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEventTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEventTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
@@ -50,6 +51,27 @@ class BasicEventTest {
                 basicEventWithCheckIfDisabledConfigured.resolve(JourneyContext.emptyContext());
 
         assertEquals(alternativeTargetState, resolve);
+    }
+
+    @Test
+    void resolveShouldReturnAlternativeStateIfACheckedFeatureFlagIsSet() throws Exception {
+        BasicEvent eventWithCheckFeatureFlagConfigured = new BasicEvent(mockConfigService);
+        BasicState featureFlagTargetState = new BasicState();
+        eventWithCheckFeatureFlagConfigured.setTargetStateObj(featureFlagTargetState);
+
+        BasicEvent defaultEvent = new BasicEvent(mockConfigService);
+        defaultEvent.setTargetStateObj(new BasicState());
+
+        when(mockConfigService.enabled(CoreFeatureFlag.MITIGATION_ENABLED.getName()))
+                .thenReturn(true);
+        LinkedHashMap<String, Event> checkFeatureFlag = new LinkedHashMap<>();
+        checkFeatureFlag.put(
+                CoreFeatureFlag.MITIGATION_ENABLED.getName(), eventWithCheckFeatureFlagConfigured);
+        defaultEvent.setCheckFeatureFlag(checkFeatureFlag);
+
+        State resolve = defaultEvent.resolve(JourneyContext.emptyContext());
+
+        assertEquals(featureFlagTargetState, resolve);
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -335,4 +335,9 @@ public class ConfigService {
         return Boolean.parseBoolean(
                 getSsmParameter(ConfigurationVariable.FEATURE_FLAGS, featureFlag.getName()));
     }
+
+    public boolean enabled(String featureFlagValue) {
+        return Boolean.parseBoolean(
+                getSsmParameter(ConfigurationVariable.FEATURE_FLAGS, featureFlagValue));
+    }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -45,6 +45,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -780,5 +781,19 @@ class ConfigServiceTest {
         environmentVariables.set("ENVIRONMENT", "test");
         when(ssmProvider.get("/test/core/cimit/config")).thenReturn("}");
         assertThrows(ConfigException.class, () -> configService.getCiMitConfig());
+    }
+
+    @Test
+    void enabledShowReturnTrueIfFeatureFlagEnabledGivenName() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/featureFlags/testFlagName")).thenReturn("true");
+        assertTrue(configService.enabled("testFlagName"));
+    }
+
+    @Test
+    void enabledShowReturnFalseIfFeatureFlagNotEnabledGivenName() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/featureFlags/testFlagName")).thenReturn("false");
+        assertFalse(configService.enabled("testFlagName"));
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed
Implement new `checkFeatureFlag` mechanism similar to `checkIfDisabled` for CRIs. 

To be used in the journey map like so:
```
A_STATE
  ...
  events:
    next:
      targetState: DEFAULT_TARGET_STATE
      checkFeatureFlag:
        aFeatureFlag:
          targetState: TARGET_STATE_IF_FEATURE_ENABLED
```

### Why did it change

So we can switch conditionally based on a feature flag - will help with staging out new work behind a feature flag such as the KBV dropout work

### Issue tracking
- [PYIC-3409](https://govukverify.atlassian.net/browse/PYIC-3409)



[PYIC-3409]: https://govukverify.atlassian.net/browse/PYIC-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ