### PR TITLE
BAU: Fix same session bug with journey map

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -517,6 +517,8 @@ MITIGATION_01_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
+    mitigation02:
+      targetState: PYI_ANOTHER_WAY
 
 # Mitigation journey (02)
 MITIGATION_02_OPTIONS:
@@ -554,6 +556,8 @@ MITIGATION_02_CRI_DCMAW:
     temporarily-unavailable:
       targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
+      targetState: PYI_ANOTHER_WAY
+    mitigation02:
       targetState: PYI_ANOTHER_WAY
 
 MITIGATION_02_POST_DCMAW_SUCCESS_PAGE:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix same session bug with journey map

### Why did it change

Enabling same session mitigations introduces a bug in separate and same session mitigation.

The way we activate separate session mitigation is by updating the CiMit config to send a user on a mitigation journey for same session, rather than failing them.

This means that if a user is at DCMAW on a mitigation journey (same or separate), and gets a failed response with no CIs, we attempt to send them back on the same session mitigation journey. This is because they still have the CI that needs mitigating and they still have a breaching score due to no mitigation check score being in place.

Attempting to send them on this journey fails as we don't define that event on the dcmaw mitigation states.

This scenario is the same as the thin file scenario. In DCMAW a user can get this by failing the liveness likeness check.

This fixes the immediate bug by updating the journey map to handle the mitigation event on the mitigation state. This is more of a band aid than a proper fix.
