### PR TITLE
Pyic 3858:  DOB correlation excludes BAV and Address CRI, while Name correlation excludes only Address CRI

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
@@ -22,4 +22,5 @@ public class CriConstants {
     public static final Set<String> NON_EVIDENCE_CRI_TYPES =
             Set.of(ADDRESS_CRI, CLAIMED_IDENTITY_CRI);
     public static final String HMRC_KBV_CRI = "hmrcKbv";
+    public static final String BAV_CRI = "bav";
 }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -428,7 +428,8 @@ public class UserIdentityService {
 
     // This method checks the birthdate requirement, which is in violation of GPG45 rules.
     // However, considering that BAV and Address CRI  does not contain a birthdate,
-    // we add this special handling only for BAV and Address CRI. For other CRIs, we continue to validate this
+    // we add this special handling only for BAV and Address CRI. For other CRIs, we continue to
+    // validate this
     // requirement.
     private List<IdentityClaim> getIdentityClaimsForBirthDateCorrelation(
             List<VcStoreItem> vcStoreItems) throws HttpResponseExceptionWithErrorBody {
@@ -437,7 +438,7 @@ public class UserIdentityService {
             IdentityClaim identityClaim =
                     getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), true);
             if (isBirthDateEmpty(identityClaim.getBirthDate())) {
-                //excluded BAV and Address CRI
+                // excluded BAV and Address CRI
                 if (EXCLUDE_CRIS_TYPES_FOR_DOB_CORRELATION.contains(item.getCredentialIssuer())) {
                     continue;
                 }
@@ -469,7 +470,7 @@ public class UserIdentityService {
             IdentityClaim identityClaim =
                     getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), true);
             if (isNamesEmpty(identityClaim.getName())) {
-                //excluded Address CRI. Because Address CRI does not contain a name,
+                // excluded Address CRI. Because Address CRI does not contain a name,
                 if (ADDRESS_CRI.equals(item.getCredentialIssuer())) {
                     continue;
                 }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -427,8 +427,8 @@ public class UserIdentityService {
     }
 
     // This method checks the birthdate requirement, which is in violation of GPG45 rules.
-    // However, considering that 'BAV' CRI does not contain a birthdate,
-    // we add this special handling only for 'BAV' CRI. For other CRIs, we continue to validate this
+    // However, considering that BAV and Address CRI  does not contain a birthdate,
+    // we add this special handling only for BAV and Address CRI. For other CRIs, we continue to validate this
     // requirement.
     private List<IdentityClaim> getIdentityClaimsForBirthDateCorrelation(
             List<VcStoreItem> vcStoreItems) throws HttpResponseExceptionWithErrorBody {
@@ -437,6 +437,7 @@ public class UserIdentityService {
             IdentityClaim identityClaim =
                     getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), true);
             if (isBirthDateEmpty(identityClaim.getBirthDate())) {
+                //excluded BAV and Address CRI
                 if (EXCLUDE_CRIS_TYPES_FOR_DOB_CORRELATION.contains(item.getCredentialIssuer())) {
                     continue;
                 }
@@ -468,6 +469,7 @@ public class UserIdentityService {
             IdentityClaim identityClaim =
                     getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), true);
             if (isNamesEmpty(identityClaim.getName())) {
+                //excluded Address CRI. Because Address CRI does not contain a name,
                 if (ADDRESS_CRI.equals(item.getCredentialIssuer())) {
                     continue;
                 }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -419,10 +419,10 @@ public class UserIdentityService {
     }
 
     // This method checks the birthdate requirement, which is in violation of GPG45 rules.
-    // However, considering that 'BAV' CRI does not conta'in a birthdate,
+    // However, considering that 'BAV' CRI does not contain a birthdate,
     // we add this special handling only for 'BAV' CRI. For other CRIs, we continue to validate this
     // requirement.
-    private List<IdentityClaim> getIdentityClaimsAndHandleDOBExceptionForBAVCRI(
+    private List<IdentityClaim> getIdentityClaimsForDOBCheckOnlyBAVCRI(
             List<VcStoreItem> vcStoreItems) throws HttpResponseExceptionWithErrorBody {
         List<IdentityClaim> identityClaims = new ArrayList<>();
         for (VcStoreItem item : vcStoreItems) {
@@ -447,7 +447,7 @@ public class UserIdentityService {
         final List<VcStoreItem> successfulVCStoreItems =
                 getSuccessfulVCStoreItems(getVcStoreItems(userId));
         List<IdentityClaim> identityClaims =
-                getIdentityClaimsAndHandleDOBExceptionForBAVCRI(successfulVCStoreItems);
+                getIdentityClaimsForDOBCheckOnlyBAVCRI(successfulVCStoreItems);
         return identityClaims.stream()
                         .map(IdentityClaim::getBirthDate)
                         .flatMap(List::stream)

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -61,6 +61,9 @@ public class UserIdentityService {
     public static final List<String> EVIDENCE_CRI_TYPES =
             List.of(PASSPORT_CRI, DCMAW_CRI, DRIVING_LICENCE_CRI, F2F_CRI);
 
+    public static final List<String> EXCLUDE_CRIS_TYPES_FOR_DOB_CORRELATION =
+            List.of(ADDRESS_CRI, BAV_CRI);
+
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String PASSPORT_PROPERTY_NAME = "passport";
     private static final String DRIVING_PERMIT_PROPERTY_NAME = "drivingPermit";
@@ -434,7 +437,7 @@ public class UserIdentityService {
             IdentityClaim identityClaim =
                     getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), true);
             if (isBirthDateEmpty(identityClaim.getBirthDate())) {
-                if (BAV_CRI.equals(item.getCredentialIssuer())) {
+                if (EXCLUDE_CRIS_TYPES_FOR_DOB_CORRELATION.contains(item.getCredentialIssuer())) {
                     continue;
                 }
                 addLogMessage(item, "Birthdate property is missing from VC");
@@ -465,6 +468,9 @@ public class UserIdentityService {
             IdentityClaim identityClaim =
                     getIdentityClaim(item.getCredential(), item.getCredentialIssuer(), true);
             if (isNamesEmpty(identityClaim.getName())) {
+                if (ADDRESS_CRI.equals(item.getCredentialIssuer())) {
+                    continue;
+                }
                 addLogMessage(item, "Name property is missing from VC");
             }
             identityClaims.add(identityClaim);

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -212,7 +212,7 @@ class UserIdentityServiceTest {
                         createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_1, Instant.now()),
                         createVcStoreItem(
                                 USER_ID_1,
-                                "ukPassport",
+                                "address",
                                 SIGNED_PASSPORT_VC_MISSING_NAME,
                                 Instant.now()),
                         createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_1, Instant.now()));
@@ -237,7 +237,7 @@ class UserIdentityServiceTest {
                                 Instant.now()),
                         createVcStoreItem(
                                 USER_ID_1,
-                                "ukPassport",
+                                "address",
                                 SIGNED_PASSPORT_VC_MISSING_NAME,
                                 Instant.now()));
 
@@ -332,6 +332,11 @@ class UserIdentityServiceTest {
                         createVcStoreItem(
                                 USER_ID_1,
                                 "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "address",
                                 SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
                                 Instant.now()));
 

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -140,7 +140,8 @@ class UserIdentityServiceTest {
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_5, Instant.now()),
-                        createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_5, Instant.now()));
+                        createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_5, Instant.now()),
+                        createVcStoreItem(USER_ID_1, "bav", SIGNED_VC_5, Instant.now()));
 
         when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
         mockCredentialIssuerConfig();
@@ -172,6 +173,22 @@ class UserIdentityServiceTest {
                 List.of(
                         createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_2, Instant.now()),
                         createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_5, Instant.now()));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        mockCredentialIssuerConfig();
+
+        boolean isValid =
+                userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(USER_ID_1);
+
+        assertFalse(isValid);
+    }
+
+    @Test
+    void checkNameCorrelationInCredentialsReturnFalseWhenNameDifferForBavCRI() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_2, Instant.now()),
+                        createVcStoreItem(USER_ID_1, "bav", SIGNED_VC_1, Instant.now()));
 
         when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
         mockCredentialIssuerConfig();
@@ -234,7 +251,28 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void checkNameCorrelationWithSameBirthDatesAndMissingBirthDateCredentialsForReturnTrue()
+    void checkNameCorrelationWithMissingNameCredentialsForOnlyBAVCRIReturnFalse() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_1, Instant.now()),
+                        createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_3, Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "bav",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        mockCredentialIssuerConfig();
+
+        boolean isValid =
+                userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(USER_ID_1);
+
+        assertFalse(isValid);
+    }
+
+    @Test
+    void checkBirthDateCorrelationWithSameBirthDatesAndMissingBirthDateCredentialsForReturnTrue()
             throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
@@ -260,7 +298,7 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void checkNameCorrelationWithMissingBirthDateCredentialsForReturnTrue() throws Exception {
+    void checkBirthDateCorrelationWithMissingBirthDateCredentialsForReturnTrue() throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -280,6 +318,83 @@ class UserIdentityServiceTest {
         boolean isValid = userIdentityService.checkBirthDateCorrelationInCredentials(USER_ID_1);
 
         assertTrue(isValid);
+    }
+
+    @Test
+    void checkBirthDateCorrelationWithMissingBirthDateForAllCRIsAndReturnTrue() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "bav",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "ukPassport",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        mockCredentialIssuerConfig();
+
+        boolean isValid = userIdentityService.checkBirthDateCorrelationInCredentials(USER_ID_1);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void checkBirthDateCorrelationWithMissingBirthDateForOnlyBAVCRIAndReturnTrue()
+            throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_2, Instant.now()),
+                        createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_3, Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                "bav",
+                                SIGNED_PASSPORT_VC_MISSING_BIRTH_DATE,
+                                Instant.now()));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        mockCredentialIssuerConfig();
+
+        boolean isValid = userIdentityService.checkBirthDateCorrelationInCredentials(USER_ID_1);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void checkBirthDateCorrelationWithBirthDateIsNotEmptyForBAVCRIAndReturnTrue() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_2, Instant.now()),
+                        createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_3, Instant.now()),
+                        createVcStoreItem(USER_ID_1, "bav", SIGNED_VC_2, Instant.now()));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        mockCredentialIssuerConfig();
+
+        boolean isValid = userIdentityService.checkBirthDateCorrelationInCredentials(USER_ID_1);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void checkBirthDateCorrelationWithBirthDateIsNotEmptyButDifferentDOBForBAVCRIAndReturnFalse()
+            throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(USER_ID_1, "ukPassport", SIGNED_VC_2, Instant.now()),
+                        createVcStoreItem(USER_ID_1, "dcmaw", SIGNED_VC_3, Instant.now()),
+                        createVcStoreItem(USER_ID_1, "bav", SIGNED_VC_1, Instant.now()));
+
+        when(userIdentityService.getVcStoreItems(USER_ID_1)).thenReturn(vcStoreItems);
+        mockCredentialIssuerConfig();
+
+        boolean isValid = userIdentityService.checkBirthDateCorrelationInCredentials(USER_ID_1);
+
+        assertFalse(isValid);
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
   We rewrote the correlation logic to ensure that each VC is associated via both name and DOB, except for BAV and Address CRI , which needs a special case to ignore the DOB and Name.
### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

   Currently the name/dob correlation only checks that there is no more than one name/dob across all the VCs, it does not check that each VC contains a correlating name and DOB.

This is wrong - we need to positively correlate each VC we use to generate an identity. However, we also need to build in an exception like  below

    - DOB correlation excludes BAV and Address CRI
    - Name correlation excludes only Address CRI

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3858](https://govukverify.atlassian.net/browse/PYIC-3858)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3858]: https://govukverify.atlassian.net/browse/PYIC-3858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ