### PR TITLE
PYIC-3490: Fix GPG45 profile matching bug

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -28,7 +28,8 @@ dependencies {
 	testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.0",
 			"org.junit.jupiter:junit-jupiter:5.10.0",
 			"org.mockito:mockito-junit-jupiter:5.4.0",
-			"uk.org.webcompere:system-stubs-jupiter:2.0.2"
+			"uk.org.webcompere:system-stubs-jupiter:2.0.2",
+			"org.hamcrest:hamcrest:2.2"
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Profile.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Profile.java
@@ -1,9 +1,9 @@
 package uk.gov.di.ipv.core.library.domain.gpg45;
 
-import java.util.List;
-
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.Evidence;
 import uk.gov.di.ipv.core.library.helpers.ListHelper;
+
+import java.util.List;
 
 /** Enumeration of all GPG 45 profiles along with their reference Gpg45Scores value. */
 public enum Gpg45Profile {
@@ -87,7 +87,8 @@ public enum Gpg45Profile {
             return false;
         }
 
-        // No profile needs more than 3 pieces of evidence so calling getPermutations should be safe.
+        // No profile needs more than 3 pieces of evidence so calling getPermutations should be
+        // safe.
         var achievedEvidencePermutations = ListHelper.getPermutations(achievedEvidences);
 
         for (List<Evidence> achievedEvidencePermutation : achievedEvidencePermutations) {
@@ -99,7 +100,8 @@ public enum Gpg45Profile {
         return false;
     }
 
-    private boolean evidencePermutationIsSatisfactory(List<Evidence> requiredEvidences, List<Evidence> achievedEvidences) {
+    private boolean evidencePermutationIsSatisfactory(
+            List<Evidence> requiredEvidences, List<Evidence> achievedEvidences) {
         for (int i = 0; i < requiredEvidences.size(); i++) {
             var requiredEvidence = requiredEvidences.get(i);
             var achievedEvidence = achievedEvidences.get(i);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ListHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ListHelper.java
@@ -23,17 +23,16 @@ public class ListHelper {
         }
 
         permutations.add(clone);
-        
+
         int i = 0;
         while (i < size) {
             if (indexes[i] < i) {
                 clone = new ArrayList<T>(clone);
-                swap(clone, i % 2 == 0 ? 0: indexes[i], i);
+                swap(clone, i % 2 == 0 ? 0 : indexes[i], i);
                 permutations.add(clone);
                 indexes[i]++;
                 i = 0;
-            }
-            else {
+            } else {
                 indexes[i] = 0;
                 i++;
             }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ListHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ListHelper.java
@@ -14,20 +14,17 @@ public class ListHelper {
     public static <T> List<List<T>> getPermutations(List<T> original) {
         var size = original.size();
 
-        var clone = new ArrayList<T>(original);
+        var clone = new ArrayList<>(original);
         var permutations = new ArrayList<List<T>>();
 
         int[] indexes = new int[size];
-        for (int i = 0; i < size; i++) {
-            indexes[i] = 0;
-        }
 
         permutations.add(clone);
 
         int i = 0;
         while (i < size) {
             if (indexes[i] < i) {
-                clone = new ArrayList<T>(clone);
+                clone = new ArrayList<>(clone);
                 swap(clone, i % 2 == 0 ? 0 : indexes[i], i);
                 permutations.add(clone);
                 indexes[i]++;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ListHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ListHelper.java
@@ -1,0 +1,50 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListHelper {
+
+    private ListHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    // Be careful with this method. The number of permutations grows extremely quickly
+    // with increasing size of the original list.
+    public static <T> List<List<T>> getPermutations(List<T> original) {
+        var size = original.size();
+
+        var clone = new ArrayList<T>(original);
+        var permutations = new ArrayList<List<T>>();
+
+        int[] indexes = new int[size];
+        for (int i = 0; i < size; i++) {
+            indexes[i] = 0;
+        }
+
+        permutations.add(clone);
+        
+        int i = 0;
+        while (i < size) {
+            if (indexes[i] < i) {
+                clone = new ArrayList<T>(clone);
+                swap(clone, i % 2 == 0 ? 0: indexes[i], i);
+                permutations.add(clone);
+                indexes[i]++;
+                i = 0;
+            }
+            else {
+                indexes[i] = 0;
+                i++;
+            }
+        }
+
+        return permutations;
+    }
+
+    private static <T> void swap(List<T> elements, int a, int b) {
+        T tmp = elements.get(a);
+        elements.set(a, elements.get(b));
+        elements.set(b, tmp);
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-
 import uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.Evidence;
 
 import java.util.ArrayList;
@@ -40,20 +39,25 @@ class Gpg45ProfileTest {
     // H2C needs evidence scores of 33 and 22
     private static Stream<Arguments> ShouldMatchDoubleEvidenceScoresTestCases() {
         return Stream.of(
-            Arguments.of(3, 3, 2, 2), // Exact match
-            Arguments.of(2, 2, 3, 3), // Exact match reversed
-            Arguments.of(4, 2, 3, 3), // Stronger evidence has weaker validity
-            Arguments.of(2, 4, 3, 3), // Weaker evidence has stronger validity 
-            Arguments.of(4, 4, 4, 4) // Higher strength and validity still matches
-        );
+                Arguments.of(3, 3, 2, 2), // Exact match
+                Arguments.of(2, 2, 3, 3), // Exact match reversed
+                Arguments.of(4, 2, 3, 3), // Stronger evidence has weaker validity
+                Arguments.of(2, 4, 3, 3), // Weaker evidence has stronger validity
+                Arguments.of(4, 4, 4, 4) // Higher strength and validity still matches
+                );
     }
+
     @ParameterizedTest
     @MethodSource("ShouldMatchDoubleEvidenceScoresTestCases")
-    void shouldMatchDoubleEvidenceScores(int evidence1Strength, int evidence1Validity, int evidence2Strength, int evidence2Validity) {
+    void shouldMatchDoubleEvidenceScores(
+            int evidence1Strength,
+            int evidence1Validity,
+            int evidence2Strength,
+            int evidence2Validity) {
         var evidence1 = new Evidence(evidence1Strength, evidence1Validity);
         var evidence2 = new Evidence(evidence2Strength, evidence2Validity);
         var scoresToTest = new Gpg45Scores(evidence1, evidence2, 1, 1, 3);
-        
+
         assertTrue(Gpg45Profile.H2C.isSatisfiedBy(scoresToTest));
     }
 
@@ -65,8 +69,9 @@ class Gpg45ProfileTest {
                 Arguments.of(4, 2, 3, 3, 2, 2), // Stronger evidence has weaker validity
                 Arguments.of(2, 4, 3, 3, 2, 2), // Weaker evidence has stronger validity
                 Arguments.of(4, 4, 4, 4, 4, 4) // Higher strength and validity still matches
-        );
+                );
     }
+
     @ParameterizedTest
     @MethodSource("ShouldMatchTripleEvidenceScoresTestCases")
     void shouldMatchTripleEvidenceScores(
@@ -86,42 +91,33 @@ class Gpg45ProfileTest {
 
     // L1C requires evidence with strength and validity scores of 1
     @ParameterizedTest
-    @CsvSource({
-        "2,1",
-        "3,1",
-        "4,1",
-        "1,2",
-        "1,3",
-        "1,4",
-        "2,2",
-        "3,3",
-        "4,4"})
+    @CsvSource({"2,1", "3,1", "4,1", "1,2", "1,3", "1,4", "2,2", "3,3", "4,4"})
     void shouldMatchHigherSingleEvidenceScore(ArgumentsAccessor argumentsAccessor) {
         var strength = argumentsAccessor.getInteger(0);
         var validity = argumentsAccessor.getInteger(1);
         var evidence = new Gpg45Scores.Evidence(strength, validity);
         var scoresToTest = new Gpg45Scores(evidence, 3, 2, 2);
-        
+
         // L1C requires evidence with strength and validity scores of 1
         assertTrue(Gpg45Profile.L1C.isSatisfiedBy(scoresToTest));
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 1, 2, 3, 4 })
+    @ValueSource(ints = {1, 2, 3, 4})
     void shouldMatchHigherActivityScore(int activityScore) {
         // L1A requires activity score of 0
         assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_22, activityScore, 1, 1)));
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 2, 3, 4 })
+    @ValueSource(ints = {2, 3, 4})
     void shouldMatchHigherFraudScore(int fraudScore) {
         // L1A requires fraud score of 1
         assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_22, 0, fraudScore, 1)));
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 2, 3, 4 })
+    @ValueSource(ints = {2, 3, 4})
     void shouldMatchHigherVerificationScore(int verificationScore) {
         // L1A requires verification score of 1
         assertTrue(Gpg45Profile.L1A.isSatisfiedBy(new Gpg45Scores(EV_22, 0, 1, verificationScore)));

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/ListHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/ListHelperTest.java
@@ -13,39 +13,37 @@ class ListHelperTest {
 
     private static Stream<Arguments> ShouldPermuteCorrectlyTestCases() {
         return Stream.of(
-                Arguments.of(List.of(1), List.of(
-                        List.of(1))),
-                Arguments.of(List.of(1, 2), List.of(
-                        List.of(1, 2),
-                        List.of(2, 1))),
-                Arguments.of(List.of(1, 2, 3), List.of(
+                Arguments.of(List.of(1), List.of(List.of(1))),
+                Arguments.of(List.of(1, 2), List.of(List.of(1, 2), List.of(2, 1))),
+                Arguments.of(
                         List.of(1, 2, 3),
-                        List.of(1, 3, 2),
-                        List.of(2, 1, 3),
-                        List.of(2, 3, 1),
-                        List.of(3, 1, 2),
-                        List.of(3, 2, 1)))
-        );
+                        List.of(
+                                List.of(1, 2, 3),
+                                List.of(1, 3, 2),
+                                List.of(2, 1, 3),
+                                List.of(2, 3, 1),
+                                List.of(3, 1, 2),
+                                List.of(3, 2, 1))));
     }
+
     @ParameterizedTest
     @MethodSource("ShouldPermuteCorrectlyTestCases")
     void shouldPermuteCorrectly(List<Integer> listToPermute, List<List<Integer>> expectedResults) {
 
         var result = ListHelper.getPermutations(listToPermute);
 
-        assertTrue(listsOfListsAreEquivalent(result, expectedResults), "Result does not match expected result");
+        assertTrue(
+                listsOfListsAreEquivalent(result, expectedResults),
+                "Result does not match expected result");
     }
 
-    private <T> boolean listsOfListsAreEquivalent(List<List<T>> a, List<List<T>> b)
-    {
+    private <T> boolean listsOfListsAreEquivalent(List<List<T>> a, List<List<T>> b) {
         if (a.size() != b.size()) {
             return false;
         }
 
         return a.stream()
-            .allMatch(al -> 
-                b.stream()
-                    .anyMatch(bl -> listsContainSameElements(al, bl)));
+                .allMatch(al -> b.stream().anyMatch(bl -> listsContainSameElements(al, bl)));
     }
 
     private static <T> boolean listsContainSameElements(List<T> a, List<T> b) {

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/ListHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/ListHelperTest.java
@@ -1,13 +1,16 @@
 package uk.gov.di.ipv.core.library.helpers;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 class ListHelperTest {
 
@@ -32,25 +35,11 @@ class ListHelperTest {
 
         var result = ListHelper.getPermutations(listToPermute);
 
-        assertTrue(
-                listsOfListsAreEquivalent(result, expectedResults),
-                "Result does not match expected result");
-    }
-
-    private <T> boolean listsOfListsAreEquivalent(List<List<T>> a, List<List<T>> b) {
-        if (a.size() != b.size()) {
-            return false;
-        }
-
-        return a.stream()
-                .allMatch(al -> b.stream().anyMatch(bl -> listsContainSameElements(al, bl)));
-    }
-
-    private static <T> boolean listsContainSameElements(List<T> a, List<T> b) {
-        if (a.size() != b.size()) {
-            return false;
-        }
-
-        return b.equals(a);
+        assertThat(
+                result,
+                containsInAnyOrder(
+                        expectedResults.stream()
+                                .map(Matchers::equalTo)
+                                .collect(Collectors.toList())));
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/ListHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/helpers/ListHelperTest.java
@@ -1,0 +1,58 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ListHelperTest {
+
+    private static Stream<Arguments> ShouldPermuteCorrectlyTestCases() {
+        return Stream.of(
+                Arguments.of(List.of(1), List.of(
+                        List.of(1))),
+                Arguments.of(List.of(1, 2), List.of(
+                        List.of(1, 2),
+                        List.of(2, 1))),
+                Arguments.of(List.of(1, 2, 3), List.of(
+                        List.of(1, 2, 3),
+                        List.of(1, 3, 2),
+                        List.of(2, 1, 3),
+                        List.of(2, 3, 1),
+                        List.of(3, 1, 2),
+                        List.of(3, 2, 1)))
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("ShouldPermuteCorrectlyTestCases")
+    void shouldPermuteCorrectly(List<Integer> listToPermute, List<List<Integer>> expectedResults) {
+
+        var result = ListHelper.getPermutations(listToPermute);
+
+        assertTrue(listsOfListsAreEquivalent(result, expectedResults), "Result does not match expected result");
+    }
+
+    private <T> boolean listsOfListsAreEquivalent(List<List<T>> a, List<List<T>> b)
+    {
+        if (a.size() != b.size()) {
+            return false;
+        }
+
+        return a.stream()
+            .allMatch(al -> 
+                b.stream()
+                    .anyMatch(bl -> listsContainSameElements(al, bl)));
+    }
+
+    private static <T> boolean listsContainSameElements(List<T> a, List<T> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+
+        return b.equals(a);
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

When comparing a GPG45 score to a profile try all permutations of evidence until one matches or we have tried them all.

### Why did it change

Previously the code ordered evidence by strength and then validity in the score and the profile and then compared the evidences in each position.
However, both strength and validity are equally important in the evidence so the ordering doesn't always work meaning that a profile needing 33 and 22 would fail to match against a score with evidence 42 and 33 because the check would try the 42 against the 33 required and fail it.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3490](https://govukverify.atlassian.net/browse/PYIC-3490)



[PYIC-3490]: https://govukverify.atlassian.net/browse/PYIC-3490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ