### PR TITLE
PYIC-3847 Move CI scoring into CheckExistingProfile so we can perform pending F2F checks first.

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -42,11 +42,6 @@
         },
         {
           "Variable": "$.journey",
-          "StringMatches": "/journey/ci-scoring",
-          "Next": "CheckCiScoreLambda"
-        },
-        {
-          "Variable": "$.journey",
           "StringMatches": "/journey/check-gpg45-score",
           "Next": "CheckGpg45ScoreLambda"
         }
@@ -92,18 +87,6 @@
     "BuildClientOauthResponseLambda": {
       "Type": "Task",
       "Resource": "${BuildClientOauthResponseFunctionArn}",
-      "Parameters": {
-        "journey.$": "$.journey",
-        "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
-        "ipAddress.$": "$$.Execution.Input.ipAddress",
-        "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
-      },
-      "Next": "ProcessNextJourney"
-    },
-    "CheckCiScoreLambda": {
-      "Type": "Task",
-      "Resource": "${CheckCiScoreFunctionArn}",
       "Parameters": {
         "journey.$": "$.journey",
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1883,6 +1883,22 @@ Resources:
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN: !Sub
+            - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicatorCredential-${env}"
+            - cimit_account_id: !If
+                - UseIndividualCiMitStubs
+                - !Ref AWS::AccountId
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref AWS::AccountId
+                  - cimitAccountId
+              env: !If
+                - UseIndividualCiMitStubs
+                - !Sub ${Environment}
+                - !FindInMap
+                  - EnvironmentConfiguration
+                  - !Ref AWS::AccountId
+                  - cimitEnvironment
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -1903,6 +1919,27 @@ Resources:
                 StringEquals:
                   "lambda:VpcIds":
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+            - Sid: invokeGetContraIndicatorCredentialFunction
+              Effect: Allow
+              Action:
+                - 'lambda:InvokeFunction'
+              Resource:
+                - !Sub
+                  - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicatorCredential-${env}"
+                  - cimit_account_id: !If
+                      - UseIndividualCiMitStubs
+                      - !Ref AWS::AccountId
+                      - !FindInMap
+                        - EnvironmentConfiguration
+                        - !Ref AWS::AccountId
+                        - cimitAccountId
+                    env: !If
+                      - UseIndividualCiMitStubs
+                      - !Sub ${Environment}
+                      - !FindInMap
+                        - EnvironmentConfiguration
+                        - !Ref AWS::AccountId
+                        - cimitEnvironment
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			project(":libs:common-services"),
+			project(":libs:cimit-service"),
 			project(":libs:journey-uris"),
 			project(":libs:cri-response-service"),
 			project(":libs:audit-service"),

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -349,14 +349,18 @@ public class CheckExistingIdentityHandler
                                 ipAddress),
                         ipvSessionItem);
 
-        if (contraIndicatorJourneyResponse.isPresent()) {
-            StringMapMessage message = new StringMapMessage();
-            JourneyResponse journeyResponse = contraIndicatorJourneyResponse.get();
-            message.with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "Returning CI error response.")
-                    .with(LOG_ERROR_JOURNEY_RESPONSE.getFieldName(), journeyResponse.toString());
-            LOGGER.info(message);
-            return Optional.of(journeyResponse);
-        }
+        contraIndicatorJourneyResponse.ifPresent(
+                (journeyResponse) -> {
+                    StringMapMessage message = new StringMapMessage();
+                    message.with(
+                                    LOG_MESSAGE_DESCRIPTION.getFieldName(),
+                                    "Returning CI error response.")
+                            .with(
+                                    LOG_ERROR_JOURNEY_RESPONSE.getFieldName(),
+                                    journeyResponse.toString());
+                    LOGGER.info(message);
+                });
+
         return contraIndicatorJourneyResponse;
     }
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -31,7 +31,7 @@ CRI_STATE:
 INITIAL_IPV_JOURNEY:
   events:
     next:
-      targetState: INITIAL_CI_SCORING
+      targetState: CHECK_EXISTING_IDENTITY
 
 F2F_START_PAGE:
   response:
@@ -69,20 +69,6 @@ BANK_ACCOUNT_START_PAGE:
     end:
       targetState: PYI_ESCAPE
 
-INITIAL_CI_SCORING:
-  response:
-    type: process
-    lambda: ci-scoring
-  events:
-    ci-score-not-breaching:
-      targetState: CHECK_EXISTING_IDENTITY
-    pyi-no-match:
-      targetState: PYI_NO_MATCH
-    error:
-      targetState: ERROR
-    enhanced-verification:
-      targetState: MITIGATION_01
-
 CHECK_EXISTING_IDENTITY:
   response:
     type: process
@@ -102,6 +88,8 @@ CHECK_EXISTING_IDENTITY:
       targetState: PYI_F2F_TECHNICAL
     error:
       targetState: ERROR
+    enhanced-verification:
+      targetState: MITIGATION_01
 
 RESET_IDENTITY:
   response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
At the moment we run CI scoring before CheckExistingIdentity. However, this means that if you have a V03, but a pending F2F request (which will mitigate it, once complete), the CI gets flagged first.

### What changed
- updated journey
- moved logic to check pending f2f request to checkExistingIdentity lambda

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3847](https://govukverify.atlassian.net/browse/PYIC-3847)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3847]: https://govukverify.atlassian.net/browse/PYIC-3847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ