### PR TITLE
BAU: Null safe error descriptions in criCallbacks

### DIFF
--- a/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
+++ b/lambdas/validate-oauth-callback/src/main/java/uk/gov/di/ipv/core/validateoauthcallback/ValidateOAuthCallbackHandler.java
@@ -38,6 +38,7 @@ import uk.gov.di.ipv.core.validateoauthcallback.dto.CriCallbackRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CLIENT_OAUTH_SESSION_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
@@ -220,7 +221,9 @@ public class ValidateOAuthCallbackHandler
             CriCallbackRequest callbackRequest)
             throws SqsException {
         String error = callbackRequest.getError();
-        String errorDescription = callbackRequest.getErrorDescription();
+        String errorDescription =
+                Objects.toString(
+                        callbackRequest.getErrorDescription(), "No error description provided");
         String criId = callbackRequest.getCredentialIssuerId();
 
         AuditExtensionErrorParams extensions =

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -50,6 +50,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     private static final String TEST_REDIRECT_URI = "https://redirect.example.com";
     private static final String TEST_OAUTH_ACCESS_DENIED_ERROR = OAuth2Error.ACCESS_DENIED_CODE;
     private static final String TEST_OAUTH_SERVER_ERROR = OAuth2Error.SERVER_ERROR_CODE;
+    private static final String TEST_ERROR = "test-error";
     private static final String TEST_ERROR_DESCRIPTION = "test error description";
     private static final String TEST_SESSION_ID = SecureTokenHelper.generate();
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
@@ -376,6 +377,24 @@ class ValidateOAuthCallbackHandlerHandlerTest {
     }
 
     @Test
+    void shouldReceiveJourneyErrorJourneyResponseWithNullErrorDescription() {
+        CriCallbackRequest criCallbackRequestWithOtherError = validCriCallbackRequest();
+        criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
+        criCallbackRequestWithOtherError.setErrorDescription(null);
+
+        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
+        when(mockCriOAuthSessionService.getCriOauthSessionItem(any()))
+                .thenReturn(criOAuthSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        Map<String, Object> output =
+                underTest.handleRequest(criCallbackRequestWithOtherError, context);
+
+        assertEquals("/journey/error", output.get("journey"));
+    }
+
+    @Test
     void shouldReceiveJourneyErrorJourneyResponseWhenAnyOtherOauthError() {
         CriCallbackRequest criCallbackRequestWithOtherError = validCriCallbackRequest();
         criCallbackRequestWithOtherError.setError(TEST_OAUTH_SERVER_ERROR);
@@ -392,6 +411,7 @@ class ValidateOAuthCallbackHandlerHandlerTest {
 
         assertEquals("/journey/error", output.get("journey"));
     }
+
 
     @Test
     void shouldAttemptRecoveryErrorResponseWhenOauthSessionIsNull() {

--- a/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
+++ b/lambdas/validate-oauth-callback/src/test/java/uk/gov/di/ipv/core/credentialissuer/ValidateOAuthCallbackHandlerHandlerTest.java
@@ -412,7 +412,6 @@ class ValidateOAuthCallbackHandlerHandlerTest {
         assertEquals("/journey/error", output.get("journey"));
     }
 
-
     @Test
     void shouldAttemptRecoveryErrorResponseWhenOauthSessionIsNull() {
         CriCallbackRequest criCallbackRequestWithOtherError = validCriCallbackRequest();


### PR DESCRIPTION
Null safe error descriptions in criCallbacks

## Proposed changes

### What changed

Validate errorDescriptions and default to a generic message when "null" error messages are provided

### Why did it change

`No value provided for key errorDescription: java.lang.IllegalArgumentException` seen in production logs for ValidateOAuthCallback lambda

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
