### PR TITLE
PYIC-3421: Route to DCMAW-only CRI escape page if F2F disabled

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -228,6 +228,16 @@ PYI_CRI_ESCAPE:
     end:
       targetState: END
 
+PYI_CRI_ESCAPE_NO_F2F:
+  response:
+    type: page
+    pageId: pyi-cri-escape-no-f2f
+  events:
+    next:
+      targetState: CRI_DCMAW_J5
+    end:
+      targetState: END
+
 ERROR:
   response:
     type: error
@@ -311,6 +321,9 @@ CRI_KBV_J2:
       checkFeatureFlag:
         criEscapeFlag:
           targetState: PYI_CRI_ESCAPE
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_CRI_ESCAPE_NO_F2F
 
 # Driving licence journey (J3)
 CRI_DRIVING_LICENCE_J3:
@@ -354,6 +367,9 @@ CRI_KBV_J3:
       checkFeatureFlag:
         criEscapeFlag:
           targetState: PYI_CRI_ESCAPE
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_CRI_ESCAPE_NO_F2F
     next:
       targetState: PYI_NO_MATCH
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Route to DCMAW-only CRI escape page if F2F disabled

Subsequent core-front PR: https://github.com/alphagov/di-ipv-core-front/pull/1032

### Why did it change

We need to handle F2F being disabled and send them to a page which only offers the DCMAW option in this case.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3421](https://govukverify.atlassian.net/browse/PYIC-3421)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3421]: https://govukverify.atlassian.net/browse/PYIC-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ