### PR TITLE
PYIC-3493 Update shared claims logic to handle socialSecurityRecord

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -77,6 +77,7 @@ public class BuildCriOauthRequestHandler
     public static final String SHARED_CLAIM_ATTR_BIRTH_DATE = "birthDate";
     public static final String SHARED_CLAIM_ATTR_ADDRESS = "address";
     public static final String SHARED_CLAIM_ATTR_EMAIL = "emailAddress";
+    public static final String SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD = "socialSecurityRecord";
     public static final String DEFAULT_ALLOWED_SHARED_ATTR = "name,birthDate,address";
     public static final String REGEX_COMMA_SEPARATION = "\\s*,\\s*";
     public static final Pattern LAST_SEGMENT_PATTERN = Pattern.compile("/([^/]+)$");
@@ -396,6 +397,9 @@ public class BuildCriOauthRequestHandler
         }
         if (!allowedSharedAttr.contains(SHARED_CLAIM_ATTR_ADDRESS)) {
             credentialsSharedClaims.setAddress(null);
+        }
+        if (!allowedSharedAttr.contains(SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD)) {
+            credentialsSharedClaims.setSocialSecurityRecord(null);
         }
     }
 

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -89,7 +89,8 @@ public class AuthorizationRequestHelper {
                         new SharedClaimsResponseDto(
                                 sharedClaims.getName(),
                                 sharedClaims.getBirthDate(),
-                                sharedClaims.getAddress());
+                                sharedClaims.getAddress(),
+                                sharedClaims.getSocialSecurityRecord());
                 claimsSetBuilder.claim(SHARED_CLAIMS, response);
             }
         }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -70,6 +70,7 @@ import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.HMRC_KBV_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_2;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_3;
@@ -104,6 +105,7 @@ class BuildCriOauthRequestHandlerTest {
 
     private static final String JOURNEY_BASE_URL = "/journey/cri/build-oauth-request/";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String TEST_NI_NUMBER = "AA000003D";
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -126,6 +128,7 @@ class BuildCriOauthRequestHandlerTest {
     private CredentialIssuerConfig kbvCredentialIssuerConfig;
     private CredentialIssuerConfig f2fCredentialIssuerConfig;
     private CredentialIssuerConfig claimedIdentityCredentialIssuerConfig;
+    private CredentialIssuerConfig hmrcKbvCredentialIssuerConfig;
     private BuildCriOauthRequestHandler underTest;
     private CriOAuthSessionItem criOAuthSessionItem;
     private ClientOAuthSessionItem clientOAuthSessionItem;
@@ -217,6 +220,19 @@ class BuildCriOauthRequestHandlerTest {
                         "http://www.example.com/audience",
                         URI.create("http://www.example.com/callback/criId"),
                         true);
+
+        hmrcKbvCredentialIssuerConfig =
+                new CredentialIssuerConfig(
+                        new URI(CRI_TOKEN_URL),
+                        new URI(CRI_CREDENTIAL_URL),
+                        new URI(CRI_AUTHORIZE_URL),
+                        IPV_CLIENT_ID,
+                        "{}",
+                        RSA_ENCRYPTION_PUBLIC_JWK,
+                        "http://www.example.com/audience",
+                        URI.create("http://www.example.com/callback/criId"),
+                        true);
+
         criOAuthSessionItem =
                 CriOAuthSessionItem.builder()
                         .criOAuthSessionId(CRI_OAUTH_SESSION_ID)
@@ -664,7 +680,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(TEST_USER_ID, signedJWT.getJWTClaimsSet().getSubject());
         assertEquals(CRI_AUDIENCE, signedJWT.getJWTClaimsSet().getAudience().get(0));
 
-        assertEquals(3, claimsSet.get(TEST_SHARED_CLAIMS).size());
+        assertEquals(4, claimsSet.get(TEST_SHARED_CLAIMS).size());
         JsonNode vcAttributes = claimsSet.get(TEST_SHARED_CLAIMS);
 
         JsonNode address = vcAttributes.get("address");
@@ -706,7 +722,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(TEST_USER_ID, signedJWT.getJWTClaimsSet().getSubject());
         assertEquals(CRI_AUDIENCE, signedJWT.getJWTClaimsSet().getAudience().get(0));
 
-        assertEquals(3, claimsSet.get(TEST_SHARED_CLAIMS).size());
+        assertEquals(4, claimsSet.get(TEST_SHARED_CLAIMS).size());
         JsonNode vcAttributes = claimsSet.get(TEST_SHARED_CLAIMS);
 
         JsonNode address = vcAttributes.get("address");
@@ -887,8 +903,8 @@ class BuildCriOauthRequestHandlerTest {
         JsonNode claimsSet = objectMapper.readTree(signedJWT.getJWTClaimsSet().toString());
 
         JsonNode names = claimsSet.get(TEST_SHARED_CLAIMS).get("name");
-        JsonNode name1NameParts = names.get(0).get("nameParts");
-        JsonNode name2NameParts = names.get(1).get("nameParts");
+        JsonNode name1NameParts = names.get(1).get("nameParts");
+        JsonNode name2NameParts = names.get(0).get("nameParts");
 
         assertEquals("GivenName", name1NameParts.get(0).get("type").asText());
         assertEquals("Alice", name1NameParts.get(0).get("value").asText());
@@ -1161,6 +1177,68 @@ class BuildCriOauthRequestHandlerTest {
         JsonNode evidenceRequested = claimsSet.get(TEST_EVIDENCE_REQUESTED);
         assertEquals(3, evidenceRequested.get("strengthScore").asInt());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
+    }
+
+    @Test
+    void shouldIncludeSocialSecurityRecordInSharedClaimsIfConfigured() throws Exception {
+        when(configService.getCredentialIssuerActiveConnectionConfig(HMRC_KBV_CRI))
+                .thenReturn(hmrcKbvCredentialIssuerConfig);
+        when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityCredentialIssuerConfig);
+        when(configService.getAllowedSharedAttributes(HMRC_KBV_CRI))
+                .thenReturn("name,birthDate,address,socialSecurityRecord");
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
+        when(mockIpvSessionItem.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
+        mockVcHelper
+                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
+                .thenReturn(true, true);
+        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                generateVerifiableCredential(
+                                        vcClaim(CREDENTIAL_ATTRIBUTES_1), IPV_ISSUER),
+                                generateVerifiableCredential(
+                                        vcClaim(CREDENTIAL_ATTRIBUTES_2), IPV_ISSUER),
+                                generateVerifiableCredential(
+                                        vcClaim(CREDENTIAL_ATTRIBUTES_3), ADDRESS_ISSUER)));
+        when(mockCriOAuthSessionService.persistCriOAuthSession(any(), any(), any()))
+                .thenReturn(criOAuthSessionItem);
+        when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        JourneyRequest input =
+                JourneyRequest.builder()
+                        .ipvSessionId(SESSION_ID)
+                        .ipAddress(TEST_IP_ADDRESS)
+                        .journey(HMRC_KBV_CRI)
+                        .build();
+
+        var responseJson = handleRequest(input, context);
+        CriResponse response = objectMapper.readValue(responseJson, CriResponse.class);
+
+        URIBuilder redirectUri = new URIBuilder(response.getCri().getRedirectUrl());
+        List<NameValuePair> queryParams = redirectUri.getQueryParams();
+
+        Optional<NameValuePair> request =
+                queryParams.stream().filter(param -> param.getName().equals("request")).findFirst();
+
+        assertTrue(request.isPresent());
+        JWEObject jweObject = JWEObject.parse(request.get().getValue());
+        jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
+
+        SignedJWT signedJWT = SignedJWT.parse(jweObject.getPayload().toString());
+        JsonNode claimsSet = objectMapper.readTree(signedJWT.getJWTClaimsSet().toString());
+
+        JsonNode sharedClaims = claimsSet.get(TEST_SHARED_CLAIMS);
+        assertEquals(1, sharedClaims.get("socialSecurityRecord").size());
+        assertEquals(
+                TEST_NI_NUMBER,
+                sharedClaims.get("socialSecurityRecord").get(0).get("personalNumber").asText());
     }
 
     private void assertErrorResponse(

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.Name;
 import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.domain.SharedClaimsResponse;
+import uk.gov.di.ipv.core.library.domain.SocialSecurityRecord;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
@@ -76,7 +77,8 @@ class AuthorizationRequestHelperTest {
                     Set.of(new Name(List.of(new NameParts("Dan", "first_name")))),
                     Set.of(new BirthDate("2011-01-01")),
                     Set.of(new Address()),
-                    TEST_EMAIL_ADDRESS);
+                    TEST_EMAIL_ADDRESS,
+                    Set.of(new SocialSecurityRecord()));
 
     private ECDSASigner signer;
 

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
@@ -16,4 +16,5 @@ public class CriConstants {
     public static final String DCMAW_CRI = "dcmaw";
     public static final String CLAIMED_IDENTITY_CRI = "claimedIdentity";
     public static final String F2F_CRI = "f2f";
+    public static final String HMRC_KBV_CRI = "hmrcKbv";
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaims.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaims.java
@@ -9,20 +9,26 @@ import java.util.Optional;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonPropertyOrder({"name", "birthDate", "address"})
+@JsonPropertyOrder({"name", "birthDate", "address", "socialSecurityRecord"})
 @JsonDeserialize(using = SharedClaimsDeserializer.class)
 @EqualsAndHashCode
 public class SharedClaims {
     private Set<Name> name;
     private Set<BirthDate> birthDate;
     private Set<Address> address;
+    private Set<SocialSecurityRecord> socialSecurityRecord;
 
     private SharedClaims() {}
 
-    public SharedClaims(Set<Name> name, Set<BirthDate> birthDate, Set<Address> address) {
+    public SharedClaims(
+            Set<Name> name,
+            Set<BirthDate> birthDate,
+            Set<Address> address,
+            Set<SocialSecurityRecord> socialSecurityRecord) {
         this.name = name;
         this.birthDate = birthDate;
         this.address = address;
+        this.socialSecurityRecord = socialSecurityRecord;
     }
 
     public static SharedClaims empty() {
@@ -41,6 +47,10 @@ public class SharedClaims {
         return Optional.ofNullable(address);
     }
 
+    public Optional<Set<SocialSecurityRecord>> getSocialSecurityRecord() {
+        return Optional.ofNullable(socialSecurityRecord);
+    }
+
     public void setName(Set<Name> name) {
         this.name = name;
     }
@@ -53,11 +63,16 @@ public class SharedClaims {
         this.address = address;
     }
 
+    public void setSocialSecurityRecord(Set<SocialSecurityRecord> socialSecurityRecord) {
+        this.socialSecurityRecord = socialSecurityRecord;
+    }
+
     public static class Builder {
 
         private Set<Name> name;
         private Set<BirthDate> birthDate;
         private Set<Address> address;
+        private Set<SocialSecurityRecord> socialSecurityRecord;
 
         public Builder setBirthDate(Set<BirthDate> birthDate) {
             this.birthDate = birthDate;
@@ -74,8 +89,13 @@ public class SharedClaims {
             return this;
         }
 
+        public Builder setSocialSecurityRecord(Set<SocialSecurityRecord> socialSecurityRecord) {
+            this.socialSecurityRecord = socialSecurityRecord;
+            return this;
+        }
+
         public SharedClaims build() {
-            return new SharedClaims(name, birthDate, address);
+            return new SharedClaims(name, birthDate, address, socialSecurityRecord);
         }
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsDeserializer.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsDeserializer.java
@@ -73,6 +73,16 @@ public class SharedClaimsDeserializer extends StdDeserializer<SharedClaims> {
             sharedAttributesBuilder.setAddress(addressList);
         }
 
+        JsonNode socialSecurityRecord = node.get("socialSecurityRecord");
+        if (socialSecurityRecord != null) {
+            Set<SocialSecurityRecord> socialSecurityRecordList = new HashSet<>();
+            for (JsonNode jo : socialSecurityRecord) {
+                socialSecurityRecordList.add(
+                        objectMapper.convertValue(jo, SocialSecurityRecord.class));
+            }
+            sharedAttributesBuilder.setSocialSecurityRecord(socialSecurityRecordList);
+        }
+
         return sharedAttributesBuilder.build();
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponse.java
@@ -9,7 +9,7 @@ import org.apache.logging.log4j.message.StringMapMessage;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-@JsonPropertyOrder({"name", "birthDate", "address", "emailAddress"})
+@JsonPropertyOrder({"name", "birthDate", "address", "emailAddress", "socialSecurityRecord"})
 public class SharedClaimsResponse {
 
     private static final Logger LOGGER = LogManager.getLogger();
@@ -18,13 +18,19 @@ public class SharedClaimsResponse {
     private final Set<BirthDate> birthDate;
     private final Set<Address> address;
     private final String emailAddress;
+    private final Set<SocialSecurityRecord> socialSecurityRecord;
 
     public SharedClaimsResponse(
-            Set<Name> name, Set<BirthDate> birthDate, Set<Address> address, String emailAddress) {
+            Set<Name> name,
+            Set<BirthDate> birthDate,
+            Set<Address> address,
+            String emailAddress,
+            Set<SocialSecurityRecord> socialSecurityRecord) {
         this.name = name;
         this.birthDate = birthDate;
         this.address = address;
         this.emailAddress = emailAddress;
+        this.socialSecurityRecord = socialSecurityRecord;
     }
 
     public Set<Name> getName() {
@@ -44,17 +50,25 @@ public class SharedClaimsResponse {
         return emailAddress;
     }
 
+    public Set<SocialSecurityRecord> getSocialSecurityRecord() {
+        return socialSecurityRecord;
+    }
+
     public static SharedClaimsResponse from(
             Set<SharedClaims> sharedAttributes, String emailAddress) {
         Set<Name> nameSet = new LinkedHashSet<>();
         Set<BirthDate> birthDateSet = new LinkedHashSet<>();
         Set<Address> addressSet = new LinkedHashSet<>();
+        Set<SocialSecurityRecord> socialSecurityRecordSet = new LinkedHashSet<>();
 
         sharedAttributes.forEach(
                 sharedAttribute -> {
                     sharedAttribute.getName().ifPresent(nameSet::addAll);
                     sharedAttribute.getBirthDate().ifPresent(birthDateSet::addAll);
                     sharedAttribute.getAddress().ifPresent(addressSet::addAll);
+                    sharedAttribute
+                            .getSocialSecurityRecord()
+                            .ifPresent(socialSecurityRecordSet::addAll);
                 });
 
         var message =
@@ -62,9 +76,11 @@ public class SharedClaimsResponse {
                         .with("sharedClaims", "built")
                         .with("names", nameSet.size())
                         .with("birthDates", birthDateSet.size())
-                        .with("addresses", addressSet.size());
+                        .with("addresses", addressSet.size())
+                        .with("socialSecurityRecords", socialSecurityRecordSet.size());
         LOGGER.info(message);
 
-        return new SharedClaimsResponse(nameSet, birthDateSet, addressSet, emailAddress);
+        return new SharedClaimsResponse(
+                nameSet, birthDateSet, addressSet, emailAddress, socialSecurityRecordSet);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseDto.java
@@ -6,17 +6,23 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import java.util.Set;
 
 @ExcludeFromGeneratedCoverageReport
-@JsonPropertyOrder({"name", "birthDate", "address"})
+@JsonPropertyOrder({"name", "birthDate", "address", "socialSecurityRecord"})
 public class SharedClaimsResponseDto {
 
     private final Set<Name> name;
     private final Set<BirthDate> birthDate;
     private final Set<Address> address;
+    private final Set<SocialSecurityRecord> socialSecurityRecord;
 
-    public SharedClaimsResponseDto(Set<Name> name, Set<BirthDate> birthDate, Set<Address> address) {
+    public SharedClaimsResponseDto(
+            Set<Name> name,
+            Set<BirthDate> birthDate,
+            Set<Address> address,
+            Set<SocialSecurityRecord> socialSecurityRecord) {
         this.name = name;
         this.birthDate = birthDate;
         this.address = address;
+        this.socialSecurityRecord = socialSecurityRecord;
     }
 
     public Set<Name> getName() {
@@ -29,5 +35,9 @@ public class SharedClaimsResponseDto {
 
     public Set<Address> getAddress() {
         return address;
+    }
+
+    public Set<SocialSecurityRecord> getSocialSecurityRecord() {
+        return socialSecurityRecord;
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SocialSecurityRecord.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SocialSecurityRecord.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@Data
+public class SocialSecurityRecord {
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private String personalNumber;
+
+    public SocialSecurityRecord() {}
+
+    public SocialSecurityRecord(String personalNumber) {
+        this.personalNumber = personalNumber;
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java
@@ -141,7 +141,9 @@ public interface TestFixtures {
                                     "validFrom", "2019-07-24"),
                             Map.of(
                                     "buildingNumber", "123",
-                                    "postalCode", "M34 1AA")));
+                                    "postalCode", "M34 1AA")),
+                    "socialSecurityRecord",
+                    List.of(Map.of("personalNumber", "AA000003D")));
 
     Map<String, Object> CREDENTIAL_ATTRIBUTES_2 =
             Map.of(


### PR DESCRIPTION
## Proposed changes

### What changed

Handle passing the new `socialSecurityRecord` entry in shared claims
```
{ 
  "socialSecurityRecord": [
    {
      "personalNumber": "AA000003D"
    }
  ]
}
```

### Why did it change

To pass the NI number we receive from NINO CRI onto HMRC KBV CRI

### Issue tracking
- [PYIC-3493](https://govukverify.atlassian.net/browse/PYIC-3493)

[PYIC-3493]: https://govukverify.atlassian.net/browse/PYIC-3493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ