### PR TITLE
PYIC 3617: Remove redundant F2F CRI states (2nd deployment)

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -419,22 +419,6 @@ ADDRESS_AND_FRAUD_J4:
     next:
       targetState: CRI_F2F
 
-CRI_F2F_J4:
-  response:
-    type: cri
-    criId: f2f
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: F2F_HANDOFF_PAGE
-    access-denied:
-      targetState: PYI_ANOTHER_WAY
-
-F2F_HANDOFF_PAGE_J4:
-  response:
-    type: page
-    pageId: page-face-to-face-handoff
-
 # CRI escape journey (J5)
 CRI_DCMAW_J5:
   response:
@@ -456,22 +440,6 @@ POST_DCMAW_SUCCESS_PAGE_J5:
   events:
     next:
       targetState: IPV_SUCCESS_PAGE
-
-CRI_F2F_J5:
-  response:
-    type: cri
-    criId: f2f
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: F2F_HANDOFF_PAGE
-    access-denied:
-      targetState: PYI_ANOTHER_WAY
-
-F2F_HANDOFF_PAGE_J5:
-  response:
-    type: page
-    pageId: page-face-to-face-handoff
 
 # HMRC KBV journey (J6)
 CRI_NINO_J6:


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove old states:
  - CRI_F2F_J4
  - F2F_HANDOFF_PAGE_J4
  - CRI_F2F_J5
  - F2F_HANDOFF_PAGE_J5

### Why did it change

- After PYIC-3617-first-deployment, given 24hrs, we can assume no users are on these states now
- In that case, we should remove redundant states since all of the flow goes through the commonised states

### Issue tracking

- [PYIC-3617](https://govukverify.atlassian.net/browse/PYIC-3617)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


[PYIC-3617]: https://govukverify.atlassian.net/browse/PYIC-3617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ