### PR TITLE
PYIC-3661: Pass context & scope from state to CRIs

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -51,6 +51,7 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -73,7 +74,7 @@ import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_REDIRECT
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getJourney;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getJourneyParameter;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 
 public class BuildCriOauthRequestHandler
@@ -88,6 +89,8 @@ public class BuildCriOauthRequestHandler
     public static final String DEFAULT_ALLOWED_SHARED_ATTR = "name,birthDate,address";
     public static final String REGEX_COMMA_SEPARATION = "\\s*,\\s*";
     public static final Pattern LAST_SEGMENT_PATTERN = Pattern.compile("/([^/]+)$");
+    public static final String CONTEXT = "context";
+    public static final String SCOPE = "scope";
 
     private final ObjectMapper mapper = new ObjectMapper();
     private final ConfigService configService;
@@ -146,7 +149,10 @@ public class BuildCriOauthRequestHandler
             String ipAddress = getIpAddress(input);
             String featureSet = getFeatureSet(input);
             configService.setFeatureSet(featureSet);
-            String journey = getJourney(input);
+            URI journeyUri = URI.create(input.getJourney());
+            String journey = journeyUri.getPath();
+            String criContext = getJourneyParameter(journeyUri, CONTEXT);
+            String criScope = getJourneyParameter(journeyUri, SCOPE);
 
             var errorResponse = validate(journey);
             if (errorResponse.isPresent()) {
@@ -187,7 +193,9 @@ public class BuildCriOauthRequestHandler
                             userId,
                             oauthState,
                             govukSigninJourneyId,
-                            criId);
+                            criId,
+                            criContext,
+                            criScope);
 
             CriResponse criResponse = getCriResponse(criConfig, jweObject, criId);
 
@@ -291,7 +299,9 @@ public class BuildCriOauthRequestHandler
             String userId,
             String oauthState,
             String govukSigninJourneyId,
-            String criId)
+            String criId,
+            String context,
+            String scope)
             throws HttpResponseExceptionWithErrorBody, ParseException, JOSEException,
                     UnknownEvidenceTypeException {
 
@@ -313,7 +323,9 @@ public class BuildCriOauthRequestHandler
                         oauthState,
                         userId,
                         govukSigninJourneyId,
-                        evidenceRequest);
+                        evidenceRequest,
+                        context,
+                        scope);
 
         RSAEncrypter rsaEncrypter = new RSAEncrypter(credentialIssuerConfig.getEncryptionKey());
         return AuthorizationRequestHelper.createJweObject(rsaEncrypter, signedJWT);

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -150,18 +150,18 @@ public class BuildCriOauthRequestHandler
             String featureSet = getFeatureSet(input);
             configService.setFeatureSet(featureSet);
             URI journeyUri = URI.create(input.getJourney());
-            String journey = journeyUri.getPath();
+            String journeyPath = journeyUri.getPath();
             String criContext = getJourneyParameter(journeyUri, CONTEXT);
             String criScope = getJourneyParameter(journeyUri, SCOPE);
 
-            var errorResponse = validate(journey);
+            var errorResponse = validate(journeyPath);
             if (errorResponse.isPresent()) {
                 return new JourneyErrorResponse(
                                 JOURNEY_ERROR_PATH, HttpStatus.SC_BAD_REQUEST, errorResponse.get())
                         .toObjectMap();
             }
 
-            String criId = getCriIdFromJourney(journey);
+            String criId = getCriIdFromJourney(journeyPath);
             String connection = configService.getActiveConnection(criId);
             CredentialIssuerConfig criConfig =
                     configService.getCriConfigForConnection(connection, criId);

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -40,6 +40,10 @@ public class AuthorizationRequestHelper {
 
     private static final String EVIDENCE_REQUESTED = "evidence_requested";
 
+    private static final String CONTEXT = "context";
+
+    private static final String SCOPE = "scope";
+
     private AuthorizationRequestHelper() {}
 
     public static SignedJWT createSignedJWT(
@@ -50,7 +54,9 @@ public class AuthorizationRequestHelper {
             String oauthState,
             String userId,
             String govukSigninJourneyId,
-            EvidenceRequest evidence)
+            EvidenceRequest evidence,
+            String context,
+            String scope)
             throws HttpResponseExceptionWithErrorBody {
         Instant now = Instant.now();
 
@@ -105,6 +111,14 @@ public class AuthorizationRequestHelper {
 
         if (Objects.nonNull(evidence)) {
             claimsSetBuilder.claim(EVIDENCE_REQUESTED, evidence);
+        }
+
+        if (Objects.nonNull(context)) {
+            claimsSetBuilder.claim(CONTEXT, context);
+        }
+
+        if (Objects.nonNull(scope)) {
+            claimsSetBuilder.claim(SCOPE, scope);
         }
 
         SignedJWT signedJWT = new SignedJWT(header, claimsSetBuilder.build());

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -118,17 +118,17 @@ class BuildCriOauthRequestHandlerTest {
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String TEST_NI_NUMBER = "AA000003D";
     private static final String CONTEXT = "context";
-    private static final String BANK_ACCOUNT_CONTEXT = "context";
+    private static final String TEST_CONTEXT = "test_context";
     private static final String CRI_WITH_CONTEXT =
-            String.format("claimedIdentity?%s=%s", CONTEXT, BANK_ACCOUNT_CONTEXT);
+            String.format("%s?%s=%s", CLAIMED_IDENTITY_CRI, CONTEXT, TEST_CONTEXT);
     private static final String SCOPE = "scope";
-    private static final String IDENTITY_CHECK_SCOPE = "identityCheck";
+    private static final String TEST_SCOPE = "test_scope";
     private static final String CRI_WITH_SCOPE =
-            String.format("claimedIdentity?%s=%s", SCOPE, IDENTITY_CHECK_SCOPE);
+            String.format("%s?%s=%s", CLAIMED_IDENTITY_CRI, SCOPE, TEST_SCOPE);
     private static final String CRI_WITH_CONTEXT_AND_SCOPE =
             String.format(
-                    "claimedIdentity?%s=%s&%s=%s",
-                    CONTEXT, BANK_ACCOUNT_CONTEXT, SCOPE, IDENTITY_CHECK_SCOPE);
+                    "%s?%s=%s&%s=%s",
+                    CLAIMED_IDENTITY_CRI, CONTEXT, TEST_CONTEXT, SCOPE, TEST_SCOPE);
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -1287,11 +1287,11 @@ class BuildCriOauthRequestHandlerTest {
 
     private static Stream<Arguments> journeyUriParameters() {
         return Stream.of(
-                Arguments.of(CRI_WITH_CONTEXT, Map.of(CONTEXT, BANK_ACCOUNT_CONTEXT)),
-                Arguments.of(CRI_WITH_SCOPE, Map.of(SCOPE, IDENTITY_CHECK_SCOPE)),
+                Arguments.of(CRI_WITH_CONTEXT, Map.of(CONTEXT, TEST_CONTEXT)),
+                Arguments.of(CRI_WITH_SCOPE, Map.of(SCOPE, TEST_SCOPE)),
                 Arguments.of(
                         CRI_WITH_CONTEXT_AND_SCOPE,
-                        Map.of(CONTEXT, BANK_ACCOUNT_CONTEXT, SCOPE, IDENTITY_CHECK_SCOPE)));
+                        Map.of(CONTEXT, TEST_CONTEXT, SCOPE, TEST_SCOPE)));
     }
 
     private void assertErrorResponse(

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -18,6 +18,9 @@ import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -59,6 +62,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -72,6 +76,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
+import static uk.gov.di.ipv.core.library.domain.CriConstants.CLAIMED_IDENTITY_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.HMRC_KBV_CRI;
@@ -112,6 +117,18 @@ class BuildCriOauthRequestHandlerTest {
     private static final String JOURNEY_BASE_URL = "/journey/cri/build-oauth-request/";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String TEST_NI_NUMBER = "AA000003D";
+    private static final String CONTEXT = "context";
+    private static final String BANK_ACCOUNT_CONTEXT = "context";
+    private static final String CRI_WITH_CONTEXT =
+            String.format("claimedIdentity?%s=%s", CONTEXT, BANK_ACCOUNT_CONTEXT);
+    private static final String SCOPE = "scope";
+    private static final String IDENTITY_CHECK_SCOPE = "identityCheck";
+    private static final String CRI_WITH_SCOPE =
+            String.format("claimedIdentity?%s=%s", SCOPE, IDENTITY_CHECK_SCOPE);
+    private static final String CRI_WITH_CONTEXT_AND_SCOPE =
+            String.format(
+                    "claimedIdentity?%s=%s&%s=%s",
+                    CONTEXT, BANK_ACCOUNT_CONTEXT, SCOPE, IDENTITY_CHECK_SCOPE);
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -282,7 +299,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId("aSessionId")
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey("Missing CriId")
+                        .journey("MissingCriId")
                         .build();
 
         var response = handleRequest(input, context);
@@ -1217,6 +1234,64 @@ class BuildCriOauthRequestHandlerTest {
                 HttpStatus.SC_INTERNAL_SERVER_ERROR,
                 response,
                 ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("journeyUriParameters")
+    void shouldIncludeGivenParametersIntoCriResponseIfInJourneyUri(
+            String journeyUri, Map<String, String> expectedClaims) throws Exception {
+        when(configService.getActiveConnection(CLAIMED_IDENTITY_CRI)).thenReturn(MAIN_CONNECTION);
+        when(configService.getCriConfigForConnection(MAIN_CONNECTION, CLAIMED_IDENTITY_CRI))
+                .thenReturn(claimedIdentityCredentialIssuerConfig);
+        when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
+        when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("5000");
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(mockIpvSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        JourneyRequest input =
+                JourneyRequest.builder()
+                        .ipvSessionId(SESSION_ID)
+                        .ipAddress(TEST_IP_ADDRESS)
+                        .journey(JOURNEY_BASE_URL + journeyUri)
+                        .build();
+
+        var responseJson = handleRequest(input, context);
+        CriResponse response = objectMapper.readValue(responseJson, CriResponse.class);
+
+        URIBuilder redirectUri = new URIBuilder(response.getCri().getRedirectUrl());
+        List<NameValuePair> queryParams = redirectUri.getQueryParams();
+
+        Optional<NameValuePair> request =
+                queryParams.stream().filter(param -> param.getName().equals("request")).findFirst();
+
+        assertTrue(request.isPresent(), "Expected request parameter to be present");
+        JWEObject jweObject = JWEObject.parse(request.get().getValue());
+        jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
+
+        SignedJWT signedJWT = SignedJWT.parse(jweObject.getPayload().toString());
+        JsonNode claimsSet = objectMapper.readTree(signedJWT.getJWTClaimsSet().toString());
+
+        for (Map.Entry<String, String> entry : expectedClaims.entrySet()) {
+            assertEquals(
+                    entry.getValue(),
+                    claimsSet.get(entry.getKey()).asText(),
+                    () ->
+                            String.format(
+                                    "Expected claim for key=%s to be %s, but found %s",
+                                    entry.getKey(),
+                                    entry.getValue(),
+                                    claimsSet.get(entry.getKey()).asText()));
+        }
+    }
+
+    private static Stream<Arguments> journeyUriParameters() {
+        return Stream.of(
+                Arguments.of(CRI_WITH_CONTEXT, Map.of(CONTEXT, BANK_ACCOUNT_CONTEXT)),
+                Arguments.of(CRI_WITH_SCOPE, Map.of(SCOPE, IDENTITY_CHECK_SCOPE)),
+                Arguments.of(
+                        CRI_WITH_CONTEXT_AND_SCOPE,
+                        Map.of(CONTEXT, BANK_ACCOUNT_CONTEXT, SCOPE, IDENTITY_CHECK_SCOPE)));
     }
 
     private void assertErrorResponse(

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -67,8 +67,8 @@ class AuthorizationRequestHelperTest {
     private static final String IPV_CLIENT_ID_VALUE = "testClientId";
     private static final String IPV_ISSUER = "http://example.com/issuer";
     private static final String AUDIENCE = "Audience";
-    private static final String BANK_ACCOUNT_CONTEXT = "bank_account";
-    private static final String IDENTITY_CHECK_SCOPE = "identityCheck";
+    private static final String TEST_CONTEXT = "test_context";
+    private static final String TEST_SCOPE = "test_scope";
     private static final String IPV_TOKEN_TTL = "900";
     private static final String MOCK_CORE_FRONT_CALLBACK_URL = "callbackUri";
     private static final String TEST_REDIRECT_URI = "http:example.com/callback/criId";
@@ -179,12 +179,12 @@ class AuthorizationRequestHelperTest {
 
     private static Stream<Arguments> journeyUriParameters() {
         return Stream.of(
-                Arguments.of(BANK_ACCOUNT_CONTEXT, null, Map.of("context", BANK_ACCOUNT_CONTEXT)),
-                Arguments.of(null, IDENTITY_CHECK_SCOPE, Map.of("scope", IDENTITY_CHECK_SCOPE)),
+                Arguments.of(TEST_CONTEXT, null, Map.of("context", TEST_CONTEXT)),
+                Arguments.of(null, TEST_SCOPE, Map.of("scope", TEST_SCOPE)),
                 Arguments.of(
-                        BANK_ACCOUNT_CONTEXT,
-                        IDENTITY_CHECK_SCOPE,
-                        Map.of("context", BANK_ACCOUNT_CONTEXT, "scope", IDENTITY_CHECK_SCOPE)));
+                        TEST_CONTEXT,
+                        TEST_SCOPE,
+                        Map.of("context", TEST_CONTEXT, "scope", TEST_SCOPE)));
     }
 
     @Test

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -32,7 +32,6 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.Journey
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageStepResponse;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.EnumMap;
 import java.util.List;
@@ -181,13 +180,6 @@ public class ProcessJourneyEventHandler
                                     ipvSessionItem.getJourneyType()));
             throw new JourneyEngineException(
                     "State machine not found for journey type, failed to execute journey engine step");
-        } catch (URISyntaxException e) {
-            LOGGER.error(
-                    new StringMapMessage()
-                            .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), e.getMessage())
-                            .with(LOG_JOURNEY_EVENT.getFieldName(), journeyEvent));
-            throw new JourneyEngineException(
-                    "State response journey URI cannot be built, failed to execute journey engine step.");
         }
     }
 

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.processjourneyevent.exceptions.JourneyEngineException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.StateMachine;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.StateMachineInitializer;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.StateMachineInitializerMode;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.StateMachineNotFoundException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownStateException;
@@ -31,6 +32,7 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.Journey
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageStepResponse;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.EnumMap;
 import java.util.List;
@@ -58,12 +60,13 @@ public class ProcessJourneyEventHandler
             IpvSessionService ipvSessionService,
             ConfigService configService,
             ClientOAuthSessionDetailsService clientOAuthSessionService,
-            List<IpvJourneyTypes> journeyTypes)
+            List<IpvJourneyTypes> journeyTypes,
+            StateMachineInitializerMode stateMachineInitializerMode)
             throws IOException {
         this.ipvSessionService = ipvSessionService;
         this.configService = configService;
         this.clientOAuthSessionService = clientOAuthSessionService;
-        this.stateMachines = loadStateMachines(journeyTypes);
+        this.stateMachines = loadStateMachines(journeyTypes, stateMachineInitializerMode);
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -71,7 +74,9 @@ public class ProcessJourneyEventHandler
         this.configService = new ConfigService();
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
-        this.stateMachines = loadStateMachines(List.of(IPV_CORE_MAIN_JOURNEY));
+        this.stateMachines =
+                loadStateMachines(
+                        List.of(IPV_CORE_MAIN_JOURNEY), StateMachineInitializerMode.STANDARD);
     }
 
     @Override
@@ -176,6 +181,13 @@ public class ProcessJourneyEventHandler
                                     ipvSessionItem.getJourneyType()));
             throw new JourneyEngineException(
                     "State machine not found for journey type, failed to execute journey engine step");
+        } catch (URISyntaxException e) {
+            LOGGER.error(
+                    new StringMapMessage()
+                            .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), e.getMessage())
+                            .with(LOG_JOURNEY_EVENT.getFieldName(), journeyEvent));
+            throw new JourneyEngineException(
+                    "State response journey URI cannot be built, failed to execute journey engine step.");
         }
     }
 
@@ -227,13 +239,17 @@ public class ProcessJourneyEventHandler
     }
 
     @Tracing
-    private Map<IpvJourneyTypes, StateMachine> loadStateMachines(List<IpvJourneyTypes> journeyTypes)
+    private Map<IpvJourneyTypes, StateMachine> loadStateMachines(
+            List<IpvJourneyTypes> journeyTypes,
+            StateMachineInitializerMode stateMachineInitializerMode)
             throws IOException {
         EnumMap<IpvJourneyTypes, StateMachine> stateMachinesMap =
                 new EnumMap<>(IpvJourneyTypes.class);
         for (IpvJourneyTypes journeyType : journeyTypes) {
             stateMachinesMap.put(
-                    journeyType, new StateMachine(new StateMachineInitializer(journeyType)));
+                    journeyType,
+                    new StateMachine(
+                            new StateMachineInitializer(journeyType, stateMachineInitializerMode)));
         }
         return stateMachinesMap;
     }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.net.URI;
@@ -11,11 +14,15 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Objects;
 
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
+
 @ExcludeFromGeneratedCoverageReport
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 public class CriStepResponse implements StepResponse {
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public static final String CRI_JOURNEY_TEMPLATE = "/journey/cri/build-oauth-request/%s";
 
@@ -25,16 +32,26 @@ public class CriStepResponse implements StepResponse {
 
     private String scope;
 
-    public Map<String, Object> value() throws URISyntaxException {
-        URIBuilder uriBuilder = new URIBuilder(String.format(CRI_JOURNEY_TEMPLATE, criId));
-        if (Objects.nonNull(context)) {
-            uriBuilder.addParameter("context", context);
-        }
-        if (Objects.nonNull(scope)) {
-            uriBuilder.addParameter("scope", scope);
-        }
-        URI journeyUri = uriBuilder.build();
+    public Map<String, Object> value() {
+        try {
+            URIBuilder uriBuilder = new URIBuilder(String.format(CRI_JOURNEY_TEMPLATE, criId));
+            if (Objects.nonNull(context)) {
+                uriBuilder.addParameter("context", context);
+            }
+            if (Objects.nonNull(scope)) {
+                uriBuilder.addParameter("scope", scope);
+            }
+            URI journeyUri = uriBuilder.build();
 
-        return Map.of("journey", journeyUri.toString());
+            return Map.of("journey", journeyUri.toString());
+        } catch (URISyntaxException e) {
+            LOGGER.error(
+                    new StringMapMessage()
+                            .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), e.getMessage())
+                            .with("criId", criId)
+                            .with("context", context)
+                            .with("scope", scope));
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -3,9 +3,13 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.http.client.utils.URIBuilder;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Objects;
 
 @ExcludeFromGeneratedCoverageReport
 @NoArgsConstructor
@@ -17,7 +21,20 @@ public class CriStepResponse implements StepResponse {
 
     private String criId;
 
-    public Map<String, Object> value() {
-        return Map.of("journey", String.format(CRI_JOURNEY_TEMPLATE, criId));
+    private String context;
+
+    private String scope;
+
+    public Map<String, Object> value() throws URISyntaxException {
+        URIBuilder uriBuilder = new URIBuilder(String.format(CRI_JOURNEY_TEMPLATE, criId));
+        if (Objects.nonNull(context)) {
+            uriBuilder.addParameter("context", context);
+        }
+        if (Objects.nonNull(scope)) {
+            uriBuilder.addParameter("scope", scope);
+        }
+        URI journeyUri = uriBuilder.build();
+
+        return Map.of("journey", journeyUri.toString());
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.net.URISyntaxException;
 import java.util.Map;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -14,5 +15,5 @@ import java.util.Map;
     @JsonSubTypes.Type(value = ProcessStepResponse.class, name = "process")
 })
 public interface StepResponse {
-    Map<String, Object> value();
+    Map<String, Object> value() throws URISyntaxException;
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-import java.net.URISyntaxException;
 import java.util.Map;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -15,5 +14,5 @@ import java.util.Map;
     @JsonSubTypes.Type(value = ProcessStepResponse.class, name = "process")
 })
 public interface StepResponse {
-    Map<String, Object> value() throws URISyntaxException;
+    Map<String, Object> value();
 }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/ipv-core-main-journey.yaml
@@ -36,6 +36,40 @@ CRI_STATE:
   events:
     enterNestedJourneyAtStateOne:
       targetState: NESTED_JOURNEY_INVOKE_STATE
+    testWithContext:
+      targetState: CRI_STATE_WITH_CONTEXT
+    testWithScope:
+      targetState: CRI_STATE_WITH_SCOPE
+    testWithContextAndScope:
+      targetState: CRI_STATE_WITH_CONTEXT_AND_SCOPE
+
+CRI_STATE_WITH_CONTEXT:
+  response:
+    type: cri
+    criId: aCriId
+    context: bank_account
+  events:
+    enterNestedJourneyAtStateOne:
+      targetState: NESTED_JOURNEY_INVOKE_STATE
+
+CRI_STATE_WITH_SCOPE:
+  response:
+    type: cri
+    criId: aCriId
+    scope: identityCheck
+  events:
+    enterNestedJourneyAtStateOne:
+      targetState: NESTED_JOURNEY_INVOKE_STATE
+
+CRI_STATE_WITH_CONTEXT_AND_SCOPE:
+  response:
+    type: cri
+    criId: aCriId
+    context: bank_account
+    scope: identityCheck
+  events:
+    enterNestedJourneyAtStateOne:
+      targetState: NESTED_JOURNEY_INVOKE_STATE
 
 ERROR_STATE:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/ipv-core-main-journey.yaml
@@ -47,7 +47,7 @@ CRI_STATE_WITH_CONTEXT:
   response:
     type: cri
     criId: aCriId
-    context: bank_account
+    context: test_context
   events:
     enterNestedJourneyAtStateOne:
       targetState: NESTED_JOURNEY_INVOKE_STATE
@@ -56,7 +56,7 @@ CRI_STATE_WITH_SCOPE:
   response:
     type: cri
     criId: aCriId
-    scope: identityCheck
+    scope: test_scope
   events:
     enterNestedJourneyAtStateOne:
       targetState: NESTED_JOURNEY_INVOKE_STATE
@@ -65,8 +65,8 @@ CRI_STATE_WITH_CONTEXT_AND_SCOPE:
   response:
     type: cri
     criId: aCriId
-    context: bank_account
-    scope: identityCheck
+    context: test_context
+    scope: test_scope
   events:
     enterNestedJourneyAtStateOne:
       targetState: NESTED_JOURNEY_INVOKE_STATE

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -254,13 +254,13 @@ class ProcessJourneyEventHandlerTest {
         return Stream.of(
                 Arguments.of(
                         "testWithContext",
-                        "/journey/cri/build-oauth-request/aCriId?context=bank_account"),
+                        "/journey/cri/build-oauth-request/aCriId?context=test_context"),
                 Arguments.of(
                         "testWithScope",
-                        "/journey/cri/build-oauth-request/aCriId?scope=identityCheck"),
+                        "/journey/cri/build-oauth-request/aCriId?scope=test_scope"),
                 Arguments.of(
                         "testWithContextAndScope",
-                        "/journey/cri/build-oauth-request/aCriId?context=bank_account&scope=identityCheck"));
+                        "/journey/cri/build-oauth-request/aCriId?context=test_context&scope=test_scope"));
     }
 
     private void mockIpvSessionItemAndTimeout(String userState) {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -116,32 +116,20 @@ class StateMachineInitializerTest {
                 ((BasicEvent) criState.getEvents().get("enterNestedJourneyAtStateOne"))
                         .getTargetStateObj());
 
-        // cri state with context assertions
+        // cri state with context assertion
         assertEquals(
-                "/journey/cri/build-oauth-request/aCriId?context=bank_account",
+                "/journey/cri/build-oauth-request/aCriId?context=test_context",
                 criWithContextState.getResponse().value().get("journey"));
-        assertEquals(
-                nestedJourneyInvokeState,
-                ((BasicEvent) criWithContextState.getEvents().get("enterNestedJourneyAtStateOne"))
-                        .getTargetStateObj());
 
-        // cri state with scope assertions
+        // cri state with scope assertion
         assertEquals(
-                "/journey/cri/build-oauth-request/aCriId?scope=identityCheck",
+                "/journey/cri/build-oauth-request/aCriId?scope=test_scope",
                 criWithScopeState.getResponse().value().get("journey"));
-        assertEquals(
-                nestedJourneyInvokeState,
-                ((BasicEvent) criWithContextState.getEvents().get("enterNestedJourneyAtStateOne"))
-                        .getTargetStateObj());
 
-        // cri state with context and scope assertions
+        // cri state with context and scope assertion
         assertEquals(
-                "/journey/cri/build-oauth-request/aCriId?context=bank_account&scope=identityCheck",
+                "/journey/cri/build-oauth-request/aCriId?context=test_context&scope=test_scope",
                 criWithContextAndScopeState.getResponse().value().get("journey"));
-        assertEquals(
-                nestedJourneyInvokeState,
-                ((BasicEvent) criWithContextState.getEvents().get("enterNestedJourneyAtStateOne"))
-                        .getTargetStateObj());
 
         // error state assertions
         assertEquals(

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -18,6 +18,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -56,7 +57,8 @@ class StateMachineInitializerTest {
 
     @java.lang.SuppressWarnings("java:S5961") // Too many assertions
     @Test
-    void stateMachineInitializerShouldCorrectlyDeserializeJourneyMaps() throws IOException {
+    void stateMachineInitializerShouldCorrectlyDeserializeJourneyMaps()
+            throws IOException, URISyntaxException {
         Map<String, State> journeyMap =
                 new StateMachineInitializer(
                                 IpvJourneyTypes.IPV_CORE_MAIN_JOURNEY,
@@ -67,6 +69,10 @@ class StateMachineInitializerTest {
         BasicState pageState = (BasicState) journeyMap.get("PAGE_STATE");
         BasicState journeyState = (BasicState) journeyMap.get("JOURNEY_STATE");
         BasicState criState = (BasicState) journeyMap.get("CRI_STATE");
+        BasicState criWithContextState = (BasicState) journeyMap.get("CRI_STATE_WITH_CONTEXT");
+        BasicState criWithScopeState = (BasicState) journeyMap.get("CRI_STATE_WITH_SCOPE");
+        BasicState criWithContextAndScopeState =
+                (BasicState) journeyMap.get("CRI_STATE_WITH_CONTEXT_AND_SCOPE");
         BasicState errorState = (BasicState) journeyMap.get("ERROR_STATE");
         BasicState processState = (BasicState) journeyMap.get("PROCESS_STATE");
         NestedJourneyInvokeState nestedJourneyInvokeState =
@@ -108,6 +114,33 @@ class StateMachineInitializerTest {
         assertEquals(
                 nestedJourneyInvokeState,
                 ((BasicEvent) criState.getEvents().get("enterNestedJourneyAtStateOne"))
+                        .getTargetStateObj());
+
+        // cri state with context assertions
+        assertEquals(
+                "/journey/cri/build-oauth-request/aCriId?context=bank_account",
+                criWithContextState.getResponse().value().get("journey"));
+        assertEquals(
+                nestedJourneyInvokeState,
+                ((BasicEvent) criWithContextState.getEvents().get("enterNestedJourneyAtStateOne"))
+                        .getTargetStateObj());
+
+        // cri state with scope assertions
+        assertEquals(
+                "/journey/cri/build-oauth-request/aCriId?scope=identityCheck",
+                criWithScopeState.getResponse().value().get("journey"));
+        assertEquals(
+                nestedJourneyInvokeState,
+                ((BasicEvent) criWithContextState.getEvents().get("enterNestedJourneyAtStateOne"))
+                        .getTargetStateObj());
+
+        // cri state with context and scope assertions
+        assertEquals(
+                "/journey/cri/build-oauth-request/aCriId?context=bank_account&scope=identityCheck",
+                criWithContextAndScopeState.getResponse().value().get("journey"));
+        assertEquals(
+                nestedJourneyInvokeState,
+                ((BasicEvent) criWithContextState.getEvents().get("enterNestedJourneyAtStateOne"))
                         .getTargetStateObj());
 
         // error state assertions

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -15,8 +14,7 @@ public class CriStepResponseTest {
     @ParameterizedTest
     @MethodSource("journeyUriParameters")
     void valueReturnsExpectedJourneyResponse(
-            String criId, String context, String scope, String expectedJourney)
-            throws URISyntaxException {
+            String criId, String context, String scope, String expectedJourney) {
         CriStepResponse response = new CriStepResponse(criId, context, scope);
         assertEquals(
                 Map.of("journey", expectedJourney),
@@ -32,18 +30,18 @@ public class CriStepResponseTest {
                 Arguments.of("aCriId", null, null, "/journey/cri/build-oauth-request/aCriId"),
                 Arguments.of(
                         "aCriId",
-                        "someContext",
+                        "test_context",
                         null,
-                        "/journey/cri/build-oauth-request/aCriId?context=someContext"),
+                        "/journey/cri/build-oauth-request/aCriId?context=test_context"),
                 Arguments.of(
                         "aCriId",
                         null,
-                        "someScope",
-                        "/journey/cri/build-oauth-request/aCriId?scope=someScope"),
+                        "test_scope",
+                        "/journey/cri/build-oauth-request/aCriId?scope=test_scope"),
                 Arguments.of(
                         "aCriId",
-                        "someContext",
-                        "someScope",
-                        "/journey/cri/build-oauth-request/aCriId?context=someContext&scope=someScope"));
+                        "test_context",
+                        "test_scope",
+                        "/journey/cri/build-oauth-request/aCriId?context=test_context&scope=test_scope"));
     }
 }

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -1,18 +1,49 @@
 package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CriStepResponseTest {
 
-    public static final CriStepResponse CRI_RESPONSE = new CriStepResponse("aCriId");
-
-    @Test
-    void valueReturnsCorrectJourneyResponse() {
+    @ParameterizedTest
+    @MethodSource("journeyUriParameters")
+    void valueReturnsExpectedJourneyResponse(
+            String criId, String context, String scope, String expectedJourney)
+            throws URISyntaxException {
+        CriStepResponse response = new CriStepResponse(criId, context, scope);
         assertEquals(
-                Map.of("journey", "/journey/cri/build-oauth-request/aCriId"), CRI_RESPONSE.value());
+                Map.of("journey", expectedJourney),
+                response.value(),
+                () ->
+                        String.format(
+                                "Expected journey for criId=%s, context=%s, scope=%s was not as expected",
+                                criId, context, scope));
+    }
+
+    private static Stream<Arguments> journeyUriParameters() {
+        return Stream.of(
+                Arguments.of("aCriId", null, null, "/journey/cri/build-oauth-request/aCriId"),
+                Arguments.of(
+                        "aCriId",
+                        "someContext",
+                        null,
+                        "/journey/cri/build-oauth-request/aCriId?context=someContext"),
+                Arguments.of(
+                        "aCriId",
+                        null,
+                        "someScope",
+                        "/journey/cri/build-oauth-request/aCriId?scope=someScope"),
+                Arguments.of(
+                        "aCriId",
+                        "someContext",
+                        "someScope",
+                        "/journey/cri/build-oauth-request/aCriId?context=someContext&scope=someScope"));
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriConstants.java
@@ -17,6 +17,7 @@ public class CriConstants {
     public static final String ADDRESS_CRI = "address";
     public static final String DCMAW_CRI = "dcmaw";
     public static final String CLAIMED_IDENTITY_CRI = "claimedIdentity";
+    public static final String NINO_CRI = "nino";
     public static final String F2F_CRI = "f2f";
 
     public static final Set<String> NON_EVIDENCE_CRI_TYPES =

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.core.library.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -11,8 +13,11 @@ import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
+import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 
@@ -107,8 +112,14 @@ public class RequestHelper {
         return featureSet;
     }
 
-    public static String getJourney(JourneyRequest request) {
-        return request.getJourney();
+    public static String getJourneyParameter(URI journeyUri, String key) {
+        List<NameValuePair> queryParams = new URIBuilder(journeyUri).getQueryParams();
+        Optional<NameValuePair> parameter =
+                queryParams.stream()
+                        .filter(query -> Objects.equals(query.getName(), key))
+                        .findFirst();
+
+        return parameter.map(NameValuePair::getValue).orElse(null);
     }
 
     public static String getScoreType(ProcessRequest request)


### PR DESCRIPTION
## Proposed changes

### What changed

- Add functionality to take context & scope from journey map state response definitions
- Then to pass it between lambdas within the journey parameter by constructing that parameter as a URI with context & scope as parameters

### Why did it change

- To be able to provide context & scope to CRIs for specific journeys

### Issue tracking

- [PYIC-3661](https://govukverify.atlassian.net/browse/PYIC-3661)

## Checklists

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3661]: https://govukverify.atlassian.net/browse/PYIC-3661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ