### PR TITLE
PYIC-3639: clear users identity if reset identity feature flag is set

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -50,6 +50,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.RESET_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
@@ -67,7 +68,6 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PA
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PENDING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_IDENTITY_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_PATH;
-import static uk.gov.di.ipv.core.library.service.ConfigService.featureFlags.RESET_IDENTITY;
 
 /** Check Existing Identity response Lambda */
 public class CheckExistingIdentityHandler
@@ -199,8 +199,7 @@ public class CheckExistingIdentityHandler
                 return JOURNEY_FAIL;
             }
 
-            if (matchedProfile.isPresent()
-                    && configService.enabled(RESET_IDENTITY.getFeatureFlag())) {
+            if (matchedProfile.isPresent() && configService.enabled(RESET_IDENTITY.getName())) {
                 LOGGER.info("resetIdentity flag is enabled, reset users identity.");
                 return JOURNEY_RESET_IDENTITY;
             }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -199,7 +199,7 @@ public class CheckExistingIdentityHandler
             }
 
             if (matchedProfile.isPresent() && configService.enabled("resetIdentity")) {
-                LOGGER.info("inside reset identity");
+                LOGGER.info("resetIdentity flag is enabled, reset users identity.");
                 return JOURNEY_RESET_IDENTITY;
             }
 

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -67,6 +67,7 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PA
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PENDING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_IDENTITY_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_PATH;
+import static uk.gov.di.ipv.core.library.service.ConfigService.featureFlags.RESET_IDENTITY;
 
 /** Check Existing Identity response Lambda */
 public class CheckExistingIdentityHandler
@@ -198,7 +199,8 @@ public class CheckExistingIdentityHandler
                 return JOURNEY_FAIL;
             }
 
-            if (matchedProfile.isPresent() && configService.enabled("resetIdentity")) {
+            if (matchedProfile.isPresent()
+                    && configService.enabled(RESET_IDENTITY.getFeatureFlag())) {
                 LOGGER.info("resetIdentity flag is enabled, reset users identity.");
                 return JOURNEY_RESET_IDENTITY;
             }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -198,6 +198,11 @@ public class CheckExistingIdentityHandler
                 return JOURNEY_FAIL;
             }
 
+            if (matchedProfile.isPresent() && configService.enabled("resetIdentity")) {
+                LOGGER.info("inside reset identity");
+                return JOURNEY_RESET_IDENTITY;
+            }
+
             if (matchedProfile.isPresent()) {
                 auditService.sendAuditEvent(
                         buildProfileMatchedAuditEvent(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -61,9 +61,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler.VOT_P2;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.RESET_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.*;
-import static uk.gov.di.ipv.core.library.service.ConfigService.featureFlags.RESET_IDENTITY;
 
 @ExtendWith(MockitoExtension.class)
 class CheckExistingIdentityHandlerTest {
@@ -189,7 +189,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(RESET_IDENTITY.getFeatureFlag())).thenReturn(false);
+        when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
 
         JourneyResponse journeyResponse =
                 toResponseClass(
@@ -229,7 +229,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1B));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(RESET_IDENTITY.getFeatureFlag())).thenReturn(true);
+        when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(true);
 
         JourneyResponse journeyResponse =
                 toResponseClass(
@@ -256,7 +256,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1B));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(RESET_IDENTITY.getFeatureFlag())).thenReturn(false);
+        when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
 
         JourneyResponse journeyResponse =
                 toResponseClass(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -63,6 +63,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler.VOT_P2;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.*;
+import static uk.gov.di.ipv.core.library.service.ConfigService.featureFlags.RESET_IDENTITY;
 
 @ExtendWith(MockitoExtension.class)
 class CheckExistingIdentityHandlerTest {
@@ -188,7 +189,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled("resetIdentity")).thenReturn(false);
+        when(configService.enabled(RESET_IDENTITY.getFeatureFlag())).thenReturn(false);
 
         JourneyResponse journeyResponse =
                 toResponseClass(
@@ -196,8 +197,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_REUSE, journeyResponse);
-
-        verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
 
         ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEvent.class);
@@ -230,7 +229,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1B));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled("resetIdentity")).thenReturn(true);
+        when(configService.enabled(RESET_IDENTITY.getFeatureFlag())).thenReturn(true);
 
         JourneyResponse journeyResponse =
                 toResponseClass(
@@ -238,8 +237,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_RESET_IDENTITY, journeyResponse);
-
-        verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
 
         ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEvent.class);
@@ -259,7 +256,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1B));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled("resetIdentity")).thenReturn(false);
+        when(configService.enabled(RESET_IDENTITY.getFeatureFlag())).thenReturn(false);
 
         JourneyResponse journeyResponse =
                 toResponseClass(
@@ -267,8 +264,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_REUSE, journeyResponse);
-
-        verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
 
         ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEvent.class);
@@ -342,7 +337,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals("/journey/next", journeyResponse.getJourney());
-        verify(userIdentityService, never()).deleteVcStoreItems(TEST_USER_ID);
 
         ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEvent.class);
@@ -394,7 +388,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_PENDING, journeyResponse);
-        verify(userIdentityService, times(0)).deleteVcStoreItems(TEST_USER_ID);
 
         verify(ipvSessionService, never()).updateIpvSession(any());
 
@@ -418,7 +411,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_FAIL, journeyResponse);
-        verify(userIdentityService, times(0)).deleteVcStoreItems(TEST_USER_ID);
 
         verify(ipvSessionService, never()).updateIpvSession(any());
 
@@ -447,7 +439,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_FAIL, journeyResponse);
-        verify(userIdentityService, times(0)).deleteVcStoreItems(TEST_USER_ID);
 
         verify(ipvSessionService, never()).updateIpvSession(any());
 
@@ -474,7 +465,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_FAIL, journeyResponse);
-        verify(userIdentityService, times(0)).deleteVcStoreItems(TEST_USER_ID);
 
         verify(ipvSessionService, never()).updateIpvSession(any());
 
@@ -502,7 +492,6 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_FAIL, journeyResponse);
-        verify(userIdentityService, times(0)).deleteVcStoreItems(TEST_USER_ID);
 
         verify(ipvSessionService, never()).updateIpvSession(any());
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -1,7 +1,9 @@
 package uk.gov.di.ipv.core.library.config;
 
 public enum CoreFeatureFlag implements FeatureFlag {
-    UNUSED_PLACEHOLDER("unusedPlaceHolder");
+    UNUSED_PLACEHOLDER("unusedPlaceHolder"),
+
+    RESET_IDENTITY("resetIdentity");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -61,6 +61,20 @@ public class ConfigService {
     private final SecretsProvider secretsProvider;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    public enum featureFlags {
+        RESET_IDENTITY("resetIdentity");
+
+        private final String featureFlag;
+
+        featureFlags(String featureFlag) {
+            this.featureFlag = featureFlag;
+        }
+
+        public String getFeatureFlag() {
+            return featureFlag;
+        }
+    }
+
     private String featureSet;
 
     public ConfigService(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -61,20 +61,6 @@ public class ConfigService {
     private final SecretsProvider secretsProvider;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public enum featureFlags {
-        RESET_IDENTITY("resetIdentity");
-
-        private final String featureFlag;
-
-        featureFlags(String featureFlag) {
-            this.featureFlag = featureFlag;
-        }
-
-        public String getFeatureFlag() {
-            return featureFlag;
-        }
-    }
-
     private String featureSet;
 
     public ConfigService(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Added a feature to reset users identity if it is already preset and reset identity featureflag is enabled.

### What changed

- Claimed identity lambda to reset users identity.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To allow QA to reset identity for the user so they can use same users multiple times.

Related PR: https://github.com/govuk-one-login/ipv-core-common-infra/pull/727

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3639](https://govukverify.atlassian.net/browse/PYIC-3639)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3639]: https://govukverify.atlassian.net/browse/PYIC-3639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ