### PR TITLE
PYIC-3829: Return exit code for contra indicators

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1238,6 +1238,8 @@ Resources:
             ParameterName: !Sub ${Environment}/core/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
         - Statement:
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -22,7 +22,8 @@ public enum ConfigurationVariable {
     JOURNEY_TYPE("self/journey/type"),
     CIMIT_SIGNING_KEY("cimit/signingKey"),
     CIMIT_COMPONENT_ID("cimit/componentId"),
-    CIMIT_CONFIG("cimit/config");
+    CIMIT_CONFIG("cimit/config"),
+    ALWAYS_REQUIRED_EXIT_CODES("self/alwaysRequiredExitCodes");
 
     private final String path;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -1,6 +1,8 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
@@ -24,6 +26,7 @@ public class UserIdentity {
     private static final String PASSPORT_CLAIM_NAME = "https://vocab.account.gov.uk/v1/passport";
     private static final String DRIVING_PERMIT_CLAIM_NAME =
             "https://vocab.account.gov.uk/v1/drivingPermit";
+    public static final String EXIT_CODE_NAME = "exit_code";
 
     @JsonProperty(VCS_CLAIM_NAME)
     private List<String> vcs;
@@ -46,6 +49,10 @@ public class UserIdentity {
 
     @JsonProperty private String vtm;
 
+    @JsonInclude(Include.NON_NULL)
+    @JsonProperty(EXIT_CODE_NAME)
+    private List<String> exitCode;
+
     @JsonCreator
     public UserIdentity(
             @JsonProperty(value = VCS_CLAIM_NAME, required = true) List<String> vcs,
@@ -55,7 +62,8 @@ public class UserIdentity {
             @JsonProperty(value = DRIVING_PERMIT_CLAIM_NAME) JsonNode drivingPermitClaim,
             @JsonProperty(value = "sub", required = true) String sub,
             @JsonProperty(value = "vot", required = true) String vot,
-            @JsonProperty(value = "vtm", required = true) String vtm) {
+            @JsonProperty(value = "vtm", required = true) String vtm,
+            @JsonProperty(value = EXIT_CODE_NAME) List<String> exitCode) {
         this.vcs = new ArrayList<>(vcs);
         this.identityClaim = identityClaim;
         this.addressClaim = addressClaim;
@@ -64,5 +72,6 @@ public class UserIdentity {
         this.sub = sub;
         this.vot = vot;
         this.vtm = vtm;
+        this.exitCode = exitCode;
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/UnrecognisedCiException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/UnrecognisedCiException.java
@@ -1,6 +1,6 @@
 package uk.gov.di.ipv.core.library.exceptions;
 
-public class UnrecognisedCiException extends Exception {
+public class UnrecognisedCiException extends RuntimeException {
     public UnrecognisedCiException(String message) {
         super(message);
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return exit code for contra indicators

### Why did it change

We want to return an exit code attribute in the user identity fetched by the orchestrator.

This change maps the CI codes a user has to the appropriate exit codes and adds them to the user identity. This is hidden behind a feature flag.

In the case that a user has achieved a P2, we only want to add exit codes for specific CIs. These are defined in config to avoid leaking sensitive information in this public repo.

In the case that a user has achieved a P0 due to breaching the CI threshold, we want to map all CI codes to their exit codes. This is looked up in a mapping table defined in config. This includes mitigated CIs. This is because a mitigated CI will still have a residual score, and so will be contributing to the threshold breach.

The case that a user has achieved a P0 but not due to a CI threshold breach will be handled in another ticket.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3829](https://govukverify.atlassian.net/browse/PYIC-3829)


[PYIC-3829]: https://govukverify.atlassian.net/browse/PYIC-3829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ