### PR TITLE
PYIC-3410: Update journey map to include new HMRC KBV stub

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -443,6 +443,20 @@ F2F_HANDOFF_PAGE_J5:
     type: page
     pageId: page-face-to-face-handoff
 
+# HMRC KBV CRI journey (J6)
+CRI_HMRC_KBV_J6:
+  response:
+    type: cri
+    criId: hmrcKbv
+  parent: CRI_STATE
+  events:
+    end:
+      targetState: IPV_SUCCESS_PAGE
+    fail-with-no-ci:
+      targetState: PRE_KBV_TRANSITION_PAGE_J3
+    next:
+      targetState: PYI_NO_MATCH
+
 # Mitigation journey (01)
 MITIGATION_01:
   response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update the journey map to handle the different responses from the CRI:

Success response (scored VC) should route to IPV success page if a profile is met same as the existing KBV CRI behaviour

Fail response (VC with CI) should route to the fail page same as the existing KBV CRI behaviour

‘Thin file’/ fail with no CI response (meaning there were insufficient questions for the user to answer) should route directly to the pre-KBV page for Experian so they can try Experian KBVs instead

### Why did it change

To create an improved verification and streamlined process to the HMRC KBV CRI during a user’s journey, when a specific set of logic and scoring is applied, which determines the success or fail of the journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3410](https://govukverify.atlassian.net/browse/PYIC-3410)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3410]: https://govukverify.atlassian.net/browse/PYIC-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ