### PR TITLE
PYIC-3753-fix: Modify F2F required Gpg45Score filtering for non-zero verification

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -333,8 +333,8 @@ public class BuildCriOauthRequestHandler
                                         requiredScores.getEvidences().size() == 1
                                                 & requiredScores.getActivity() == 0
                                                 & requiredScores.getFraud() == 0
-                                                & requiredScores.getVerification() == 0)
-                        .map(subList -> subList.getEvidences().get(0))
+                                                & requiredScores.getVerification() <= 3)
+                        .map(requiredScores -> requiredScores.getEvidences().get(0))
                         .mapToInt(Gpg45Scores.Evidence::getStrength)
                         .min();
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Change filter of required Gpg45Scores for F2F evidence request to allow non-zero verification scores

### Why did it change

- F2F can produce verification scores of up to 3

### Issue tracking

- [PYIC-3753](https://govukverify.atlassian.net/browse/PYIC-3753)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


[PYIC-3753]: https://govukverify.atlassian.net/browse/PYIC-3753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ