### PR TITLE
PYIC-3673: Add backendSessionTtl int & ISO parsing

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Expiry.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Expiry.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public class Expiry {
+    public final String iso8061;
+
+    public Expiry(String durationSecondsOrISO8061, Instant start) {
+        iso8061 = start.plusSeconds(this.toSeconds(durationSecondsOrISO8061)).toString();
+    }
+
+    private long toSeconds(String durationSecondsOrISO8061) {
+        try {
+            return Long.parseLong(durationSecondsOrISO8061);
+        } catch (NumberFormatException error) {
+            return Duration.parse(durationSecondsOrISO8061).toSeconds();
+        }
+    }
+
+    public long toEpochSeconds() {
+        return Instant.parse(iso8061).getEpochSecond();
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.Expiry;
 import uk.gov.di.ipv.core.library.persistence.item.DynamodbItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
@@ -62,9 +63,8 @@ public class DataStore<T extends DynamodbItem> {
 
     public void create(T item, ConfigurationVariable tableTtl) {
         item.setTtl(
-                Instant.now()
-                        .plusSeconds(Long.parseLong(configService.getSsmParameter(tableTtl)))
-                        .getEpochSecond());
+                new Expiry(configService.getSsmParameter(tableTtl), Instant.now())
+                        .toEpochSeconds());
         table.putItem(item);
     }
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistance/DataStoreTest.java
@@ -74,7 +74,7 @@ class DataStoreTest {
 
     @Test
     void shouldPutItemIntoDynamoDbTable() {
-        when(mockConfigService.getSsmParameter(BACKEND_SESSION_TTL)).thenReturn("7200");
+        when(mockConfigService.getSsmParameter(BACKEND_SESSION_TTL)).thenReturn("PT2H");
 
         dataStore.create(authorizationCodeItem, BACKEND_SESSION_TTL);
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -655,7 +655,7 @@ class ConfigServiceTest {
         BACKEND_SESSION_TIMEOUT(
                 "self/backendSessionTimeout", "7200", Map.of("FS02", "7300", "FS03", "7400")),
         BACKEND_SESSION_TTL(
-                "self/backendSessionTtl", "3600", Map.of("FS03", "3700", "FS04", "3800")),
+                "self/backendSessionTtl", "PT2H", Map.of("FS03", "3700", "FS04", "P2H")),
         CLIENT_VALID_REDIRECT_URLS(
                 "clients/aClientId/validRedirectUrls",
                 "one.example.com/callback,two.example.com/callback,three.example.com/callback",


### PR DESCRIPTION
## Proposed changes

### What changed

- Add parsing for new and old formats of backend session ttl durations
- Added Expiry class

### Why did it change

- We want ISO 8061 duration formats, so this allows us to change the value of the config value
- Expiry class allows us to centralise how we deal with expiry datetimes
  - There are many formats and different classes representing expiries - we can use this class to bring them together
- Config value only used when creating a data store item

### Issue tracking

- [PYIC-3673](https://govukverify.atlassian.net/browse/PYIC-3673)
- Parent: [PYIC-2491](https://govukverify.atlassian.net/browse/PYIC-2491)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed _in this repo_

### Other considerations

- [x] Might want to save ttl in the data store as ISO 8061 as well! If possible - will do after [spike](https://govukverify.atlassian.net/browse/PYIC-3686)


[PYIC-3673]: https://govukverify.atlassian.net/browse/PYIC-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-2491]: https://govukverify.atlassian.net/browse/PYIC-2491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ