### PR TITLE
PYIC-3638: Remove legacy cimit config code

### DIFF
--- a/lambdas/check-ci-score/src/main/java/uk/gov/di/ipv/core/checkciscore/CheckCiScoreHandler.java
+++ b/lambdas/check-ci-score/src/main/java/uk/gov/di/ipv/core/checkciscore/CheckCiScoreHandler.java
@@ -37,7 +37,6 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_P
 
 public class CheckCiScoreHandler implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final String USER_STATE_INITIAL_CI_SCORING = "INITIAL_CI_SCORING";
     private static final JourneyResponse JOURNEY_CI_SCORE_NOT_BREACHING =
             new JourneyResponse(JOURNEY_CI_SCORE_NOT_BREACHING_PATH);
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
@@ -95,7 +94,6 @@ public class CheckCiScoreHandler implements RequestHandler<JourneyRequest, Map<S
                                     clientOAuthSessionItem.getUserId(),
                                     govukSigninJourneyId,
                                     ipAddress),
-                            USER_STATE_INITIAL_CI_SCORING.equals(ipvSessionItem.getUserState()),
                             ipvSessionItem);
 
             if (contraIndicatorJourneyResponse.isPresent()) {

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -54,8 +54,6 @@ INITIAL_CI_SCORING:
       targetState: PYI_F2F_TECHNICAL
     error:
       targetState: ERROR
-    mitigation01:
-      targetState: MITIGATION_01
     enhanced-verification:
       targetState: MITIGATION_01
 
@@ -324,8 +322,6 @@ CRI_KBV_J2:
       checkIfDisabled:
         f2f:
           targetState: PYI_CRI_ESCAPE_NO_F2F
-    mitigation02:
-      targetState: MITIGATION_02_OPTIONS
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
 
@@ -386,8 +382,6 @@ CRI_KBV_J3:
           targetState: PYI_CRI_ESCAPE_NO_F2F
     next:
       targetState: PYI_NO_MATCH
-    mitigation02:
-      targetState: MITIGATION_02_OPTIONS
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
 
@@ -521,8 +515,6 @@ MITIGATION_01_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
-    mitigation02:
-      targetState: PYI_ANOTHER_WAY
     enhanced-verification:
       targetState: PYI_ANOTHER_WAY
 
@@ -560,8 +552,6 @@ MITIGATION_02_CRI_DCMAW:
     temporarily-unavailable:
       targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
-      targetState: PYI_ANOTHER_WAY
-    mitigation02:
       targetState: PYI_ANOTHER_WAY
     enhanced-verification:
       targetState: PYI_ANOTHER_WAY

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -21,7 +21,6 @@ import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.config.FeatureFlag;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorMitigation;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
@@ -313,17 +312,6 @@ public class ConfigService {
         } catch (JsonProcessingException e) {
             LOGGER.error("Failed to parse contra-indicator scoring config");
             return Collections.emptyMap();
-        }
-    }
-
-    public Map<String, ContraIndicatorMitigation> getLegacyCimitConfig() throws ConfigException {
-        final String cimitConfig = getSsmParameter(ConfigurationVariable.CIMIT_CONFIG);
-        try {
-            return objectMapper.readValue(
-                    cimitConfig,
-                    new TypeReference<HashMap<String, ContraIndicatorMitigation>>() {});
-        } catch (JsonProcessingException e) {
-            throw new ConfigException("Failed to parse legacy CIMit configuration");
         }
     }
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -24,7 +24,6 @@ import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.FeatureFlag;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorMitigation;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
@@ -39,7 +38,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
@@ -787,41 +785,12 @@ class ConfigServiceTest {
     }
 
     @Test
-    void shouldFetchLegacyCimitConfig() throws ConfigException {
-        environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/cimit/config"))
-                .thenReturn(
-                        "{\""
-                                + "X01\":{"
-                                + "\"sameSessionStep\":\"/journey/j1\","
-                                + "\"separateSessionStep\":\"/journey/j2\","
-                                + "\"mitigatingCredentialIssuers\":[\"cri1\"]"
-                                + "}}");
-        Map<String, ContraIndicatorMitigation> expectedCiMitConfig =
-                Map.of(
-                        "X01",
-                        ContraIndicatorMitigation.builder()
-                                .sameSessionStep("/journey/j1")
-                                .separateSessionStep("/journey/j2")
-                                .mitigatingCredentialIssuers(List.of("cri1"))
-                                .build());
-        assertEquals(expectedCiMitConfig, configService.getLegacyCimitConfig());
-    }
-
-    @Test
     void shouldFetchCimitConfig() throws ConfigException {
         environmentVariables.set("ENVIRONMENT", "test");
         when(ssmProvider.get("/test/core/cimit/config"))
                 .thenReturn("{\"X01\":\"/journey/do-a-thing\"}");
         Map<String, String> expectedCiMitConfig = Map.of("X01", "/journey/do-a-thing");
         assertEquals(expectedCiMitConfig, configService.getCimitConfig());
-    }
-
-    @Test
-    void shouldThrowErrorOnInvalidLegacyCimitConfig() {
-        environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/cimit/config")).thenReturn("}");
-        assertThrows(ConfigException.class, () -> configService.getLegacyCimitConfig());
     }
 
     @Test


### PR DESCRIPTION
**Not to be merged before https://github.com/alphagov/di-ipv-core-common-infra/pull/713**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove legacy cimit config code

### Why did it change

We changed how we define the cimit config. Core was supporting both styles of cimit config.

We've now switched to just using the new version, so we can remove all the old legacy handling cruft.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3638](https://govukverify.atlassian.net/browse/PYIC-3638)


[PYIC-3638]: https://govukverify.atlassian.net/browse/PYIC-3638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ