### PR TITLE
PYIC-3466: Removed the old URL address within the internal API GW.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1829,13 +1829,6 @@ Resources:
           Properties:
             RestApiId:
               Ref: IPVCorePrivateAPI
-            Path: /journey/build-proven-user-identity-details
-            Method: GET
-        IPVCorePrivateAPINewPath:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCorePrivateAPI
             Path: /user/proven-identity-details
             Method: GET
       AutoPublishAlias: live

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -200,42 +200,6 @@ paths:
                 #end
                 $input.body
 
-  /journey/build-proven-user-identity-details:
-    get:
-      description: "Called when core front needs to display information about a users proven identity"
-      responses:
-        200:
-          description: "User identity response"
-          content:
-            application/json:
-              schema:
-                type: "object"
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildProvenUserIdentityDetailsFunction.Arn}:live/invocations
-        passthroughBehavior: "when_no_match"
-        type: "aws"
-        requestTemplates:
-          application/x-www-form-urlencoded:
-            Fn::Sub: |
-              {
-                "ipvSessionId": "$input.params('ipv-session-id')",
-                "ipAddress": "$input.params('ip-address')",
-                "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
-              }
-        responses:
-          default:
-            statusCode: 200
-            responseTemplates:
-              application/json: |
-                #set ($bodyObj = $util.parseJson($input.body))
-                #if ($bodyObj.statusCode)
-                #set($context.responseOverride.status = $bodyObj.statusCode)
-                #end
-                $input.body
-
   /user/proven-identity-details:
     get:
       description: "Called when core front needs to display information about a users proven identity"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed the old URL address '/journey/build-proven-user-identity-details' within the internal API GW.

### Why did it change

Core-front has started calling the new URL address '/user/proven-identity-details'. We no longer need the old URL address '/journey/build-proven-user-identity-details'.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3466](https://govukverify.atlassian.net/browse/PYIC-3466)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3466]: https://govukverify.atlassian.net/browse/PYIC-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ