### PR TITLE
BAU: Update local-running Dockerfiles

### DIFF
--- a/local-running/compose.yaml
+++ b/local-running/compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: orch-stub
     build:
       context: ../../ipv-stubs/di-ipv-orchestrator-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - ORCHESTRATOR_CLIENT_ID=orchestrator
       - ORCHESTRATOR_JAR_ENCRYPTION_PUBLIC_KEY=eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsImtpZCI6ImI0NTRhYzA3LWUxODgtNDE1ZC1hM2M4LWYxZDBkMzhhYWVjZCIsIm4iOiJsb0hlYVN4dk1naUhTdEttYi1aSzVaUHB3UldyaFNTUS1uVHl1S1FqLW1ZV1lGTkdnR0dOUC0zN1p2em80NTNiVUd0RWVGdTF6ZGxMQW9IeVQza2dzMVhkcVhDdlBpbk5jY3BKOGxXR1hjRktHUmhqNWp4SWlJTXZFQkhmTHNfLWNNSVdXMDE2Nm5kVFQ5M29jb1hkWGFQNjRtSDJpRjdXV0R5S3FPY3JWanVhVW5iRmJTNFgyZmhKd3dSUGpfS2luNWpwSkN4M01KZDllSXVZeUpCNENsdGJMVHBYMjVvQ3dMdzl0LXAybHpIZmF6SlNJVGNmVHpFYk9aVjQwZlBKSVI2SGxKaTdBcFhZZkFRLWRsYmpNc1lpbkZRblk2SUxKWGtic2pENEpYV1VZYUIwUmJLOFdUVEt5ZWhGVTdQX1E4dkZiN3FXVTRYajlNVEVIYzdXM1EifQ==
@@ -87,7 +87,7 @@ services:
     container_name: dcmaw-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=DOC Checking App (Stub)
       - CREDENTIAL_ISSUER_TYPE=DOC_CHECK_APP
@@ -110,7 +110,7 @@ services:
     container_name: address-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=Address (Stub)
       - CREDENTIAL_ISSUER_TYPE=USER_ASSERTED
@@ -133,7 +133,7 @@ services:
     container_name: fraud-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=Fraud Check (Stub)
       - CREDENTIAL_ISSUER_TYPE=FRAUD
@@ -156,7 +156,7 @@ services:
     container_name: driving-license-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=Driving Licence (Stub)
       - CREDENTIAL_ISSUER_TYPE=EVIDENCE_DRIVING_LICENCE
@@ -179,7 +179,7 @@ services:
     container_name: passport-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=UK Passport (Stub)
       - CREDENTIAL_ISSUER_TYPE=EVIDENCE
@@ -202,7 +202,7 @@ services:
     container_name: kbv-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=Knowledge Based Verification (Stub)
       - CREDENTIAL_ISSUER_TYPE=VERIFICATION
@@ -225,7 +225,7 @@ services:
     container_name: claimed-identity-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=Claimed Identity (Stub)
       - CREDENTIAL_ISSUER_TYPE=USER_ASSERTED
@@ -248,7 +248,7 @@ services:
     container_name: f2f-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=Face to Face Check (Stub)
       - CREDENTIAL_ISSUER_TYPE=F2F
@@ -273,7 +273,7 @@ services:
     container_name: nino-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=National Insurance Number (Stub)
       - CREDENTIAL_ISSUER_TYPE=NINO
@@ -296,7 +296,7 @@ services:
     container_name: hmrc-kbv-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=HMRC Knowledge Based Verification (Stub)
       - CREDENTIAL_ISSUER_TYPE=VERIFICATION
@@ -319,7 +319,7 @@ services:
     container_name: bav-stub
     build:
       context: ../../ipv-stubs/di-ipv-credential-issuer-stub
-      dockerfile: Dockerfile
+      dockerfile: core-dev-deploy/Dockerfile
     environment:
       - CREDENTIAL_ISSUER_NAME=Bank account verification (Stub)
       - CREDENTIAL_ISSUER_TYPE=EVIDENCE


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update local-running Dockerfiles

### Why did it change

The dockerfiles that were being used have had Dynatrace added to them. As part of that a remote resource is fetched from a container registry that is behind auth. Which makes it hard to build locally.

New dockerfiles were created that were the same as the old ones but didn't include dynatrace. We can use those instead.
