### PR TITLE
SPIKE: Enable snapstart in dev

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -6,6 +6,8 @@ Description: >-
 Globals:
   Function:
     Timeout: 40
+    SnapStart:
+      ApplyOn: !If [IsDevelopment, PublishedVersions, None]
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
@@ -402,7 +404,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/issue-client-access-token
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -488,7 +490,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/build-client-oauth-response
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -583,7 +585,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/initialise-ipv-session
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -687,7 +689,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/retrieve-cri-oauth-access-token
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -836,7 +838,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/retrieve-cri-credential
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1025,7 +1027,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/build-cri-oauth-request
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 3008
       Tracing: Active
       Environment:
@@ -1135,7 +1137,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/build-user-identity
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1264,12 +1266,12 @@ Resources:
     Properties:
       DefinitionUri: criReturnStepFunction.asl.json
       DefinitionSubstitutions:
-        IPVProcessJourneyEventFunctionArn: !GetAtt IPVProcessJourneyEventFunction.Arn
-        RetrieveCriCredentialFunctionArn: !GetAtt RetrieveCriCredentialFunction.Arn
-        RetrieveCriOauthAccessTokenFunctionArn: !GetAtt RetrieveCriOauthAccessTokenFunction.Arn
-        ValidateOAuthCallbackFunctionArn: !GetAtt ValidateOAuthCallbackFunction.Arn
-        EvaluateGpg45ScoresFunctionArn: !GetAtt EvaluateGpg45ScoresFunction.Arn
-        CiScoringFunctionArn: !GetAtt CiScoringFunction.Arn
+        IPVProcessJourneyEventFunctionArn: !Ref IPVProcessJourneyEventFunction.Alias
+        RetrieveCriCredentialFunctionArn: !Ref RetrieveCriCredentialFunction.Alias
+        RetrieveCriOauthAccessTokenFunctionArn: !Ref RetrieveCriOauthAccessTokenFunction.Alias
+        ValidateOAuthCallbackFunctionArn: !Ref ValidateOAuthCallbackFunction.Alias
+        EvaluateGpg45ScoresFunctionArn: !Ref EvaluateGpg45ScoresFunction.Alias
+        CiScoringFunctionArn: !Ref CiScoringFunction.Alias
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1364,12 +1366,12 @@ Resources:
     Properties:
       DefinitionUri: journeyEngineStepFunction.asl.json
       DefinitionSubstitutions:
-        IPVProcessJourneyEventFunctionArn: !GetAtt IPVProcessJourneyEventFunction.Arn
-        CheckExistingIdentityFunctionArn: !GetAtt CheckExistingIdentityFunction.Arn
-        ResetIdentityFunctionArn: !GetAtt ResetIdentityFunction.Arn
-        BuildCriOauthRequestFunctionArn: !GetAtt BuildCriOauthRequestFunction.Arn
-        BuildClientOauthResponseFunctionArn: !GetAtt BuildClientOauthResponseFunction.Arn
-        CiScoringFunctionArn: !GetAtt CiScoringFunction.Arn
+        IPVProcessJourneyEventFunctionArn: !Ref IPVProcessJourneyEventFunction.Alias
+        CheckExistingIdentityFunctionArn: !Ref CheckExistingIdentityFunction.Alias
+        ResetIdentityFunctionArn: !Ref ResetIdentityFunction.Alias
+        BuildCriOauthRequestFunctionArn: !Ref BuildCriOauthRequestFunction.Alias
+        BuildClientOauthResponseFunctionArn: !Ref BuildClientOauthResponseFunction.Alias
+        CiScoringFunctionArn: !Ref CiScoringFunction.Alias
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1473,7 +1475,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/process-journey-event
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1552,7 +1554,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/evaluate-gpg45-scores
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1643,7 +1645,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/validate-oauth-callback
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1745,7 +1747,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/build-proven-user-identity-details
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1838,7 +1840,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/check-existing-identity
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1931,7 +1933,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/reset-identity
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -2022,7 +2024,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/process-async-cri-credential
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Timeout: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, asyncCriLambdaTimeout ]
       Tracing: Active
@@ -2224,7 +2226,7 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/ci-scoring
       Architectures:
-        - arm64
+        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -8,6 +8,8 @@ Globals:
     Timeout: 40
     SnapStart:
       ApplyOn: !If [IsDevelopment, PublishedVersions, None]
+    Architectures:
+      - !If [ IsDevelopment, x86_64, arm64 ]
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
@@ -403,8 +405,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/issue-client-access-token
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -489,8 +489,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/build-client-oauth-response
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -584,8 +582,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/initialise-ipv-session
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -688,8 +684,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/retrieve-cri-oauth-access-token
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -837,8 +831,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/retrieve-cri-credential
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1026,8 +1018,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/build-cri-oauth-request
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 3008
       Tracing: Active
       Environment:
@@ -1136,8 +1126,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/build-user-identity
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1474,8 +1462,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/process-journey-event
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1553,8 +1539,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/evaluate-gpg45-scores
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1644,8 +1628,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/validate-oauth-callback
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1746,8 +1728,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/build-proven-user-identity-details
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1839,8 +1819,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/check-existing-identity
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -1932,8 +1910,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/reset-identity
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:
@@ -2023,8 +1999,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/process-async-cri-credential
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Timeout: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, asyncCriLambdaTimeout ]
       Tracing: Active
@@ -2225,8 +2199,6 @@ Resources:
       Runtime: java17
       PackageType: Zip
       CodeUri: ../lambdas/ci-scoring
-      Architectures:
-        - !If [IsDevelopment, x86_64, arm64]
       MemorySize: 2048
       Tracing: Active
       Environment:

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -61,7 +61,6 @@ public class BuildClientOauthResponseHandler
     private final ClientOAuthSessionDetailsService clientOAuthSessionService;
     private final AuthRequestValidator authRequestValidator;
     private final AuditService auditService;
-    private final String componentId;
 
     @ExcludeFromGeneratedCoverageReport
     public BuildClientOauthResponseHandler() {
@@ -70,7 +69,6 @@ public class BuildClientOauthResponseHandler
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.authRequestValidator = new AuthRequestValidator(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
-        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     public BuildClientOauthResponseHandler(
@@ -84,7 +82,6 @@ public class BuildClientOauthResponseHandler
         this.clientOAuthSessionService = clientOAuthSessionService;
         this.authRequestValidator = authRequestValidator;
         this.auditService = auditService;
-        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override
@@ -92,7 +89,7 @@ public class BuildClientOauthResponseHandler
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest input, Context context) {
 
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
 
         try {
             String ipvSessionId = getIpvSessionIdAllowNull(input);
@@ -171,7 +168,10 @@ public class BuildClientOauthResponseHandler
                                 clientOAuthSessionItem, authorizationCode.getValue());
             }
             auditService.sendAuditEvent(
-                    new AuditEvent(AuditEventTypes.IPV_JOURNEY_END, componentId, auditEventUser));
+                    new AuditEvent(
+                            AuditEventTypes.IPV_JOURNEY_END,
+                            configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
+                            auditEventUser));
 
             var message =
                     new StringMapMessage()

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -87,7 +87,7 @@ public class BuildProvenUserIdentityDetailsHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest input, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
         ProvenUserIdentityDetails.ProvenUserIdentityDetailsBuilder
                 provenUserIdentityDetailsBuilder = ProvenUserIdentityDetails.builder();
         try {

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -57,7 +57,6 @@ public class BuildUserIdentityHandler
     private final AuditService auditService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final CiMitService ciMitService;
-    private final String componentId;
 
     public BuildUserIdentityHandler(
             UserIdentityService userIdentityService,
@@ -72,7 +71,6 @@ public class BuildUserIdentityHandler
         this.auditService = auditService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
         this.ciMitService = ciMitService;
-        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -83,7 +81,6 @@ public class BuildUserIdentityHandler
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.ciMitService = new CiMitService(configService);
-        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override
@@ -91,7 +88,7 @@ public class BuildUserIdentityHandler
     @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
         try {
             String featureSet = RequestHelper.getFeatureSet(input);
             configService.setFeatureSet(featureSet);
@@ -160,7 +157,7 @@ public class BuildUserIdentityHandler
             auditService.sendAuditEvent(
                     new AuditEvent(
                             AuditEventTypes.IPV_IDENTITY_ISSUED,
-                            componentId,
+                            configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
                             auditEventUser,
                             extensions));
 

--- a/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
+++ b/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
@@ -74,7 +74,7 @@ public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<Stri
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest event, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
 
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(event);

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -87,7 +87,6 @@ public class EvaluateGpg45ScoresHandler
     private final ConfigService configService;
     private final AuditService auditService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
-    private final String componentId;
 
     @SuppressWarnings("unused") // Used by tests through injection
     public EvaluateGpg45ScoresHandler(
@@ -103,8 +102,6 @@ public class EvaluateGpg45ScoresHandler
         this.configService = configService;
         this.auditService = auditService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
-
-        componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @SuppressWarnings("unused") // Used by AWS
@@ -116,15 +113,13 @@ public class EvaluateGpg45ScoresHandler
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
-
-        componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
     }
 
     @Override
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest event, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
 
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(event);
@@ -349,7 +344,7 @@ public class EvaluateGpg45ScoresHandler
                         ipAddress);
         return new AuditEvent(
                 AuditEventTypes.IPV_GPG45_PROFILE_MATCHED,
-                componentId,
+                configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
                 auditEventUser,
                 new AuditExtensionGpg45ProfileMatched(
                         gpg45Profile, gpg45Scores, extractTxnIdsFromCredentials(credentials)));

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -31,12 +31,15 @@ public class KmsRsaDecrypter implements JWEDecrypter {
             Set.of(EncryptionMethod.A256GCM);
 
     private final AWSKMS kmsClient;
-    private final String keyId;
+    private String keyId;
     private final JWEJCAContext jwejcaContext = new JWEJCAContext();
 
-    public KmsRsaDecrypter(String keyId) {
-        this.keyId = keyId;
+    public KmsRsaDecrypter() {
         this.kmsClient = AWSKMSClientBuilder.defaultClient();
+    }
+
+    public void setKeyId(String keyId) {
+        this.keyId = keyId;
     }
 
     @Override

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
@@ -50,8 +50,9 @@ public class JarValidator {
         this.configService = configService;
     }
 
-    public SignedJWT decryptJWE(JWEObject jweObject) throws JarValidationException {
+    public SignedJWT decryptJWE(JWEObject jweObject, String keyId) throws JarValidationException {
         try {
+            kmsRsaDecrypter.setKeyId(keyId);
             jweObject.decrypt(kmsRsaDecrypter);
 
             return jweObject.getPayload().toSignedJWT();

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
@@ -66,6 +66,7 @@ class JarValidatorTest {
     private final String audienceClaim = "test-audience";
     private final String issuerClaim = "test-issuer";
     private final String subjectClaim = "test-subject";
+    private final String keyId = "test-key-id";
 
     private final String responseTypeClaim = "code";
     private final String clientIdClaim = "test-client-id";
@@ -88,7 +89,7 @@ class JarValidatorTest {
         String jweObjectString =
                 "eyJ0eXAiOiJKV0UiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.ZpVOfw61XyBBgsR4CRNRMn2oj_S65pMJO-iaEHpR6QrPcIuD4ysZexolo28vsZyZNR-kfVdw_5CjQanwMS-yw3U3nSUvXUrTs3uco-FSXulIeDYTRbBtQuDyvBMVoos6DyIfC6eBj30GMe5g6DF5KJ1Q0eXQdF0kyM9olg76uYAUqZ5rW52rC_SOHb5_tMj7UbO2IViIStdzLgVfgnJr7Ms4bvG0C8-mk4Otd7m2Km2-DNyGaNuFQSKclAGu7Zgg-qDyhH4V1Z6WUHt79TuG4TxseUr-6oaFFVD23JYSBy7Aypt0321ycq13qcN-PBiOWtumeW5-_CQuHLaPuOc4-w.RO9IB2KcS2hD3dWlKXSreQ.93Ntu3e0vNSYv4hoMwZ3Aw.YRvWo4bwsP_l7dL_29imGg";
 
-        SignedJWT decryptedJwt = jarValidator.decryptJWE(JWEObject.parse(jweObjectString));
+        SignedJWT decryptedJwt = jarValidator.decryptJWE(JWEObject.parse(jweObjectString), keyId);
 
         JWTClaimsSet claimsSet = decryptedJwt.getJWTClaimsSet();
         assertEquals(redirectUriClaim, claimsSet.getStringClaim("redirect_uri"));
@@ -104,7 +105,7 @@ class JarValidatorTest {
         JarValidationException thrown =
                 assertThrows(
                         JarValidationException.class,
-                        () -> jarValidator.decryptJWE(JWEObject.parse(jweObjectString)));
+                        () -> jarValidator.decryptJWE(JWEObject.parse(jweObjectString), keyId));
         assertEquals(
                 OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), thrown.getErrorObject().getCode());
     }

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -82,7 +82,7 @@ public class IssueClientAccessTokenHandler
     @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
         try {
             String featureSet = RequestHelper.getFeatureSet(input);
             configService.setFeatureSet(featureSet);

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidator.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidator.java
@@ -32,16 +32,18 @@ public class TokenRequestValidator {
     private final ConfigService configService;
 
     private final ClientAuthJwtIdService clientAuthJwtIdService;
-    private final ClientAuthenticationVerifier<Object> verifier;
+    private ClientAuthenticationVerifier<Object> verifier;
 
     public TokenRequestValidator(
             ConfigService configService, ClientAuthJwtIdService clientAuthJwtIdService) {
         this.configService = configService;
         this.clientAuthJwtIdService = clientAuthJwtIdService;
-        this.verifier = getClientAuthVerifier(configService);
     }
 
     public void authenticateClient(String requestBody) throws ClientAuthenticationException {
+        if (verifier == null) {
+            this.verifier = getClientAuthVerifier(configService);
+        }
         PrivateKeyJWT clientJwt;
         try {
             clientJwt = PrivateKeyJWT.parse(requestBody);

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -78,7 +78,7 @@ public class ProcessJourneyEventHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(Map<String, String> input, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
 
         try {
             String ipvSessionId = StepFunctionHelpers.getIpvSessionId(input);

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -35,6 +35,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TIMEOUT;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY;
 
 @ExtendWith(MockitoExtension.class)
@@ -228,6 +229,7 @@ class ProcessJourneyEventHandlerTest {
         ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.generate());
         ipvSessionItem.setJourneyType(IPV_CORE_MAIN_JOURNEY);
 
+        when(mockConfigService.getSsmParameter(COMPONENT_ID)).thenReturn("core");
         when(mockConfigService.getSsmParameter(BACKEND_SESSION_TIMEOUT)).thenReturn("7200");
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -7,7 +7,6 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
@@ -40,9 +39,7 @@ public class ResetIdentityHandler implements RequestHandler<JourneyRequest, Map<
     private final UserIdentityService userIdentityService;
     private final CriResponseService criResponseService;
     private final IpvSessionService ipvSessionService;
-    private final AuditService auditService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
-    private final String componentId;
 
     @SuppressWarnings("unused") // Used by AWS
     public ResetIdentityHandler(
@@ -57,9 +54,7 @@ public class ResetIdentityHandler implements RequestHandler<JourneyRequest, Map<
         this.configService = configService;
         this.userIdentityService = userIdentityService;
         this.ipvSessionService = ipvSessionService;
-        this.auditService = auditService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
-        this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
         this.criResponseService = criResponseService;
     }
 
@@ -69,9 +64,7 @@ public class ResetIdentityHandler implements RequestHandler<JourneyRequest, Map<
         this.configService = new ConfigService();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
-        componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
         this.criResponseService = new CriResponseService(configService);
     }
 
@@ -79,7 +72,7 @@ public class ResetIdentityHandler implements RequestHandler<JourneyRequest, Map<
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest event, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
 
         try {
             String ipvSessionId = getIpvSessionId(event);

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -86,8 +86,6 @@ public class RetrieveCriCredentialHandler
     private final ClientOAuthSessionDetailsService clientOAuthSessionService;
     private final CriResponseService criResponseService;
 
-    private String componentId;
-
     public RetrieveCriCredentialHandler(
             VerifiableCredentialService verifiableCredentialService,
             IpvSessionService ipvSessionService,
@@ -126,7 +124,7 @@ public class RetrieveCriCredentialHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(Map<String, String> input, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
 
         String ipAddress = StepFunctionHelpers.getIpAddress(input);
         String featureSet = StepFunctionHelpers.getFeatureSet(input);
@@ -157,8 +155,6 @@ public class RetrieveCriCredentialHandler
 
             LogHelper.attachGovukSigninJourneyIdToLogs(
                     clientOAuthSessionItem.getGovukSigninJourneyId());
-
-            this.componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
 
             CredentialIssuerConfig credentialIssuerConfig =
                     configService.getCredentialIssuerActiveConnectionConfig(credentialIssuerId);
@@ -322,7 +318,7 @@ public class RetrieveCriCredentialHandler
         AuditEvent auditEvent =
                 new AuditEvent(
                         AuditEventTypes.IPV_VC_RECEIVED,
-                        componentId,
+                        configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
                         auditEventUser,
                         getAuditExtensions(verifiableCredential, isSuccessful));
         auditService.sendAuditEvent(auditEvent);

--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.JourneyError;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
+import uk.gov.di.ipv.core.library.kmses256signer.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -58,6 +59,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
     private static final String TEST_AUTH_CODE = "test-auth-code";
 
     @Mock private Context context;
+    @Mock private KmsEs256Signer signer;
     @Mock private AuthCodeToAccessTokenService authCodeToAccessTokenService;
     @Mock private AuditService auditService;
     @Mock private static ConfigService configService;

--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -73,7 +73,6 @@ public class ValidateOAuthCallbackHandler
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
     private final AuditService auditService;
-    private final String componentId;
     private final CriOAuthSessionService criOAuthSessionService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
 
@@ -86,7 +85,6 @@ public class ValidateOAuthCallbackHandler
         this.configService = configService;
         this.ipvSessionService = ipvSessionService;
         this.auditService = auditService;
-        this.componentId = this.configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
         this.criOAuthSessionService = criOAuthSessionService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
     }
@@ -96,7 +94,6 @@ public class ValidateOAuthCallbackHandler
         this.configService = new ConfigService();
         this.ipvSessionService = new IpvSessionService(configService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
-        this.componentId = this.configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
     }
@@ -105,7 +102,7 @@ public class ValidateOAuthCallbackHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(CriCallbackRequest callbackRequest, Context context) {
-        LogHelper.attachComponentIdToLogs();
+        LogHelper.attachComponentIdToLogs(configService);
 
         IpvSessionItem ipvSessionItem = null;
         CriOAuthSessionItem criOAuthSessionItem = null;
@@ -350,7 +347,7 @@ public class ValidateOAuthCallbackHandler
         auditService.sendAuditEvent(
                 new AuditEvent(
                         AuditEventTypes.IPV_CRI_AUTH_RESPONSE_RECEIVED,
-                        componentId,
+                        configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
                         new AuditEventUser(
                                 clientOAuthSessionItem.getUserId(),
                                 ipvSessionItem.getIpvSessionId(),

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -6,11 +6,12 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 
 @ExcludeFromGeneratedCoverageReport
 public class LogHelper {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final String CORE_COMPONENT_ID = "core";
     public static final String GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE = "unknown";
 
     public enum LogField {
@@ -69,8 +70,10 @@ public class LogHelper {
         throw new IllegalStateException("Utility class");
     }
 
-    public static void attachComponentIdToLogs() {
-        attachFieldToLogs(LogField.LOG_COMPONENT_ID, CORE_COMPONENT_ID);
+    public static void attachComponentIdToLogs(ConfigService configService) {
+        attachFieldToLogs(
+                LogField.LOG_COMPONENT_ID,
+                configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID));
     }
 
     public static void attachClientIdToLogs(String clientId) {

--- a/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256Signer.java
+++ b/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256Signer.java
@@ -28,17 +28,19 @@ public class KmsEs256Signer implements JWSSigner {
 
     private static final Base64.Encoder b64UrlEncoder = Base64.getUrlEncoder();
     private final JCAContext jcaContext = new JCAContext();
-    private final String keyId;
+    private String keyId;
 
     @ExcludeFromGeneratedCoverageReport
-    public KmsEs256Signer(String keyId) {
-        this.keyId = keyId;
+    public KmsEs256Signer() {
         this.kmsClient = AWSKMSClientBuilder.defaultClient();
     }
 
-    public KmsEs256Signer(String keyId, AWSKMS kmsClient) {
-        this.keyId = keyId;
+    public KmsEs256Signer(AWSKMS kmsClient) {
         this.kmsClient = kmsClient;
+    }
+
+    public void setKeyId(String keyId) {
+        this.keyId = keyId;
     }
 
     @Override

--- a/libs/kms-es256-signer/src/test/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerTest.java
+++ b/libs/kms-es256-signer/src/test/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerTest.java
@@ -26,8 +26,6 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.DER_SIGNATURE;
 @ExtendWith(MockitoExtension.class)
 class KmsEs256SignerTest {
 
-    private static final String KEY_ID = "test";
-
     @Mock private AWSKMS kmsClient;
     @Mock private SignResult signResult;
 
@@ -37,7 +35,7 @@ class KmsEs256SignerTest {
 
         byte[] bytes = Base64URL.from(DER_SIGNATURE).decode();
         when(signResult.getSignature()).thenReturn(ByteBuffer.wrap(bytes));
-        KmsEs256Signer kmsSigner = new KmsEs256Signer(KEY_ID, kmsClient);
+        KmsEs256Signer kmsSigner = new KmsEs256Signer(kmsClient);
 
         JSONObject jsonPayload = new JSONObject(Map.of("test", "test"));
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enable snapstart in dev

### Why did it change

This is a spike to see what happens if we use snapstart. https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html

* It only applies changes in the dev env
* Snapstart only works with x86_64 architecture
* Our step functions weren't invoking our lambdas with a published version (via an alias). Instead they were just invoking whatever the latest version was. You need to specify the version for snapstart to work, hence the changes to the step function resources in the template.
* There needed to be a change to the TokenRequestValidator. The audience value to validate the request against had been baked in to the snapstart image and was set to the wrong thing. This ensures that the audience gets set at first runtime.

These changes made the dev experience much...snappier. It might be a good thing to implement, and if we like it we could maybe even use it in prod and turn off provisioned concurrency. Do we *need* to run arm64 in prod though? We'd also need to do a bunch of checking to ensure we weren't shooting ourselves in the foot like with the audience issue mentioned above.
