### PR TITLE
PYIC-3617: Create common F2F CRI states

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -119,6 +119,22 @@ IPV_IDENTITY_START_PAGE:
         f2f:
           targetState: PYI_ANOTHER_WAY
 
+CRI_F2F:
+  response:
+    type: cri
+    criId: f2f
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: F2F_HANDOFF_PAGE
+    access-denied:
+      targetState: PYI_ANOTHER_WAY
+
+F2F_HANDOFF_PAGE:
+  response:
+    type: page
+    pageId: page-face-to-face-handoff
+
 PYI_ANOTHER_WAY:
   response:
     type: page
@@ -224,7 +240,7 @@ PYI_CRI_ESCAPE:
     dcmaw:
       targetState: CRI_DCMAW_J5
     f2f:
-      targetState: CRI_F2F_J5
+      targetState: CRI_F2F
     end:
       targetState: END
 
@@ -401,7 +417,7 @@ ADDRESS_AND_FRAUD_J4:
   nestedJourney: ADDRESS_AND_FRAUD
   exitEvents:
     next:
-      targetState: CRI_F2F_J4
+      targetState: CRI_F2F
 
 CRI_F2F_J4:
   response:
@@ -410,7 +426,7 @@ CRI_F2F_J4:
   parent: CRI_STATE
   events:
     next:
-      targetState: F2F_HANDOFF_PAGE_J4
+      targetState: F2F_HANDOFF_PAGE
     access-denied:
       targetState: PYI_ANOTHER_WAY
 
@@ -448,7 +464,7 @@ CRI_F2F_J5:
   parent: CRI_STATE
   events:
     next:
-      targetState: F2F_HANDOFF_PAGE_J5
+      targetState: F2F_HANDOFF_PAGE
     access-denied:
       targetState: PYI_ANOTHER_WAY
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Added in the common CRI and F2F states
- Redirect users to these, to continue normal flow
- This doesn't remove the old states, but does redirect from those states to the new ones: this allows us to remove those states after a period of time so all users can be assumed to be off those states

### Why did it change

- To commonise the f2f & cri states for J4 and J5

### Issue tracking

- [PYIC-3617](https://govukverify.atlassian.net/browse/PYIC-3617)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

[PYIC-3617]: https://govukverify.atlassian.net/browse/PYIC-3617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ