### PR TITLE
PYIC-3533 Handle NINO evidence type

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/Gpg45ProfileEvaluator.java
@@ -353,7 +353,8 @@ public class Gpg45ProfileEvaluator {
                         CredentialEvidenceItem.EvidenceType.VERIFICATION, new ArrayList<>(),
                         CredentialEvidenceItem.EvidenceType.DCMAW, new ArrayList<>(),
                         CredentialEvidenceItem.EvidenceType.F2F, new ArrayList<>(),
-                        CredentialEvidenceItem.EvidenceType.FRAUD_WITH_ACTIVITY, new ArrayList<>());
+                        CredentialEvidenceItem.EvidenceType.FRAUD_WITH_ACTIVITY, new ArrayList<>(),
+                        CredentialEvidenceItem.EvidenceType.NINO, new ArrayList<>());
 
         for (SignedJWT signedJWT : credentials) {
             List<CredentialEvidenceItem> credentialEvidenceList =

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/domain/CredentialEvidenceItem.java
@@ -75,6 +75,8 @@ public class CredentialEvidenceItem {
             return EvidenceType.F2F;
         } else if (isFraudWithActivity()) {
             return EvidenceType.FRAUD_WITH_ACTIVITY;
+        } else if (isNino()) {
+            return EvidenceType.NINO;
         } else {
             throw new UnknownEvidenceTypeException();
         }
@@ -146,6 +148,14 @@ public class CredentialEvidenceItem {
                 && (checkDetails != null || failedCheckDetails != null);
     }
 
+    private boolean isNino() {
+        return strengthScore == null
+                && validityScore == null
+                && identityFraudScore == null
+                && verificationScore == null
+                && (checkDetails != null || failedCheckDetails != null);
+    }
+
     @Getter
     public enum EvidenceType {
         ACTIVITY(
@@ -160,6 +170,7 @@ public class CredentialEvidenceItem {
                 CredentialEvidenceItem::getVerificationScore),
         DCMAW(null, null),
         F2F(null, null),
+        NINO(null, null),
         FRAUD_WITH_ACTIVITY(null, null);
 
         public final Comparator<CredentialEvidenceItem> comparator;

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/validation/Gpg45NinoValidator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/domain/gpg45/validation/Gpg45NinoValidator.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.core.library.domain.gpg45.validation;
+
+import uk.gov.di.ipv.core.library.domain.gpg45.domain.CredentialEvidenceItem;
+
+public class Gpg45NinoValidator {
+
+    private Gpg45NinoValidator() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static boolean isSuccessful(CredentialEvidenceItem item) {
+        if (item.getFailedCheckDetails() != null) {
+            return false;
+        }
+        return item.getCheckDetails() != null;
+    }
+}

--- a/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
+++ b/libs/vc-helper/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
@@ -13,6 +13,7 @@ import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45DcmawValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45EvidenceValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45F2fValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45FraudValidator;
+import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45NinoValidator;
 import uk.gov.di.ipv.core.library.domain.gpg45.validation.Gpg45VerificationValidator;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
@@ -114,6 +115,8 @@ public class VcHelper {
                         return Gpg45DcmawValidator.isSuccessful(item);
                     case F2F:
                         return Gpg45F2fValidator.isSuccessful(item);
+                    case NINO:
+                        return Gpg45NinoValidator.isSuccessful(item);
                 }
             }
             return false;


### PR DESCRIPTION
## Proposed changes

### What changed

Identity NINO evidence type (no scores just a checkDetails/failedCheckDetails block) - if checkDetails is present it's successful, otherwise or if failedCheckDetails is present it's unsuccessful

### Why did it change

So we can correctly handle the VC we get back from NINO CRI

### Issue tracking
- [PYIC-3533](https://govukverify.atlassian.net/browse/PYIC-3533)



[PYIC-3533]: https://govukverify.atlassian.net/browse/PYIC-3533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ