### PR TITLE
Update CODEOWNERS for github move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alphagov/digital-identity-ipv
+* @govuk-one-login/core-team


### PR DESCRIPTION
Update CODEOWNERS to make the IPV core team (JET + HILUX) default reviewers for PRs