### PR TITLE
PYIC-3773: Update core identity claim generation to evaluate all relevant VCs

### DIFF
--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -6,7 +6,6 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain.ProvenUserIdentityDetails;
@@ -47,6 +46,8 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_MULTI_ADDRESS
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_MULTI_ADDRESS_VC_WITHOUT_VALID_FROM_FIELD;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_VC;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_PASSPORT_VC_MISSING_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class BuildProvenUserIdentityDetailsHandlerTest {
@@ -59,8 +60,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
             createCredentialIssuerConfig("https://review-a.integration.account.gov.uk");
     private static final CredentialIssuerConfig ISSUER_CONFIG_CLAIMED_IDENTITY =
             createCredentialIssuerConfig("https://review-c.integration.account.gov.uk");
-    private static final CredentialIssuerConfig ISSUER_CONFIG_UK_PASSPORT =
-            createCredentialIssuerConfig("https://review-p.integration.account.gov.uk");
 
     @Mock private Context context;
     @Mock private ConfigService mockConfigService;
@@ -69,7 +68,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionDetailsService;
     @Mock private IpvSessionItem mockIpvSessionItem;
 
-    @InjectMocks private BuildProvenUserIdentityDetailsHandler handler;
+    private BuildProvenUserIdentityDetailsHandler handler;
     private ClientOAuthSessionItem clientOAuthSessionItem;
 
     @BeforeEach
@@ -83,11 +82,19 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         .govukSigninJourneyId("test-journey-id")
                         .userId(TEST_USER_ID)
                         .build();
+
+        handler =
+                new BuildProvenUserIdentityDetailsHandler(
+                        mockIpvSessionService,
+                        mockUserIdentityService,
+                        mockConfigService,
+                        mockClientOAuthSessionDetailsService);
     }
 
     @Test
     void shouldReceive200ResponseCodeProvenUserIdentityDetails() throws Exception {
         when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
@@ -100,8 +107,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
 
         when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
-        when(mockConfigService.getComponentId(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
         when(mockConfigService.getComponentId(ADDRESS_CRI))
                 .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
 
@@ -121,9 +126,47 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     }
 
     @Test
+    void shouldReceive200ResponseCodeProvenUserIdentityDetailsWithNameAndDoBOnDifferentVcs()
+            throws Exception {
+        when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
+        when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
+        when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                createVcStoreItem(PASSPORT_CRI, SIGNED_PASSPORT_VC_MISSING_NAME),
+                                createVcStoreItem(
+                                        PASSPORT_CRI, SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE),
+                                createVcStoreItem(ADDRESS_CRI, M1A_ADDRESS_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
+
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
+
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        JourneyRequest input = createRequestEvent();
+
+        ProvenUserIdentityDetails provenUserIdentityDetails =
+                toResponseClass(
+                        handler.handleRequest(input, context), ProvenUserIdentityDetails.class);
+
+        assertEquals("Paul", provenUserIdentityDetails.getName());
+        assertEquals("2020-02-03", provenUserIdentityDetails.getDateOfBirth());
+        assertEquals("BA2 5AA", provenUserIdentityDetails.getAddresses().get(0).getPostalCode());
+        verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+    }
+
+    @Test
     void shouldReceive200ResponseCodeProvenUserIdentityDetailsWithCorrectlyOrderedAddressHistory()
             throws Exception {
         when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
@@ -136,8 +179,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
 
         when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
-        when(mockConfigService.getComponentId(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
         when(mockConfigService.getComponentId(ADDRESS_CRI))
                 .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
 
@@ -165,6 +206,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
             shouldReceive200ResponseCodeProvenUserIdentityDetailsWith1stAddressIfCurrentAddressCantBeFound()
                     throws Exception {
         when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
@@ -178,8 +220,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
 
         when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
-        when(mockConfigService.getComponentId(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
         when(mockConfigService.getComponentId(ADDRESS_CRI))
                 .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -198,7 +238,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     }
 
     @Test
-    void shouldReceive400ResponseCodeWhenEvidenceVcIsMissing() {
+    void shouldReceive400ResponseCodeWhenEvidenceVcIsMissing() throws Exception {
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
@@ -232,7 +273,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
 
     @Test
     void shouldReceive400ResponseCodeWhenAddressVcIsMissing() throws Exception {
-        when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
@@ -244,8 +285,6 @@ class BuildProvenUserIdentityDetailsHandlerTest {
 
         when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
-        when(mockConfigService.getComponentId(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
         when(mockConfigService.getComponentId(ADDRESS_CRI))
                 .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -266,8 +305,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     }
 
     @Test
-    void shouldReceive400ResponseCodeWhenEvidenceVcIsNotSuccessful() throws Exception {
-        when(mockUserIdentityService.isVcSuccessful(any(), any())).thenCallRealMethod();
+    void shouldReceive500ResponseCodeWhenEvidenceVcIsNotSuccessful() throws Exception {
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
         when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
         when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
@@ -280,8 +319,75 @@ class BuildProvenUserIdentityDetailsHandlerTest {
 
         when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
                 .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
-        when(mockConfigService.getComponentId(PASSPORT_CRI))
-                .thenReturn(ISSUER_CONFIG_UK_PASSPORT.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        JourneyRequest input = createRequestEvent();
+        JourneyErrorResponse errorResponse =
+                toResponseClass(handler.handleRequest(input, context), JourneyErrorResponse.class);
+
+        assertEquals(500, errorResponse.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_GENERATE_PROVEN_USER_IDENTITY_DETAILS.getCode(),
+                errorResponse.getCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_GENERATE_PROVEN_USER_IDENTITY_DETAILS.getMessage(),
+                errorResponse.getMessage());
+        verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+    }
+
+    @Test
+    void shouldReceive500ResponseCodeWhenMissingNameInVcs() throws Exception {
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
+        when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
+        when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                createVcStoreItem(PASSPORT_CRI, SIGNED_PASSPORT_VC_MISSING_NAME),
+                                createVcStoreItem(ADDRESS_CRI, M1A_ADDRESS_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
+
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
+        when(mockConfigService.getComponentId(ADDRESS_CRI))
+                .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        JourneyRequest input = createRequestEvent();
+        JourneyErrorResponse errorResponse =
+                toResponseClass(handler.handleRequest(input, context), JourneyErrorResponse.class);
+
+        assertEquals(500, errorResponse.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_GENERATE_PROVEN_USER_IDENTITY_DETAILS.getCode(),
+                errorResponse.getCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_GENERATE_PROVEN_USER_IDENTITY_DETAILS.getMessage(),
+                errorResponse.getMessage());
+        verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+    }
+
+    @Test
+    void shouldReceive500ResponseCodeWhenMissingDoBInVcs() throws Exception {
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
+        when(mockIpvSessionItem.getClientOAuthSessionId()).thenReturn(TEST_CLIENT_OAUTH_SESSION_ID);
+        when(mockUserIdentityService.getVcStoreItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                createVcStoreItem(
+                                        PASSPORT_CRI, SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE),
+                                createVcStoreItem(ADDRESS_CRI, M1A_ADDRESS_VC),
+                                createVcStoreItem(FRAUD_CRI, M1A_FRAUD_VC),
+                                createVcStoreItem(KBV_CRI, M1A_VERIFICATION_VC)));
+
+        when(mockConfigService.getComponentId(CLAIMED_IDENTITY_CRI))
+                .thenReturn(ISSUER_CONFIG_CLAIMED_IDENTITY.getComponentId());
         when(mockConfigService.getComponentId(ADDRESS_CRI))
                 .thenReturn(ISSUER_CONFIG_ADDRESS.getComponentId());
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -342,6 +448,7 @@ class BuildProvenUserIdentityDetailsHandlerTest {
 
     @Test
     void shouldReturn500IfNoVcStatusForIssuer() throws Exception {
+        when(mockUserIdentityService.findIdentityClaim(any())).thenCallRealMethod();
         when(mockUserIdentityService.isVcSuccessful(any(), any()))
                 .thenThrow(new NoVcStatusForIssuerException("Bad"));
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialConstants.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialConstants.java
@@ -17,6 +17,8 @@ public class VerifiableCredentialConstants {
     public static final String IDENTITY_CHECK_CREDENTIAL_TYPE = "IdentityCheckCredential";
     public static final String VC_CREDENTIAL_SUBJECT = "credentialSubject";
     public static final String VC_EVIDENCE = "evidence";
+    public static final String VC_EVIDENCE_VALIDITY = "validityScore";
+    public static final String VC_EVIDENCE_STRENGTH = "strengthScore";
     public static final String VC_EVIDENCE_TXN = "txn";
     public static final String VC_CLAIM = "vc";
 }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -52,10 +52,12 @@ import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.BAV_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DRIVING_LICENCE_CRI;
-import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE_STRENGTH;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE_VALIDITY;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ISSUER;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 
@@ -65,8 +67,6 @@ public class UserIdentityService {
     private static final List<String> PASSPORT_CRI_TYPES = List.of(PASSPORT_CRI, DCMAW_CRI);
     private static final List<String> DRIVING_PERMIT_CRI_TYPES =
             List.of(DCMAW_CRI, DRIVING_LICENCE_CRI);
-    public static final List<String> EVIDENCE_CRI_TYPES =
-            List.of(PASSPORT_CRI, DCMAW_CRI, DRIVING_LICENCE_CRI, F2F_CRI);
 
     public static final List<String> CRI_TYPES_EXCLUDED_FOR_NAME_CORRELATION = List.of(ADDRESS_CRI);
     public static final List<String> CRI_TYPES_EXCLUDED_FOR_DOB_CORRELATION =
@@ -154,7 +154,7 @@ public class UserIdentityService {
         if (vot.equals(VectorOfTrust.P2.toString())) {
             final List<VcStoreItem> successfulVCStoreItems =
                     getSuccessfulVCStoreItems(vcStoreItems);
-            Optional<IdentityClaim> identityClaim = generateIdentityClaim(successfulVCStoreItems);
+            Optional<IdentityClaim> identityClaim = findIdentityClaim(successfulVCStoreItems);
             identityClaim.ifPresent(userIdentityBuilder::identityClaim);
 
             Optional<JsonNode> addressClaim = generateAddressClaim(vcStoreItems);
@@ -235,32 +235,23 @@ public class UserIdentityService {
         return Optional.empty();
     }
 
-    private JsonNode getVCClaimNode(String credential) throws HttpResponseExceptionWithErrorBody {
+    private JsonNode getVCClaimNode(String credential, String node)
+            throws CredentialParseException {
         try {
             return objectMapper
                     .readTree(SignedJWT.parse(credential).getPayload().toString())
                     .path(VC_CLAIM)
-                    .path(VC_CREDENTIAL_SUBJECT);
-        } catch (ParseException | JsonProcessingException e) {
-            LOGGER.error("Failed to parse VC JWT because: {}", e.getMessage());
-            throw new HttpResponseExceptionWithErrorBody(
-                    500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
+                    .path(node);
+        } catch (JsonProcessingException | ParseException e) {
+            throw new CredentialParseException(
+                    "Encountered a parsing error while attempting to parse VC store item");
         }
     }
 
-    private <T> T getJsonProperty(
-            JsonNode jsonNode,
-            String propertyName,
-            String credentialIssuer,
-            CollectionType valueType,
-            boolean validateCorrelation)
+    private <T> T getJsonProperty(JsonNode jsonNode, String propertyName, CollectionType valueType)
             throws HttpResponseExceptionWithErrorBody {
         JsonNode propertyNode = jsonNode.path(propertyName);
-        if (!validateCorrelation && propertyNode.isMissingNode()) {
-            LOGGER.error("Property [{}] is missing from [{}] VC.", propertyName, credentialIssuer);
-            throw new HttpResponseExceptionWithErrorBody(
-                    500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
-        } else if (propertyNode.isMissingNode()) {
+        if (propertyNode.isMissingNode()) {
             try {
                 return objectMapper.readValue(new JSONArray().toJSONString(), valueType);
             } catch (JsonProcessingException e) {
@@ -278,42 +269,66 @@ public class UserIdentityService {
         }
     }
 
-    private IdentityClaim getIdentityClaim(
-            String credential, String credentialIssuer, boolean validateCorrelation)
-            throws HttpResponseExceptionWithErrorBody {
-        JsonNode vcClaimNode = getVCClaimNode(credential);
+    private IdentityClaim getIdentityClaim(String credential)
+            throws HttpResponseExceptionWithErrorBody, CredentialParseException {
+        JsonNode vcClaimNode = getVCClaimNode(credential, VC_CREDENTIAL_SUBJECT);
         List<Name> names =
                 getJsonProperty(
                         vcClaimNode,
                         NAME_PROPERTY_NAME,
-                        credentialIssuer,
                         objectMapper
                                 .getTypeFactory()
-                                .constructCollectionType(List.class, Name.class),
-                        validateCorrelation);
+                                .constructCollectionType(List.class, Name.class));
         List<BirthDate> birthDates =
                 getJsonProperty(
                         vcClaimNode,
                         BIRTH_DATE_PROPERTY_NAME,
-                        credentialIssuer,
                         objectMapper
                                 .getTypeFactory()
-                                .constructCollectionType(List.class, BirthDate.class),
-                        validateCorrelation);
+                                .constructCollectionType(List.class, BirthDate.class));
 
         return new IdentityClaim(names, birthDates);
     }
 
-    private Optional<IdentityClaim> generateIdentityClaim(List<VcStoreItem> successfulVCStoreItems)
-            throws HttpResponseExceptionWithErrorBody {
-        for (VcStoreItem item : successfulVCStoreItems) {
-            if (EVIDENCE_CRI_TYPES.contains(item.getCredentialIssuer())) {
-                return Optional.of(
-                        getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), false));
+    public Optional<IdentityClaim> findIdentityClaim(List<VcStoreItem> vcStoreItems)
+            throws HttpResponseExceptionWithErrorBody, CredentialParseException {
+        List<IdentityClaim> identityClaims = new ArrayList<>();
+        for (VcStoreItem vcStoreItem : vcStoreItems) {
+            try {
+                if (isEvidenceVc(vcStoreItem)
+                        && VcHelper.isSuccessfulVc(SignedJWT.parse(vcStoreItem.getCredential()))) {
+                    identityClaims.add(getIdentityClaim(vcStoreItem.getCredential()));
+                }
+            } catch (ParseException e) {
+                {
+                    throw new CredentialParseException(
+                            "Encountered a parsing error while attempting to parse VC store item");
+                }
             }
         }
-        LOGGER.warn("Failed to generate identity claim");
-        return Optional.empty();
+
+        if (identityClaims.isEmpty()) {
+            LOGGER.warn("Failed to generate identity claim");
+            return Optional.empty();
+        }
+
+        Optional<IdentityClaim> claimWithName =
+                identityClaims.stream()
+                        .filter(identityClaim -> !identityClaim.getName().isEmpty())
+                        .findFirst();
+        Optional<IdentityClaim> claimWithBirthDate =
+                identityClaims.stream()
+                        .filter(identityClaim -> !identityClaim.getBirthDate().isEmpty())
+                        .findFirst();
+        if (claimWithName.isEmpty() || claimWithBirthDate.isEmpty()) {
+            LOGGER.error("Failed to generate identity claim");
+            throw new HttpResponseExceptionWithErrorBody(
+                    500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
+        }
+        IdentityClaim identityClaim =
+                new IdentityClaim(
+                        claimWithName.get().getName(), claimWithBirthDate.get().getBirthDate());
+        return Optional.of(identityClaim);
     }
 
     private Optional<JsonNode> generateAddressClaim(List<VcStoreItem> vcStoreItems)
@@ -458,6 +473,17 @@ public class UserIdentityService {
                 .getIsSuccessfulVc();
     }
 
+    private boolean isEvidenceVc(VcStoreItem item) throws CredentialParseException {
+        JsonNode vcEvidenceNode = getVCClaimNode(item.getCredential(), VC_EVIDENCE);
+        for (JsonNode evidence : vcEvidenceNode) {
+            if (evidence.path(VC_EVIDENCE_VALIDITY).isInt()
+                    && evidence.path(VC_EVIDENCE_STRENGTH).isInt()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean checkBirthDateCorrelationInCredentials(String userId)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
         final List<VcStoreItem> successfulVCStoreItems =
@@ -474,11 +500,11 @@ public class UserIdentityService {
     }
 
     private List<IdentityClaim> getIdentityClaimsForBirthDateCorrelation(
-            List<VcStoreItem> vcStoreItems) throws HttpResponseExceptionWithErrorBody {
+            List<VcStoreItem> vcStoreItems)
+            throws HttpResponseExceptionWithErrorBody, CredentialParseException {
         List<IdentityClaim> identityClaims = new ArrayList<>();
         for (VcStoreItem item : vcStoreItems) {
-            IdentityClaim identityClaim =
-                    getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), true);
+            IdentityClaim identityClaim = getIdentityClaim(item.getCredential());
             if (isBirthDateEmpty(identityClaim.getBirthDate())) {
                 if (CRI_TYPES_EXCLUDED_FOR_DOB_CORRELATION.contains(item.getCredentialIssuer())) {
                     continue;
@@ -505,11 +531,10 @@ public class UserIdentityService {
     }
 
     private List<IdentityClaim> getIdentityClaimsForNameCorrelation(List<VcStoreItem> vcStoreItems)
-            throws HttpResponseExceptionWithErrorBody {
+            throws HttpResponseExceptionWithErrorBody, CredentialParseException {
         List<IdentityClaim> identityClaims = new ArrayList<>();
         for (VcStoreItem item : vcStoreItems) {
-            IdentityClaim identityClaim =
-                    getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), true);
+            IdentityClaim identityClaim = getIdentityClaim(item.getCredential());
             if (isNamesEmpty(identityClaim.getName())) {
                 if (CRI_TYPES_EXCLUDED_FOR_NAME_CORRELATION.contains(item.getCredentialIssuer())) {
                     continue;


### PR DESCRIPTION
Refine the logic for selecting a VC to use for the identity claims.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Updated UserIdentityService to check all relevant VCs for a name and date of birth, find the first of each (if present) and generate identity containing a combination of the two. Maintains existing error states one or both are missing.
- Updated BuildProvenUserIdentityDetailsHandler to find first vc nodes containing name and date of birth and construct `NameAndDateOfBirth` if both are present. 

### Why did it change

Currently our core identity claim is generated by finding the first VC from the EVIDENCE_CRI_TYPES (which is currently passport, DCMAW, driving licence and F2F) and it reads both the name and DOB from this VC.

This isn’t really suitable for M2B:
- Adding BAV to the list won’t work, as it only contains the name (not DOB)
- Adding NINO to the list is inconsistent, as it is not always ‘evidence’ (and adding NINO without BAV is weird)

The same thing applies to getting the proven identity details during a reuse journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3773](https://govukverify.atlassian.net/browse/PYIC-3773)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3773]: https://govukverify.atlassian.net/browse/PYIC-3773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ