### PR TITLE
PYIC-3609: Allow all options to be used

### DIFF
--- a/journey-map/public/index.html
+++ b/journey-map/public/index.html
@@ -40,7 +40,7 @@
             form select {
                 flex: 0 0 30%;
             }
-            span {
+            #checkbox-controls {
                 display: flex;
                 flex-direction: row;
                 justify-content: space-between;
@@ -51,7 +51,7 @@
         <div id="header">
             <h1>IPV Core Journey Map</h1>
             <form id="configuration-form">
-                <span>
+                <span id="checkbox-controls">
                     <fieldset id="disabledInput">
                         <legend>Disabled CRI:</legend>
                     </fieldset>
@@ -94,50 +94,30 @@
             const nestedResponse = await fetch('./nested-journey-definitions.yaml');
             const nestedJourneys = yaml.parse(await nestedResponse.text());
 
+            const setupOptions = (name, options, fieldset) => {
+                if (options.length) {
+                    options.forEach((option) => {
+                        const input = document.createElement('input');
+                        input.type = 'checkbox';
+                        input.name = name;
+                        input.value = option;
+                        input.id = option;
+
+                        const label = document.createElement('label');
+                        label.innerText = option;
+                        label.appendChild(input);
+
+                        fieldset.appendChild(label);
+                    });
+                } else {
+                    fieldset.append("N/A")
+                }
+            };
+
             // Set up the form options
             const { disabledOptions, featureFlagOptions } = getOptions(journeyMap);
-            if (disabledOptions.length > 0) {
-                disabledOptions.forEach((option) => {
-                    const input = document.createElement('input');
-                    input.type = 'checkbox';
-                    input.name = 'disabledCri';
-                    input.value = option;
-                    input.id = option;
-
-                    const label = document.createElement('label');
-                    label.htmlFor = option;
-                    label.innerText = option;
-
-                    const span = document.createElement('span');
-                    span.appendChild(label);
-                    span.appendChild(input);
-                    disabledInput.appendChild(span);
-                });
-            } else {
-                disabledInput.append("N/A")
-            }
-
-            if (featureFlagOptions.length > 0) {
-                featureFlagOptions.forEach((option) => {
-                    const input = document.createElement('input');
-                    input.type = 'checkbox';
-                    input.name = 'flag';
-                    input.value = option;
-                    input.id = option;
-
-                    const label = document.createElement('label');
-                    label.htmlFor = option;
-                    label.innerText = option;
-
-                    const span = document.createElement('span');
-                    span.appendChild(label);
-                    span.appendChild(input);
-                    featureFlagInput.appendChild(span)
-                });
-            } else {
-                featureFlagInput.append("N/A");
-            }
-
+            setupOptions('disabledCri', disabledOptions, disabledInput);
+            setupOptions('featureFlag', featureFlagOptions, featureFlagInput);
 
             // Render the journey map SVG
             const renderSvg = async (formData) => {

--- a/journey-map/public/index.html
+++ b/journey-map/public/index.html
@@ -24,7 +24,7 @@
                 height: 100%;
             }
             form {
-                width: 250px;
+                width: 260px;
                 margin-top: 16px;
                 display: flex;
                 flex-direction: column;
@@ -40,20 +40,25 @@
             form select {
                 flex: 0 0 30%;
             }
+            span {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-between;
+            }
         </style>
     </head>
     <body>
         <div id="header">
             <h1>IPV Core Journey Map</h1>
             <form id="configuration-form">
-                <label>
-                    <div>Disabled CRI:</div>
-                    <select id="disabledInput" name="disabled"></select>
-                </label>
-                <label>
-                    <div>Feature flag:</div>
-                    <select id="featureFlagInput" name="featureFlag"></select>
-                </label>
+                <span>
+                    <fieldset id="disabledInput">
+                        <legend>Disabled CRI:</legend>
+                    </fieldset>
+                    <fieldset id="featureFlagInput">
+                        <legend>Feature flag:</legend>
+                    </fieldset>
+                </span>
                 <label>
                     <div>Include errors:</div>
                     <input id="includeErrorsInput" name="includeErrors" type="checkbox">
@@ -91,23 +96,52 @@
 
             // Set up the form options
             const { disabledOptions, featureFlagOptions } = getOptions(journeyMap);
-            disabledOptions.forEach((option) => {
-                const element = document.createElement('option');
-                element.value = option;
-                element.innerText = option;
-                disabledInput.appendChild(element);
-            });
-            featureFlagOptions.forEach((option) => {
-                const element = document.createElement('option');
-                element.value = option;
-                element.innerText = option;
-                featureFlagInput.appendChild(element);
-            });
+            if (disabledOptions.length > 0) {
+                disabledOptions.forEach((option) => {
+                    const input = document.createElement('input');
+                    input.type = 'checkbox';
+                    input.name = 'disabledCri';
+                    input.value = option;
+                    input.id = option;
+
+                    const label = document.createElement('label');
+                    label.htmlFor = option;
+                    label.innerText = option;
+
+                    const span = document.createElement('span');
+                    span.appendChild(label);
+                    span.appendChild(input);
+                    disabledInput.appendChild(span);
+                });
+            } else {
+                disabledInput.append("N/A")
+            }
+
+            if (featureFlagOptions.length > 0) {
+                featureFlagOptions.forEach((option) => {
+                    const input = document.createElement('input');
+                    input.type = 'checkbox';
+                    input.name = 'flag';
+                    input.value = option;
+                    input.id = option;
+
+                    const label = document.createElement('label');
+                    label.htmlFor = option;
+                    label.innerText = option;
+
+                    const span = document.createElement('span');
+                    span.appendChild(label);
+                    span.appendChild(input);
+                    featureFlagInput.appendChild(span)
+                });
+            } else {
+                featureFlagInput.append("N/A");
+            }
+
 
             // Render the journey map SVG
             const renderSvg = async (formData) => {
-                const options = Object.fromEntries(formData || []);
-                const diagram = render(journeyMap, nestedJourneys, options);
+                const diagram = render(journeyMap, nestedJourneys, formData);
                 const diagramElement = document.getElementById('diagram');
                 const { svg } = await mermaid.render('diagramSvg', diagram);
                 diagramElement.innerHTML = svg;

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -42,6 +42,12 @@ INITIAL_CI_SCORING:
   events:
     ci-score-not-breaching:
       targetState: CHECK_EXISTING_IDENTITY
+      checkFeatureFlag:
+        sausages:
+          targetState: CRI_DCMAW
+          checkFeatureFlag:
+            bananas:
+              targetState: F2F_START_PAGE
     reuse:
       targetState: IPV_IDENTITY_REUSE_PAGE
     pending:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -42,12 +42,6 @@ INITIAL_CI_SCORING:
   events:
     ci-score-not-breaching:
       targetState: CHECK_EXISTING_IDENTITY
-      checkFeatureFlag:
-        sausages:
-          targetState: CRI_DCMAW
-          checkFeatureFlag:
-            bananas:
-              targetState: F2F_START_PAGE
     reuse:
       targetState: IPV_IDENTITY_REUSE_PAGE
     pending:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow all options to be used

### Why did it change

Updates the html and scripts to allow multiple CRIs to be disabled and multiple flags to be activated.

Updates the way the CRI and flag options are gathered by recursively checking the events. Setting a disabled or flag check in the journey map allows for events to be defined underneath it. These may have options not used at the top level else where.

Update to consider these sub events when resolving the target states. Previously we were only resolving the top level.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3609](https://govukverify.atlassian.net/browse/PYIC-3609)


[PYIC-3609]: https://govukverify.atlassian.net/browse/PYIC-3609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ