### PR TITLE
BAU: Add debugging for core-front

### DIFF
--- a/local-running/README.md
+++ b/local-running/README.md
@@ -60,7 +60,7 @@ noisier. And JSONier.
 
 ### Debugging
 
-All of the running Java containers expose a debug port to connect to. This allows you to attach your debugger and see
+All of the running containers expose a debug port to connect to. This allows you to attach your debugger and see
 what's going on. The debug port is 2000 ports above the http port the services are listening on. Look at the Docker
 compose file to see which port to use for which service.
 

--- a/local-running/compose.yaml
+++ b/local-running/compose.yaml
@@ -35,12 +35,18 @@ services:
       - NODE_ENV=development
       - EXTERNAL_WEBSITE_HOST=http://localhost:3001
       - PORT=3001
+      - CDN_DOMAIN=
       - AWS_REGION
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
     ports:
       - "3001:3001"
+      - "5001:9229"
+    command:
+      - node
+      - "--inspect=0.0.0.0"
+      - "src/app.js"
 
   core-back:
     image: core-back:latest


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add debugging for core-front

### Why did it change

This overrides core-front's docker images command to allow a debugger to be attached. It also exposes port 5001 which is routed to the default node debugger port.

This also sets the `CDN_DOMAIN` for core-front to null. This was previously being interpreted as `undefined` by node which caused some static files to fail to load, causing some noise in the logs.

