### PR TITLE
PYIC-3539: Use stored CRI connection

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -317,8 +317,6 @@ public class BuildCriOauthRequestHandler
     private SharedClaimsResponse getSharedAttributesForUser(
             IpvSessionItem ipvSessionItem, String userId, String criId)
             throws HttpResponseExceptionWithErrorBody {
-        CredentialIssuerConfig addressCriConfig =
-                criConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI);
 
         List<String> credentials = userIdentityService.getUserIssuedCredentials(userId);
 
@@ -343,7 +341,7 @@ public class BuildCriOauthRequestHandler
 
                     SharedClaims credentialsSharedClaims =
                             mapper.readValue(credentialSubject.toString(), SharedClaims.class);
-                    if (credentialIss.equals(addressCriConfig.getComponentId())) {
+                    if (credentialIss.equals(criConfigService.getComponentId(ADDRESS_CRI))) {
                         hasAddressVc = true;
                         sharedClaimsSet.forEach(sharedClaims -> sharedClaims.setAddress(null));
                     } else if (hasAddressVc) {

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -292,8 +292,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -363,8 +363,6 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(false, false);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -435,8 +433,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -506,8 +504,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -576,8 +574,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(dcmawCredentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -725,8 +723,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -780,8 +778,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -833,8 +831,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -905,8 +903,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -962,8 +960,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(credentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, false);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID))
@@ -1019,8 +1017,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn("name,birthDate,address,emailAddress");
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getEmailAddress()).thenReturn(null);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVcIgnoringCi(any())).thenReturn(true, true);
@@ -1077,8 +1075,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(f2fCredentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(configService.getAllowedSharedAttributes(F2F_CRI))
                 .thenReturn("name,birthDate,address,emailAddress");
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
@@ -1138,8 +1136,8 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(hmrcKbvCredentialIssuerConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressCredentialIssuerConfig);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(addressCredentialIssuerConfig.getComponentId());
         when(configService.getAllowedSharedAttributes(HMRC_KBV_CRI))
                 .thenReturn("name,birthDate,address,socialSecurityRecord");
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -22,7 +22,6 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.Name;
-import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
@@ -154,12 +153,10 @@ public class BuildProvenUserIdentityDetailsHandler
             throws ParseException, JsonProcessingException, ProvenUserIdentityDetailsException,
                     NoVcStatusForIssuerException {
         for (VcStoreItem item : credentialIssuerItems) {
-            CredentialIssuerConfig credentialIssuerConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(
-                            item.getCredentialIssuer());
             if (EVIDENCE_CRI_TYPES.contains(item.getCredentialIssuer())
                     && userIdentityService.isVcSuccessful(
-                            currentVcStatuses, credentialIssuerConfig.getComponentId())) {
+                            currentVcStatuses,
+                            configService.getComponentId(item.getCredentialIssuer()))) {
                 JsonNode vcSubjectNode =
                         mapper.readTree(
                                         SignedJWT.parse(item.getCredential())
@@ -201,12 +198,10 @@ public class BuildProvenUserIdentityDetailsHandler
             throws ParseException, JsonProcessingException, ProvenUserIdentityDetailsException,
                     NoVcStatusForIssuerException {
         for (VcStoreItem item : credentialIssuerItems) {
-            CredentialIssuerConfig credentialIssuerConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(
-                            item.getCredentialIssuer());
             if (item.getCredentialIssuer().equals(ADDRESS_CRI)
                     && userIdentityService.isVcSuccessful(
-                            currentVcStatuses, credentialIssuerConfig.getComponentId())) {
+                            currentVcStatuses,
+                            configService.getComponentId(item.getCredentialIssuer()))) {
                 JsonNode addressNode =
                         mapper.readTree(
                                         SignedJWT.parse(item.getCredential())

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -59,10 +59,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
             createCredentialIssuerConfig("https://review-a.integration.account.gov.uk");
     private static final CredentialIssuerConfig ISSUER_CONFIG_CLAIMED_IDENTITY =
             createCredentialIssuerConfig("https://review-c.integration.account.gov.uk");
-    private static final CredentialIssuerConfig ISSUER_CONFIG_FRAUD =
-            createCredentialIssuerConfig("https://review-f.integration.account.gov.uk");
-    private static final CredentialIssuerConfig ISSUER_CONFIG_KBV =
-            createCredentialIssuerConfig("https://review-k.integration.account.gov.uk");
     private static final CredentialIssuerConfig ISSUER_CONFIG_UK_PASSPORT =
             createCredentialIssuerConfig("https://review-p.integration.account.gov.uk");
 
@@ -102,12 +98,12 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
                                 createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(ISSUER_CONFIG_ADDRESS);
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
 
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -138,12 +134,12 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
                                 createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(ISSUER_CONFIG_ADDRESS);
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
 
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -180,12 +176,12 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
                                 createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(ISSUER_CONFIG_ADDRESS);
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -202,12 +198,12 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     }
 
     @Test
-    void shouldReceive400ResponseCodeWhenEvidenceVcIsMissing() throws Exception {
+    void shouldReceive400ResponseCodeWhenEvidenceVcIsMissing() {
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(ISSUER_CONFIG_ADDRESS);
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
 
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
@@ -246,17 +242,12 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
                                 createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(ISSUER_CONFIG_ADDRESS);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
-                .thenReturn(ISSUER_CONFIG_FRAUD);
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(KBV_CRI))
-                .thenReturn(ISSUER_CONFIG_KBV);
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -287,17 +278,12 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
                                 createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(ISSUER_CONFIG_ADDRESS);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(FRAUD_CRI))
-                .thenReturn(ISSUER_CONFIG_FRAUD);
-
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(KBV_CRI))
-                .thenReturn(ISSUER_CONFIG_KBV);
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -368,12 +354,12 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                 createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
                                 createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
 
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT);
-        when(mockConfigService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(ISSUER_CONFIG_ADDRESS);
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(PASSPORT_CRI))
+                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
 
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -180,10 +180,6 @@ class CheckExistingIdentityHandlerTest {
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
-        when(configService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(claimedIdentityConfig);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -263,10 +259,6 @@ class CheckExistingIdentityHandlerTest {
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenCallRealMethod();
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(configService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(claimedIdentityConfig);
 
         JourneyResponse journeyResponse =
                 toResponseClass(
@@ -536,10 +528,6 @@ class CheckExistingIdentityHandlerTest {
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(ACCEPTED_PROFILES)))
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
-        when(configService.getCredentialIssuerActiveConnectionConfig("address"))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig("claimedIdentity"))
-                .thenReturn(claimedIdentityConfig);
 
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -410,18 +410,8 @@ class EvaluateGpg45ScoresHandlerTest {
 
         mockCredentialIssuerConfig();
         // This causes the address vc (which has no evidence) to be treated as an unsuccessful vc
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(
-                        new CredentialIssuerConfig(
-                                new URI("http://example.com/token"),
-                                new URI("http://example.com/credential"),
-                                new URI("http://example.com/authorize"),
-                                "ipv-core",
-                                "test-jwk",
-                                "test-encryption-jwk",
-                                "http://example.com",
-                                new URI("http://example.com/redirect"),
-                                true));
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn("https://a-component-id-that-doesn't-match-the-address-vc");
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(testIpvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
@@ -445,7 +435,6 @@ class EvaluateGpg45ScoresHandlerTest {
         testIpvSessionItem.setIpvSessionId(TEST_SESSION_ID);
         testIpvSessionItem.setVisitedCredentialIssuerDetails(List.of());
 
-        mockCredentialIssuerConfig();
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(testIpvSessionItem);
         when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
@@ -556,9 +545,8 @@ class EvaluateGpg45ScoresHandlerTest {
     }
 
     private void mockCredentialIssuerConfig() {
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
+        when(configService.getComponentId(ADDRESS_CRI)).thenReturn(addressConfig.getComponentId());
+        when(configService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig.getComponentId());
     }
 }

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -258,7 +258,7 @@ class ProcessAsyncCriCredentialHandlerTest {
     }
 
     @Test
-    void willnotPersistVerifiableCredentialIfFailsToPostMitigatingCredentialToCIMIT()
+    void willNotPersistVerifiableCredentialIfFailsToPostMitigatingCredentialToCIMIT()
             throws JsonProcessingException, CiPostMitigationsException, SqsException,
                     CiPutException {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE);
@@ -416,9 +416,9 @@ class ProcessAsyncCriCredentialHandlerTest {
     private void mockCredentialIssuerConfig() {
         when(configService.getCredentialIssuerActiveConnectionConfig(TEST_CREDENTIAL_ISSUER_ID))
                 .thenReturn(TEST_CREDENTIAL_ISSUER_CONFIG);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(TEST_CREDENTIAL_ISSUER_CONFIG_ADDRESS);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(TEST_CREDENTIAL_ISSUER_CONFIG_CLAIMED_IDENTITY);
+        when(configService.getComponentId(ADDRESS_CRI))
+                .thenReturn(TEST_CREDENTIAL_ISSUER_CONFIG_ADDRESS.getComponentId());
+        when(configService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(TEST_CREDENTIAL_ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
     }
 }

--- a/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
+++ b/lambdas/retrieve-cri-credential/src/main/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandler.java
@@ -157,7 +157,7 @@ public class RetrieveCriCredentialHandler
                     clientOAuthSessionItem.getGovukSigninJourneyId());
 
             CredentialIssuerConfig credentialIssuerConfig =
-                    configService.getCredentialIssuerActiveConnectionConfig(credentialIssuerId);
+                    configService.getCriConfig(criOAuthSessionItem);
 
             String apiKey =
                     credentialIssuerConfig.getRequiresApiKey()

--- a/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
+++ b/lambdas/retrieve-cri-credential/src/test/java/uk/gov/di/ipv/core/retrievecricredential/RetrieveCriCredentialHandlerTest.java
@@ -63,8 +63,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.USE_POST_MITIGATIONS;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATORS;
@@ -183,10 +181,6 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldReturnJourneyResponseOnSuccessfulRequest() throws Exception {
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
         when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
@@ -216,10 +210,6 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldUpdateSessionWithDetailsOfVisitedCri() throws ParseException {
         mockServiceCalls();
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
         when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
@@ -328,10 +318,6 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldReturnErrorJourneyResponseIfSqsExceptionIsThrown() throws Exception {
         mockServiceCallsAndSessionItem();
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
         when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
@@ -380,10 +366,6 @@ class RetrieveCriCredentialHandlerTest {
     @Test
     void shouldSendIpvVcReceivedAuditEvent() throws Exception {
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
         when(verifiableCredentialService.getVerifiableCredentialResponse(
                         testBearerAccessToken,
                         testPassportIssuer,
@@ -431,10 +413,6 @@ class RetrieveCriCredentialHandlerTest {
                         VerifiableCredentialResponse.builder()
                                 .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)))
                                 .build());
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
         mockServiceCallsAndSessionItem();
 
         handler.handleRequest(testInput, context);
@@ -471,10 +449,6 @@ class RetrieveCriCredentialHandlerTest {
                                 .verifiableCredentials(List.of(SignedJWT.parse(SIGNED_ADDRESS_VC)))
                                 .build());
         mockServiceCalls();
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
         when(configService.enabled(USE_POST_MITIGATIONS)).thenReturn(true);
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -520,10 +494,6 @@ class RetrieveCriCredentialHandlerTest {
                                 .verifiableCredentials(List.of(TEST_SIGNED_ADDRESS_VC))
                                 .build());
         mockServiceCalls();
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
         when(configService.enabled(USE_POST_MITIGATIONS)).thenReturn(true);
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -575,10 +545,6 @@ class RetrieveCriCredentialHandlerTest {
                                 .verifiableCredentials(List.of(TEST_SIGNED_ADDRESS_VC))
                                 .build());
         mockServiceCalls();
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
         when(configService.enabled(USE_POST_MITIGATIONS)).thenReturn(true);
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -629,10 +595,6 @@ class RetrieveCriCredentialHandlerTest {
                         new URI("https://www.example.com/credential-issuers/callback/criId"),
                         false);
         when(configService.getCriConfig(criOAuthSessionItem)).thenReturn(testCriNotRequiringApiKey);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);

--- a/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/main/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandler.java
@@ -112,7 +112,7 @@ public class RetrieveCriOauthAccessTokenHandler
                     clientOAuthSessionItem.getGovukSigninJourneyId());
 
             CredentialIssuerConfig credentialIssuerConfig =
-                    getCredentialIssuerConfig(credentialIssuerId);
+                    configService.getCriConfig(criOAuthSessionItem);
 
             String apiKey =
                     credentialIssuerConfig.getRequiresApiKey()
@@ -183,11 +183,6 @@ public class RetrieveCriOauthAccessTokenHandler
             criOAuthSessionItem.setAccessToken(accessToken.toAuthorizationHeader());
             criOAuthSessionService.updateCriOAuthSessionItem(criOAuthSessionItem);
         }
-    }
-
-    @Tracing
-    private CredentialIssuerConfig getCredentialIssuerConfig(String criId) {
-        return configService.getCredentialIssuerActiveConnectionConfig(criId);
     }
 
     @Tracing

--- a/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
+++ b/lambdas/retrieve-cri-oauth-access-token/src/test/java/uk/gov/di/ipv/core/retrievecrioauthaccesstoken/RetrieveCriOauthAccessTokenHandlerTest.java
@@ -137,23 +137,14 @@ class RetrieveCriOauthAccessTokenHandlerTest {
 
     @Test
     void shouldThrowJourneyErrorIfCredentialIssuerServiceThrowsException() {
-        Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
-
+        mockServiceCallsAndSessionItem();
         when(authCodeToAccessTokenService.exchangeCodeForToken(
                         TEST_AUTH_CODE, passportIssuer, testApiKey, CREDENTIAL_ISSUER_ID))
                 .thenThrow(
                         new AuthCodeToAccessTokenException(
                                 HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
 
-        when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
-                .thenReturn(passportIssuer);
-        when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
-
-        when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-        when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);
-        when(mockClientOAuthSessionService.getClientOAuthSession(any()))
-                .thenReturn(getClientOAuthSessionItem());
-
+        Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
         assertThrows(JourneyError.class, () -> handler.handleRequest(input, context));
     }
 
@@ -187,54 +178,30 @@ class RetrieveCriOauthAccessTokenHandlerTest {
     }
 
     private void mockServiceCallsAndSessionItem() {
-        when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
-                .thenReturn(passportIssuer);
-
+        when(configService.getCriConfig(criOAuthSessionItem)).thenReturn(passportIssuer);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
-
         when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
-
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-
         when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);
-
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
                 .thenReturn(getClientOAuthSessionItem());
     }
 
     @Test
     void shouldThrowJourneyErrorIfSqsExceptionIsThrown() throws SqsException {
-        Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
-
-        JSONObject testCredential = new JSONObject();
-        testCredential.appendField("foo", "bar");
-
-        when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-        when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);
-        when(mockClientOAuthSessionService.getClientOAuthSession(any()))
-                .thenReturn(getClientOAuthSessionItem());
-        when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
-                .thenReturn(passportIssuer);
+        mockServiceCallsAndSessionItem();
         doThrow(new SqsException("Test sqs error"))
                 .when(auditService)
                 .sendAuditEvent(any(AuditEvent.class));
 
+        Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
         assertThrows(JourneyError.class, () -> handler.handleRequest(input, context));
         verify(criOAuthSessionService, times(1)).getCriOauthSessionItem(any());
     }
 
     @Test
     void shouldUpdateSessionWithDetailsOfFailedCriVisitOnCredentialIssuerException() {
-        Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
-
-        JSONObject testCredential = new JSONObject();
-        testCredential.appendField("foo", "bar");
-
-        when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
-                .thenReturn(passportIssuer);
-
-        when(configService.getCriPrivateApiKey(anyString())).thenReturn(testApiKey);
-
+        mockServiceCallsAndSessionItem();
         when(authCodeToAccessTokenService.exchangeCodeForToken(
                         TEST_AUTH_CODE, passportIssuer, testApiKey, CREDENTIAL_ISSUER_ID))
                 .thenThrow(
@@ -242,12 +209,9 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                                 HTTPResponse.SC_BAD_REQUEST, ErrorResponse.INVALID_TOKEN_REQUEST));
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId("someIpvSessionId");
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-        when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);
-        when(mockClientOAuthSessionService.getClientOAuthSession(any()))
-                .thenReturn(getClientOAuthSessionItem());
 
+        Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
         assertThrows(JourneyError.class, () -> handler.handleRequest(input, context));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
@@ -271,27 +235,14 @@ class RetrieveCriOauthAccessTokenHandlerTest {
 
     @Test
     void shouldUpdateSessionWithDetailsOfFailedVisitedCriOnSqsException() throws SqsException {
-        Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
-
-        JSONObject testCredential = new JSONObject();
-        testCredential.appendField("foo", "bar");
-
-        when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
-                .thenReturn(passportIssuer);
-
-        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
-
+        mockServiceCallsAndSessionItem();
+        IpvSessionItem ipvSessionItem = new IpvSessionItem();
+        when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         doThrow(new SqsException("Test sqs error"))
                 .when(auditService)
                 .sendAuditEvent(any(AuditEvent.class));
 
-        IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId("someIpvSessionId");
-        when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-        when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);
-        when(mockClientOAuthSessionService.getClientOAuthSession(any()))
-                .thenReturn(getClientOAuthSessionItem());
-
+        Map<String, String> input = Map.of(IPV_SESSION_ID, sessionId);
         assertThrows(JourneyError.class, () -> handler.handleRequest(input, context));
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
@@ -327,8 +278,7 @@ class RetrieveCriOauthAccessTokenHandlerTest {
                         "test-audience",
                         new URI("http://www.example.com/credential-issuers/callback/criId"),
                         false);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CREDENTIAL_ISSUER_ID))
-                .thenReturn(testCriNotRequiringApiKey);
+        when(configService.getCriConfig(criOAuthSessionItem)).thenReturn(testCriNotRequiringApiKey);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(testComponentId);
         when(ipvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(criOAuthSessionService.getCriOauthSessionItem(any())).thenReturn(criOAuthSessionItem);

--- a/lib/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
+++ b/lib/src/main/java/uk/gov/di/ipv/core/library/vchelper/VcHelper.java
@@ -39,11 +39,7 @@ public class VcHelper {
 
     private static Set<String> getNonEvidenceCredentialIssuers() {
         return NON_EVIDENCE_CRI_TYPES.stream()
-                .map(
-                        credentialIssuer ->
-                                configService
-                                        .getCredentialIssuerActiveConnectionConfig(credentialIssuer)
-                                        .getComponentId())
+                .map(credentialIssuer -> configService.getComponentId(credentialIssuer))
                 .collect(Collectors.toSet());
     }
 

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
-import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.VcStatusDto;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -823,20 +822,8 @@ class UserIdentityServiceTest {
     private void mockCredentialIssuerConfig() {
         NON_EVIDENCE_CRI_TYPES.forEach(
                 credentialIssuer -> {
-                    CredentialIssuerConfig credentialIssuerConfig =
-                            new CredentialIssuerConfig(
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    credentialIssuer,
-                                    null,
-                                    false);
-                    when(mockConfigService.getCredentialIssuerActiveConnectionConfig(
-                                    credentialIssuer))
-                            .thenReturn(credentialIssuerConfig);
+                    when(mockConfigService.getComponentId(credentialIssuer))
+                            .thenReturn(credentialIssuer);
                 });
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/core/library/vchelper/VcHelperTest.java
@@ -168,9 +168,8 @@ class VcHelperTest {
 
     private void mockCredentialIssuerConfig() {
         VcHelper.setConfigService(configService);
-        when(configService.getCredentialIssuerActiveConnectionConfig(ADDRESS_CRI))
-                .thenReturn(addressConfig);
-        when(configService.getCredentialIssuerActiveConnectionConfig(CLAIMED_IDENTITY_CRI))
-                .thenReturn(claimedIdentityConfig);
+        when(configService.getComponentId(ADDRESS_CRI)).thenReturn(addressConfig.getComponentId());
+        when(configService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityConfig.getComponentId());
     }
 }


### PR DESCRIPTION
**Not to be merged until https://github.com/alphagov/di-ipv-core-back/pull/1193# has been merged for 2 hours**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use stored CRI connection to finish OAuth journey.

### Why did it change

[PYIC-3539: Use stored connection](https://github.com/alphagov/di-ipv-core-back/commit/b462663af4c6a0830deecbeb242b4a34d1894c04) 

We need to use the stored connection a user initiated a journey with a
CRI with.

[PYIC-3539: Use active connection directly less](https://github.com/alphagov/di-ipv-core-back/commit/a2f17cba0ba8bc23d8940e8f691e9f2f07083c5d) 

In a few places we were fetching a CRIs config using the method in the
config service for fetching the active connection.
In these places we were just trying to determine the CRIs component ID.
We have a method for doing that without pulling back the entire config.

It also means that we're using the "active" connection less directly.
Sure, the component ID method is using it under the hood, but we can
refactor that at some point in the future if we needed to.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3539](https://govukverify.atlassian.net/browse/PYIC-3539)


[PYIC-3539]: https://govukverify.atlassian.net/browse/PYIC-3539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ