### PR TITLE
[PYIC-3395] Rename CI scoring success event

### DIFF
--- a/deploy/criReturnStepFunction.asl.json
+++ b/deploy/criReturnStepFunction.asl.json
@@ -92,7 +92,7 @@
         },
         {
           "Variable": "$.lambdaResult.journey",
-          "StringEquals": "/journey/next",
+          "StringEquals": "/journey/ci-score-not-breaching",
           "Next": "EvaluateGpg45Scores"
         }
       ],

--- a/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
+++ b/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
@@ -36,11 +36,11 @@ import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_CI_SCORE_NOT_BREACHING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 
-
 public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String USER_STATE_INITIAL_CI_SCORING = "INITIAL_CI_SCORING";
-    private static final JourneyResponse JOURNEY_CI_SCORE_NOT_BREACHING = new JourneyResponse(JOURNEY_CI_SCORE_NOT_BREACHING_PATH);
+    private static final JourneyResponse JOURNEY_CI_SCORE_NOT_BREACHING =
+            new JourneyResponse(JOURNEY_CI_SCORE_NOT_BREACHING_PATH);
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final CiMitService ciMitService;
     private final ConfigService configService;

--- a/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
+++ b/lambdas/ci-scoring/src/main/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandler.java
@@ -33,13 +33,14 @@ import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_JOURNEY_RESPONSE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_CI_SCORE_NOT_BREACHING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
+
 
 public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String USER_STATE_INITIAL_CI_SCORING = "INITIAL_CI_SCORING";
-    private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse(JOURNEY_NEXT_PATH);
+    private static final JourneyResponse JOURNEY_CI_SCORE_NOT_BREACHING = new JourneyResponse(JOURNEY_CI_SCORE_NOT_BREACHING_PATH);
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final CiMitService ciMitService;
     private final ConfigService configService;
@@ -107,7 +108,7 @@ public class CiScoringHandler implements RequestHandler<JourneyRequest, Map<Stri
                 return contraIndicatorErrorJourneyResponse.get().toObjectMap();
             }
 
-            return JOURNEY_NEXT.toObjectMap();
+            return JOURNEY_CI_SCORE_NOT_BREACHING.toObjectMap();
         } catch (HttpResponseExceptionWithErrorBody e) {
             LOGGER.error("Received HTTP response exception", e);
             return new JourneyErrorResponse(

--- a/lambdas/ci-scoring/src/test/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandlerTest.java
+++ b/lambdas/ci-scoring/src/test/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandlerTest.java
@@ -51,7 +51,8 @@ class CiScoringHandlerTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String JOURNEY_ERROR = "/journey/error";
-    private static final JourneyResponse JOURNEY_CI_SCORE_NOT_BREACHING = new JourneyResponse("/journey/ci-score-not-breaching");
+    private static final JourneyResponse JOURNEY_CI_SCORE_NOT_BREACHING =
+            new JourneyResponse("/journey/ci-score-not-breaching");
     private static final String JOURNEY_PYI_NO_MATCH = "/journey/pyi-no-match";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     private static final ObjectMapper mapper = new ObjectMapper();
@@ -104,7 +105,8 @@ class CiScoringHandlerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void shouldReturnJourneyCIScoreNotBreachingIfNoBreachingCIs(boolean useContraIndicatorVC) throws Exception {
+    void shouldReturnJourneyCIScoreNotBreachingIfNoBreachingCIs(boolean useContraIndicatorVC)
+            throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(configService.enabled(USE_CONTRA_INDICATOR_VC)).thenReturn(useContraIndicatorVC);
         mockCiJourneyResponse(useContraIndicatorVC, Optional.empty(), false);

--- a/lambdas/ci-scoring/src/test/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandlerTest.java
+++ b/lambdas/ci-scoring/src/test/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandlerTest.java
@@ -51,7 +51,7 @@ class CiScoringHandlerTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String JOURNEY_ERROR = "/journey/error";
-    private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
+    private static final JourneyResponse JOURNEY_CI_SCORE_NOT_BREACHING = new JourneyResponse("/journey/ci-score-not-breaching");
     private static final String JOURNEY_PYI_NO_MATCH = "/journey/pyi-no-match";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     private static final ObjectMapper mapper = new ObjectMapper();
@@ -104,7 +104,7 @@ class CiScoringHandlerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    void shouldReturnJourneyNextIfNoBreachingCIs(boolean useContraIndicatorVC) throws Exception {
+    void shouldReturnJourneyCIScoreNotBreachingIfNoBreachingCIs(boolean useContraIndicatorVC) throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(configService.enabled(USE_CONTRA_INDICATOR_VC)).thenReturn(useContraIndicatorVC);
         mockCiJourneyResponse(useContraIndicatorVC, Optional.empty(), false);
@@ -115,7 +115,7 @@ class CiScoringHandlerTest {
                 toResponseClass(
                         ciScoringHandler.handleRequest(request, context), JourneyResponse.class);
 
-        assertEquals(JOURNEY_NEXT.getJourney(), response.getJourney());
+        assertEquals(JOURNEY_CI_SCORE_NOT_BREACHING.getJourney(), response.getJourney());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
     }
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -40,7 +40,7 @@ INITIAL_CI_SCORING:
     type: process
     lambda: ci-scoring
   events:
-    next:
+    ci-score-not-breaching:
       targetState: CHECK_EXISTING_IDENTITY
     reuse:
       targetState: IPV_IDENTITY_REUSE_PAGE

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -12,7 +12,8 @@ public class JourneyUris {
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
     public static final String JOURNEY_NOT_FOUND_PATH = "/journey/not-found";
     public static final String JOURNEY_CI_SCORING_PATH = "/journey/ci-scoring";
-    public static final String JOURNEY_CI_SCORE_NOT_BREACHING_PATH = "/journey/ci-score-not-breaching";
+    public static final String JOURNEY_CI_SCORE_NOT_BREACHING_PATH =
+            "/journey/ci-score-not-breaching";
     public static final String JOURNEY_FAIL_PATH = "/journey/fail";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
     public static final String JOURNEY_NEXT_PATH = "/journey/next";

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -12,6 +12,7 @@ public class JourneyUris {
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
     public static final String JOURNEY_NOT_FOUND_PATH = "/journey/not-found";
     public static final String JOURNEY_CI_SCORING_PATH = "/journey/ci-scoring";
+    public static final String JOURNEY_CI_SCORE_NOT_BREACHING_PATH = "/journey/ci-score-not-breaching";
     public static final String JOURNEY_FAIL_PATH = "/journey/fail";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
     public static final String JOURNEY_NEXT_PATH = "/journey/next";


### PR DESCRIPTION
## Proposed changes

- Change the journey event that the `ci-scoring` lambda emits on success from `/journey/next` to `/journey/ci-score-not-breaching`

### What changed

- Changed the journey event from `/journey/next` to `/journey/ci-score-not-breaching`
- Modify the statemachine to deal with the new name

### Issue tracking

- [PYIC-3395](https://govukverify.atlassian.net/browse/PYIC-3395)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Testing

- Follow the flow in [PYIC-3283](https://govukverify.atlassian.net/browse/PYIC-3283) > "Outcome"

[PYIC-3395]: https://govukverify.atlassian.net/browse/PYIC-3395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PYIC-3283]: https://govukverify.atlassian.net/browse/PYIC-3283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ