### PR TITLE
PYIC-3501 : Identify non-evidential credential issuers for VcHelper.isSuccessfulVc* as a set of issuers rather than full CRI configs

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -57,7 +57,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
@@ -109,6 +108,7 @@ public class BuildCriOauthRequestHandler
         this.criOAuthSessionService = criOAuthSessionService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
         this.gpg45ProfileEvaluator = gpg45ProfileEvaluator;
+        VcHelper.setConfigService(this.credentialIssuerConfigService);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -123,6 +123,7 @@ public class BuildCriOauthRequestHandler
         this.clientOAuthSessionDetailsService =
                 new ClientOAuthSessionDetailsService(credentialIssuerConfigService);
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(new ConfigService());
+        VcHelper.setConfigService(this.credentialIssuerConfigService);
     }
 
     @Override
@@ -323,11 +324,6 @@ public class BuildCriOauthRequestHandler
         CredentialIssuerConfig addressCriConfig =
                 credentialIssuerConfigService.getCredentialIssuerActiveConnectionConfig(
                         ADDRESS_CRI);
-        List<CredentialIssuerConfig> excludedCriConfig =
-                List.of(
-                        addressCriConfig,
-                        credentialIssuerConfigService.getCredentialIssuerActiveConnectionConfig(
-                                CLAIMED_IDENTITY_CRI));
 
         List<String> credentials = userIdentityService.getUserIssuedCredentials(userId);
 
@@ -339,7 +335,7 @@ public class BuildCriOauthRequestHandler
                 SignedJWT signedJWT = SignedJWT.parse(credential);
                 String credentialIss = signedJWT.getJWTClaimsSet().getIssuer();
 
-                if (VcHelper.isSuccessfulVcIgnoringCi(signedJWT, excludedCriConfig)) {
+                if (VcHelper.isSuccessfulVcIgnoringCi(signedJWT)) {
                     JsonNode credentialSubject =
                             mapper.readTree(signedJWT.getPayload().toString())
                                     .path(VC_CLAIM)

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -1151,5 +1151,4 @@ class BuildCriOauthRequestHandlerTest {
         final var response = underTest.handleRequest(event, context);
         return getJsonResponse(objectMapper.convertValue(response, new TypeReference<>() {}));
     }
-
 }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -67,7 +67,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
@@ -276,12 +275,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -351,12 +346,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(false, false);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(false, false);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -426,12 +417,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -501,12 +488,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -575,12 +558,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -728,12 +707,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -787,12 +762,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -844,12 +815,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -920,12 +887,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -981,12 +944,8 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, false);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, false);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -1042,13 +1001,9 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getEmailAddress()).thenReturn(null);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(
@@ -1105,15 +1060,11 @@ class BuildCriOauthRequestHandlerTest {
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
                 .thenReturn(addressCredentialIssuerConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityCredentialIssuerConfig);
         when(configService.getAllowedSharedAttributes(F2F_CRI))
                 .thenReturn("name,birthDate,address,emailAddress");
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
-        mockVcHelper
-                .when(() -> VcHelper.isSuccessfulVcIgnoringCi(any(), any()))
-                .thenReturn(true, true);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
                 .thenReturn(
                         List.of(

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -1151,4 +1151,5 @@ class BuildCriOauthRequestHandlerTest {
         final var response = underTest.handleRequest(event, context);
         return getJsonResponse(objectMapper.convertValue(response, new TypeReference<>() {}));
     }
+
 }

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -73,6 +72,7 @@ public class BuildProvenUserIdentityDetailsHandler
         this.userIdentityService = userIdentityService;
         this.configService = configService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
+        VcHelper.setConfigService(this.configService);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -81,6 +81,7 @@ public class BuildProvenUserIdentityDetailsHandler
         this.ipvSessionService = new IpvSessionService(configService);
         this.userIdentityService = new UserIdentityService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
+        VcHelper.setConfigService(this.configService);
     }
 
     @Override
@@ -238,12 +239,7 @@ public class BuildProvenUserIdentityDetailsHandler
 
         for (VcStoreItem item : credentials) {
             SignedJWT signedJWT = SignedJWT.parse(item.getCredential());
-            List<CredentialIssuerConfig> excludedCriConfig =
-                    List.of(
-                            configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI),
-                            configService.getCredentialIssuerActiveConnectionConfig(
-                                    CLAIMED_IDENTITY_CRI));
-            boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT, excludedCriConfig);
+            boolean isSuccessful = VcHelper.isSuccessfulVcIgnoringCi(signedJWT);
 
             vcStatuses.add(new VcStatusDto(signedJWT.getJWTClaimsSet().getIssuer(), isSuccessful));
         }

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -54,8 +54,6 @@ import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.USE_POST_MITIGATIONS;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
@@ -105,6 +103,7 @@ public class RetrieveCriCredentialHandler
         this.criOAuthSessionService = criOAuthSessionService;
         this.clientOAuthSessionService = clientOAuthSessionService;
         this.criResponseService = criResponseService;
+        VcHelper.setConfigService(this.configService);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -118,6 +117,7 @@ public class RetrieveCriCredentialHandler
         this.criOAuthSessionService = new CriOAuthSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.criResponseService = new CriResponseService(configService);
+        VcHelper.setConfigService(this.configService);
     }
 
     @Override
@@ -276,18 +276,13 @@ public class RetrieveCriCredentialHandler
                         clientOAuthSessionItem.getGovukSigninJourneyId(),
                         ipAddress);
 
-        final List<CredentialIssuerConfig> excludedCriConfigs =
-                List.of(
-                        configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI),
-                        configService.getCredentialIssuerActiveConnectionConfig(
-                                CLAIMED_IDENTITY_CRI));
         final String govukSigninJourneyId = clientOAuthSessionItem.getGovukSigninJourneyId();
 
         String issuer = null;
         for (SignedJWT vc : verifiableCredentials) {
             verifiableCredentialJwtValidator.validate(vc, credentialIssuerConfig, userId);
 
-            boolean isSuccessful = VcHelper.isSuccessfulVc(vc, excludedCriConfigs);
+            boolean isSuccessful = VcHelper.isSuccessfulVc(vc);
 
             sendIpvVcReceivedAuditEvent(auditEventUser, vc, isSuccessful);
 

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -361,10 +361,6 @@ class RetrieveCriCredentialHandlerTest {
 
     @Test
     void shouldReturnErrorJourneyIfVCFailsValidation() throws Exception {
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
         when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,

--- a/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
+++ b/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
@@ -14,49 +14,73 @@ import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45EvidenceValidator
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45F2fValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45FraudValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45VerificationValidator;
-import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.text.ParseException;
 import java.util.List;
+import java.util.Set;
 
+import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 
 public class VcHelper {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Gson gson = new Gson();
+    private static ConfigService configService;
 
     private VcHelper() {}
 
-    public static boolean isSuccessfulVc(
-            SignedJWT vc, List<CredentialIssuerConfig> excludedCriConfig) throws ParseException {
+    public static void setConfigService(ConfigService configService) {
+        VcHelper.configService = configService;
+    }
+
+    private static Set<String> getExcludedCredentialIssuers() {
+        return Set.of(
+                configService
+                        .getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI)
+                        .getComponentId(),
+                configService
+                        .getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI)
+                        .getComponentId());
+    }
+
+    public static boolean isSuccessfulVc(SignedJWT vc) throws ParseException {
         boolean shouldCheckContraIndicators = true;
-        return isSuccessfulVc(vc, excludedCriConfig, shouldCheckContraIndicators);
+        return isSuccessfulVc(vc, getExcludedCredentialIssuers(), shouldCheckContraIndicators);
+    }
+
+    public static boolean isSuccessfulVc(SignedJWT vc, Set<String> excludedCredentialIssuers)
+            throws ParseException {
+        boolean shouldCheckContraIndicators = true;
+        return isSuccessfulVc(vc, excludedCredentialIssuers, shouldCheckContraIndicators);
+    }
+
+    public static boolean isSuccessfulVcIgnoringCi(SignedJWT vc) throws ParseException {
+        boolean shouldCheckContraIndicators = false;
+        return isSuccessfulVc(vc, getExcludedCredentialIssuers(), shouldCheckContraIndicators);
     }
 
     public static boolean isSuccessfulVcIgnoringCi(
-            SignedJWT vc, List<CredentialIssuerConfig> excludedCriConfig) throws ParseException {
+            SignedJWT vc, Set<String> excludedCredentialIssuers) throws ParseException {
         boolean shouldCheckContraIndicators = false;
-        return isSuccessfulVc(vc, excludedCriConfig, shouldCheckContraIndicators);
+        return isSuccessfulVc(vc, excludedCredentialIssuers, shouldCheckContraIndicators);
     }
 
     private static boolean isSuccessfulVc(
             SignedJWT vc,
-            List<CredentialIssuerConfig> excludedCriConfig,
+            Set<String> excludedCredentialIssuers,
             boolean shouldCheckContraIndicators)
             throws ParseException {
         JSONObject vcClaim = (JSONObject) vc.getJWTClaimsSet().getClaim(VC_CLAIM);
         JSONArray evidenceArray = (JSONArray) vcClaim.get(VC_EVIDENCE);
         if (evidenceArray == null) {
-            String vcIss = vc.getJWTClaimsSet().getIssuer();
-            boolean excludeConfig =
-                    excludedCriConfig.stream()
-                            .map(CredentialIssuerConfig::getComponentId)
-                            .anyMatch(vcIss::equals);
-            if (excludeConfig) {
+            String vcIssuer = vc.getJWTClaimsSet().getIssuer();
+            if (excludedCredentialIssuers.contains(vcIssuer)) {
                 return true;
             }
-            LOGGER.warn("Unexpected missing evidence on VC from issuer: {}", vcIss);
+            LOGGER.warn("Unexpected missing evidence on VC from issuer: {}", vcIssuer);
             return false;
         }
 

--- a/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
+++ b/libs/vc-helper/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
@@ -2,14 +2,21 @@ package uk.gov.di.ipv.core.library.vchelper;
 
 import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FAILED_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FAILED_PASSPORT_VC;
@@ -21,21 +28,39 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1B_DCMAW_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1_PASSPORT_VC_MISSING_EVIDENCE;
 
+@ExtendWith(MockitoExtension.class)
 class VcHelperTest {
+    @Mock private ConfigService configService;
+
+    public static Set<String> EXCLUDED_CREDENTIAL_ISSUERS =
+            Set.of("https://review-a.integration.account.gov.uk");
+
     public static CredentialIssuerConfig addressConfig = null;
+    public static CredentialIssuerConfig claimedIdentityConfig = null;
 
     static {
         try {
             addressConfig =
                     new CredentialIssuerConfig(
-                            new URI("https://example.com/token"),
-                            new URI("https://example.com/credential"),
-                            new URI("https://example.com/authorize"),
+                            new URI("http://example.com/token"),
+                            new URI("http://example.com/credential"),
+                            new URI("http://example.com/authorize"),
                             "ipv-core",
                             "test-jwk",
                             "test-encryption-jwk",
                             "https://review-a.integration.account.gov.uk",
-                            new URI("https://example.com/redirect"),
+                            new URI("http://example.com/redirect"),
+                            true);
+            claimedIdentityConfig =
+                    new CredentialIssuerConfig(
+                            new URI("http://example.com/token"),
+                            new URI("http://example.com/credential"),
+                            new URI("http://example.com/authorize"),
+                            "ipv-core",
+                            "test-jwk",
+                            "test-encryption-jwk",
+                            "https://review-c.integration.account.gov.uk",
+                            new URI("http://example.com/redirect"),
                             true);
         } catch (URISyntaxException e) {
             e.printStackTrace();
@@ -45,78 +70,107 @@ class VcHelperTest {
     @Test
     void shouldReturnTrueOnSuccessfulPassportVc() throws Exception {
         assertTrue(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC), List.of(addressConfig)));
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_PASSPORT_VC), EXCLUDED_CREDENTIAL_ISSUERS));
+    }
+
+    @Test
+    void shouldReturnTrueOnSuccessfulPassportVcForWithDefaultExcludedCredentialIssues()
+            throws Exception {
+        mockCredentialIssuerConfig();
+        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_PASSPORT_VC)));
     }
 
     @Test
     void shouldReturnFalseOnFailedPassportVc() throws Exception {
         assertFalse(
                 VcHelper.isSuccessfulVc(
-                        SignedJWT.parse(M1A_FAILED_PASSPORT_VC), List.of(addressConfig)));
+                        SignedJWT.parse(M1A_FAILED_PASSPORT_VC), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnFalseOnPassportVcContainingCi() throws Exception {
         assertFalse(
                 VcHelper.isSuccessfulVc(
-                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), List.of(addressConfig)));
+                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulAddressVc() throws Exception {
         assertTrue(
-                VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_ADDRESS_VC), List.of(addressConfig)));
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_ADDRESS_VC), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulFraudVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1A_FRAUD_VC), List.of(addressConfig)));
+        assertTrue(
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1A_FRAUD_VC), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnFalseOnFailedFraudVc() throws Exception {
         assertFalse(
                 VcHelper.isSuccessfulVc(
-                        SignedJWT.parse(M1A_FAILED_FRAUD_VC), List.of(addressConfig)));
+                        SignedJWT.parse(M1A_FAILED_FRAUD_VC), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnFalseOnFraudVcContainingCi() throws Exception {
         assertFalse(
                 VcHelper.isSuccessfulVc(
-                        SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), List.of(addressConfig)));
+                        SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnTrueOnFraudVcContainingA01Ci() throws Exception {
         assertFalse(
                 VcHelper.isSuccessfulVc(
-                        SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), List.of(addressConfig)));
+                        SignedJWT.parse(M1A_FRAUD_VC_WITH_CI_D02), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulKbvVc() throws Exception {
         assertTrue(
                 VcHelper.isSuccessfulVc(
-                        SignedJWT.parse(M1A_VERIFICATION_VC), List.of(addressConfig)));
+                        SignedJWT.parse(M1A_VERIFICATION_VC), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnTrueOnSuccessfulDcmawVc() throws Exception {
-        assertTrue(VcHelper.isSuccessfulVc(SignedJWT.parse(M1B_DCMAW_VC), List.of(addressConfig)));
+        assertTrue(
+                VcHelper.isSuccessfulVc(
+                        SignedJWT.parse(M1B_DCMAW_VC), EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnFalseOnVcMissingEvidenceBlock() throws Exception {
         assertFalse(
                 VcHelper.isSuccessfulVc(
-                        SignedJWT.parse(M1_PASSPORT_VC_MISSING_EVIDENCE), List.of(addressConfig)));
+                        SignedJWT.parse(M1_PASSPORT_VC_MISSING_EVIDENCE),
+                        EXCLUDED_CREDENTIAL_ISSUERS));
     }
 
     @Test
     void shouldReturnTrueOnPassportVcContainingCiWhenIgnoringCi() throws Exception {
         assertTrue(
                 VcHelper.isSuccessfulVcIgnoringCi(
-                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), List.of(addressConfig)));
+                        SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI), EXCLUDED_CREDENTIAL_ISSUERS));
+    }
+
+    @Test
+    void shouldReturnTrueOnPassportVcContainingCiWhenIgnoringCiAndWithoutExcludedCredetialIssuers()
+            throws Exception {
+        mockCredentialIssuerConfig();
+        assertTrue(VcHelper.isSuccessfulVcIgnoringCi(SignedJWT.parse(M1A_PASSPORT_VC_WITH_CI)));
+    }
+
+    private void mockCredentialIssuerConfig() {
+        VcHelper.setConfigService(configService);
+        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
+                .thenReturn(addressConfig);
+        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig);
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Identify non-evidential credential issuers for VcHelper.isSuccessfulVc* as a set of issuers rather than full CRI configs

### Why did it change

We need to simplify the supply of the non-evidence credential issuers - we only need a set of issuers rather than a full set of CRI configs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3501](https://govukverify.atlassian.net/browse/PYIC-3501)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3501]: https://govukverify.atlassian.net/browse/PYIC-3501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ