### PR TITLE
PYIC-3547: Removed criEscapeFlag

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -320,13 +320,10 @@ CRI_KBV_J2:
     end:
       targetState: IPV_SUCCESS_PAGE
     fail-with-no-ci:
-      targetState: PYI_KBV_THIN_FILE
-      checkFeatureFlag:
-        criEscapeFlag:
-          targetState: PYI_CRI_ESCAPE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_CRI_ESCAPE_NO_F2F
+      targetState: PYI_CRI_ESCAPE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_CRI_ESCAPE_NO_F2F
     mitigation02:
       targetState: MITIGATION_02_OPTIONS
 
@@ -381,13 +378,10 @@ CRI_KBV_J3:
     end:
       targetState: IPV_SUCCESS_PAGE
     fail-with-no-ci:
-      targetState: PYI_KBV_THIN_FILE
-      checkFeatureFlag:
-        criEscapeFlag:
-          targetState: PYI_CRI_ESCAPE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_CRI_ESCAPE_NO_F2F
+      targetState: PYI_CRI_ESCAPE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_CRI_ESCAPE_NO_F2F
     next:
       targetState: PYI_NO_MATCH
     mitigation02:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed CRI Escape flag

Subsequent PR: https://github.com/alphagov/di-ipv-core-common-infra/pull/671

### Why did it change

Going live with change to routing - Redirect to PYI-Escape-page by default

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3547](https://govukverify.atlassian.net/browse/PYIC-3547)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-3547]: https://govukverify.atlassian.net/browse/PYIC-3547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ