### PR TITLE
PYIC-3635: Accept legacy and new cimit config

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -56,6 +56,8 @@ INITIAL_CI_SCORING:
       targetState: ERROR
     mitigation01:
       targetState: MITIGATION_01
+    enhanced-verification:
+      targetState: MITIGATION_01
 
 CHECK_EXISTING_IDENTITY:
   response:
@@ -78,8 +80,6 @@ CHECK_EXISTING_IDENTITY:
       targetState: PYI_F2F_TECHNICAL
     error:
       targetState: ERROR
-    mitigation01:
-      targetState: MITIGATION_01
 
 RESET_IDENTITY:
   response:
@@ -326,6 +326,8 @@ CRI_KBV_J2:
           targetState: PYI_CRI_ESCAPE_NO_F2F
     mitigation02:
       targetState: MITIGATION_02_OPTIONS
+    enhanced-verification:
+      targetState: MITIGATION_02_OPTIONS
 
 # Driving licence journey (J3)
 CRI_DRIVING_LICENCE_J3:
@@ -385,6 +387,8 @@ CRI_KBV_J3:
     next:
       targetState: PYI_NO_MATCH
     mitigation02:
+      targetState: MITIGATION_02_OPTIONS
+    enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
 
 # F2F journey (J4)
@@ -519,6 +523,8 @@ MITIGATION_01_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     mitigation02:
       targetState: PYI_ANOTHER_WAY
+    enhanced-verification:
+      targetState: PYI_ANOTHER_WAY
 
 # Mitigation journey (02)
 MITIGATION_02_OPTIONS:
@@ -556,4 +562,6 @@ MITIGATION_02_CRI_DCMAW:
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
     mitigation02:
+      targetState: PYI_ANOTHER_WAY
+    enhanced-verification:
       targetState: PYI_ANOTHER_WAY

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -316,14 +316,24 @@ public class ConfigService {
         }
     }
 
-    public Map<String, ContraIndicatorMitigation> getCiMitConfig() throws ConfigException {
-        final String ciMitConfig = getSsmParameter(ConfigurationVariable.CIMIT_CONFIG);
+    public Map<String, ContraIndicatorMitigation> getLegacyCimitConfig() throws ConfigException {
+        final String cimitConfig = getSsmParameter(ConfigurationVariable.CIMIT_CONFIG);
         try {
             return objectMapper.readValue(
-                    ciMitConfig,
+                    cimitConfig,
                     new TypeReference<HashMap<String, ContraIndicatorMitigation>>() {});
         } catch (JsonProcessingException e) {
-            throw new ConfigException("Failed to parse CIMIT configuration");
+            throw new ConfigException("Failed to parse legacy CIMit configuration");
+        }
+    }
+
+    public Map<String, String> getCimitConfig() throws ConfigException {
+        final String cimitConfig = getSsmParameter(ConfigurationVariable.CIMIT_CONFIG);
+        try {
+            return objectMapper.readValue(
+                    cimitConfig, new TypeReference<HashMap<String, String>>() {});
+        } catch (JsonProcessingException e) {
+            throw new ConfigException("Failed to parse CIMit configuration");
         }
     }
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -787,7 +787,7 @@ class ConfigServiceTest {
     }
 
     @Test
-    void shouldFetchCiMitConfig() throws ConfigException {
+    void shouldFetchLegacyCimitConfig() throws ConfigException {
         environmentVariables.set("ENVIRONMENT", "test");
         when(ssmProvider.get("/test/core/cimit/config"))
                 .thenReturn(
@@ -805,14 +805,30 @@ class ConfigServiceTest {
                                 .separateSessionStep("/journey/j2")
                                 .mitigatingCredentialIssuers(List.of("cri1"))
                                 .build());
-        assertEquals(expectedCiMitConfig, configService.getCiMitConfig());
+        assertEquals(expectedCiMitConfig, configService.getLegacyCimitConfig());
     }
 
     @Test
-    void shouldThrowErrorOnInvalidCiMitConfig() {
+    void shouldFetchCimitConfig() throws ConfigException {
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/cimit/config"))
+                .thenReturn("{\"X01\":\"/journey/do-a-thing\"}");
+        Map<String, String> expectedCiMitConfig = Map.of("X01", "/journey/do-a-thing");
+        assertEquals(expectedCiMitConfig, configService.getCimitConfig());
+    }
+
+    @Test
+    void shouldThrowErrorOnInvalidLegacyCimitConfig() {
         environmentVariables.set("ENVIRONMENT", "test");
         when(ssmProvider.get("/test/core/cimit/config")).thenReturn("}");
-        assertThrows(ConfigException.class, () -> configService.getCiMitConfig());
+        assertThrows(ConfigException.class, () -> configService.getLegacyCimitConfig());
+    }
+
+    @Test
+    void shouldThrowErrorOnInvalidCimitConfig() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/cimit/config")).thenReturn("}");
+        assertThrows(ConfigException.class, () -> configService.getCimitConfig());
     }
 
     @Test

--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
@@ -8,9 +8,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorItem;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorMitigation;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.cimitvc.ContraIndicator;
@@ -33,25 +31,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.KBV_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CI_SCORE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_NO_OF_CI_ITEMS;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PYI_KBV_FAIL_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PYI_NO_MATCH_PATH;
 
 public class Gpg45ProfileEvaluator {
+    private static final Logger LOGGER = LogManager.getLogger();
     private static final JourneyResponse JOURNEY_RESPONSE_PYI_NO_MATCH =
             new JourneyResponse(JOURNEY_PYI_NO_MATCH_PATH);
-    private static final JourneyResponse JOURNEY_RESPONSE_PYI_KBV_FAIL =
-            new JourneyResponse(JOURNEY_PYI_KBV_FAIL_PATH);
-    private static final Logger LOGGER = LogManager.getLogger();
     private static final Gson gson = new Gson();
     private static final int NO_SCORE = 0;
     private final ConfigService configService;
@@ -113,57 +105,6 @@ public class Gpg45ProfileEvaluator {
         }
 
         return Optional.of(JOURNEY_RESPONSE_PYI_NO_MATCH);
-    }
-
-    public Optional<JourneyResponse> getJourneyResponseForStoredCis(
-            List<ContraIndicatorItem> ciItems, IpvSessionItem ipvSession)
-            throws UnrecognisedCiException {
-        List<ContraIndicatorItem> contraIndicatorItems = new ArrayList<>(ciItems);
-        LOGGER.info(
-                new StringMapMessage()
-                        .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "Retrieved user's CI items.")
-                        .with(LOG_NO_OF_CI_ITEMS.getFieldName(), ciItems.size()));
-
-        Set<String> ciSet =
-                contraIndicatorItems.stream()
-                        .map(ContraIndicatorItem::getCi)
-                        .collect(Collectors.toSet());
-
-        Map<String, ContraIndicatorScore> contraIndicatorScoresMap =
-                configService.getContraIndicatorScoresMap();
-
-        int ciScore = 0;
-        for (String ci : ciSet) {
-            if (!contraIndicatorScoresMap.containsKey(ci)) {
-                throw new UnrecognisedCiException("Unrecognised CI code received from CIMIT");
-            }
-            ContraIndicatorScore scoresConfig = contraIndicatorScoresMap.get(ci);
-            ciScore += scoresConfig.getDetectedScore();
-        }
-        LOGGER.info(
-                new StringMapMessage()
-                        .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "Calculated user's CI score.")
-                        .with(LOG_CI_SCORE.getFieldName(), ciScore));
-
-        int ciScoreThreshold =
-                Integer.parseInt(configService.getSsmParameter(CI_SCORING_THRESHOLD));
-        if (ciScore > ciScoreThreshold) {
-            ipvSession.setCiFail(true);
-            ipvSessionService.updateIpvSession(ipvSession);
-            Collections.sort(contraIndicatorItems);
-            String lastCiIssuer =
-                    contraIndicatorItems.get(contraIndicatorItems.size() - 1).getIss();
-            String kbvIssuer = configService.getComponentId(KBV_CRI);
-
-            return Optional.of(
-                    lastCiIssuer.equals(kbvIssuer)
-                            ? JOURNEY_RESPONSE_PYI_KBV_FAIL
-                            : JOURNEY_RESPONSE_PYI_NO_MATCH);
-        } else {
-            ipvSession.setCiFail(false);
-            ipvSessionService.updateIpvSession(ipvSession);
-            return Optional.empty();
-        }
     }
 
     public Optional<Gpg45Profile> getFirstMatchingProfile(

--- a/libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -62,8 +62,11 @@ class Gpg45ProfileEvaluatorTest {
             new JourneyResponse(JOURNEY_PYI_CI3_FAIL_SEPARATE_SESSION);
     private static final String JOURNEY_PYI_CI3_FAIL_SAME_SESSION =
             "/journey/pyi-ci3-fail-same-session";
+    private static final String JOURNEY_PYI_CI3_FAIL = "/journey/pyi-ci3-fail";
     private static final JourneyResponse JOURNEY_RESPONSE_PYI_CI3_FAIL_SAME_SESSION =
             new JourneyResponse(JOURNEY_PYI_CI3_FAIL_SAME_SESSION);
+    private static final JourneyResponse JOURNEY_RESPONSE_PYI_CI3_FAIL =
+            new JourneyResponse(JOURNEY_PYI_CI3_FAIL);
     @Mock ConfigService mockConfigService;
     @Mock IpvSessionService mockIpvSessionService;
     @Mock IpvSessionItem mockIpvSessionItem;
@@ -99,13 +102,16 @@ class Gpg45ProfileEvaluatorTest {
                     CI3,
                     new ContraIndicatorScore(CI3, 4, -3, null, Collections.emptyList()));
 
-    private static final Map<String, ContraIndicatorMitigation> TEST_CI_MITIGATION_CONFIG =
+    private static final Map<String, ContraIndicatorMitigation> TEST_CI_MITIGATION_LEGACY_CONFIG =
             Map.of(
                     CI3,
                     ContraIndicatorMitigation.builder()
                             .sameSessionStep(JOURNEY_PYI_CI3_FAIL_SAME_SESSION)
                             .separateSessionStep(JOURNEY_PYI_CI3_FAIL_SEPARATE_SESSION)
                             .build());
+
+    private static final Map<String, String> TEST_CI_MITIGATION_CONFIG =
+            Map.of(CI3, JOURNEY_PYI_CI3_FAIL);
 
     @Test
     void getFirstMatchingProfileShouldReturnSatisfiedProfile() {
@@ -482,8 +488,14 @@ class Gpg45ProfileEvaluatorTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
     }
 
-    private void setupMockContraIndicatorTreatmentConfig() throws ConfigException {
-        when(mockConfigService.getCiMitConfig()).thenReturn(TEST_CI_MITIGATION_CONFIG);
+    private void setupMockContraIndicatorTreatmentLegacyConfig() throws ConfigException {
+        when(mockConfigService.getLegacyCimitConfig()).thenReturn(TEST_CI_MITIGATION_LEGACY_CONFIG);
+    }
+
+    private void setupMockContraIndicatorMitigationConfig() throws ConfigException {
+        when(mockConfigService.getLegacyCimitConfig())
+                .thenThrow(new ConfigException("The config has changed"));
+        when(mockConfigService.getCimitConfig()).thenReturn(TEST_CI_MITIGATION_CONFIG);
     }
 
     @Nested
@@ -559,14 +571,30 @@ class Gpg45ProfileEvaluatorTest {
         }
 
         @Test
-        void
-                shouldReturnPyiNoMatchJourneyIfContraIndicatorsBreachThresholdAndNoConfigForLatestContraIndicator()
-                        throws ConfigException, UnrecognisedCiException {
+        void shouldReturnPyiNoMatchJourneyIfBreachingCIsAndNoLegacyConfigForLatestContraIndicator()
+                throws ConfigException, UnrecognisedCiException {
             final ContraIndicators contraIndications =
                     buildTestContraIndications(
                             new TestContraIndicator(CI3), new TestContraIndicator(CI1));
             setupMockContraIndicatorScoringConfig();
-            setupMockContraIndicatorTreatmentConfig();
+            setupMockContraIndicatorTreatmentLegacyConfig();
+            IpvSessionItem ipvSessionItem = new IpvSessionItem();
+            final Optional<JourneyResponse> journeyResponse =
+                    evaluator.getJourneyResponseForStoredContraIndicators(
+                            contraIndications, false, ipvSessionItem);
+            assertEquals(JOURNEY_RESPONSE_PYI_NO_MATCH, journeyResponse.get());
+            assertTrue(ipvSessionItem.isCiFail());
+            verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
+        }
+
+        @Test
+        void shouldReturnPyiNoMatchJourneyIfBreachingCIsAndNoConfigForLatestContraIndicator()
+                throws ConfigException, UnrecognisedCiException {
+            final ContraIndicators contraIndications =
+                    buildTestContraIndications(
+                            new TestContraIndicator(CI3), new TestContraIndicator(CI1));
+            setupMockContraIndicatorScoringConfig();
+            setupMockContraIndicatorMitigationConfig();
             IpvSessionItem ipvSessionItem = new IpvSessionItem();
             final Optional<JourneyResponse> journeyResponse =
                     evaluator.getJourneyResponseForStoredContraIndicators(
@@ -578,13 +606,13 @@ class Gpg45ProfileEvaluatorTest {
 
         @Test
         void
-                shouldReturnCustomSeparateSessionJourneyIfContraIndicatorsBreachThresholdAndConfigForLatestContraIndicator()
+                shouldReturnCustomSeparateSessionJourneyIfBreachingCIsAndLegacyConfigForLatestContraIndicator()
                         throws ConfigException, UnrecognisedCiException {
             final ContraIndicators contraIndications =
                     buildTestContraIndications(
                             new TestContraIndicator(CI1), new TestContraIndicator(CI3));
             setupMockContraIndicatorScoringConfig();
-            setupMockContraIndicatorTreatmentConfig();
+            setupMockContraIndicatorTreatmentLegacyConfig();
             IpvSessionItem ipvSessionItem = new IpvSessionItem();
             final Optional<JourneyResponse> journeyResponse =
                     evaluator.getJourneyResponseForStoredContraIndicators(
@@ -596,18 +624,35 @@ class Gpg45ProfileEvaluatorTest {
 
         @Test
         void
-                shouldReturnCustomSameSessionJourneyIfContraIndicatorsBreachThresholdAndConfigForLatestContraIndicator()
+                shouldReturnCustomSameSessionJourneyIfBeachingCIsAndLegacyConfigForLatestContraIndicator()
                         throws ConfigException, UnrecognisedCiException {
             final ContraIndicators contraIndications =
                     buildTestContraIndications(
                             new TestContraIndicator(CI1), new TestContraIndicator(CI3));
             setupMockContraIndicatorScoringConfig();
-            setupMockContraIndicatorTreatmentConfig();
+            setupMockContraIndicatorTreatmentLegacyConfig();
             IpvSessionItem ipvSessionItem = new IpvSessionItem();
             final Optional<JourneyResponse> journeyResponse =
                     evaluator.getJourneyResponseForStoredContraIndicators(
                             contraIndications, false, ipvSessionItem);
             assertEquals(JOURNEY_RESPONSE_PYI_CI3_FAIL_SAME_SESSION, journeyResponse.get());
+            assertTrue(ipvSessionItem.isCiFail());
+            verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
+        }
+
+        @Test
+        void shouldReturnMitigationJourneyIfBreachingCIsAndConfigForLatestContraIndicator()
+                throws ConfigException, UnrecognisedCiException {
+            final ContraIndicators contraIndications =
+                    buildTestContraIndications(
+                            new TestContraIndicator(CI1), new TestContraIndicator(CI3));
+            setupMockContraIndicatorScoringConfig();
+            setupMockContraIndicatorMitigationConfig();
+            IpvSessionItem ipvSessionItem = new IpvSessionItem();
+            final Optional<JourneyResponse> journeyResponse =
+                    evaluator.getJourneyResponseForStoredContraIndicators(
+                            contraIndications, false, ipvSessionItem);
+            assertEquals(JOURNEY_RESPONSE_PYI_CI3_FAIL, journeyResponse.get());
             assertTrue(ipvSessionItem.isCiFail());
             verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
         }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Accept legacy and new cimit config

### Why did it change

We want to simplify the way we configure the journey events for mitigation. This means not maintaining separate events for same and separate session.

We need to deploy this out in a way that won’t cause downtime.

First job is to allow core to handle both types of config.

This change will attempt to use the original config style and fall back to the new style if it can't (because the config has been updated).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3635](https://govukverify.atlassian.net/browse/PYIC-3635)


[PYIC-3635]: https://govukverify.atlassian.net/browse/PYIC-3635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ