### PR TITLE
PYIC-3661: Add ability to set "context" for a CRI in the journey map

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -82,6 +82,7 @@
       "Resource": "${BuildCriOauthRequestFunctionArn}",
       "Parameters": {
         "journey.$": "$.journey",
+        "context.$": "$.context",
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -74,6 +74,7 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getJourney;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getContext;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 
 public class BuildCriOauthRequestHandler
@@ -147,6 +148,7 @@ public class BuildCriOauthRequestHandler
             String featureSet = getFeatureSet(input);
             configService.setFeatureSet(featureSet);
             String journey = getJourney(input);
+            String criContext = getContext(input);
 
             var errorResponse = validate(journey);
             if (errorResponse.isPresent()) {
@@ -187,7 +189,8 @@ public class BuildCriOauthRequestHandler
                             userId,
                             oauthState,
                             govukSigninJourneyId,
-                            criId);
+                            criId,
+                            criContext);
 
             CriResponse criResponse = getCriResponse(criConfig, jweObject, criId);
 
@@ -291,7 +294,8 @@ public class BuildCriOauthRequestHandler
             String userId,
             String oauthState,
             String govukSigninJourneyId,
-            String criId)
+            String criId,
+            String context)
             throws HttpResponseExceptionWithErrorBody, ParseException, JOSEException,
                     UnknownEvidenceTypeException {
 
@@ -313,7 +317,8 @@ public class BuildCriOauthRequestHandler
                         oauthState,
                         userId,
                         govukSigninJourneyId,
-                        evidenceRequest);
+                        evidenceRequest,
+                        context);
 
         RSAEncrypter rsaEncrypter = new RSAEncrypter(credentialIssuerConfig.getEncryptionKey());
         return AuthorizationRequestHelper.createJweObject(rsaEncrypter, signedJWT);

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -70,11 +70,11 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_REDIRECT_URI;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getContext;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getJourney;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getContext;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 
 public class BuildCriOauthRequestHandler

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -70,7 +70,6 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_REDIRECT_URI;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getContext;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
@@ -148,7 +147,7 @@ public class BuildCriOauthRequestHandler
             String featureSet = getFeatureSet(input);
             configService.setFeatureSet(featureSet);
             String journey = getJourney(input);
-            String criContext = getContext(input);
+            String criContext = input.getContext();
 
             var errorResponse = validate(journey);
             if (errorResponse.isPresent()) {

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -40,6 +40,8 @@ public class AuthorizationRequestHelper {
 
     private static final String EVIDENCE_REQUESTED = "evidence_requested";
 
+    private static final String CONTEXT = "context";
+
     private AuthorizationRequestHelper() {}
 
     public static SignedJWT createSignedJWT(
@@ -50,7 +52,8 @@ public class AuthorizationRequestHelper {
             String oauthState,
             String userId,
             String govukSigninJourneyId,
-            EvidenceRequest evidence)
+            EvidenceRequest evidence,
+            String context)
             throws HttpResponseExceptionWithErrorBody {
         Instant now = Instant.now();
 
@@ -105,6 +108,10 @@ public class AuthorizationRequestHelper {
 
         if (Objects.nonNull(evidence)) {
             claimsSetBuilder.claim(EVIDENCE_REQUESTED, evidence);
+        }
+
+        if (Objects.nonNull(context)) {
+            claimsSetBuilder.claim(CONTEXT, context);
         }
 
         SignedJWT signedJWT = new SignedJWT(header, claimsSetBuilder.build());

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -116,6 +116,7 @@ class AuthorizationRequestHelperTest {
                         OAUTH_STATE,
                         TEST_USER_ID,
                         TEST_JOURNEY_ID,
+                        null,
                         null);
 
         assertEquals(IPV_ISSUER, result.getJWTClaimsSet().getIssuer());
@@ -147,6 +148,7 @@ class AuthorizationRequestHelperTest {
                         OAUTH_STATE,
                         TEST_USER_ID,
                         TEST_JOURNEY_ID,
+                        null,
                         null);
         assertNull(result.getJWTClaimsSet().getClaims().get(TEST_SHARED_CLAIMS));
     }
@@ -168,6 +170,7 @@ class AuthorizationRequestHelperTest {
                                         OAUTH_STATE,
                                         TEST_USER_ID,
                                         TEST_JOURNEY_ID,
+                                        null,
                                         null));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to sign Shared Attributes", exception.getErrorReason());

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -62,6 +62,7 @@ class AuthorizationRequestHelperTest {
     private static final String IPV_CLIENT_ID_VALUE = "testClientId";
     private static final String IPV_ISSUER = "http://example.com/issuer";
     private static final String AUDIENCE = "Audience";
+    private static final String BANK_ACCOUNT_CONTEXT = "bank_account";
     private static final String IPV_TOKEN_TTL = "900";
     private static final String MOCK_CORE_FRONT_CALLBACK_URL = "callbackUri";
     private static final String TEST_REDIRECT_URI = "http:example.com/callback/criId";
@@ -131,6 +132,30 @@ class AuthorizationRequestHelperTest {
                 IPV_CLIENT_ID_VALUE, result.getJWTClaimsSet().getClaims().get(CLIENT_ID_FIELD));
         assertEquals(TEST_REDIRECT_URI, result.getJWTClaimsSet().getClaims().get("redirect_uri"));
         assertTrue(result.verify(new ECDSAVerifier(ECKey.parse(EC_PUBLIC_JWK))));
+    }
+
+    @Test
+    void shouldCreateSignedJWTWithContextIfExists()
+            throws ParseException, HttpResponseExceptionWithErrorBody {
+        setupCredentialIssuerConfigMock();
+        setupConfigurationServiceMock();
+        when(credentialIssuerConfig.getComponentId()).thenReturn(AUDIENCE);
+        when(credentialIssuerConfig.getClientCallbackUrl())
+                .thenReturn(URI.create(TEST_REDIRECT_URI));
+
+        SignedJWT result =
+                AuthorizationRequestHelper.createSignedJWT(
+                        sharedClaims,
+                        signer,
+                        credentialIssuerConfig,
+                        configService,
+                        OAUTH_STATE,
+                        TEST_USER_ID,
+                        TEST_JOURNEY_ID,
+                        null,
+                        BANK_ACCOUNT_CONTEXT);
+
+        assertEquals(BANK_ACCOUNT_CONTEXT, result.getJWTClaimsSet().getStringClaim("context"));
     }
 
     @Test

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.processjourneyevent.exceptions.JourneyEngineException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.StateMachine;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.StateMachineInitializer;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.StateMachineInitializerMode;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.StateMachineNotFoundException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownStateException;
@@ -58,12 +59,27 @@ public class ProcessJourneyEventHandler
             IpvSessionService ipvSessionService,
             ConfigService configService,
             ClientOAuthSessionDetailsService clientOAuthSessionService,
-            List<IpvJourneyTypes> journeyTypes)
+            List<IpvJourneyTypes> journeyTypes,
+            StateMachineInitializerMode stateMachineInitializerMode)
             throws IOException {
         this.ipvSessionService = ipvSessionService;
         this.configService = configService;
         this.clientOAuthSessionService = clientOAuthSessionService;
-        this.stateMachines = loadStateMachines(journeyTypes);
+        this.stateMachines = loadStateMachines(journeyTypes, stateMachineInitializerMode);
+    }
+
+    public ProcessJourneyEventHandler(
+            IpvSessionService ipvSessionService,
+            ConfigService configService,
+            ClientOAuthSessionDetailsService clientOAuthSessionService,
+            List<IpvJourneyTypes> journeyTypes)
+            throws IOException {
+        this(
+                ipvSessionService,
+                configService,
+                clientOAuthSessionService,
+                journeyTypes,
+                StateMachineInitializerMode.STANDARD);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -227,14 +243,23 @@ public class ProcessJourneyEventHandler
     }
 
     @Tracing
-    private Map<IpvJourneyTypes, StateMachine> loadStateMachines(List<IpvJourneyTypes> journeyTypes)
+    private Map<IpvJourneyTypes, StateMachine> loadStateMachines(
+            List<IpvJourneyTypes> journeyTypes,
+            StateMachineInitializerMode stateMachineInitializerMode)
             throws IOException {
         EnumMap<IpvJourneyTypes, StateMachine> stateMachinesMap =
                 new EnumMap<>(IpvJourneyTypes.class);
         for (IpvJourneyTypes journeyType : journeyTypes) {
             stateMachinesMap.put(
-                    journeyType, new StateMachine(new StateMachineInitializer(journeyType)));
+                    journeyType,
+                    new StateMachine(
+                            new StateMachineInitializer(journeyType, stateMachineInitializerMode)));
         }
         return stateMachinesMap;
+    }
+
+    private Map<IpvJourneyTypes, StateMachine> loadStateMachines(List<IpvJourneyTypes> journeyTypes)
+            throws IOException {
+        return loadStateMachines(journeyTypes, StateMachineInitializerMode.STANDARD);
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -68,26 +68,14 @@ public class ProcessJourneyEventHandler
         this.stateMachines = loadStateMachines(journeyTypes, stateMachineInitializerMode);
     }
 
-    public ProcessJourneyEventHandler(
-            IpvSessionService ipvSessionService,
-            ConfigService configService,
-            ClientOAuthSessionDetailsService clientOAuthSessionService,
-            List<IpvJourneyTypes> journeyTypes)
-            throws IOException {
-        this(
-                ipvSessionService,
-                configService,
-                clientOAuthSessionService,
-                journeyTypes,
-                StateMachineInitializerMode.STANDARD);
-    }
-
     @ExcludeFromGeneratedCoverageReport
     public ProcessJourneyEventHandler() throws IOException {
         this.configService = new ConfigService();
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
-        this.stateMachines = loadStateMachines(List.of(IPV_CORE_MAIN_JOURNEY));
+        this.stateMachines =
+                loadStateMachines(
+                        List.of(IPV_CORE_MAIN_JOURNEY), StateMachineInitializerMode.STANDARD);
     }
 
     @Override
@@ -256,10 +244,5 @@ public class ProcessJourneyEventHandler
                             new StateMachineInitializer(journeyType, stateMachineInitializerMode)));
         }
         return stateMachinesMap;
-    }
-
-    private Map<IpvJourneyTypes, StateMachine> loadStateMachines(List<IpvJourneyTypes> journeyTypes)
-            throws IOException {
-        return loadStateMachines(journeyTypes, StateMachineInitializerMode.STANDARD);
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.Map;
+import java.util.Objects;
 
 @ExcludeFromGeneratedCoverageReport
 @NoArgsConstructor
@@ -17,7 +18,11 @@ public class CriStepResponse implements StepResponse {
 
     private String criId;
 
+    private String context;
+
     public Map<String, Object> value() {
-        return Map.of("journey", String.format(CRI_JOURNEY_TEMPLATE, criId));
+        return Objects.nonNull(context)
+                ? Map.of("journey", String.format(CRI_JOURNEY_TEMPLATE, criId), "context", context)
+                : Map.of("journey", String.format(CRI_JOURNEY_TEMPLATE, criId));
     }
 }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/ipv-core-main-journey.yaml
@@ -36,6 +36,17 @@ CRI_STATE:
   events:
     enterNestedJourneyAtStateOne:
       targetState: NESTED_JOURNEY_INVOKE_STATE
+    testWithContext:
+      targetState: CRI_STATE_WITH_CONTEXT
+
+CRI_STATE_WITH_CONTEXT:
+  response:
+    type: cri
+    criId: aCriId
+    context: bank_account
+  events:
+    enterNestedJourneyAtStateOne:
+      targetState: NESTED_JOURNEY_INVOKE_STATE
 
 ERROR_STATE:
   response:

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -140,7 +140,8 @@ class ProcessJourneyEventHandlerTest {
                         mockIpvSessionService,
                         mockConfigService,
                         mockClientOAuthSessionService,
-                        List.of());
+                        List.of(),
+                        StateMachineInitializerMode.STANDARD);
 
         Map<String, Object> output = processJourneyEventHandler.handleRequest(input, mockContext);
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.StateMachineInitializerMode;
 import uk.gov.di.ipv.core.processjourneyevent.utils.ProcessJourneyStepEvents;
 import uk.gov.di.ipv.core.processjourneyevent.utils.ProcessJourneyStepPages;
 import uk.gov.di.ipv.core.processjourneyevent.utils.ProcessJourneyStepStates;
@@ -44,6 +45,7 @@ class ProcessJourneyEventHandlerTest {
     private static final String CODE = "code";
     private static final String IPV_SESSION_ID = "ipvSessionId";
     private static final String JOURNEY = "journey";
+    private static final String CONTEXT = "context";
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
 
@@ -221,6 +223,21 @@ class ProcessJourneyEventHandlerTest {
         assertNull(sessionArgumentCaptor.getValue().getCriOAuthSessionId());
     }
 
+    @Test
+    void shouldReturnContextIfExists() throws Exception {
+        String context = "bank_account";
+
+        Map<String, String> input = Map.of(JOURNEY, "testWithContext", IPV_SESSION_ID, "1234");
+
+        mockIpvSessionItemAndTimeout("CRI_STATE");
+
+        var processJourneyEventOutput =
+                getProcessJourneyStepHandler(StateMachineInitializerMode.TEST)
+                        .handleRequest(input, mockContext);
+
+        assertEquals(context, processJourneyEventOutput.get(CONTEXT));
+    }
+
     private void mockIpvSessionItemAndTimeout(String userState) {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
@@ -247,11 +264,17 @@ class ProcessJourneyEventHandlerTest {
                 .build();
     }
 
-    private ProcessJourneyEventHandler getProcessJourneyStepHandler() throws IOException {
+    private ProcessJourneyEventHandler getProcessJourneyStepHandler(
+            StateMachineInitializerMode stateMachineInitializerMode) throws IOException {
         return new ProcessJourneyEventHandler(
                 mockIpvSessionService,
                 mockConfigService,
                 mockClientOAuthSessionService,
-                List.of(IPV_CORE_MAIN_JOURNEY));
+                List.of(IPV_CORE_MAIN_JOURNEY),
+                stateMachineInitializerMode);
+    }
+
+    private ProcessJourneyEventHandler getProcessJourneyStepHandler() throws IOException {
+        return getProcessJourneyStepHandler(StateMachineInitializerMode.STANDARD);
     }
 }

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -67,6 +67,7 @@ class StateMachineInitializerTest {
         BasicState pageState = (BasicState) journeyMap.get("PAGE_STATE");
         BasicState journeyState = (BasicState) journeyMap.get("JOURNEY_STATE");
         BasicState criState = (BasicState) journeyMap.get("CRI_STATE");
+        BasicState criWithContextState = (BasicState) journeyMap.get("CRI_STATE_WITH_CONTEXT");
         BasicState errorState = (BasicState) journeyMap.get("ERROR_STATE");
         BasicState processState = (BasicState) journeyMap.get("PROCESS_STATE");
         NestedJourneyInvokeState nestedJourneyInvokeState =
@@ -108,6 +109,16 @@ class StateMachineInitializerTest {
         assertEquals(
                 nestedJourneyInvokeState,
                 ((BasicEvent) criState.getEvents().get("enterNestedJourneyAtStateOne"))
+                        .getTargetStateObj());
+
+        // cri state with context assertions
+        assertEquals(
+                "/journey/cri/build-oauth-request/aCriId",
+                criWithContextState.getResponse().value().get("journey"));
+        assertEquals("bank_account", criWithContextState.getResponse().value().get("context"));
+        assertEquals(
+                nestedJourneyInvokeState,
+                ((BasicEvent) criWithContextState.getEvents().get("enterNestedJourneyAtStateOne"))
                         .getTargetStateObj());
 
         // error state assertions

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CriStepResponseTest {
 
-    public static final CriStepResponse CRI_RESPONSE = new CriStepResponse("aCriId");
+    public static final CriStepResponse CRI_RESPONSE = new CriStepResponse("aCriId", null);
 
     @Test
     void valueReturnsCorrectJourneyResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -9,10 +9,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class CriStepResponseTest {
 
     public static final CriStepResponse CRI_RESPONSE = new CriStepResponse("aCriId", null);
+    public static final CriStepResponse CRI_RESPONSE_WITH_CONTEXT =
+            new CriStepResponse("aCriId", "someContext");
 
     @Test
     void valueReturnsCorrectJourneyResponse() {
         assertEquals(
                 Map.of("journey", "/journey/cri/build-oauth-request/aCriId"), CRI_RESPONSE.value());
+    }
+
+    @Test
+    void valueReturnsJourneyResponseWithContextIfExists() {
+        assertEquals(
+                Map.of(
+                        "journey",
+                        "/journey/cri/build-oauth-request/aCriId",
+                        "context",
+                        "someContext"),
+                CRI_RESPONSE_WITH_CONTEXT.value());
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -14,5 +14,6 @@ public class JourneyRequest {
     private String ipAddress;
     private String clientOAuthSessionId;
     private String journey;
+    private String context;
     private String featureSet;
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
@@ -18,10 +18,11 @@ public class ProcessRequest extends JourneyRequest {
             String ipAddress,
             String clientOAuthSessionId,
             String journey,
+            String context,
             String featureSet,
             String scoreType,
             Integer scoreThreshold) {
-        super(ipvSessionId, ipAddress, clientOAuthSessionId, journey, featureSet);
+        super(ipvSessionId, ipAddress, clientOAuthSessionId, journey, context, featureSet);
         this.scoreType = scoreType;
         this.scoreThreshold = scoreThreshold;
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -111,10 +111,6 @@ public class RequestHelper {
         return request.getJourney();
     }
 
-    public static String getContext(JourneyRequest request) {
-        return request.getContext();
-    }
-
     public static String getScoreType(ProcessRequest request)
             throws HttpResponseExceptionWithErrorBody {
         String scoreType = request.getScoreType();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -111,6 +111,10 @@ public class RequestHelper {
         return request.getJourney();
     }
 
+    public static String getContext(JourneyRequest request) {
+        return request.getContext();
+    }
+
     public static String getScoreType(ProcessRequest request)
             throws HttpResponseExceptionWithErrorBody {
         String scoreType = request.getScoreType();

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
@@ -41,6 +41,7 @@ public class LambdaHandler {
             new TypeToken<Map<String, String>>() {}.getType();
     public static final String APPLICATION_JSON = "application/json";
     public static final String JOURNEY = "journey";
+    public static final String CONTEXT = "context";
     public static final String IPV_SESSION_ID = "ipv-session-id";
     public static final String IP_ADDRESS = "ip-address";
     public static final String CLIENT_SESSION_ID = "client-session-id";
@@ -108,6 +109,7 @@ public class LambdaHandler {
                                     EMPTY_CONTEXT);
 
                     journey = (String) processJourneyEventOutput.get(JOURNEY);
+                    String context = (String) processJourneyEventOutput.get(CONTEXT);
 
                     if ("/journey/check-existing-identity".equals(journey)) {
                         lambdaOutput =
@@ -129,7 +131,7 @@ public class LambdaHandler {
                             && journey.matches("/journey/cri/build-oauth-request/.*")) {
                         lambdaOutput =
                                 buildCriOauthRequestHandler.handleRequest(
-                                        buildJourneyRequest(request, journey), EMPTY_CONTEXT);
+                                        buildJourneyRequest(request, journey, context), EMPTY_CONTEXT);
                         if (!lambdaOutput.containsKey(JOURNEY)) {
                             return gson.toJson(lambdaOutput);
                         }
@@ -248,14 +250,19 @@ public class LambdaHandler {
                 return responseEvent.getBody();
             };
 
-    private JourneyRequest buildJourneyRequest(Request request, String journey) {
+    private JourneyRequest buildJourneyRequest(Request request, String journey, String context) {
         return JourneyRequest.builder()
                 .ipvSessionId(request.headers(IPV_SESSION_ID))
                 .ipAddress(request.headers(IP_ADDRESS))
                 .clientOAuthSessionId(request.headers(CLIENT_SESSION_ID))
                 .featureSet(request.headers(FEATURE_SET))
                 .journey(journey)
+                .context(context)
                 .build();
+    }
+
+    private JourneyRequest buildJourneyRequest(Request request, String journey) {
+        return buildJourneyRequest(request, journey, null);
     }
 
     private Map<String, String> buildCriReturnLambdaInput(Request request) {

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
@@ -109,7 +109,6 @@ public class LambdaHandler {
                                     EMPTY_CONTEXT);
 
                     journey = (String) processJourneyEventOutput.get(JOURNEY);
-                    String context = (String) processJourneyEventOutput.get(CONTEXT);
 
                     if ("/journey/check-existing-identity".equals(journey)) {
                         lambdaOutput =
@@ -131,7 +130,10 @@ public class LambdaHandler {
                             && journey.matches("/journey/cri/build-oauth-request/.*")) {
                         lambdaOutput =
                                 buildCriOauthRequestHandler.handleRequest(
-                                        buildJourneyRequest(request, journey, context),
+                                        buildJourneyRequest(
+                                                request,
+                                                journey,
+                                                (String) processJourneyEventOutput.get(CONTEXT)),
                                         EMPTY_CONTEXT);
                         if (!lambdaOutput.containsKey(JOURNEY)) {
                             return gson.toJson(lambdaOutput);

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
@@ -131,7 +131,8 @@ public class LambdaHandler {
                             && journey.matches("/journey/cri/build-oauth-request/.*")) {
                         lambdaOutput =
                                 buildCriOauthRequestHandler.handleRequest(
-                                        buildJourneyRequest(request, journey, context), EMPTY_CONTEXT);
+                                        buildJourneyRequest(request, journey, context),
+                                        EMPTY_CONTEXT);
                         if (!lambdaOutput.containsKey(JOURNEY)) {
                             return gson.toJson(lambdaOutput);
                         }


### PR DESCRIPTION
## Proposed changes

### What changed

- Allowed states in the journey map to pass context to BuildCriOauthRequest to request from the CRI with the context included
- Enabled ProcessEventHandler tests to access test journey map

### Why did it change

- The CIC CRI is currently tailored for a photo ID journey, but it will also be used in No Photo ID journeys. The content on the screens needs to be adaptable based on the use case.

### Issue tracking

- [PYIC-3661](https://govukverify.atlassian.net/browse/PYIC-3661)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


[PYIC-3661]: https://govukverify.atlassian.net/browse/PYIC-3661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ