### PR TITLE
PYIC-3493 Update shared claims logic to handle socialSecurityRecord

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -19,6 +19,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.EvidenceRequest;
+import uk.gov.di.ipv.core.library.domain.NinoSharedClaimsResponseDto;
 import uk.gov.di.ipv.core.library.domain.SharedClaimsResponse;
 import uk.gov.di.ipv.core.library.domain.SharedClaimsResponseDto;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
@@ -84,13 +85,20 @@ public class AuthorizationRequestHelper {
         if (Objects.nonNull(sharedClaims)) {
             if (sharedClaims.getEmailAddress() != null) {
                 claimsSetBuilder.claim(SHARED_CLAIMS, sharedClaims);
+            } else if (!sharedClaims.getSocialSecurityRecord().isEmpty()) {
+                NinoSharedClaimsResponseDto response =
+                        new NinoSharedClaimsResponseDto(
+                                sharedClaims.getName(),
+                                sharedClaims.getBirthDate(),
+                                sharedClaims.getAddress(),
+                                sharedClaims.getSocialSecurityRecord());
+                claimsSetBuilder.claim(SHARED_CLAIMS, response);
             } else {
                 SharedClaimsResponseDto response =
                         new SharedClaimsResponseDto(
                                 sharedClaims.getName(),
                                 sharedClaims.getBirthDate(),
-                                sharedClaims.getAddress(),
-                                sharedClaims.getSocialSecurityRecord());
+                                sharedClaims.getAddress());
                 claimsSetBuilder.claim(SHARED_CLAIMS, response);
             }
         }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -680,7 +680,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(TEST_USER_ID, signedJWT.getJWTClaimsSet().getSubject());
         assertEquals(CRI_AUDIENCE, signedJWT.getJWTClaimsSet().getAudience().get(0));
 
-        assertEquals(4, claimsSet.get(TEST_SHARED_CLAIMS).size());
+        assertEquals(3, claimsSet.get(TEST_SHARED_CLAIMS).size());
         JsonNode vcAttributes = claimsSet.get(TEST_SHARED_CLAIMS);
 
         JsonNode address = vcAttributes.get("address");
@@ -722,7 +722,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(TEST_USER_ID, signedJWT.getJWTClaimsSet().getSubject());
         assertEquals(CRI_AUDIENCE, signedJWT.getJWTClaimsSet().getAudience().get(0));
 
-        assertEquals(4, claimsSet.get(TEST_SHARED_CLAIMS).size());
+        assertEquals(3, claimsSet.get(TEST_SHARED_CLAIMS).size());
         JsonNode vcAttributes = claimsSet.get(TEST_SHARED_CLAIMS);
 
         JsonNode address = vcAttributes.get("address");

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/NinoSharedClaimsResponseDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/NinoSharedClaimsResponseDto.java
@@ -1,0 +1,25 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.Set;
+
+@ExcludeFromGeneratedCoverageReport
+@JsonPropertyOrder({"name", "birthDate", "address", "socialSecurityRecord"})
+public class NinoSharedClaimsResponseDto extends SharedClaimsResponseDto {
+    private final Set<SocialSecurityRecord> socialSecurityRecord;
+
+    public NinoSharedClaimsResponseDto(
+            Set<Name> name,
+            Set<BirthDate> birthDate,
+            Set<Address> address,
+            Set<SocialSecurityRecord> socialSecurityRecord) {
+        super(name, birthDate, address);
+        this.socialSecurityRecord = socialSecurityRecord;
+    }
+
+    public Set<SocialSecurityRecord> getSocialSecurityRecord() {
+        return socialSecurityRecord;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseDto.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/SharedClaimsResponseDto.java
@@ -12,17 +12,11 @@ public class SharedClaimsResponseDto {
     private final Set<Name> name;
     private final Set<BirthDate> birthDate;
     private final Set<Address> address;
-    private final Set<SocialSecurityRecord> socialSecurityRecord;
 
-    public SharedClaimsResponseDto(
-            Set<Name> name,
-            Set<BirthDate> birthDate,
-            Set<Address> address,
-            Set<SocialSecurityRecord> socialSecurityRecord) {
+    public SharedClaimsResponseDto(Set<Name> name, Set<BirthDate> birthDate, Set<Address> address) {
         this.name = name;
         this.birthDate = birthDate;
         this.address = address;
-        this.socialSecurityRecord = socialSecurityRecord;
     }
 
     public Set<Name> getName() {
@@ -35,9 +29,5 @@ public class SharedClaimsResponseDto {
 
     public Set<Address> getAddress() {
         return address;
-    }
-
-    public Set<SocialSecurityRecord> getSocialSecurityRecord() {
-        return socialSecurityRecord;
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Handle passing the new `socialSecurityRecord` entry in shared claims
```
{ 
  "socialSecurityRecord": [
    {
      "personalNumber": "AA000003D"
    }
  ]
}
```
It will only be passed if it's non-empty

### Why did it change

To pass the NI number we receive from NINO CRI onto HMRC KBV CRI

### Issue tracking
- [PYIC-3493](https://govukverify.atlassian.net/browse/PYIC-3493)

[PYIC-3493]: https://govukverify.atlassian.net/browse/PYIC-3493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ