### PR TITLE
PYIC-3298: Remove cimitService.getCis

### DIFF
--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.cimit.domain.GetCiRequest;
-import uk.gov.di.ipv.core.library.cimit.domain.GetCiResponse;
 import uk.gov.di.ipv.core.library.cimit.domain.PostCiMitigationRequest;
 import uk.gov.di.ipv.core.library.cimit.domain.PutCiRequest;
 import uk.gov.di.ipv.core.library.cimit.dto.ContraIndicatorCredentialDto;
@@ -24,7 +23,6 @@ import uk.gov.di.ipv.core.library.cimit.exception.CiPutException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.cimitvc.CiMitJwt;
@@ -46,7 +44,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN;
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CI_STORAGE_GET_LAMBDA_ARN;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CI_STORAGE_PUT_LAMBDA_ARN;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR;
@@ -124,21 +121,6 @@ public class CiMitService {
             logLambdaExecutionError(result, CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN);
             throw new CiPostMitigationsException(FAILED_LAMBDA_MESSAGE);
         }
-    }
-
-    public List<ContraIndicatorItem> getCIs(
-            String userId, String govukSigninJourneyId, String ipAddress)
-            throws CiRetrievalException {
-        InvokeResult result =
-                invokeClientToGetCIResult(
-                        CI_STORAGE_GET_LAMBDA_ARN,
-                        govukSigninJourneyId,
-                        ipAddress,
-                        userId,
-                        "Retrieving CIs from CIMIT.");
-        String jsonResponse = new String(result.getPayload().array(), StandardCharsets.UTF_8);
-        GetCiResponse response = gson.fromJson(jsonResponse, GetCiResponse.class);
-        return response.getContraIndicators();
     }
 
     public ContraIndicators getContraIndicatorsVC(


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove cimitService.getCis

### Why did it change

We no longer use this method anywhere as we've migrated over to using the VC endpoint. Yank it all out and put it in the bin.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3298](https://govukverify.atlassian.net/browse/PYIC-3298)


[PYIC-3298]: https://govukverify.atlassian.net/browse/PYIC-3298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ