### PR TITLE
PYIC-3856: Consume new ci-config

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -965,7 +965,7 @@ Resources:
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/*/connections/*/api-key-*
         - AWSSecretsManagerGetSecretValuePolicy:
-            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:
@@ -1644,7 +1644,7 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - AWSSecretsManagerGetSecretValuePolicy:
-            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:
         !If
@@ -1923,7 +1923,7 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
         - AWSSecretsManagerGetSecretValuePolicy:
-            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
       AutoPublishAlias: live
@@ -2126,7 +2126,7 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - AWSSecretsManagerGetSecretValuePolicy:
-            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
         - Statement:
             - Sid: kmsSigningKeyPermission
               Effect: Allow
@@ -2295,7 +2295,7 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
         - AWSSecretsManagerGetSecretValuePolicy:
-            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-scoring-config-*
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
         - Statement:
           - Sid: EnforceStayinSpecificVpc
             Effect: Allow

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -13,7 +13,7 @@ public enum ConfigurationVariable {
     AUTH_CODE_EXPIRY_SECONDS("self/authCodeExpirySeconds"),
     PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("clients/%s/publicKeyMaterialForCoreToVerify"),
     CLIENT_VALID_REDIRECT_URLS("clients/%s/validRedirectUrls"),
-    CI_SCORING_CONFIG("self/ci-scoring-config"),
+    CI_CONFIG("self/ci-config"),
     CI_SCORING_THRESHOLD("self/ciScoringThreshold"),
     VC_TTL("self/vcTtl"),
     CREDENTIAL_ISSUERS("credentialIssuers"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorConfig.java
@@ -4,15 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ContraIndicatorScore {
+public class ContraIndicatorConfig {
     private String ci;
     private Integer detectedScore;
     private Integer checkedScore;
-    private String fidCode;
-    private List<String> mitigations;
+    private String exitCode;
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicators.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicators.java
@@ -20,7 +20,7 @@ public class ContraIndicators {
     private final Map<String, ContraIndicator> contraIndicatorsMap;
 
     public Integer getContraIndicatorScore(
-            final Map<String, ContraIndicatorScore> contraIndicatorScores)
+            final Map<String, ContraIndicatorConfig> contraIndicatorScores)
             throws UnrecognisedCiException {
         validateContraIndicators(contraIndicatorScores);
         return calculateDetectedScore(contraIndicatorScores)
@@ -38,7 +38,7 @@ public class ContraIndicators {
     }
 
     private void validateContraIndicators(
-            final Map<String, ContraIndicatorScore> contraIndicatorScores)
+            final Map<String, ContraIndicatorConfig> contraIndicatorScores)
             throws UnrecognisedCiException {
         final Set<String> knownContraIndicators = contraIndicatorScores.keySet();
         final List<String> unknownContraIndicators =
@@ -51,7 +51,7 @@ public class ContraIndicators {
     }
 
     private Integer calculateDetectedScore(
-            final Map<String, ContraIndicatorScore> contraIndicatorScores) {
+            final Map<String, ContraIndicatorConfig> contraIndicatorScores) {
         return contraIndicatorsMap.keySet().stream()
                 .map(
                         contraIndicatorCode ->
@@ -60,7 +60,7 @@ public class ContraIndicators {
     }
 
     private Integer calculateCheckedScore(
-            final Map<String, ContraIndicatorScore> contraIndicatorScores) {
+            final Map<String, ContraIndicatorConfig> contraIndicatorScores) {
         return contraIndicatorsMap.values().stream()
                 .filter(
                         contraIndicator ->

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -21,7 +21,7 @@ import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.config.FeatureFlag;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.NoConfigForConnectionException;
@@ -308,20 +308,19 @@ public class ConfigService {
         return Boolean.parseBoolean(getSsmParameterWithOverride(pathTemplate, credentialIssuerId));
     }
 
-    public Map<String, ContraIndicatorScore> getContraIndicatorScoresMap() {
-        String secretId = resolveBasePath() + ConfigurationVariable.CI_SCORING_CONFIG.getPath();
+    public Map<String, ContraIndicatorConfig> getContraIndicatorConfigMap() {
+        String secretId = resolveBasePath() + ConfigurationVariable.CI_CONFIG.getPath();
         try {
             String secretValue = getSecretValue(secretId);
-            List<ContraIndicatorScore> scoresList =
+            List<ContraIndicatorConfig> configList =
                     objectMapper.readValue(secretValue, new TypeReference<>() {});
-            Map<String, ContraIndicatorScore> scoresMap = new HashMap<>();
-            for (ContraIndicatorScore scores : scoresList) {
-                String ci = scores.getCi();
-                scoresMap.put(ci, scores);
+            Map<String, ContraIndicatorConfig> configMap = new HashMap<>();
+            for (ContraIndicatorConfig config : configList) {
+                configMap.put(config.getCi(), config);
             }
-            return scoresMap;
+            return configMap;
         } catch (JsonProcessingException e) {
-            LOGGER.error("Failed to parse contra-indicator scoring config");
+            LOGGER.error("Failed to parse contra-indicator config");
             return Collections.emptyMap();
         }
     }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorsTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorsTest.java
@@ -23,14 +23,14 @@ class ContraIndicatorsTest {
 
     private static final String TEST_CI4_UNKNOWN = "CI4";
     private static final Instant BASE_TIME = Instant.now();
-    private static final Map<String, ContraIndicatorScore> CONTRA_INDICATOR_SCORE_MAP =
+    private static final Map<String, ContraIndicatorConfig> CONTRA_INDICATOR_CONFIG_MAP =
             Map.of(
                     TEST_CI1,
-                    new ContraIndicatorScore(TEST_CI1, 4, -3, null, null),
+                    new ContraIndicatorConfig(TEST_CI1, 4, -3, "1"),
                     TEST_CI2,
-                    new ContraIndicatorScore(TEST_CI2, 3, -3, null, null),
+                    new ContraIndicatorConfig(TEST_CI2, 3, -3, "2"),
                     TEST_CI3,
-                    new ContraIndicatorScore(TEST_CI3, 2, -1, null, null));
+                    new ContraIndicatorConfig(TEST_CI3, 2, -1, "3"));
 
     @BeforeEach
     void setup() {
@@ -45,7 +45,7 @@ class ContraIndicatorsTest {
     @Test
     void shouldReturnZeroScoreWhenNoContraIndicatorExistInContraIndications()
             throws UnrecognisedCiException {
-        assertEquals(0, contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP));
+        assertEquals(0, contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_CONFIG_MAP));
     }
 
     @Test
@@ -54,7 +54,7 @@ class ContraIndicatorsTest {
                 TEST_CI1, BASE_TIME.minusSeconds(1), List.of(Mitigation.builder().build()));
         addContraIndicators(
                 TEST_CI2, BASE_TIME.minusSeconds(2), List.of(Mitigation.builder().build()));
-        assertEquals(1, contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP));
+        assertEquals(1, contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_CONFIG_MAP));
     }
 
     @Test
@@ -64,7 +64,7 @@ class ContraIndicatorsTest {
                 TEST_CI1, BASE_TIME.minusSeconds(1), List.of(Mitigation.builder().build()));
         addContraIndicators(TEST_CI2, BASE_TIME.minusSeconds(2), Collections.emptyList());
         addContraIndicators(TEST_CI3, BASE_TIME.minusSeconds(4), null);
-        assertEquals(6, contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP));
+        assertEquals(6, contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_CONFIG_MAP));
     }
 
     @Test
@@ -97,7 +97,7 @@ class ContraIndicatorsTest {
                 TEST_CI4_UNKNOWN, BASE_TIME.minusSeconds(2), List.of(Mitigation.builder().build()));
         assertThrows(
                 UnrecognisedCiException.class,
-                () -> contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_SCORE_MAP));
+                () -> contraIndicators.getContraIndicatorScore(CONTRA_INDICATOR_CONFIG_MAP));
     }
 
     @Test

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -24,7 +24,7 @@ import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.FeatureFlag;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.NoConfigForConnectionException;
@@ -548,25 +548,29 @@ class ConfigServiceTest {
     }
 
     @Test
-    void shouldGetContraIndicatorScoresMap() {
+    void shouldGetContraIndicatorConfigMap() {
         String scoresJsonString =
-                "[{ \"ci\": \"X01\", \"detectedScore\": 3, \"checkedScore\": -3, \"fidCode\": \"YZ01\" }, { \"ci\": \"Z03\", \"detectedScore\": 5, \"checkedScore\": -3 }]";
+                "[{\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"exitCode\":\"1\"},{\"ci\":\"Z03\",\"detectedScore\":5,\"checkedScore\":-3,\"exitCode\":\"1\"}]";
         when(secretsProvider.get(any())).thenReturn(scoresJsonString);
 
-        Map<String, ContraIndicatorScore> scoresMap = configService.getContraIndicatorScoresMap();
+        Map<String, ContraIndicatorConfig> configMap = configService.getContraIndicatorConfigMap();
 
-        assertEquals(2, scoresMap.size());
-        assertTrue(scoresMap.containsKey("X01"));
-        assertTrue(scoresMap.containsKey("Z03"));
+        assertEquals(2, configMap.size());
+        assertTrue(configMap.containsKey("X01"));
+        assertTrue(configMap.containsKey("Z03"));
+        assertEquals("X01", configMap.get("X01").getCi());
+        assertEquals(3, configMap.get("X01").getDetectedScore());
+        assertEquals(-3, configMap.get("X01").getCheckedScore());
+        assertEquals("1", configMap.get("X01").getExitCode());
     }
 
     @Test
-    void shouldReturnEmptyCollectionOnInvalidContraIndicatorScoresMap() {
-        final String invalidCIScoresJsonString =
-                "[\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"fidCode\":\"YZ01\"}]";
-        when(secretsProvider.get(any())).thenReturn(invalidCIScoresJsonString);
-        Map<String, ContraIndicatorScore> scoresMap = configService.getContraIndicatorScoresMap();
-        assertTrue(scoresMap.isEmpty());
+    void shouldReturnEmptyCollectionOnInvalidContraIndicatorConfigsMap() {
+        final String invalidCIConfigJsonString =
+                "[\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"exitCode\":\"1\"}]";
+        when(secretsProvider.get(any())).thenReturn(invalidCIConfigJsonString);
+        Map<String, ContraIndicatorConfig> configMap = configService.getContraIndicatorConfigMap();
+        assertTrue(configMap.isEmpty());
     }
 
     @Test

--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
@@ -63,7 +63,7 @@ public class Gpg45ProfileEvaluator {
                                 contraIndicators.getContraIndicatorsMap().size()));
         final int ciScore =
                 contraIndicators.getContraIndicatorScore(
-                        configService.getContraIndicatorScoresMap());
+                        configService.getContraIndicatorConfigMap());
         LOGGER.info(
                 new StringMapMessage()
                         .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "Calculated user's CI score.")

--- a/libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java
+++ b/libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.cimitvc.ContraIndicator;
@@ -79,14 +79,14 @@ class Gpg45ProfileEvaluatorTest {
     private static final String CI1 = "X98";
     private static final String CI2 = "X99";
     private static final String CI3 = "X97";
-    private static final Map<String, ContraIndicatorScore> TEST_CI_SCORES =
+    private static final Map<String, ContraIndicatorConfig> TEST_CI_CONFIG =
             Map.of(
                     CI1,
-                    new ContraIndicatorScore(CI1, 1, -1, null, Collections.emptyList()),
+                    new ContraIndicatorConfig(CI1, 1, -1, "1"),
                     CI2,
-                    new ContraIndicatorScore(CI2, 3, -2, null, Collections.emptyList()),
+                    new ContraIndicatorConfig(CI2, 3, -2, "2"),
                     CI3,
-                    new ContraIndicatorScore(CI3, 4, -3, null, Collections.emptyList()));
+                    new ContraIndicatorConfig(CI3, 4, -3, "3"));
 
     private static final Map<String, String> TEST_CI_MITIGATION_CONFIG =
             Map.of(CI3, JOURNEY_PYI_CI3_FAIL);
@@ -371,8 +371,8 @@ class Gpg45ProfileEvaluatorTest {
                         "Should return unsuccessful activity/fraud/verification scores."));
     }
 
-    private void setupMockContraIndicatorScoringConfig() {
-        when(mockConfigService.getContraIndicatorScoresMap()).thenReturn(TEST_CI_SCORES);
+    private void setupMockContraIndicatorConfig() {
+        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(TEST_CI_CONFIG);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("3");
     }
 
@@ -427,7 +427,7 @@ class Gpg45ProfileEvaluatorTest {
         void shouldNotReturnJourneyIfNoContraIndicators()
                 throws ConfigException, UnrecognisedCiException {
             final ContraIndicators contraIndications = buildTestContraIndications();
-            setupMockContraIndicatorScoringConfig();
+            setupMockContraIndicatorConfig();
             IpvSessionItem ipvSessionItem = new IpvSessionItem();
             final Optional<JourneyResponse> journeyResponse =
                     evaluator.getJourneyResponseForStoredContraIndicators(
@@ -442,7 +442,7 @@ class Gpg45ProfileEvaluatorTest {
                 throws ConfigException, UnrecognisedCiException {
             final ContraIndicators contraIndications =
                     buildTestContraIndications(new TestContraIndicator(CI2));
-            setupMockContraIndicatorScoringConfig();
+            setupMockContraIndicatorConfig();
             IpvSessionItem ipvSessionItem = new IpvSessionItem();
             final Optional<JourneyResponse> journeyResponse =
                     evaluator.getJourneyResponseForStoredContraIndicators(
@@ -458,7 +458,7 @@ class Gpg45ProfileEvaluatorTest {
             final ContraIndicators contraIndications =
                     buildTestContraIndications(
                             new TestContraIndicator(CI3), new TestContraIndicator(CI1));
-            setupMockContraIndicatorScoringConfig();
+            setupMockContraIndicatorConfig();
             setupMockContraIndicatorMitigationConfig();
             IpvSessionItem ipvSessionItem = new IpvSessionItem();
             final Optional<JourneyResponse> journeyResponse =
@@ -475,7 +475,7 @@ class Gpg45ProfileEvaluatorTest {
             final ContraIndicators contraIndications =
                     buildTestContraIndications(
                             new TestContraIndicator(CI1), new TestContraIndicator(CI3));
-            setupMockContraIndicatorScoringConfig();
+            setupMockContraIndicatorConfig();
             setupMockContraIndicatorMitigationConfig();
             IpvSessionItem ipvSessionItem = new IpvSessionItem();
             final Optional<JourneyResponse> journeyResponse =
@@ -493,7 +493,7 @@ class Gpg45ProfileEvaluatorTest {
                     buildTestContraIndications(
                             new TestContraIndicator(CI1),
                             new TestContraIndicator(CI3, List.of("mitigated")));
-            setupMockContraIndicatorScoringConfig();
+            setupMockContraIndicatorConfig();
             IpvSessionItem ipvSessionItem = new IpvSessionItem();
             final Optional<JourneyResponse> journeyResponse =
                     evaluator.getJourneyResponseForStoredContraIndicators(

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidator.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidator.java
@@ -18,7 +18,7 @@ import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -142,8 +142,8 @@ public class VerifiableCredentialJwtValidator {
     }
 
     private void validateCiCodes(SignedJWT verifiableCredential) {
-        Map<String, ContraIndicatorScore> contraIndicatorScoresMap =
-                configService.getContraIndicatorScoresMap();
+        Map<String, ContraIndicatorConfig> contraIndicatorConfigMap =
+                configService.getContraIndicatorConfigMap();
 
         try {
             JSONObject vcClaim =
@@ -163,7 +163,7 @@ public class VerifiableCredentialJwtValidator {
                                 cis.stream()
                                         .anyMatch(
                                                 ciCode ->
-                                                        !contraIndicatorScoresMap.containsKey(
+                                                        !contraIndicatorConfigMap.containsKey(
                                                                 ciCode));
                         if (anyUnrecognisedCiCodes) {
                             break;

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidatorTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidatorTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorScore;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -37,8 +37,8 @@ class VerifiableCredentialJwtValidatorTest {
             "https://staging-di-ipv-cri-address-front.london.cloudapps.digital";
     private static final ECKey TEST_SIGNING_KEY;
     private static final ECKey TEST_SIGNING_KEY2;
-    private static final Map<String, ContraIndicatorScore> CI_MAP =
-            Map.of("A02", new ContraIndicatorScore(), "A03", new ContraIndicatorScore());
+    private static final Map<String, ContraIndicatorConfig> CI_MAP =
+            Map.of("A02", new ContraIndicatorConfig(), "A03", new ContraIndicatorConfig());
 
     static {
         try {
@@ -64,7 +64,7 @@ class VerifiableCredentialJwtValidatorTest {
 
     @Test
     void validatesValidVerifiableCredentialsSuccessfully() {
-        when(mockConfigService.getContraIndicatorScoresMap()).thenReturn(CI_MAP);
+        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(CI_MAP);
 
         setCredentialIssuerConfigMockResponses(TEST_SIGNING_KEY);
         vcJwtValidator.validate(verifiableCredentials, credentialIssuerConfig, TEST_USER);
@@ -125,7 +125,7 @@ class VerifiableCredentialJwtValidatorTest {
     @Test
     void validatesValidVerifiableCredentialsWithDerSignatureSuccessfully()
             throws JOSEException, ParseException {
-        when(mockConfigService.getContraIndicatorScoresMap()).thenReturn(CI_MAP);
+        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(CI_MAP);
 
         setCredentialIssuerConfigMockResponses(TEST_SIGNING_KEY);
         var jwtParts = verifiableCredentials.getParsedParts();
@@ -169,7 +169,7 @@ class VerifiableCredentialJwtValidatorTest {
 
     @Test
     void validatesValidVCSuccessfully() throws ParseException {
-        when(mockConfigService.getContraIndicatorScoresMap()).thenReturn(CI_MAP);
+        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(CI_MAP);
 
         setCredentialIssuerConfigMockResponses(TEST_SIGNING_KEY);
         vcJwtValidator.validate(
@@ -181,8 +181,8 @@ class VerifiableCredentialJwtValidatorTest {
 
     @Test
     void validateThrowsIfCiCodesAreNotRecognised() throws Exception {
-        when(mockConfigService.getContraIndicatorScoresMap())
-                .thenReturn(Map.of("NO", new ContraIndicatorScore()));
+        when(mockConfigService.getContraIndicatorConfigMap())
+                .thenReturn(Map.of("NO", new ContraIndicatorConfig()));
         setCredentialIssuerConfigMockResponses(TEST_SIGNING_KEY);
         ECKey signingKey = credentialIssuerConfig.getSigningKey();
         String componentId = credentialIssuerConfig.getComponentId();


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Consume new ci-config

### Why did it change

A new json blob has been added to secrets manager for ci-config. This replaces the ci-scoring-config we have been using. The blob now contains more information that just ci-scores so it has a new name.

This pulls that new blob in and renames stuff in core-back to reflect this.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3856](https://govukverify.atlassian.net/browse/PYIC-3856)


[PYIC-3856]: https://govukverify.atlassian.net/browse/PYIC-3856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ