### PR TITLE
WIP - Don't delete VCs for separate session mitigation

### DIFF
--- a/lambdas/build-cri-oauth-request/build.gradle
+++ b/lambdas/build-cri-oauth-request/build.gradle
@@ -18,7 +18,8 @@ dependencies {
 			project(":lib"),
 			project(":libs:credential-issuer-config-service"),
 			project(":libs:kms-es256-signer"),
-			project(":libs:journey-uris")
+			project(":libs:journey-uris"),
+			project(":libs:vc-helper")
 
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
 			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -55,7 +55,7 @@ INITIAL_CI_SCORING:
     error:
       targetState: ERROR
     mitigation01:
-      targetState: MITIGATION_01
+      targetState: MITIGATION_01_IDENTITY_START_PAGE
 
 CHECK_EXISTING_IDENTITY:
   response:
@@ -444,13 +444,6 @@ F2F_HANDOFF_PAGE_J5:
     pageId: page-face-to-face-handoff
 
 # Mitigation journey (01)
-MITIGATION_01:
-  response:
-    type: journey
-    journeyStepId: /journey/reset-identity
-  events:
-    next:
-      targetState: MITIGATION_01_IDENTITY_START_PAGE
 
 MITIGATION_01_IDENTITY_START_PAGE:
   response:
@@ -476,4 +469,3 @@ MITIGATION_01_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
-


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Don't delete VCs for separate session mitigation.

This generates the current VC statues on the fly in the build-cri-oauth-request lambda. This is necessary because the user has a new session and so has no VC statues at all, which doesn't match with all the VCs they have.

It removes the state in the mitigation journey that resets the users identity.

It *doesn't* remove the address and fraud states in the that mitigation journey flow. But when the user successfully completes DCMAW they skip those and get a success response. Thanks evaluate-gpg45-scores lambda. Those states should be removed though if we go with this approach so the users doesn't visit them if the fail DCMAW.

If you want to test this, you'll need to sub in Mary Watson's name, address and postcode into the DCMAW test data. I used Joe Schmoe and changed the relevant bits.

### Why did it change

For fun.

