### PR TITLE
PYIC-3464: Added a new URL '/user/proven-identity-details' to the internal API GW

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1804,6 +1804,13 @@ Resources:
               Ref: IPVCorePrivateAPI
             Path: /journey/build-proven-user-identity-details
             Method: GET
+        IPVCorePrivateAPINewPath:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
+            Path: /user/build-proven-user-identity-details
+            Method: GET
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1809,7 +1809,7 @@ Resources:
           Properties:
             RestApiId:
               Ref: IPVCorePrivateAPI
-            Path: /user/build-proven-user-identity-details
+            Path: /user/proven-identity-details
             Method: GET
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -236,7 +236,7 @@ paths:
                 #end
                 $input.body
 
-  /user/build-proven-user-identity-details:
+  /user/proven-identity-details:
     get:
       description: "Called when core front needs to display information about a users proven identity"
       responses:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -236,6 +236,42 @@ paths:
                 #end
                 $input.body
 
+  /user/build-proven-user-identity-details:
+    get:
+      description: "Called when core front needs to display information about a users proven identity"
+      responses:
+        200:
+          description: "User identity response"
+          content:
+            application/json:
+              schema:
+                type: "object"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildProvenUserIdentityDetailsFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
+        type: "aws"
+        requestTemplates:
+          application/x-www-form-urlencoded:
+            Fn::Sub: |
+              {
+                "ipvSessionId": "$input.params('ipv-session-id')",
+                "ipAddress": "$input.params('ip-address')",
+                "clientOAuthSessionId": "$input.params('client-session-id')",
+                "featureSet": "$input.params('feature-set')"
+              }
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                #set ($bodyObj = $util.parseJson($input.body))
+                #if ($bodyObj.statusCode)
+                #set($context.responseOverride.status = $bodyObj.statusCode)
+                #end
+                $input.body
+
 components:
   schemas:
     journeyType:


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added a new URL '/user/proven-user-identity-details' to the internal API GW

### Why did it change

The build-proven-user-identity-details lambda builds a collection of user data so that it can be presented by the frontend, it is not part of the Journey Engine. The /journey/* route should only be used for the journey engine, but the build-proven-user-identity-details lambda is currently triggered from /journey/build-proven-user-identity-details

Update the internal API to create a new url for this lambda.

This will require that the frontend be updated to use the new url. There is no change in functionality. Please ensure that all updates are staged out to ensure zero downtime.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3464](https://govukverify.atlassian.net/browse/PYIC-3464)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3464]: https://govukverify.atlassian.net/browse/PYIC-3464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ