### PR TITLE
PYIC-3510: Correlate data for F2F VC

### DIFF
--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -406,7 +406,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(any(), any()))
                 .thenReturn(true);
-        when(userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(any(), any()))
+        when(userIdentityService.checkBirthDateCorrelationInCredentials(any(), any()))
                 .thenReturn(false);
 
         JourneyResponse journeyResponse =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -65,7 +65,8 @@ public enum ErrorResponse {
     FAILED_TO_PARSE_CIMIT_SIGNING_KEY(1053, "Failed to parse CIMIT signing key"),
     UNRECOGNISED_CI_CODE(1054, "Unrecognised CI code"),
     NO_VC_STATUS_FOR_CREDENTIAL_ISSUER(1055, "No VC status found for issuer"),
-    FAILED_TO_PARSE_CONFIG(1056, "Failed to parse configuration");
+    FAILED_TO_PARSE_CONFIG(1056, "Failed to parse configuration"),
+    FAILED_TO_CORRELATE_DATA(1057, "Failed to correlate data");
 
     @JsonProperty("code")
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -54,7 +54,8 @@ public class LogHelper {
         LOG_STATUS_CODE("statusCode"),
         LOG_PARAMETER_PATH("parameterPath"),
         LOG_FEATURE_SET("featureSet"),
-        LOG_JOURNEY_TYPE("journeyType");
+        LOG_JOURNEY_TYPE("journeyType"),
+        LOG_UNCORRELATABLE_DATA("uncorrelatableData");
         private final String fieldName;
 
         LogField(String fieldName) {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Correlate data for F2F VC

### Why did it change

The f2f VC is collected async. We weren't doing the usual checks on the data in contains to be sure it correlates with the data in the other VCs. This meant data was being sent to SPoT that was being rejected.

This change will do the correlation in the check-existing-identity lambda and send the user to the F2F fail page if the data doesn't match. The user will then have the opportunity to reset their identity.

We don't need to take any action of the data doesn't correlate if we're not on an F2F journey. This is an expected scenario and will be picked up by them not matching a profile and be sent to the reset-journey lambda separately.

This also moves the call to updateVcStatues higher in the handler so it's available for the correlation check. This way the F2F VC is included.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3510](https://govukverify.atlassian.net/browse/PYIC-3510)


[PYIC-3510]: https://govukverify.atlassian.net/browse/PYIC-3510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ