### PR TITLE
BAU: Remove unused state from journey map

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -547,8 +547,6 @@ MITIGATION_02_CRI_DCMAW:
     criId: dcmaw
   parent: CRI_STATE
   events:
-    next:
-      targetState: MITIGATION_02_POST_DCMAW_SUCCESS_PAGE
     not-found:
       targetState: PYI_NO_MATCH
     access-denied:
@@ -559,13 +557,3 @@ MITIGATION_02_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     mitigation02:
       targetState: PYI_ANOTHER_WAY
-
-MITIGATION_02_POST_DCMAW_SUCCESS_PAGE:
-  response:
-    type: page
-    pageId: page-dcmaw-success
-  events:
-    end:
-      targetState: IPV_SUCCESS_PAGE
-    next:
-      targetState: PYI_NO_MATCH


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove unused state from journey map

### Why did it change

The `MITIGATION_02_POST_DCMAW_SUCCESS_PAGE` is not needed. The content in it is not appropriate as it mentions going on to provide your address and complete a fraud check. At this point in the journey the user already has those things. Instead we should just show them the success page.

Thankfully the page was plumed in wrong and was being skipped - the user was taken straight to the success page.

This removes it in from the journey map. It also removes the `next` event from the `MITIGATION_02_CRI_DCMAW` state. This is because the actual event provided on a successful mitigation in DCMAW is `end`. This is defined on the parent `CRI_STATE` state. This is the reason that we were skipping the unnecessary page in the first place.
