### PR TITLE
PYIC-3532: Shared Audit data - Milliseconds event timestamping

### DIFF
--- a/lambdas/delete-user-data/src/utils/send-audit-event.ts
+++ b/lambdas/delete-user-data/src/utils/send-audit-event.ts
@@ -18,8 +18,10 @@ export const sendAuditEvent = async (
   logger.info("Sending audit event", { event: { name: eventName } });
   try {
     const componentId = await getConfigParam("core/self/componentId");
+    const now = Date.now();
     const auditEvent: AuditEvent = {
-      timestamp: Math.trunc(Date.now() / 1000),
+      timestamp: Math.floor(now / 1000),
+      event_timestamp_ms: now;
       component_id: componentId,
       event_name: eventName,
       user,

--- a/lambdas/delete-user-data/src/utils/send-audit-event.ts
+++ b/lambdas/delete-user-data/src/utils/send-audit-event.ts
@@ -21,7 +21,7 @@ export const sendAuditEvent = async (
     const now = Date.now();
     const auditEvent: AuditEvent = {
       timestamp: Math.floor(now / 1000),
-      event_timestamp_ms: now;
+      event_timestamp_ms: now,
       component_id: componentId,
       event_name: eventName,
       user,

--- a/lambdas/delete-user-data/tests/utils/send-audit-event.test.ts
+++ b/lambdas/delete-user-data/tests/utils/send-audit-event.test.ts
@@ -42,8 +42,10 @@ describe("sendAuditEvent", () => {
   });
 
   test("sends audit event to SQS queue", async () => {
+    const mockNow = Date.now();
     const expectedAuditEvent = {
-      timestamp: Math.trunc(Date.now() / 1000),
+      timestamp: Math.floor(mockNow / 1000),
+      event_timestamp_ms: mockNow,
       component_id: mockComponentId,
       event_name: mockAuditEventName,
       user: mockAuditUser,

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEvent.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEvent.java
@@ -14,6 +14,9 @@ import java.time.Instant;
 public class AuditEvent {
     @JsonProperty private final long timestamp;
 
+    @JsonProperty("event_timestamp_ms")
+    private final long timestampMs;
+
     @JsonProperty("event_name")
     private final AuditEventTypes eventName;
 
@@ -37,7 +40,9 @@ public class AuditEvent {
             @JsonProperty(value = "user", required = false) AuditEventUser user,
             @JsonProperty(value = "extensions", required = false) AuditExtensions extensions,
             @JsonProperty(value = "restricted", required = false) AuditRestricted restricted) {
-        this.timestamp = Instant.now().getEpochSecond();
+        Instant now = Instant.now();
+        this.timestamp = now.getEpochSecond();
+        this.timestampMs = now.toEpochMilli();
         this.eventName = eventName;
         this.componentId = componentId;
         this.user = user;

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionGpg45ProfileMatchedTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionGpg45ProfileMatchedTest.java
@@ -79,6 +79,8 @@ class AuditExtensionGpg45ProfileMatchedTest {
                         + "\"vcTxnIds\":[\"txn1\",\"txn2\",\"txn3\"]"
                         + "},"
                         + "\"timestamp\":1666170506"
+                        + ","
+                        + "\"event_timestamp_ms\":1666170506000"
                         + "}";
 
         assertEquals(expected, om.writeValueAsString(auditEvent));

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionGpg45ProfileMatchedTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionGpg45ProfileMatchedTest.java
@@ -30,7 +30,7 @@ class AuditExtensionGpg45ProfileMatchedTest {
         clockMock = mockStatic(Clock.class);
         Clock spyClock = spy(Clock.class);
         clockMock.when(Clock::systemUTC).thenReturn(spyClock);
-        Instant instantValue = Instant.ofEpochSecond(1666170506);
+        Instant instantValue = Instant.ofEpochMilli(1666170506321);
         when(spyClock.instant()).thenReturn(instantValue);
         when(spyClock.instant().now()).thenReturn(instantValue);
     }
@@ -80,7 +80,7 @@ class AuditExtensionGpg45ProfileMatchedTest {
                         + "},"
                         + "\"timestamp\":1666170506"
                         + ","
-                        + "\"event_timestamp_ms\":1666170506000"
+                        + "\"event_timestamp_ms\":1666170506321"
                         + "}";
 
         assertEquals(expected, om.writeValueAsString(auditEvent));

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionGpg45ProfileMatchedTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionGpg45ProfileMatchedTest.java
@@ -30,7 +30,7 @@ class AuditExtensionGpg45ProfileMatchedTest {
         clockMock = mockStatic(Clock.class);
         Clock spyClock = spy(Clock.class);
         clockMock.when(Clock::systemUTC).thenReturn(spyClock);
-        Instant instantValue = Instant.ofEpochMilli(1666170506321);
+        Instant instantValue = Instant.ofEpochMilli(1666170506321L);
         when(spyClock.instant()).thenReturn(instantValue);
         when(spyClock.instant().now()).thenReturn(instantValue);
     }


### PR DESCRIPTION
Shared Audit data - Milliseconds event timestamping

## Proposed changes

### What changed

`event_timestamp_ms` field added to all audit events

### Why did it change

meet HMRCs shared signal millisecond requirement

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3532](https://govukverify.atlassian.net/browse/PYIC-3532)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3532]: https://govukverify.atlassian.net/browse/PYIC-3532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ