### PR TITLE
PYIC-3661: Add context and scope to journey map

### DIFF
--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -166,7 +166,9 @@ const renderStates = (journeyMap, states) => {
                     ? `    ${state}[${state}\\n${definition.response.pageId}]:::error_page`
                     : `    ${state}[${state}\\n${definition.response.pageId}]:::page`;
             case 'cri':
-                return `    ${state}([${state}\\n${definition.response.criId}]):::cri`;
+                let contextInfo = definition.response.context ? `\\n context: ${definition.response.context}` : "";
+                let scopeInfo = definition.response.scope ? `\\n scope: ${definition.response.scope}` : "";
+                return `    ${state}([${state}\\n${definition.response.criId}${contextInfo}${scopeInfo}]):::cri`;
             case 'error':
                 return `    ${state}:::error_page`
             default:

--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -166,8 +166,8 @@ const renderStates = (journeyMap, states) => {
                     ? `    ${state}[${state}\\n${definition.response.pageId}]:::error_page`
                     : `    ${state}[${state}\\n${definition.response.pageId}]:::page`;
             case 'cri':
-                let contextInfo = definition.response.context ? `\\n context: ${definition.response.context}` : "";
-                let scopeInfo = definition.response.scope ? `\\n scope: ${definition.response.scope}` : "";
+                const contextInfo = definition.response.context ? `\\n context: ${definition.response.context}` : "";
+                const scopeInfo = definition.response.scope ? `\\n scope: ${definition.response.scope}` : "";
                 return `    ${state}([${state}\\n${definition.response.criId}${contextInfo}${scopeInfo}]):::cri`;
             case 'error':
                 return `    ${state}:::error_page`


### PR DESCRIPTION
## Proposed changes

### What changed

Example:
<img width="676" alt="Screenshot 2023-11-03 at 15 17 51" src="https://github.com/govuk-one-login/ipv-core-back/assets/144116535/44de012b-f3ae-4414-aad7-74e73e40e7ac">

### Why did it change

- To visualise context and scope in the journey map, to be better informed when using the reference
- Was made to be simple, instead of using a tooltip, because this is sufficient and less code
