### PR TITLE
BAU: Use process step response instead of journey

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponse.java
@@ -4,19 +4,25 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProcessStepResponse implements StepResponse {
-    public static final String JOURNEY = "journey";
-    public static final String LAMBDA_INPUT = "lambdaInput";
+    private static final String JOURNEY = "journey";
+    private static final String LAMBDA_INPUT = "lambdaInput";
+    private static final String JOURNEY_TEMPLATE = "/journey/%s";
     private String lambda;
     private Map<String, Object> lambdaInput;
 
     @Override
     public Map<String, Object> value() {
-        return Map.of(JOURNEY, String.format("/journey/%s", lambda), LAMBDA_INPUT, lambdaInput);
+        HashMap<String, Object> response = new HashMap<>();
+        response.put(JOURNEY, String.format(JOURNEY_TEMPLATE, lambda));
+        response.put(LAMBDA_INPUT, lambdaInput);
+
+        return response;
     }
 }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -37,8 +37,8 @@ F2F_START_PAGE:
 
 INITIAL_CI_SCORING:
   response:
-    type: journey
-    journeyStepId: /journey/ci-scoring
+    type: process
+    lambda: ci-scoring
   events:
     next:
       targetState: CHECK_EXISTING_IDENTITY
@@ -59,8 +59,8 @@ INITIAL_CI_SCORING:
 
 CHECK_EXISTING_IDENTITY:
   response:
-    type: journey
-    journeyStepId: /journey/check-existing-identity
+    type: process
+    lambda: check-existing-identity
   events:
     next:
       targetState: IPV_IDENTITY_START_PAGE
@@ -83,8 +83,8 @@ CHECK_EXISTING_IDENTITY:
 
 RESET_IDENTITY:
   response:
-    type: journey
-    journeyStepId: /journey/reset-identity
+    type: process
+    lambda: reset-identity
   events:
     next:
       targetState: IPV_IDENTITY_START_PAGE
@@ -259,8 +259,8 @@ IPV_SUCCESS_PAGE:
 
 END:
   response:
-    type: journey
-    journeyStepId: /journey/build-client-oauth-response
+    type: process
+    lambda: build-client-oauth-response
 
 # DCMAW journey (J1)
 POST_DCMAW_SUCCESS_PAGE:
@@ -477,8 +477,8 @@ CRI_HMRC_KBV_J6:
 # Mitigation journey (01)
 MITIGATION_01:
   response:
-    type: journey
-    journeyStepId: /journey/reset-identity
+    type: process
+    lambda: reset-identity
   events:
     next:
       targetState: MITIGATION_01_IDENTITY_START_PAGE


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use process step response instead of journey

### Why did it change

Now we have the process step response, we can use it in the places that were using the journey step response.

This also refactors the ProcessStepResponse to not use the `Map.of()` method. This doesn't allow nulls. If we're not passing any values to the lambda this will blow up. Constructing it with a new HashMap works.
