### PR TITLE
PYIC-3411: Point core dev and build at stubs-prod CiMit stub

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -80,7 +80,8 @@ Mappings:
   EnvironmentConfiguration:
     "130355686670": # Old Development Account
       provisionedConcurrency: 0
-      ciStorageAccountId: 322814139578 # di-ipv-cri-dev
+      cimitAccountId: 388905755587 # di-ipv-stubs-prod
+      cimitEnvironment: production # targeting the "production" CiMit stub
       environment: dev
       criReturnStepFunctionLogLevel: "ALL"
       journeyEngineStepFunctionLogLevel: "ALL"
@@ -93,7 +94,8 @@ Mappings:
       asyncCriLambdaTimeout: 30
     "175872367215": # New Development Account
       provisionedConcurrency: 0
-      ciStorageAccountId: 158853307826 # new CIMIT dev
+      cimitAccountId: 388905755587 # di-ipv-stubs-prod
+      cimitEnvironment: production # targeting the "production" CiMit stub
       environment: dev
       criReturnStepFunctionLogLevel: "ALL"
       journeyEngineStepFunctionLogLevel: "ALL"
@@ -104,7 +106,8 @@ Mappings:
       asyncCriLambdaTimeout: 30
     "457601271792": # Build
       provisionedConcurrency: 1
-      ciStorageAccountId: 755415363251 # di-ipv-contra-indicators-build
+      cimitAccountId: 388905755587 # di-ipv-stubs-prod
+      cimitEnvironment: production # targeting the "production" CiMit stub
       environment: build
       criReturnStepFunctionLogLevel: "ALL"
       journeyEngineStepFunctionLogLevel: "ALL"
@@ -115,7 +118,8 @@ Mappings:
       asyncCriLambdaTimeout: 30
     "335257547869": # Staging
       provisionedConcurrency: 1
-      ciStorageAccountId: 265689800486 # di-ipv-contra-indicators-staging
+      cimitAccountId: 265689800486 # di-ipv-contra-indicators-staging
+      cimitEnvironment: staging
       environment: staging
       criReturnStepFunctionLogLevel: "ALL"
       journeyEngineStepFunctionLogLevel: "ALL"
@@ -126,7 +130,8 @@ Mappings:
       asyncCriLambdaTimeout: 30
     "991138514218": # Integration
       provisionedConcurrency: 1
-      ciStorageAccountId: 697519714716 # di-ipv-contra-indicators-integration
+      cimitAccountId: 697519714716 # di-ipv-contra-indicators-integration
+      cimitEnvironment: integration
       environment: integration
       criReturnStepFunctionLogLevel: "OFF"
       journeyEngineStepFunctionLogLevel: "OFF"
@@ -137,7 +142,8 @@ Mappings:
       asyncCriLambdaTimeout: 30
     "075701497069": # Production
       provisionedConcurrency: 1
-      ciStorageAccountId: 442136572379 # di-ipv-contra-indicators-prod
+      cimitAccountId: 442136572379 # di-ipv-contra-indicators-prod
+      cimitEnvironment: production
       environment: production
       criReturnStepFunctionLogLevel: "OFF"
       journeyEngineStepFunctionLogLevel: "OFF"
@@ -698,21 +704,21 @@ Resources:
           CRI_OAUTH_SESSIONS_TABLE_NAME: !Ref CriOAuthSessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           CI_STORAGE_PUT_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraIndicators-${env}"
-            - contra_indicator_storage_account_id: !If
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:putContraIndicators-${env}"
+            - cimit_account_id: !If
                 - UseIndividualCiMitStubs
                 - !Ref AWS::AccountId
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - ciStorageAccountId
+                  - cimitAccountId
               env: !If
                 - UseIndividualCiMitStubs
                 - !Sub ${Environment}
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - environment
+                  - cimitEnvironment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -773,14 +779,14 @@ Resources:
                 - 'lambda:InvokeFunction'
               Resource:
                 - !Sub
-                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraIndicators-${env}"
-                  - contra_indicator_storage_account_id: !If
+                  - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:putContraIndicators-${env}"
+                  - cimit_account_id: !If
                       - UseIndividualCiMitStubs
                       - !Ref AWS::AccountId
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - ciStorageAccountId
+                        - cimitAccountId
                     env: !If
                       - UseIndividualCiMitStubs
                       - !Sub ${Environment}
@@ -848,14 +854,14 @@ Resources:
           CRI_OAUTH_SESSIONS_TABLE_NAME: !Ref CriOAuthSessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           CI_STORAGE_PUT_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraIndicators-${env}"
-            - contra_indicator_storage_account_id: !If
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:putContraIndicators-${env}"
+            - cimit_account_id: !If
                 - UseIndividualCiMitStubs
                 - !Ref AWS::AccountId
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - ciStorageAccountId
+                  - cimitAccountId
               env: !If
                 - UseIndividualCiMitStubs
                 - !Sub ${Environment}
@@ -864,14 +870,14 @@ Resources:
                   - !Ref AWS::AccountId
                   - environment
           CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:postMitigations-${env}"
-            - contra_indicator_storage_account_id: !If
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:postMitigations-${env}"
+            - cimit_account_id: !If
                 - UseIndividualCiMitStubs
                 - !Ref AWS::AccountId
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - ciStorageAccountId
+                  - cimitAccountId
               env: !If
                 - UseIndividualCiMitStubs
                 - !Sub ${Environment}
@@ -941,14 +947,14 @@ Resources:
                 - 'lambda:InvokeFunction'
               Resource:
                 - !Sub
-                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraIndicators-${env}"
-                  - contra_indicator_storage_account_id: !If
+                  - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:putContraIndicators-${env}"
+                  - cimit_account_id: !If
                       - UseIndividualCiMitStubs
                       - !Ref AWS::AccountId
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - ciStorageAccountId
+                        - cimitAccountId
                     env: !If
                       - UseIndividualCiMitStubs
                       - !Sub ${Environment}
@@ -962,14 +968,14 @@ Resources:
                 - 'lambda:InvokeFunction'
               Resource:
                 - !Sub
-                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:postMitigations-${env}"
-                  - contra_indicator_storage_account_id: !If
+                  - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:postMitigations-${env}"
+                  - cimit_account_id: !If
                       - UseIndividualCiMitStubs
                       - !Ref AWS::AccountId
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - ciStorageAccountId
+                        - cimitAccountId
                     env: !If
                       - UseIndividualCiMitStubs
                       - !Sub ${Environment}
@@ -1144,14 +1150,14 @@ Resources:
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt ClientOAuthSessionsTable.Arn ] ]
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicatorCredential-${env}"
-            - contra_indicator_storage_account_id: !If
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicatorCredential-${env}"
+            - cimit_account_id: !If
                 - UseIndividualCiMitStubs
                 - !Ref AWS::AccountId
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - ciStorageAccountId
+                  - cimitAccountId
               env: !If
                 - UseIndividualCiMitStubs
                 - !Sub ${Environment}
@@ -1210,14 +1216,14 @@ Resources:
                 - 'lambda:InvokeFunction'
               Resource:
                 - !Sub
-                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicatorCredential-${env}"
-                  - contra_indicator_storage_account_id: !If
+                  - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicatorCredential-${env}"
+                  - cimit_account_id: !If
                       - UseIndividualCiMitStubs
                       - !Ref AWS::AccountId
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - ciStorageAccountId
+                        - cimitAccountId
                     env: !If
                       - UseIndividualCiMitStubs
                       - !Sub ${Environment}
@@ -2035,14 +2041,14 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub process-async-cri-credential-${Environment}
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CI_STORAGE_PUT_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraIndicators-${env}"
-            - contra_indicator_storage_account_id: !If
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:putContraIndicators-${env}"
+            - cimit_account_id: !If
                 - UseIndividualCiMitStubs
                 - !Ref AWS::AccountId
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - ciStorageAccountId
+                  - cimitAccountId
               env: !If
                 - UseIndividualCiMitStubs
                 - !Sub ${Environment}
@@ -2051,14 +2057,14 @@ Resources:
                   - !Ref AWS::AccountId
                   - environment
           CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:postMitigations-${env}"
-            - contra_indicator_storage_account_id: !If
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:postMitigations-${env}"
+            - cimit_account_id: !If
                 - UseIndividualCiMitStubs
                 - !Ref AWS::AccountId
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - ciStorageAccountId
+                  - cimitAccountId
               env: !If
                 - UseIndividualCiMitStubs
                 - !Sub ${Environment}
@@ -2118,14 +2124,14 @@ Resources:
                 - 'lambda:InvokeFunction'
               Resource:
                 - !Sub
-                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:putContraIndicators-${env}"
-                  - contra_indicator_storage_account_id: !If
+                  - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:putContraIndicators-${env}"
+                  - cimit_account_id: !If
                       - UseIndividualCiMitStubs
                       - !Ref AWS::AccountId
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - ciStorageAccountId
+                        - cimitAccountId
                     env: !If
                       - UseIndividualCiMitStubs
                       - !Sub ${Environment}
@@ -2139,14 +2145,14 @@ Resources:
                 - 'lambda:InvokeFunction'
               Resource:
                 - !Sub
-                  - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:postMitigations-${env}"
-                  - contra_indicator_storage_account_id: !If
+                  - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:postMitigations-${env}"
+                  - cimit_account_id: !If
                       - UseIndividualCiMitStubs
                       - !Ref AWS::AccountId
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - ciStorageAccountId
+                        - cimitAccountId
                     env: !If
                       - UseIndividualCiMitStubs
                       - !Sub ${Environment}
@@ -2234,14 +2240,14 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           CI_STORAGE_GET_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
-            - contra_indicator_storage_account_id: !If
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicators-${env}"
+            - cimit_account_id: !If
                 - UseIndividualCiMitStubs
                 - !Ref AWS::AccountId
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - ciStorageAccountId
+                  - cimitAccountId
               env: !If
                 - UseIndividualCiMitStubs
                 - !Sub ${Environment}
@@ -2250,14 +2256,14 @@ Resources:
                   - !Ref AWS::AccountId
                   - environment
           CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN: !Sub
-            - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicatorCredential-${env}"
-            - contra_indicator_storage_account_id: !If
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicatorCredential-${env}"
+            - cimit_account_id: !If
                 - UseIndividualCiMitStubs
                 - !Ref AWS::AccountId
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - ciStorageAccountId
+                  - cimitAccountId
               env: !If
                 - UseIndividualCiMitStubs
                 - !Sub ${Environment}
@@ -2301,14 +2307,14 @@ Resources:
               - 'lambda:InvokeFunction'
             Resource:
               - !Sub
-                - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicators-${env}"
-                - contra_indicator_storage_account_id: !If
+                - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicators-${env}"
+                - cimit_account_id: !If
                     - UseIndividualCiMitStubs
                     - !Ref AWS::AccountId
                     - !FindInMap
                       - EnvironmentConfiguration
                       - !Ref AWS::AccountId
-                      - ciStorageAccountId
+                      - cimitAccountId
                   env: !If
                     - UseIndividualCiMitStubs
                     - !Sub ${Environment}
@@ -2322,14 +2328,14 @@ Resources:
               - 'lambda:InvokeFunction'
             Resource:
               - !Sub
-                - "arn:aws:lambda:eu-west-2:${contra_indicator_storage_account_id}:function:getContraIndicatorCredential-${env}"
-                - contra_indicator_storage_account_id: !If
+                - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicatorCredential-${env}"
+                - cimit_account_id: !If
                     - UseIndividualCiMitStubs
                     - !Ref AWS::AccountId
                     - !FindInMap
                       - EnvironmentConfiguration
                       - !Ref AWS::AccountId
-                      - ciStorageAccountId
+                      - cimitAccountId
                   env: !If
                     - UseIndividualCiMitStubs
                     - !Sub ${Environment}

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -868,7 +868,7 @@ Resources:
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - environment
+                  - cimitEnvironment
           CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:postMitigations-${env}"
             - cimit_account_id: !If
@@ -884,7 +884,7 @@ Resources:
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - environment
+                  - cimitEnvironment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -1164,7 +1164,7 @@ Resources:
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - environment
+                  - cimitEnvironment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2071,7 +2071,7 @@ Resources:
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - environment
+                  - cimitEnvironment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2254,7 +2254,7 @@ Resources:
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - environment
+                  - cimitEnvironment
           CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicatorCredential-${env}"
             - cimit_account_id: !If
@@ -2270,7 +2270,7 @@ Resources:
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - environment
+                  - cimitEnvironment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -793,7 +793,7 @@ Resources:
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - environment
+                        - cimitEnvironment
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -961,7 +961,7 @@ Resources:
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - environment
+                        - cimitEnvironment
             - Sid: invokePostCiMitigationFunction
               Effect: Allow
               Action:
@@ -982,7 +982,7 @@ Resources:
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - environment
+                        - cimitEnvironment
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1230,7 +1230,7 @@ Resources:
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - environment
+                        - cimitEnvironment
       Events:
         IPVCoreExternalAPI:
           Type: Api
@@ -2138,7 +2138,7 @@ Resources:
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - environment
+                        - cimitEnvironment
             - Sid: invokePostCiMitigationFunction
               Effect: Allow
               Action:
@@ -2159,7 +2159,7 @@ Resources:
                       - !FindInMap
                         - EnvironmentConfiguration
                         - !Ref AWS::AccountId
-                        - environment
+                        - cimitEnvironment
             - Sid: asyncCriResponseQueuePermission
               Effect: Allow
               Action:
@@ -2321,7 +2321,7 @@ Resources:
                     - !FindInMap
                       - EnvironmentConfiguration
                       - !Ref AWS::AccountId
-                      - environment
+                      - cimitEnvironment
           - Sid: invokeGetContraIndicatorCredentialFunction
             Effect: Allow
             Action:
@@ -2342,7 +2342,7 @@ Resources:
                     - !FindInMap
                       - EnvironmentConfiguration
                       - !Ref AWS::AccountId
-                      - environment
+                      - cimitEnvironment
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2055,7 +2055,7 @@ Resources:
                 - !FindInMap
                   - EnvironmentConfiguration
                   - !Ref AWS::AccountId
-                  - environment
+                  - cimitEnvironment
           CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:postMitigations-${env}"
             - cimit_account_id: !If


### PR DESCRIPTION
**To be merged in conjunction with https://github.com/alphagov/di-ipv-core-common-infra/pull/572**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Point core dev and build at stubs-prod CiMit stub

### Why did it change

This updates the core-back template to have the build and dev environments use the CiMit stub in the stubs-prod account. It also updates the naming of some template params to be more consistent.

Devs still have the option to use their own deploy if desired - only the default has changed.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3411](https://govukverify.atlassian.net/browse/PYIC-3411)


[PYIC-3411]: https://govukverify.atlassian.net/browse/PYIC-3411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ