### PR TITLE
PYIC-3607: Routing for same-session F2F CIMIT

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -137,6 +137,8 @@ CRI_F2F:
       targetState: F2F_HANDOFF_PAGE
     access-denied:
       targetState: PYI_ANOTHER_WAY
+    enhanced-verification:
+      targetState: F2F_HANDOFF_PAGE
 
 F2F_HANDOFF_PAGE:
   response:
@@ -350,6 +352,9 @@ CRI_KBV_J2:
           targetState: PYI_CRI_ESCAPE_NO_F2F
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
+      checkFeatureFlag:
+        f2fCimit:
+          targetState: MITIGATION_02_OPTIONS_WITH_F2F
 
 # Driving licence journey (J3)
 CRI_DRIVING_LICENCE_J3:
@@ -410,6 +415,10 @@ CRI_KBV_J3:
       targetState: PYI_NO_MATCH
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS
+      checkFeatureFlag:
+        f2fCimit:
+          targetState: MITIGATION_02_OPTIONS_WITH_F2F
+
 
 # F2F journey (J4)
 CRI_CLAIMED_IDENTITY_J4:
@@ -548,4 +557,24 @@ MITIGATION_02_CRI_DCMAW:
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
     enhanced-verification:
+      targetState: MITIGATION_02_SUGGEST_F2F
+
+MITIGATION_02_OPTIONS_WITH_F2F:
+  response:
+    type: page
+    pageId: pyi-suggest-other-options
+  events:
+    f2f:
+      targetState: CRI_F2F
+    dcmaw:
+      targetState: MITIGATION_02_CRI_ELIGIBILITY
+    end:
       targetState: PYI_ANOTHER_WAY
+
+MITIGATION_02_SUGGEST_F2F:
+  response:
+    type: page
+    pageId: pyi-ipv-suggest-f2f
+  events:
+    next:
+      targetState: CRI_F2F

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -585,7 +585,7 @@ MITIGATION_02_OPTIONS_WITH_F2F:
 MITIGATION_02_SUGGEST_F2F:
   response:
     type: page
-    pageId: pyi-ipv-suggest-f2f
+    pageId: pyi-suggest-f2f
   events:
     next:
       targetState: CRI_F2F

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -557,7 +557,10 @@ MITIGATION_02_CRI_DCMAW:
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
     enhanced-verification:
-      targetState: MITIGATION_02_SUGGEST_F2F
+      targetState: PYI_ANOTHER_WAY
+      checkFeatureFlag:
+        f2fCimit:
+          targetState: MITIGATION_02_SUGGEST_F2F
 
 MITIGATION_02_OPTIONS_WITH_F2F:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -357,7 +357,7 @@ CRI_KBV_J2:
           targetState: MITIGATION_02_OPTIONS_WITH_F2F
           checkIfDisabled:
             f2f:
-              targetState: PYI_ANOTHER_WAY
+              targetState: MITIGATION_02_OPTIONS
 
 # Driving licence journey (J3)
 CRI_DRIVING_LICENCE_J3:
@@ -423,7 +423,7 @@ CRI_KBV_J3:
           targetState: MITIGATION_02_OPTIONS_WITH_F2F
           checkIfDisabled:
             f2f:
-              targetState: PYI_ANOTHER_WAY
+              targetState: MITIGATION_02_OPTIONS
 
 # F2F journey (J4)
 CRI_CLAIMED_IDENTITY_J4:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -355,6 +355,9 @@ CRI_KBV_J2:
       checkFeatureFlag:
         f2fCimit:
           targetState: MITIGATION_02_OPTIONS_WITH_F2F
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_ANOTHER_WAY
 
 # Driving licence journey (J3)
 CRI_DRIVING_LICENCE_J3:
@@ -418,7 +421,9 @@ CRI_KBV_J3:
       checkFeatureFlag:
         f2fCimit:
           targetState: MITIGATION_02_OPTIONS_WITH_F2F
-
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_ANOTHER_WAY
 
 # F2F journey (J4)
 CRI_CLAIMED_IDENTITY_J4:
@@ -561,6 +566,9 @@ MITIGATION_02_CRI_DCMAW:
       checkFeatureFlag:
         f2fCimit:
           targetState: MITIGATION_02_SUGGEST_F2F
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_ANOTHER_WAY
 
 MITIGATION_02_OPTIONS_WITH_F2F:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -546,6 +546,12 @@ MITIGATION_02_CRI_ELIGIBILITY:
       targetState: MITIGATION_02_CRI_DCMAW
     end:
       targetState: PYI_ANOTHER_WAY
+      checkFeatureFlag:
+        f2fCimit:
+          targetState: MITIGATION_02_SUGGEST_F2F
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_ANOTHER_WAY
 
 MITIGATION_02_CRI_DCMAW:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -557,10 +557,28 @@ MITIGATION_02_CRI_DCMAW:
       targetState: PYI_NO_MATCH
     access-denied:
       targetState: PYI_ANOTHER_WAY
+      checkFeatureFlag:
+        f2fCimit:
+          targetState: MITIGATION_02_SUGGEST_F2F
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_ANOTHER_WAY
     temporarily-unavailable:
       targetState: PYI_ANOTHER_WAY
+      checkFeatureFlag:
+        f2fCimit:
+          targetState: MITIGATION_02_SUGGEST_F2F
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
       targetState: PYI_ANOTHER_WAY
+      checkFeatureFlag:
+        f2fCimit:
+          targetState: MITIGATION_02_SUGGEST_F2F
+          checkIfDisabled:
+            f2f:
+              targetState: PYI_ANOTHER_WAY
     enhanced-verification:
       targetState: PYI_ANOTHER_WAY
       checkFeatureFlag:


### PR DESCRIPTION
Implement the F2F routing for CIMIT behind a feature flag.

## Proposed changes

### What changed

Added two new states and respective pages:
- MITIGATION_02_OPTIONS_WITH_F2F (pyi-ipv-suggest-other-options)
- MITIGATION_02_SUGGEST_F2F (pyi-ipv-suggest-f2f)

Added new routing:
- If `f2fCimit` feature flag is enabled & F2F CRI is enabled route KBV mitigations to MITIGATION_02_OPTIONS_WITH_F2F
- Routes from new `pyi-ipv-suggest-other-options` page to dcmaw/f2f/another way
- If `f2fCimit` feature flag is enabled & F2F CRI is enabled route DCMAW mitigation to suggest f2f
- Failure/abandon/illegible mapping to suggest f2f page


Maintains:
- Default to current mitigation routing when `f2fCimit` or F2F CRI flags are disabled

Current mitigation journey
![image](https://github.com/govuk-one-login/ipv-core-back/assets/55875065/6572ae92-66cf-48f2-8148-fe3eb38c46de)

Mitigation journey with f2fCimit flag enabled
![image](https://github.com/govuk-one-login/ipv-core-back/assets/55875065/dff3488b-8abc-49bf-a2f0-4cded28005e0)

Mitigation journey with F2F cri disabled
![image](https://github.com/govuk-one-login/ipv-core-back/assets/55875065/5ff7933c-05e4-4834-9e79-d5d83688d953)

### Why did it change

Enables routing for same-session F2F mitigations

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3607](https://govukverify.atlassian.net/browse/PYIC-3607)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3607]: https://govukverify.atlassian.net/browse/PYIC-3607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ