### PR TITLE
BAU: Check success ignoring CIs

### DIFF
--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -176,7 +176,7 @@ public class UserIdentityService {
         VcStoreItem vcStoreItem = getVcStoreItem(userId, criId);
         if (vcStoreItem != null) {
             SignedJWT vc = SignedJWT.parse(vcStoreItem.getCredential());
-            return Optional.of(VcHelper.isSuccessfulVc(vc));
+            return Optional.of(VcHelper.isSuccessfulVcIgnoringCi(vc));
         }
         LOGGER.info("vcStoreItem for CRI '{}' was null", criId);
         return Optional.empty();


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Check success ignoring CIs

### Why did it change

When deciding if a VC is successful in the gpg45-evaluation lambda, we should ignore CIs in the VCs. We've already been through CI scoring.

The fraud VC can contain CIs and still be regarded as a success.
