### PR TITLE
PYIC 3516 limit gpg45 evidence diffs

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Profile.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Profile.java
@@ -60,10 +60,6 @@ public enum Gpg45Profile {
         return String.format("%1$s%2$s", label, scores.toString());
     }
 
-    public Gpg45Scores difference(Gpg45Scores target) {
-        return scores.difference(target);
-    }
-
     /**
      * Checks if that the provided {@code Gpg45Scores} satisfy the {@code Gpg45Scores} for this
      * profile.

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45Scores.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
  *
  * <p>Objects if this class are immutable.
  */
-public class Gpg45Scores implements Comparable<Gpg45Scores> {
+public class Gpg45Scores {
 
     public static final Evidence EV_00 = new Gpg45Scores.Evidence(0, 0);
     public static final Evidence EV_11 = new Gpg45Scores.Evidence(1, 1);
@@ -109,7 +109,7 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
                 && evidences.equals(that.evidences);
     }
 
-    public Gpg45Scores difference(Gpg45Scores other) {
+    private Gpg45Scores difference(Gpg45Scores other) {
         return new Gpg45Scores(
                 diffEvidence(other),
                 other.getActivity() - activity,
@@ -175,58 +175,6 @@ public class Gpg45Scores implements Comparable<Gpg45Scores> {
     @Override
     public int hashCode() {
         return Objects.hash(evidences, activity, fraud, verification);
-    }
-
-    /**
-     * Compares the score to another. A negative value indicates that there is some negative value
-     * in the {@code difference} between this score and the other. A positive value indicates that
-     * there is some positive value in the {@code difference}. A value of zero indicates that there
-     * is no difference.
-     *
-     * @param other
-     * @return integer
-     */
-    @Override
-    public int compareTo(Gpg45Scores other) {
-        var diff = difference(other);
-        int negativeCount = 0;
-        int positiveCount = 0;
-        for (Evidence e : diff.getEvidences()) {
-            if (e.getStrength() < 0) {
-                negativeCount += e.getStrength();
-            } else {
-                positiveCount += e.getStrength();
-            }
-            if (e.getValidity() < 0) {
-                negativeCount += e.getValidity();
-            } else {
-                positiveCount += e.getValidity();
-            }
-        }
-
-        if (diff.getActivity() < 0) {
-            negativeCount += diff.getActivity();
-        } else {
-            positiveCount += diff.getActivity();
-        }
-
-        if (diff.getFraud() < 0) {
-            negativeCount += diff.getFraud();
-        } else {
-            positiveCount += diff.getFraud();
-        }
-
-        if (diff.getVerification() < 0) {
-            negativeCount += diff.getVerification();
-        } else {
-            positiveCount += diff.getVerification();
-        }
-
-        if (negativeCount < 0) {
-            return negativeCount;
-        }
-
-        return positiveCount;
     }
 
     static class Builder {

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ListHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/helpers/ListHelper.java
@@ -1,10 +1,13 @@
 package uk.gov.di.ipv.core.library.helpers;
 
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class ListHelper {
 
+    @ExcludeFromGeneratedCoverageReport
     private ListHelper() {
         throw new IllegalStateException("Utility class");
     }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileTest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_11;
@@ -25,7 +24,6 @@ import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_32;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_33;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_42;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_43;
-import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_44;
 
 class Gpg45ProfileTest {
 
@@ -143,19 +141,6 @@ class Gpg45ProfileTest {
     @Test
     void shouldNotMatchMissingEvidence() {
         assertFalse(Gpg45Profile.V2A.isSatisfiedBy(new Gpg45Scores(EV_33, 3, 2, 3)));
-    }
-
-    @Test
-    void shouldFindDifference() {
-        assertEquals(
-                new Gpg45Scores(-2, -2, -2, -1, -3),
-                Gpg45Profile.H1B.difference(new Gpg45Scores(EV_11, 0, 0, 0)));
-        assertEquals(
-                new Gpg45Scores(0, 0, 0, 0, 0),
-                Gpg45Profile.H1B.difference(new Gpg45Scores(EV_33, 2, 1, 3)));
-        assertEquals(
-                new Gpg45Scores(1, 1, 1, 1, 1),
-                Gpg45Profile.H1B.difference(new Gpg45Scores(EV_44, 3, 2, 4)));
     }
 
     @Test

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
@@ -9,12 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.H2D;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.M1A;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.M1B;
-import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Profile.V2A;
-import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_00;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_11;
+import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_22;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_32;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_33;
 import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_42;
-import static uk.gov.di.ipv.core.library.domain.gpg45.Gpg45Scores.EV_43;
 
 class Gpg45ScoresTest {
 
@@ -54,12 +53,6 @@ class Gpg45ScoresTest {
     }
 
     @Test
-    void getEvidenceShouldReturnEvidenceWithZeroScoresWhenNoEvidences() {
-        Gpg45Scores gpg45Scores = new Gpg45Scores(List.of(), 0, 1, 3);
-        assertEquals(new Gpg45Scores.Evidence(0, 0), gpg45Scores.getEvidence(0));
-    }
-
-    @Test
     void calculateRequiredScoresShouldReturnScoresRequiredToMeetGivenProfile() {
         assertEquals(
                 new Gpg45Scores(EV_42, 0, 0, 2),
@@ -74,9 +67,6 @@ class Gpg45ScoresTest {
                 new Gpg45Scores(EV_32, 1, 0, 2),
                 new Gpg45Scores(0, 0, 0, 2, 0).calculateRequiredScores(M1B));
         assertEquals(
-                new Gpg45Scores(List.of(EV_33, EV_00), 3, 0, 3),
-                new Gpg45Scores(List.of(EV_00, EV_43), 0, 2, 0).calculateRequiredScores(V2A));
-        assertEquals(
                 new Gpg45Scores(EV_42, 0, 0, 2),
                 new Gpg45Scores(List.of(), 0, 1, 0).calculateRequiredScores(M1A));
         assertEquals(
@@ -85,28 +75,37 @@ class Gpg45ScoresTest {
         assertEquals(
                 new Gpg45Scores(EV_32, 0, 0, 2),
                 new Gpg45Scores(List.of(), 1, 2, 0).calculateRequiredScores(M1B));
+        assertEquals(
+                new Gpg45Scores(0, 0, 0, 0, 2),
+                new Gpg45Scores(EV_32, 1, 2, 0).calculateRequiredScores(M1B));
+        assertEquals(
+                new Gpg45Scores(EV_32, 0, 0, 2),
+                new Gpg45Scores(EV_11, 1, 2, 0).calculateRequiredScores(M1B));
+        assertEquals(
+                new Gpg45Scores(EV_32, 0, 0, 2),
+                new Gpg45Scores(EV_22, 1, 2, 0).calculateRequiredScores(M1B));
     }
 
     @Test
     void compareToShouldReturnNegativeIfOtherHasALowerScore() {
-        Gpg45Scores score1 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
-        Gpg45Scores score2 = new Gpg45Scores(EV_33, EV_32, 0, 1, 1);
+        Gpg45Scores score1 = new Gpg45Scores(EV_33, 0, 1, 3);
+        Gpg45Scores score2 = new Gpg45Scores(EV_33, 0, 1, 1);
 
         assertTrue(score1.compareTo(score2) < 0);
     }
 
     @Test
     void compareToShouldReturnPositiveIfOtherHasAHigherScore() {
-        Gpg45Scores score1 = new Gpg45Scores(EV_33, EV_32, 0, 1, 1);
-        Gpg45Scores score2 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
+        Gpg45Scores score1 = new Gpg45Scores(EV_33, 0, 1, 1);
+        Gpg45Scores score2 = new Gpg45Scores(EV_33, 0, 1, 3);
 
         assertTrue(score1.compareTo(score2) > 0);
     }
 
     @Test
     void compareToShouldReturnZeroIfOtherHasSameScore() {
-        Gpg45Scores score1 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
-        Gpg45Scores score2 = new Gpg45Scores(EV_33, EV_32, 0, 1, 3);
+        Gpg45Scores score1 = new Gpg45Scores(EV_33, 0, 1, 3);
+        Gpg45Scores score2 = new Gpg45Scores(EV_33, 0, 1, 3);
 
         assertEquals(0, score1.compareTo(score2));
     }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ScoresTest.java
@@ -85,28 +85,4 @@ class Gpg45ScoresTest {
                 new Gpg45Scores(EV_32, 0, 0, 2),
                 new Gpg45Scores(EV_22, 1, 2, 0).calculateRequiredScores(M1B));
     }
-
-    @Test
-    void compareToShouldReturnNegativeIfOtherHasALowerScore() {
-        Gpg45Scores score1 = new Gpg45Scores(EV_33, 0, 1, 3);
-        Gpg45Scores score2 = new Gpg45Scores(EV_33, 0, 1, 1);
-
-        assertTrue(score1.compareTo(score2) < 0);
-    }
-
-    @Test
-    void compareToShouldReturnPositiveIfOtherHasAHigherScore() {
-        Gpg45Scores score1 = new Gpg45Scores(EV_33, 0, 1, 1);
-        Gpg45Scores score2 = new Gpg45Scores(EV_33, 0, 1, 3);
-
-        assertTrue(score1.compareTo(score2) > 0);
-    }
-
-    @Test
-    void compareToShouldReturnZeroIfOtherHasSameScore() {
-        Gpg45Scores score1 = new Gpg45Scores(EV_33, 0, 1, 3);
-        Gpg45Scores score2 = new Gpg45Scores(EV_33, 0, 1, 3);
-
-        assertEquals(0, score1.compareTo(score2));
-    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

If you call Gpg45Scores.calculateRequiredScores() with either a score or profile that contains multiple pieces of evidence an IllegalArgumentException will be thrown.

### Why did it change

It isn't currently defined how this method should work when there are multiple pieces of evidence. The existing implementation would do something sensible in most, but not all cases. If it was relied on in the future it could lead to subtle issues that might not be noticed for a while.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3516](https://govukverify.atlassian.net/browse/PYIC-3516)



[PYIC-3516]: https://govukverify.atlassian.net/browse/PYIC-3516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ