### PR TITLE
3611: Add test for journey map event consistency

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -6,14 +6,22 @@ END_JOURNEY:
 
 CRI_STATE:
   events:
+    next:
+      targetState: ERROR
+    not-found:
+      targetState: ERROR
+    fail-with-no-ci:
+      targetState: ERROR
     error:
       targetState: ERROR
     access-denied:
-      targetState: PYI_NO_MATCH
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
     temporarily-unavailable:
-      targetState: PYI_NO_MATCH
+      targetState: ERROR
     end:
-      targetState: IPV_SUCCESS_PAGE
+      targetState: ERROR
     pyi-no-match:
       targetState: PYI_NO_MATCH
     pyi-kbv-fail:
@@ -137,16 +145,6 @@ CRI_F2F:
       targetState: F2F_HANDOFF_PAGE
     access-denied:
       targetState: PYI_ANOTHER_WAY
-    not-found:
-      targetState: ERROR
-    temporarily-unavailable:
-      targetState: ERROR
-    fail-with-no-ci:
-      targetState: ERROR
-    end:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: ERROR
 
 F2F_HANDOFF_PAGE:
   response:
@@ -187,12 +185,6 @@ CRI_DCMAW:
       checkIfDisabled:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
-    end:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: ERROR
-    access-denied:
-      targetState: ERROR
 
 MULTIPLE_DOC_CHECK_PAGE:
   response:
@@ -333,16 +325,6 @@ CRI_UK_PASSPORT_J2:
       checkIfDisabled:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
-    not-found:
-      targetState: ERROR
-    temporarily-unavailable:
-      targetState: ERROR
-    fail-with-no-ci:
-      targetState: ERROR
-    end:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: ERROR
 
 ADDRESS_AND_FRAUD_J2:
   nestedJourney: ADDRESS_AND_FRAUD
@@ -378,14 +360,6 @@ CRI_KBV_J2:
           targetState: PYI_CRI_ESCAPE_NO_F2F
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
-    next:
-      targetState: ERROR
-    not-found:
-      targetState: ERROR
-    temporarily-unavailable:
-      targetState: ERROR
-    access-denied:
-      targetState: ERROR
 
 # Driving licence journey (J3)
 CRI_DRIVING_LICENCE_J3:
@@ -401,16 +375,6 @@ CRI_DRIVING_LICENCE_J3:
       checkIfDisabled:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
-    not-found:
-      targetState: ERROR
-    temporarily-unavailable:
-      targetState: ERROR
-    fail-with-no-ci:
-      targetState: ERROR
-    end:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: ERROR
 
 ADDRESS_AND_FRAUD_J3:
   nestedJourney: ADDRESS_AND_FRAUD
@@ -418,7 +382,7 @@ ADDRESS_AND_FRAUD_J3:
     next:
       targetState: CHECK_FRAUD_SCORE_J3
     end:
-      targetState: END
+      targetState: ERROR
 
 CHECK_FRAUD_SCORE_J3:
   response:
@@ -458,12 +422,6 @@ CRI_KBV_J3:
       targetState: PYI_NO_MATCH
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
-    not-found:
-      targetState: ERROR
-    temporarily-unavailable:
-      targetState: ERROR
-    access-denied:
-      targetState: ERROR
 
 # F2F journey (J4)
 CRI_CLAIMED_IDENTITY_J4:
@@ -474,18 +432,6 @@ CRI_CLAIMED_IDENTITY_J4:
   events:
     next:
       targetState: ADDRESS_AND_FRAUD_J4
-    not-found:
-      targetState: ERROR
-    temporarily-unavailable:
-      targetState: ERROR
-    fail-with-no-ci:
-      targetState: ERROR
-    end:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: ERROR
-    access-denied:
-      targetState: ERROR
 
 ADDRESS_AND_FRAUD_J4:
   nestedJourney: ADDRESS_AND_FRAUD
@@ -508,14 +454,6 @@ CRI_DCMAW_J5:
       targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
-    temporarily-unavailable:
-      targetState: ERROR
-    end:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: ERROR
-    access-denied:
-      targetState: ERROR
 
 POST_DCMAW_SUCCESS_PAGE_J5:
   response:
@@ -536,16 +474,6 @@ CRI_NINO_J6:
       targetState: CRI_HMRC_KBV_J6
     fail-with-no-ci:
       targetState: PRE_KBV_TRANSITION_PAGE_J2
-    not-found:
-      targetState: ERROR
-    temporarily-unavailable:
-      targetState: ERROR
-    end:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: ERROR
-    access-denied:
-      targetState: ERROR
 
 CRI_HMRC_KBV_J6:
   response:
@@ -559,14 +487,6 @@ CRI_HMRC_KBV_J6:
       targetState: PRE_KBV_TRANSITION_PAGE_J3
     next:
       targetState: PYI_NO_MATCH
-    not-found:
-      targetState: ERROR
-    temporarily-unavailable:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: ERROR
-    access-denied:
-      targetState: ERROR
 
 # Mitigation journey (01)
 MITIGATION_01:
@@ -605,8 +525,6 @@ MITIGATION_01_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     enhanced-verification:
       targetState: PYI_ANOTHER_WAY
-    end:
-      targetState: ERROR
 
 # Mitigation journey (02)
 MITIGATION_02_OPTIONS:
@@ -645,7 +563,3 @@ MITIGATION_02_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     enhanced-verification:
       targetState: PYI_ANOTHER_WAY
-    next:
-      targetState: ERROR
-    end:
-      targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -137,6 +137,16 @@ CRI_F2F:
       targetState: F2F_HANDOFF_PAGE
     access-denied:
       targetState: PYI_ANOTHER_WAY
+    not-found:
+      targetState: ERROR
+    temporarily-unavailable:
+      targetState: ERROR
+    fail-with-no-ci:
+      targetState: ERROR
+    end:
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
 
 F2F_HANDOFF_PAGE:
   response:
@@ -177,6 +187,12 @@ CRI_DCMAW:
       checkIfDisabled:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
+    end:
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
+    access-denied:
+      targetState: ERROR
 
 MULTIPLE_DOC_CHECK_PAGE:
   response:
@@ -317,6 +333,16 @@ CRI_UK_PASSPORT_J2:
       checkIfDisabled:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
+    not-found:
+      targetState: ERROR
+    temporarily-unavailable:
+      targetState: ERROR
+    fail-with-no-ci:
+      targetState: ERROR
+    end:
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
 
 ADDRESS_AND_FRAUD_J2:
   nestedJourney: ADDRESS_AND_FRAUD
@@ -350,6 +376,14 @@ CRI_KBV_J2:
           targetState: PYI_CRI_ESCAPE_NO_F2F
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
+    next:
+      targetState: ERROR
+    not-found:
+      targetState: ERROR
+    temporarily-unavailable:
+      targetState: ERROR
+    access-denied:
+      targetState: ERROR
 
 # Driving licence journey (J3)
 CRI_DRIVING_LICENCE_J3:
@@ -365,6 +399,16 @@ CRI_DRIVING_LICENCE_J3:
       checkIfDisabled:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
+    not-found:
+      targetState: ERROR
+    temporarily-unavailable:
+      targetState: ERROR
+    fail-with-no-ci:
+      targetState: ERROR
+    end:
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
 
 ADDRESS_AND_FRAUD_J3:
   nestedJourney: ADDRESS_AND_FRAUD
@@ -410,6 +454,12 @@ CRI_KBV_J3:
       targetState: PYI_NO_MATCH
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
+    not-found:
+      targetState: ERROR
+    temporarily-unavailable:
+      targetState: ERROR
+    access-denied:
+      targetState: ERROR
 
 # F2F journey (J4)
 CRI_CLAIMED_IDENTITY_J4:
@@ -420,6 +470,18 @@ CRI_CLAIMED_IDENTITY_J4:
   events:
     next:
       targetState: ADDRESS_AND_FRAUD_J4
+    not-found:
+      targetState: ERROR
+    temporarily-unavailable:
+      targetState: ERROR
+    fail-with-no-ci:
+      targetState: ERROR
+    end:
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
+    access-denied:
+      targetState: ERROR
 
 ADDRESS_AND_FRAUD_J4:
   nestedJourney: ADDRESS_AND_FRAUD
@@ -440,6 +502,14 @@ CRI_DCMAW_J5:
       targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
+    temporarily-unavailable:
+      targetState: ERROR
+    end:
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
+    access-denied:
+      targetState: ERROR
 
 POST_DCMAW_SUCCESS_PAGE_J5:
   response:
@@ -460,6 +530,16 @@ CRI_NINO_J6:
       targetState: CRI_HMRC_KBV_J6
     fail-with-no-ci:
       targetState: PRE_KBV_TRANSITION_PAGE_J2
+    not-found:
+      targetState: ERROR
+    temporarily-unavailable:
+      targetState: ERROR
+    end:
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
+    access-denied:
+      targetState: ERROR
 
 CRI_HMRC_KBV_J6:
   response:
@@ -473,6 +553,14 @@ CRI_HMRC_KBV_J6:
       targetState: PRE_KBV_TRANSITION_PAGE_J3
     next:
       targetState: PYI_NO_MATCH
+    not-found:
+      targetState: ERROR
+    temporarily-unavailable:
+      targetState: ERROR
+    enhanced-verification:
+      targetState: ERROR
+    access-denied:
+      targetState: ERROR
 
 # Mitigation journey (01)
 MITIGATION_01:
@@ -511,6 +599,8 @@ MITIGATION_01_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     enhanced-verification:
       targetState: PYI_ANOTHER_WAY
+    end:
+      targetState: ERROR
 
 # Mitigation journey (02)
 MITIGATION_02_OPTIONS:
@@ -549,3 +639,7 @@ MITIGATION_02_CRI_DCMAW:
       targetState: PYI_ANOTHER_WAY
     enhanced-verification:
       targetState: PYI_ANOTHER_WAY
+    next:
+      targetState: ERROR
+    end:
+      targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -15,13 +15,13 @@ CRI_STATE:
     error:
       targetState: ERROR
     access-denied:
-      targetState: ERROR
+      targetState: PYI_NO_MATCH
     enhanced-verification:
       targetState: ERROR
     temporarily-unavailable:
-      targetState: ERROR
+      targetState: PYI_NO_MATCH
     end:
-      targetState: ERROR
+      targetState: IPV_SUCCESS_PAGE
     pyi-no-match:
       targetState: PYI_NO_MATCH
     pyi-kbv-fail:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -352,6 +352,8 @@ ADDRESS_AND_FRAUD_J2:
       checkIfDisabled:
         hmrcKbv:
           targetState: PRE_KBV_TRANSITION_PAGE_J2
+    end:
+      targetState: ERROR
 
 PRE_KBV_TRANSITION_PAGE_J2:
   response:
@@ -415,6 +417,8 @@ ADDRESS_AND_FRAUD_J3:
   exitEvents:
     next:
       targetState: CHECK_FRAUD_SCORE_J3
+    end:
+      targetState: END
 
 CHECK_FRAUD_SCORE_J3:
   response:
@@ -488,6 +492,8 @@ ADDRESS_AND_FRAUD_J4:
   exitEvents:
     next:
       targetState: CRI_F2F
+    end:
+      targetState: ERROR
 
 # CRI escape journey (J5)
 CRI_DCMAW_J5:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -11,18 +11,6 @@ ADDRESS_AND_FRAUD:
       events:
         next:
           targetState: CRI_FRAUD
-        not-found:
-          targetState: ERROR
-        temporarily-unavailable:
-          targetState: ERROR
-        fail-with-no-ci:
-          targetState: ERROR
-        end:
-          targetState: ERROR
-        enhanced-verification:
-          targetState: ERROR
-        access-denied:
-          targetState: ERROR
     CRI_FRAUD:
       response:
         type: cri
@@ -33,13 +21,3 @@ ADDRESS_AND_FRAUD:
           exitEventToEmit: end
         next:
           exitEventToEmit: next
-        not-found:
-          targetState: ERROR
-        temporarily-unavailable:
-          targetState: ERROR
-        fail-with-no-ci:
-          targetState: ERROR
-        enhanced-verification:
-          targetState: ERROR
-        access-denied:
-          targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -11,6 +11,18 @@ ADDRESS_AND_FRAUD:
       events:
         next:
           targetState: CRI_FRAUD
+        not-found:
+          targetState: ERROR
+        temporarily-unavailable:
+          targetState: ERROR
+        fail-with-no-ci:
+          targetState: ERROR
+        end:
+          targetState: ERROR
+        enhanced-verification:
+          targetState: ERROR
+        access-denied:
+          targetState: ERROR
     CRI_FRAUD:
       response:
         type: cri
@@ -21,3 +33,13 @@ ADDRESS_AND_FRAUD:
           exitEventToEmit: end
         next:
           exitEventToEmit: next
+        not-found:
+          targetState: ERROR
+        temporarily-unavailable:
+          targetState: ERROR
+        fail-with-no-ci:
+          targetState: ERROR
+        enhanced-verification:
+          targetState: ERROR
+        access-denied:
+          targetState: ERROR

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -1,0 +1,125 @@
+package uk.gov.di.ipv.core.processjourneyevent;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.StateMachineInitializer;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.NestedJourneyInvokeState;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.CriStepResponse;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageStepResponse;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.StepResponse;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SystemStubsExtension.class)
+public class JourneyMapTest {
+    @SystemStub private static EnvironmentVariables environmentVariables;
+
+    @BeforeAll
+    private static void beforeAll() {
+        environmentVariables.set("IS_LOCAL", "true");
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void shouldHandleSameEventsForAllCris(IpvJourneyTypes journeyType) throws IOException {
+        StateMachineInitializer stateMachineInitialiser = new StateMachineInitializer(journeyType);
+        Map<String, State> stateMachine = stateMachineInitialiser.initialize();
+
+        List<StateAndEvents> criStates = new ArrayList<>();
+        Set<String> criStateEvents = new HashSet<>();
+        findCriStatesAndEvents(stateMachine, criStates, criStateEvents);
+
+        for (StateAndEvents stateAndEvents : criStates) {
+            assertEquals(criStateEvents, stateAndEvents.events, String.format("%s doesn't handle all CRI state events", stateAndEvents.state));
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void shouldHandleSameEventsForSamePage(IpvJourneyTypes journeyType) throws IOException {
+        StateMachineInitializer stateMachineInitialiser = new StateMachineInitializer(journeyType);
+        Map<String, State> stateMachine = stateMachineInitialiser.initialize();
+
+        Map<String, List<StateAndEvents>> pageStateMap = new HashMap<>();
+        findPageSpecificStatesAndEvents(stateMachine, pageStateMap);
+
+        for (List<StateAndEvents> statesAndEvents : pageStateMap.values()) {
+            Set<String> pageStateEvents = new HashSet<>();
+
+            for (StateAndEvents singleStateAndEvent : statesAndEvents) {
+                pageStateEvents.addAll(singleStateAndEvent.events);
+            }
+
+            for (StateAndEvents singleStateAndEvent : statesAndEvents) {
+                assertEquals(pageStateEvents, singleStateAndEvent.events, String.format("%s doesn't handle all events for this page", singleStateAndEvent.state));
+            }
+        }
+        
+    }
+
+    private void findCriStatesAndEvents(Map<String, State> stateMachine, List<StateAndEvents> criStates, Set<String> criEvents) {
+        for (Map.Entry<String, State> entry : stateMachine.entrySet()) {
+            String key = entry.getKey();
+            State state = entry.getValue();
+    
+            if (state instanceof BasicState) {
+                StepResponse response = ((BasicState) state).getResponse();
+
+                if (response instanceof CriStepResponse) {
+                    Set<String> events = ((BasicState) state).getEvents().keySet();
+
+                    criStates.add(new StateAndEvents(key, events));
+                    criEvents.addAll(events);
+                }
+            } else if (state instanceof NestedJourneyInvokeState) {
+                Map<String, State> nestedStateMachine = ((NestedJourneyInvokeState) state).getNestedJourneyDefinition().getNestedJourneyStates();
+                findCriStatesAndEvents(nestedStateMachine, criStates, criEvents);
+            }
+        }
+    }
+
+    private void findPageSpecificStatesAndEvents(Map<String, State> stateMachine, Map<String, List<StateAndEvents>> pageStateMap) {
+        for (String key : stateMachine.keySet()) {
+            State state = stateMachine.get(key);
+    
+            if (state instanceof BasicState) {
+                StepResponse response = ((BasicState) state).getResponse();
+            
+                if (response instanceof PageStepResponse) {
+                    String pageId = (String) response.value().get("page");
+                    Set<String> events = ((BasicState) state).getEvents().keySet();
+
+                    pageStateMap.computeIfAbsent(pageId, k -> new ArrayList<>()).add(new StateAndEvents(key, events));
+                }
+            } else if (state instanceof NestedJourneyInvokeState) {
+                Map<String, State> nestedStateMachine = ((NestedJourneyInvokeState) state).getNestedJourneyDefinition().getNestedJourneyStates();
+                findPageSpecificStatesAndEvents(nestedStateMachine, pageStateMap);
+            }
+        }
+    }
+}
+
+class StateAndEvents {
+    public String state;
+    public Set<String> events;
+    public StateAndEvents(String state, Set<String> events) {
+        this.state = state;
+        this.events = events;
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed

- Test all CRI states have the same events handled
- Test all states for the same page have the same events handled
- Test events consistent entering and exiting nested journeys
- Update CRI states with Error targets for events not handled

### Why did it change

- To make interactions with CRIs more consistent
- To know nested journeys have events covered
- To catch inconsistent journey map behaviour

### Issue tracking

- [PYIC-3611](https://govukverify.atlassian.net/browse/PYIC-3611)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3611]: https://govukverify.atlassian.net/browse/PYIC-3611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ