### PR TITLE
PYIC-3869: Extend featureSets to backchannel lambdas

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -124,6 +124,9 @@ public class BuildClientOauthResponseHandler
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_SESSION_ID);
             }
 
+            ipvSessionItem.setFeatureSet(featureSet);
+            sessionService.updateIpvSession(ipvSessionItem);
+
             LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
             LogHelper.attachClientSessionIdToLogs(clientOAuthSessionItem.getClientOAuthSessionId());
             LogHelper.attachClientIdToLogs(clientOAuthSessionItem.getClientId());

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -92,8 +92,6 @@ public class BuildUserIdentityHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs(configService);
         try {
-            String featureSet = RequestHelper.getFeatureSet(input);
-            configService.setFeatureSet(featureSet);
             AccessToken accessToken =
                     AccessToken.parse(
                             RequestHelper.getHeaderByKey(
@@ -108,6 +106,8 @@ public class BuildUserIdentityHandler
             if (Objects.isNull((ipvSessionItem))) {
                 return getUnknownAccessTokenApiGatewayProxyResponseEvent();
             }
+
+            configService.setFeatureSet(ipvSessionItem.getFeatureSet());
 
             AccessTokenMetadata accessTokenMetadata = ipvSessionItem.getAccessTokenMetadata();
 

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -116,6 +116,7 @@ class BuildUserIdentityHandlerTest {
         ipvSessionItem.setAccessToken(TEST_ACCESS_TOKEN);
         ipvSessionItem.setAccessTokenMetadata(new AccessTokenMetadata());
         ipvSessionItem.setVot("P2");
+        ipvSessionItem.setFeatureSet("someCoolNewThing");
 
         buildUserIdentityHandler =
                 new BuildUserIdentityHandler(
@@ -194,6 +195,8 @@ class BuildUserIdentityHandlerTest {
         assertTrue(extensions.isHasMitigations());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
         verify(mockCiMitService, times(1)).getContraIndicatorsVCJwt(any(), any(), any());
+
+        verify(mockConfigService).setFeatureSet("someCoolNewThing");
     }
 
     @Test

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -29,7 +29,6 @@ import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
@@ -84,8 +83,6 @@ public class IssueClientAccessTokenHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LogHelper.attachComponentIdToLogs(configService);
         try {
-            String featureSet = RequestHelper.getFeatureSet(input);
-            configService.setFeatureSet(featureSet);
             tokenRequestValidator.authenticateClient(input.getBody());
 
             AuthorizationCodeGrant authorizationGrant =
@@ -107,6 +104,9 @@ public class IssueClientAccessTokenHandler
                             .getIpvSessionByAuthorizationCode(
                                     authorizationGrant.getAuthorizationCode().getValue())
                             .orElseThrow();
+
+            configService.setFeatureSet(ipvSessionItem.getFeatureSet());
+
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.getClientOAuthSession(
                             ipvSessionItem.getClientOAuthSessionId());

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java
@@ -94,6 +94,7 @@ class IssueClientAccessTokenHandlerTest {
         mockSessionItem.setIpvSessionId(TEST_SESSION_ID);
         mockSessionItem.setAuthorizationCode(TEST_AUTHORIZATION_CODE);
         mockSessionItem.setAuthorizationCodeMetadata(mockAuthorizationCodeMetadata);
+        mockSessionItem.setFeatureSet("someCoolNewThing");
     }
 
     @Test
@@ -126,6 +127,8 @@ class IssueClientAccessTokenHandlerTest {
         assertEquals(
                 tokenResponse.toSuccessResponse().getTokens().getAccessToken().getValue(),
                 responseBody.get("access_token").toString());
+
+        verify(mockConfigService).setFeatureSet("someCoolNewThing");
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -37,6 +37,9 @@ public class IpvSessionItem implements DynamodbItem {
     private List<ContraIndicatorMitigationDetailsDto> contraIndicatorMitigationDetails;
     private String emailAddress;
     private boolean ciFail;
+    // Only for passing the featureSet to the external API lambdas at the end of the user journey.
+    // Not for general use.
+    private String featureSet;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Extend featureSets to backchannel lambdas

### Why did it change

Feature sets are set in the config service by a value passed through in the request. This value comes from the users frontend session.

Lambdas that are called directly by clients don’t have access to the value from the frontend session, meaning that the feature sets can’t be used.

We can store the feature set in the users backend session at the last appropriate moment - in the build-client-oauth-response handler. This makes it available in those lambdas not called as part of a users request.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3869](https://govukverify.atlassian.net/browse/PYIC-3869)


[PYIC-3869]: https://govukverify.atlassian.net/browse/PYIC-3869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ