### PR TITLE
PYIC-3397: Route fail-with-no-ci to new escape page

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -216,6 +216,18 @@ PYI_ESCAPE:
     end:
       targetState: END
 
+PYI_CRI_ESCAPE:
+  response:
+    type: page
+    pageId: pyi-cri-escape
+  events:
+    dcmaw:
+      targetState: CRI_DCMAW_J5
+    f2f:
+      targetState: CRI_F2F_J5
+    end:
+      targetState: END
+
 ERROR:
   response:
     type: error
@@ -296,6 +308,9 @@ CRI_KBV_J2:
       targetState: IPV_SUCCESS_PAGE
     fail-with-no-ci:
       targetState: PYI_KBV_THIN_FILE
+      checkFeatureFlag:
+        criEscapeFlag:
+          targetState: PYI_CRI_ESCAPE
 
 # Driving licence journey (J3)
 CRI_DRIVING_LICENCE_J3:
@@ -336,6 +351,9 @@ CRI_KBV_J3:
       targetState: IPV_SUCCESS_PAGE
     fail-with-no-ci:
       targetState: PYI_KBV_THIN_FILE
+      checkFeatureFlag:
+        criEscapeFlag:
+          targetState: PYI_CRI_ESCAPE
     next:
       targetState: PYI_NO_MATCH
 
@@ -366,8 +384,45 @@ CRI_F2F_J4:
     access-denied:
       targetState: PYI_ANOTHER_WAY
 
-
 F2F_HANDOFF_PAGE_J4:
+  response:
+    type: page
+    pageId: page-face-to-face-handoff
+
+# CRI escape journey (J5)
+CRI_DCMAW_J5:
+  response:
+    type: cri
+    criId: dcmaw
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: POST_DCMAW_SUCCESS_PAGE_J5
+    not-found:
+      targetState: PYI_ANOTHER_WAY
+    fail-with-no-ci:
+      targetState: PYI_ANOTHER_WAY
+
+POST_DCMAW_SUCCESS_PAGE_J5:
+  response:
+    type: page
+    pageId: page-dcmaw-success
+  events:
+    next:
+      targetState: IPV_SUCCESS_PAGE
+
+CRI_F2F_J5:
+  response:
+    type: cri
+    criId: f2f
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: F2F_HANDOFF_PAGE_J5
+    access-denied:
+      targetState: PYI_ANOTHER_WAY
+
+F2F_HANDOFF_PAGE_J5:
   response:
     type: page
     pageId: page-face-to-face-handoff


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Route fail-with-no-ci to new escape page

### Why did it change

If the user has a thin file or abandons KBV (selects ‘cannot answer the questions’) KBV CRI returns to us a fail VC with no CI. Currently we redirect the user to the pyi-kbv-thin-file page. We need to send them to a new ‘escape’ page which will offer DCMAW as an alternative route to prove their identity. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3397](https://govukverify.atlassian.net/browse/PYIC-3397)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3397]: https://govukverify.atlassian.net/browse/PYIC-3397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ