### PR TITLE
BAU: Write the session after setting VOT

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -246,6 +246,7 @@ public class EvaluateGpg45ScoresHandler
                             credentials,
                             ipAddress));
             ipvSessionItem.setVot(VOT_P2);
+            ipvSessionService.updateIpvSession(ipvSessionItem);
 
             LOGGER.info(
                     new StringMapMessage()

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -196,7 +197,8 @@ class EvaluateGpg45ScoresHandlerTest {
         assertEquals(JOURNEY_END.getJourney(), response.getJourney());
         verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
 
-        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+        verify(ipvSessionService, atLeast(1))
+                .updateIpvSession(ipvSessionItemArgumentCaptor.capture());
         IpvSessionItem updatedSessionItem = ipvSessionItemArgumentCaptor.getValue();
 
         List<VcStatusDto> currentVcStatuses = updatedSessionItem.getCurrentVcStatuses();
@@ -249,7 +251,8 @@ class EvaluateGpg45ScoresHandlerTest {
         verify(userIdentityService).getUserIssuedCredentials(TEST_USER_ID);
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
 
-        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+        verify(ipvSessionService, atLeast(1))
+                .updateIpvSession(ipvSessionItemArgumentCaptor.capture());
         assertEquals(VOT_P2, ipvSessionItemArgumentCaptor.getValue().getVot());
     }
 
@@ -481,7 +484,8 @@ class EvaluateGpg45ScoresHandlerTest {
         assertEquals(ErrorResponse.FAILED_TO_FIND_VISITED_CRI.getCode(), response.getCode());
         assertEquals(ErrorResponse.FAILED_TO_FIND_VISITED_CRI.getMessage(), response.getMessage());
 
-        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+        verify(ipvSessionService, atLeast(1))
+                .updateIpvSession(ipvSessionItemArgumentCaptor.capture());
         assertNull(ipvSessionItemArgumentCaptor.getValue().getVot());
     }
 
@@ -529,7 +533,8 @@ class EvaluateGpg45ScoresHandlerTest {
                 extension.getVcTxnIds());
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
 
-        verify(ipvSessionService).updateIpvSession(ipvSessionItemArgumentCaptor.capture());
+        verify(ipvSessionService, atLeast(1))
+                .updateIpvSession(ipvSessionItemArgumentCaptor.capture());
         assertEquals(VOT_P2, ipvSessionItemArgumentCaptor.getValue().getVot());
     }
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Write the session to the database after we update the VOT.

### Why did it change

A previous update moved the order of some calls so that the session was no longer being written after setting the vot when a profile was matched. This change adds writing the session to the database after setting the vot.

We should look to refactor this code to make it clearer what the sequence of events and session writing clearer to avoid similar issues in the future.
