### PR TITLE
BAU: Use pattern matching for instanceof in statemachine init

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
@@ -50,13 +50,13 @@ public class StateMachineInitializer {
     private void initializeJourneyStates() {
         journeyStates.forEach(
                 (stateName, state) -> {
-                    if (state instanceof BasicState) {
-                        initializeBasicState((BasicState) state, stateName, journeyStates);
+                    if (state instanceof BasicState basicState) {
+                        initializeBasicState(basicState, stateName, journeyStates);
                     }
 
-                    if (state instanceof NestedJourneyInvokeState) {
+                    if (state instanceof NestedJourneyInvokeState nestedJourneyInvokeState) {
                         initializeNestedJourneyInvokeState(
-                                (NestedJourneyInvokeState) state, stateName, journeyStates);
+                                nestedJourneyInvokeState, stateName, journeyStates);
                     }
                 });
     }
@@ -95,9 +95,8 @@ public class StateMachineInitializer {
             Map<String, Event> nestedJourneyExitEvents) {
         eventMap.forEach(
                 (eventName, event) -> {
-                    if (event instanceof ExitNestedJourneyEvent) {
-                        ((ExitNestedJourneyEvent) event)
-                                .setNestedJourneyExitEvents(nestedJourneyExitEvents);
+                    if (event instanceof ExitNestedJourneyEvent exitNestedJourneyEvent) {
+                        exitNestedJourneyEvent.setNestedJourneyExitEvents(nestedJourneyExitEvents);
                     } else {
                         event.initialize(eventName, eventStatesSource);
                     }
@@ -136,16 +135,19 @@ public class StateMachineInitializer {
                             String name =
                                     createNestedJourneyStateName(
                                             nestedJourneyInvokeState, nestedJourneyStateName);
-                            if (nestedJourneyState instanceof BasicState) {
+                            if (nestedJourneyState instanceof BasicState basicState) {
                                 initializeBasicState(
-                                        (BasicState) nestedJourneyState,
+                                        basicState,
                                         name,
                                         nestedJourneyDefinition.getNestedJourneyStates(),
                                         nestedJourneyInvokeState.getExitEvents());
                             }
-                            if (nestedJourneyState instanceof NestedJourneyInvokeState) {
+                            if (nestedJourneyState
+                                    instanceof
+                                    NestedJourneyInvokeState
+                                    subNestedJourneyInvokeState) {
                                 initializeNestedJourneyInvokeState(
-                                        (NestedJourneyInvokeState) nestedJourneyState,
+                                        subNestedJourneyInvokeState,
                                         name,
                                         nestedJourneyDefinition.getNestedJourneyStates());
                             }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use pattern matching for instanceof in statemachine init

### Why did it change

I just learnt about pattern matching for intanceof. We can use it to tidy up a few bits in the statemachine init.

See here for more details: https://sonarcloud.io/organizations/alphagov/rules?open=java%3AS6201&rule_key=java%3AS6201
