### PR TITLE
PYIC-3534 Update journey map to route through NINO CRI

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -298,7 +298,10 @@ ADDRESS_AND_FRAUD_J2:
   nestedJourney: ADDRESS_AND_FRAUD
   exitEvents:
     next:
-      targetState: PRE_KBV_TRANSITION_PAGE_J2
+      targetState: CRI_NINO_J6
+      checkIfDisabled:
+        hmrcKbv:
+          targetState: PRE_KBV_TRANSITION_PAGE_J2
 
 PRE_KBV_TRANSITION_PAGE_J2:
   response:
@@ -460,7 +463,18 @@ F2F_HANDOFF_PAGE_J5:
     type: page
     pageId: page-face-to-face-handoff
 
-# HMRC KBV CRI journey (J6)
+# HMRC KBV journey (J6)
+CRI_NINO_J6:
+  response:
+    type: cri
+    criId: nino
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: CRI_HMRC_KBV_J6
+    fail-with-no-ci:
+      targetState: PRE_KBV_TRANSITION_PAGE_J2
+
 CRI_HMRC_KBV_J6:
   response:
     type: cri


### PR DESCRIPTION
## Proposed changes

### What changed

Update journey map to route through NINO CRI. If HMRC KBV is disabled, route to pre-kbv page for Experian

### Why did it change

Wiring up the new HMRC KBV journey

### Issue tracking
- [PYIC-3534](https://govukverify.atlassian.net/browse/PYIC-3534)


[PYIC-3534]: https://govukverify.atlassian.net/browse/PYIC-3534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ