### PR TITLE
Tidy up initial CI scoring events

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -60,16 +60,8 @@ INITIAL_CI_SCORING:
   events:
     ci-score-not-breaching:
       targetState: CHECK_EXISTING_IDENTITY
-    reuse:
-      targetState: IPV_IDENTITY_REUSE_PAGE
-    pending:
-      targetState: IPV_IDENTITY_PENDING_PAGE
     pyi-no-match:
       targetState: PYI_NO_MATCH
-    pyi-kbv-fail:
-      targetState: PYI_KBV_FAIL
-    fail:
-      targetState: PYI_F2F_TECHNICAL
     error:
       targetState: ERROR
     enhanced-verification:
@@ -90,8 +82,6 @@ CHECK_EXISTING_IDENTITY:
       targetState: IPV_IDENTITY_PENDING_PAGE
     pyi-no-match:
       targetState: PYI_NO_MATCH
-    pyi-kbv-fail:
-      targetState: PYI_KBV_FAIL
     fail:
       targetState: PYI_F2F_TECHNICAL
     error:


### PR DESCRIPTION
The initial CI scoring step has a bunch of events that are not emitted by the lambda. This tidies them up, to help streamline the diagram.

Before:
![image](https://github.com/govuk-one-login/ipv-core-back/assets/142887793/a731fe15-5998-4ec9-951a-01979742d364)

After:
![image](https://github.com/govuk-one-login/ipv-core-back/assets/142887793/571b7e88-7e79-401a-9551-f29885a88337)