### PR TITLE
Fix silent failure in BuildUserIdentityDetails when no invoke permissions on getContraIndicatorCredential lambda

### DIFF
--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -190,14 +190,12 @@ public class BuildUserIdentityHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getResponseCode(), e.getErrorBody());
         } catch (CiRetrievalException e) {
-            LogHelper.logErrorMessage(
-                    "Error when fetching CIs from storage system.", e.getMessage());
+            var errorHeader = "Error when fetching CIs from storage system.";
+            LogHelper.logErrorMessage(errorHeader, e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     OAuth2Error.SERVER_ERROR.getHTTPStatusCode(),
                     OAuth2Error.SERVER_ERROR
-                            .appendDescription(
-                                    " - Error when fetching CIs from storage system. "
-                                            + e.getMessage())
+                            .appendDescription(" - " + errorHeader + " " + e.getMessage())
                             .toJSONObject());
         }
     }

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -194,7 +194,11 @@ public class BuildUserIdentityHandler
                     "Error when fetching CIs from storage system.", e.getMessage());
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     OAuth2Error.SERVER_ERROR.getHTTPStatusCode(),
-                    OAuth2Error.SERVER_ERROR.toJSONObject());
+                    OAuth2Error.SERVER_ERROR
+                            .appendDescription(
+                                    " - Error when fetching CIs from storage system. "
+                                            + e.getMessage())
+                            .toJSONObject());
         }
     }
 

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -354,15 +354,16 @@ class BuildUserIdentityHandlerTest {
         when(mockConfigService.enabled(USE_CONTRA_INDICATOR_VC)).thenReturn(true);
         when(mockConfigService.enabled(BUNDLE_CIMIT_VC)).thenReturn(true);
         when(mockCiMitService.getContraIndicatorsVCJwt(any(), any(), any()))
-                .thenThrow(
-                        new CiRetrievalException("Error when fetching CIs from storage system."));
+                .thenThrow(new CiRetrievalException("Lambda execution failed"));
 
         APIGatewayProxyResponseEvent response = userInfoHandler.handleRequest(event, mockContext);
         responseBody = objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(500, response.getStatusCode());
         assertEquals("server_error", responseBody.get("error"));
-        assertEquals("Unexpected server error", responseBody.get("error_description"));
+        assertEquals(
+                "Unexpected server error - Error when fetching CIs from storage system. Lambda execution failed",
+                responseBody.get("error_description"));
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
         verify(mockCiMitService, times(1)).getContraIndicatorsVCJwt(any(), any(), any());
     }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix silent failure in BuildUserIdentityDetails when no invoke permissions on getContraIndicatorCredential lambda

### Why did it change


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3402](https://govukverify.atlassian.net/browse/PYIC-3402)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3402]: https://govukverify.atlassian.net/browse/PYIC-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ