### PR TITLE
BAU: Update sdkman config to use java 17

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.17-amzn
+java=17.0.8-amzn


### PR DESCRIPTION

## Proposed changes

### What changed

Update sdkman config to use java 17

### Why did it change

We now use java 17 for our lambdas. This change will use the correct java version for people using sdkman.
