### PR TITLE
PYIC-3661-fix: Put empty string context if absent

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -110,7 +110,7 @@ public class AuthorizationRequestHelper {
             claimsSetBuilder.claim(EVIDENCE_REQUESTED, evidence);
         }
 
-        if (Objects.nonNull(context)) {
+        if (Objects.nonNull(context) && !context.isEmpty()) {
             claimsSetBuilder.claim(CONTEXT, context);
         }
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -118,7 +118,7 @@ class AuthorizationRequestHelperTest {
                         TEST_USER_ID,
                         TEST_JOURNEY_ID,
                         null,
-                        null);
+                        "");
 
         assertEquals(IPV_ISSUER, result.getJWTClaimsSet().getIssuer());
         assertEquals(TEST_USER_ID, result.getJWTClaimsSet().getSubject());
@@ -174,7 +174,7 @@ class AuthorizationRequestHelperTest {
                         TEST_USER_ID,
                         TEST_JOURNEY_ID,
                         null,
-                        null);
+                        "");
         assertNull(result.getJWTClaimsSet().getClaims().get(TEST_SHARED_CLAIMS));
     }
 
@@ -196,7 +196,7 @@ class AuthorizationRequestHelperTest {
                                         TEST_USER_ID,
                                         TEST_JOURNEY_ID,
                                         null,
-                                        null));
+                                        ""));
         assertEquals(500, exception.getResponseCode());
         assertEquals("Failed to sign Shared Attributes", exception.getErrorReason());
     }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -34,7 +34,6 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageSte
 import java.io.IOException;
 import java.time.Instant;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -34,6 +34,7 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageSte
 import java.io.IOException;
 import java.time.Instant;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -23,6 +23,6 @@ public class CriStepResponse implements StepResponse {
     public Map<String, Object> value() {
         return Objects.nonNull(context)
                 ? Map.of("journey", String.format(CRI_JOURNEY_TEMPLATE, criId), "context", context)
-                : Map.of("journey", String.format(CRI_JOURNEY_TEMPLATE, criId));
+                : Map.of("journey", String.format(CRI_JOURNEY_TEMPLATE, criId), "context", "");
     }
 }

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -15,7 +15,8 @@ public class CriStepResponseTest {
     @Test
     void valueReturnsCorrectJourneyResponse() {
         assertEquals(
-                Map.of("journey", "/journey/cri/build-oauth-request/aCriId"), CRI_RESPONSE.value());
+                Map.of("journey", "/journey/cri/build-oauth-request/aCriId", "context", ""),
+                CRI_RESPONSE.value());
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -14,7 +14,6 @@ public class JourneyRequest {
     private String ipAddress;
     private String clientOAuthSessionId;
     private String journey;
-    @Builder.Default
-    private String context = "";
+    @Builder.Default private String context = "";
     private String featureSet;
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -14,6 +14,7 @@ public class JourneyRequest {
     private String ipAddress;
     private String clientOAuthSessionId;
     private String journey;
-    private String context;
+    @Builder.Default
+    private String context = "";
     private String featureSet;
 }


### PR DESCRIPTION
 and convert it to null in BuildCriOauthRequestHandler

## Proposed changes

### What changed

- Put empty string context if absent in state data

### Why did it change

- Because step function doesn't allow nullable fields, and so was breaking pipeline as all states have no context (yet)

### Issue tracking

- [PYIC-3661](https://govukverify.atlassian.net/browse/PYIC-3661)

[PYIC-3661]: https://govukverify.atlassian.net/browse/PYIC-3661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ