### PR TITLE
PYIC-3581: Include mitigation details in audit event

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2275,6 +2275,8 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
         - SSMParameterReadPolicy:

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -122,7 +122,8 @@ public class BuildCriOauthRequestHandler
         this.criOAuthSessionService = new CriOAuthSessionService(criConfigService);
         this.clientOAuthSessionDetailsService =
                 new ClientOAuthSessionDetailsService(criConfigService);
-        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(new ConfigService());
+        this.gpg45ProfileEvaluator =
+                new Gpg45ProfileEvaluator(new ConfigService(), ipvSessionService);
         VcHelper.setConfigService(this.criConfigService);
     }
 

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -141,16 +141,19 @@ public class BuildUserIdentityHandler
                     userIdentityService.generateUserIdentity(
                             userId, userId, ipvSessionItem.getVot());
 
+            boolean hasMitigations = false;
             if (configService.enabled(CoreFeatureFlag.USE_CONTRA_INDICATOR_VC)
                     && configService.enabled(CoreFeatureFlag.BUNDLE_CIMIT_VC)) {
                 SignedJWT signedCiMitJwt =
                         ciMitService.getContraIndicatorsVCJwt(
                                 userId, clientOAuthSessionItem.getGovukSigninJourneyId(), null);
                 userIdentity.getVcs().add(signedCiMitJwt.serialize());
+                hasMitigations = ciMitService.getContraIndicators(signedCiMitJwt).hasMitigations();
             }
 
             AuditExtensionsUserIdentity extensions =
-                    new AuditExtensionsUserIdentity(ipvSessionItem.getVot());
+                    new AuditExtensionsUserIdentity(
+                            ipvSessionItem.getVot(), ipvSessionItem.isCiFail(), hasMitigations);
 
             auditService.sendAuditEvent(
                     new AuditEvent(

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -124,7 +124,7 @@ public class CheckExistingIdentityHandler
         this.configService = new ConfigService();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
-        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService);
+        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService, ipvSessionService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.criResponseService = new CriResponseService(configService);

--- a/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
+++ b/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
@@ -72,8 +72,8 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
     public CheckGpg45ScoreHandler() {
         this.configService = new ConfigService();
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
-        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService);
         this.ipvSessionService = new IpvSessionService(configService);
+        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService, ipvSessionService);
         this.userIdentityService = new UserIdentityService(configService);
 
         componentId = configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID);

--- a/lambdas/ci-scoring/src/test/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandlerTest.java
+++ b/lambdas/ci-scoring/src/test/java/uk/gov/di/ipv/core/ciscoring/CiScoringHandlerTest.java
@@ -230,10 +230,10 @@ class CiScoringHandlerTest {
             throws UnrecognisedCiException, ConfigException {
         if (useContraIndicatorVC) {
             when(gpg45ProfileEvaluator.getJourneyResponseForStoredContraIndicators(
-                            any(), eq(separateSession)))
+                            any(), eq(separateSession), any()))
                     .thenReturn(mockResponse);
         } else {
-            when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any()))
+            when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), any()))
                     .thenReturn(mockResponse);
         }
     }
@@ -242,10 +242,11 @@ class CiScoringHandlerTest {
             throws UnrecognisedCiException, ConfigException {
         if (useContraIndicatorVC) {
             when(gpg45ProfileEvaluator.getJourneyResponseForStoredContraIndicators(
-                            any(), anyBoolean()))
+                            any(), anyBoolean(), any()))
                     .thenThrow(exception);
         } else {
-            when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any())).thenThrow(exception);
+            when(gpg45ProfileEvaluator.getJourneyResponseForStoredCis(any(), any()))
+                    .thenThrow(exception);
         }
     }
 }

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -108,7 +108,7 @@ public class EvaluateGpg45ScoresHandler
         this.configService = new ConfigService();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
-        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService);
+        this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator(configService, ipvSessionService);
         this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         VcHelper.setConfigService(this.configService);

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsUserIdentity.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsUserIdentity.java
@@ -1,17 +1,19 @@
 package uk.gov.di.ipv.core.library.auditing.extension;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @ExcludeFromGeneratedCoverageReport
 @Getter
 public class AuditExtensionsUserIdentity implements AuditExtensions {
-    @JsonProperty("levelOfConfidence")
     private final String levelOfConfidence;
+    private final boolean ciFail;
+    private final boolean hasMitigations;
 
     public AuditExtensionsUserIdentity(
-            @JsonProperty(value = "levelOfConfidence") String levelOfConfidence) {
+            String levelOfConfidence, boolean ciFail, boolean hasMitigations) {
         this.levelOfConfidence = levelOfConfidence;
+        this.ciFail = ciFail;
+        this.hasMitigations = hasMitigations;
     }
 }

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -145,9 +145,13 @@ public class CiMitService {
             String userId, String govukSigninJourneyId, String ipAddress)
             throws CiRetrievalException {
         SignedJWT ciSignedJWT = getContraIndicatorsVCJwt(userId, govukSigninJourneyId, ipAddress);
-        EvidenceItem contraIndicatorEvidence = parseContraIndicatorEvidence(ciSignedJWT);
 
-        return mapToContraIndicators(contraIndicatorEvidence);
+        return getContraIndicators(ciSignedJWT);
+    }
+
+    public ContraIndicators getContraIndicators(SignedJWT contraIndicatorsVc)
+            throws CiRetrievalException {
+        return mapToContraIndicators(parseContraIndicatorEvidence(contraIndicatorsVc));
     }
 
     public SignedJWT getContraIndicatorsVCJwt(
@@ -182,7 +186,7 @@ public class CiMitService {
                                 gson.toJson(
                                         new GetCiRequest(govukSigninJourneyId, ipAddress, userId)));
 
-        InvokeResult result = null;
+        InvokeResult result;
         try {
             result = lambdaClient.invoke(request);
         } catch (AWSLambdaException awsLEx) {

--- a/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CiMitServiceTest.java
+++ b/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CiMitServiceTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -428,6 +429,15 @@ class CiMitServiceTest {
                 () ->
                         ciMitService.getContraIndicatorsVC(
                                 TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
+    }
+
+    @Test
+    void getContraIndicatorsReturnsContraIndicatorsFromSignedJwt() throws Exception {
+        SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC);
+        ContraIndicators contraIndicators =
+                ciMitService.getContraIndicators(SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC));
+
+        assertTrue(contraIndicators.hasMitigations());
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicators.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicators.java
@@ -19,6 +19,25 @@ import java.util.Set;
 public class ContraIndicators {
     private final Map<String, ContraIndicator> contraIndicatorsMap;
 
+    public Integer getContraIndicatorScore(
+            final Map<String, ContraIndicatorScore> contraIndicatorScores,
+            final boolean includeMitigation)
+            throws UnrecognisedCiException {
+        validateContraIndicators(contraIndicatorScores);
+        return calculateDetectedScore(contraIndicatorScores)
+                + (includeMitigation ? calculateCheckedScore(contraIndicatorScores) : 0);
+    }
+
+    public Optional<ContraIndicator> getLatestContraIndicator() {
+        return contraIndicatorsMap.values().stream()
+                .max(Comparator.comparing(ContraIndicator::getIssuanceDate));
+    }
+
+    public boolean hasMitigations() {
+        return contraIndicatorsMap.values().stream()
+                .anyMatch(ci -> ci.getMitigation() != null && !ci.getMitigation().isEmpty());
+    }
+
     private void validateContraIndicators(
             final Map<String, ContraIndicatorScore> contraIndicatorScores)
             throws UnrecognisedCiException {
@@ -53,19 +72,5 @@ public class ContraIndicators {
                                         .get(contraIndicator.getCode())
                                         .getCheckedScore())
                 .reduce(0, Integer::sum);
-    }
-
-    public Integer getContraIndicatorScore(
-            final Map<String, ContraIndicatorScore> contraIndicatorScores,
-            final boolean includeMitigation)
-            throws UnrecognisedCiException {
-        validateContraIndicators(contraIndicatorScores);
-        return calculateDetectedScore(contraIndicatorScores)
-                + (includeMitigation ? calculateCheckedScore(contraIndicatorScores) : 0);
-    }
-
-    public Optional<ContraIndicator> getLatestContraIndicator() {
-        return contraIndicatorsMap.values().stream()
-                .max(Comparator.comparing(ContraIndicator::getIssuanceDate));
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -40,6 +40,7 @@ public class IpvSessionItem implements DynamodbItem {
     private List<ContraIndicatorMitigationDetailsDto> contraIndicatorMitigationDetails;
     private String emailAddress;
     private List<RequiredGpg45ScoresDto> requiredGpg45Scores;
+    private boolean ciFail;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorsTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorsTest.java
@@ -111,6 +111,22 @@ class ContraIndicatorsTest {
                 () -> contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP, true));
     }
 
+    @Test
+    void hasMitigationsShouldReturnTrueIfMitigationsExist() {
+        addContraIndicators(TEST_CI1, BASE_TIME, null);
+        addContraIndicators(TEST_CI2, BASE_TIME, null);
+        addContraIndicators(TEST_CI3, BASE_TIME, List.of(Mitigation.builder().build()));
+        assertTrue(contraIndicators.hasMitigations());
+    }
+
+    @Test
+    void hasMitigationsShouldReturnFalseIfNoMitigationsExist() {
+        addContraIndicators(TEST_CI1, BASE_TIME, null);
+        addContraIndicators(TEST_CI2, BASE_TIME, null);
+        addContraIndicators(TEST_CI3, BASE_TIME, null);
+        assertFalse(contraIndicators.hasMitigations());
+    }
+
     private void addContraIndicators(
             final String code, Instant issuanceDate, List<Mitigation> mitigations) {
         ContraIndicator contraIndicator =


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Include mitigation details in audit event

### Why did it change

This adds a couple of bits of info to the `IPV_IDENTITY_ISSUED` audit event issued in the build-user-identity handler. This idea is to allow us to track how successful the mitigations work has been. For all identities issued we'll be able to see if the user has a mitigation. We'll also be able to see if they were breaching the CI threshold.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3581](https://govukverify.atlassian.net/browse/PYIC-3581)


[PYIC-3581]: https://govukverify.atlassian.net/browse/PYIC-3581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Sample audit events from our stub queue
#### Straight through success
```
{
    "event_name": "IPV_IDENTITY_ISSUED",
    "component_id": "https://dev-chrisw.01.dev.identity.account.gov.uk",
    "user": {
        "user_id": "urn:uuid:8123620e-a8b2-4b0d-950c-dbbb0b5ae263",
        "session_id": "AIrR-pl6jKRdi_vkgEd9loTDcd7UcDglPvMtaLJBIeE",
        "govuk_signin_journey_id": "47ca8cd7-aec2-4a77-b9ef-1973ef7ceca0",
        "ip_address": null
    },
    "extensions": {
        "levelOfConfidence": "P2",
        "ciFail": false,
        "hasMitigations": false
    },
    "timestamp": 1695132966
}
```
#### Existing identity (as above)
```
{
    "event_name": "IPV_IDENTITY_ISSUED",
    "component_id": "https://dev-chrisw.01.dev.identity.account.gov.uk",
    "user": {
        "user_id": "urn:uuid:8123620e-a8b2-4b0d-950c-dbbb0b5ae263",
        "session_id": "bI5Zn9RQatK2vkJqRQ-5UzJWxLbf2OD1DB_S07ERfPM",
        "govuk_signin_journey_id": "2140f35c-cd1a-44ea-ba8b-4bd879101f95",
        "ip_address": null
    },
    "extensions": {
        "levelOfConfidence": "P2",
        "ciFail": false,
        "hasMitigations": false
    },
    "timestamp": 1695133723
}
```
#### Failure with a CI
```
{
    "event_name": "IPV_IDENTITY_ISSUED",
    "component_id": "https://dev-chrisw.01.dev.identity.account.gov.uk",
    "user": {
        "user_id": "f2829474-6580-44bc-ae2c-042a1927f540",
        "session_id": "RJVZD8xFmmX_W95321u4lO67dXP6B7SsS2o1GNkNueQ",
        "govuk_signin_journey_id": "de17fb58-0909-4fd2-87ff-f5d3602c9443",
        "ip_address": null
    },
    "extensions": {
        "levelOfConfidence": "P0",
        "ciFail": true,
        "hasMitigations": false
    },
    "timestamp": 1695133591
}
```
#### Mitigating the previous failure
```
{
    "event_name": "IPV_IDENTITY_ISSUED",
    "component_id": "https://dev-chrisw.01.dev.identity.account.gov.uk",
    "user": {
        "user_id": "f2829474-6580-44bc-ae2c-042a1927f540",
        "session_id": "HpqSjeZp44O8sJJQHWj0VI0DfF5m_ILe-wPD4tXonRI",
        "govuk_signin_journey_id": "3d79e031-2f5e-4c0a-a7b3-035846a01458",
        "ip_address": null
    },
    "extensions": {
        "levelOfConfidence": "P2",
        "ciFail": false,
        "hasMitigations": true
    },
    "timestamp": 1695133659
}
```

