### PR TITLE
BAU: Store session in check-existing-identity handler

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -211,6 +211,7 @@ public class CheckExistingIdentityHandler
                                 auditEventUser));
 
                 ipvSessionItem.setVot(VOT_P2);
+                ipvSessionService.updateIpvSession(ipvSessionItem);
 
                 return JOURNEY_REUSE;
             }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Store session in check-existing-identity handler

### Why did it change

The call to store the session was dropped by accident. This adds it back in so the P2 VOT is available on the session.
