### PR TITLE
BAU: Remove eval-gpg45-scores lambda from journey engine step function

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -32,11 +32,6 @@
         },
         {
           "Variable": "$.journey",
-          "StringMatches": "/journey/evaluate-gpg45-scores",
-          "Next": "EvaluateGpg45ScoresFunction"
-        },
-        {
-          "Variable": "$.journey",
           "StringMatches": "/journey/cri/build-oauth-request/*",
           "Next": "BuildCriOauthRequestLambda"
         },
@@ -68,18 +63,6 @@
     "ResetIdentityLambda": {
       "Type": "Task",
       "Resource": "${ResetIdentityFunctionArn}",
-      "Parameters": {
-        "journey.$": "$.journey",
-        "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
-        "ipAddress.$": "$$.Execution.Input.ipAddress",
-        "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
-      },
-      "Next": "ProcessNextJourney"
-    },
-    "EvaluateGpg45ScoresFunction": {
-      "Type": "Task",
-      "Resource": "${EvaluateGpg45ScoresFunctionArn}",
       "Parameters": {
         "journey.$": "$.journey",
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1367,7 +1367,6 @@ Resources:
         IPVProcessJourneyEventFunctionArn: !GetAtt IPVProcessJourneyEventFunction.Arn
         CheckExistingIdentityFunctionArn: !GetAtt CheckExistingIdentityFunction.Arn
         ResetIdentityFunctionArn: !GetAtt ResetIdentityFunction.Arn
-        EvaluateGpg45ScoresFunctionArn: !GetAtt EvaluateGpg45ScoresFunction.Arn
         BuildCriOauthRequestFunctionArn: !GetAtt BuildCriOauthRequestFunction.Arn
         BuildClientOauthResponseFunctionArn: !GetAtt BuildClientOauthResponseFunction.Arn
         CiScoringFunctionArn: !GetAtt CiScoringFunction.Arn
@@ -1392,8 +1391,6 @@ Resources:
             FunctionName: !Ref CheckExistingIdentityFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref ResetIdentityFunction
-        - LambdaInvokePolicy:
-            FunctionName: !Ref EvaluateGpg45ScoresFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref BuildCriOauthRequestFunction
         - LambdaInvokePolicy:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove eval-gpg45-scores lambda from journey engine step function

### Why did it change

The journeyEngineStepFunction no longer needs to call the evaluate-gpg45-scores lambda. It's invoked instead from the criReturnStepFunction. This is a hangover from a previous refactor and can be removed.
