### PR TITLE
BAU Remove evidence request feature flag

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -26,7 +26,6 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
-import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.credentialissuer.CredentialIssuerConfigService;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.EvidenceRequest;
@@ -283,8 +282,7 @@ public class BuildCriOauthRequestHandler
         SharedClaimsResponse sharedClaimsResponse =
                 getSharedAttributes(ipvSessionItem, userId, currentVcStatuses, criId);
         EvidenceRequest evidenceRequest = null;
-        if (credentialIssuerConfigService.enabled(CoreFeatureFlag.EVIDENCE_REQUEST_ENABLED)
-                && criId.equals(F2F_CRI)) {
+        if (criId.equals(F2F_CRI)) {
             int strengthScore =
                     gpg45ProfileEvaluator.calculateF2FRequiredStrengthScore(
                             ipvSessionItem.getRequiredGpg45Scores());

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -64,7 +64,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVIDENCE_REQUEST_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
@@ -1090,7 +1089,6 @@ class BuildCriOauthRequestHandlerTest {
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(EVIDENCE_REQUEST_ENABLED)).thenReturn(true);
         when(mockGpg45ProfileEvaluator.calculateF2FRequiredStrengthScore(any())).thenReturn(3);
 
         JourneyRequest input =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -4,7 +4,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     USE_CONTRA_INDICATOR_VC("useContraIndicatorVC"),
     USE_POST_MITIGATIONS("usePostMitigations"),
     MITIGATION_ENABLED("mitigationEnabled"),
-    EVIDENCE_REQUEST_ENABLED("evidenceRequestEnabled"),
     BUNDLE_CIMIT_VC("bundleCimitVC");
 
     private final String name;


### PR DESCRIPTION
Evidence request is enabled in all envs now, we only needed it behind a feature flag while we were staging out the changes