### PR TITLE
PYIC-3796: Add evaluate gpg45 scores to end

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -44,6 +44,11 @@
           "Variable": "$.journey",
           "StringMatches": "/journey/check-gpg45-score",
           "Next": "CheckGpg45ScoreLambda"
+        },
+        {
+          "Variable": "$.journey",
+          "StringMatches": "/journey/evaluate-gpg45-scores",
+          "Next": "EvaluateGpg45Scores"
         }
       ],
       "Default": "Success"
@@ -87,6 +92,18 @@
     "BuildClientOauthResponseLambda": {
       "Type": "Task",
       "Resource": "${BuildClientOauthResponseFunctionArn}",
+      "Parameters": {
+        "journey.$": "$.journey",
+        "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
+        "ipAddress.$": "$$.Execution.Input.ipAddress",
+        "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
+        "featureSet.$": "$$.Execution.Input.featureSet"
+      },
+      "Next": "ProcessNextJourney"
+    },
+    "EvaluateGpg45Scores": {
+      "Type": "Task",
+      "Resource": "${EvaluateGpg45ScoresFunctionArn}",
       "Parameters": {
         "journey.$": "$.journey",
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1412,6 +1412,7 @@ Resources:
         BuildClientOauthResponseFunctionArn: !Ref BuildClientOauthResponseFunction.Alias
         CheckCiScoreFunctionArn: !Ref CheckCiScoreFunction.Alias
         CheckGpg45ScoreFunctionArn: !Ref CheckGpg45ScoreFunction.Alias
+        EvaluateGpg45ScoresFunctionArn: !Ref EvaluateGpg45ScoresFunction.Alias
       Events:
         IPVCorePrivateAPI:
           Type: Api
@@ -1441,6 +1442,8 @@ Resources:
             FunctionName: !Ref CheckCiScoreFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref CheckGpg45ScoreFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref EvaluateGpg45ScoresFunction
         - Statement:
             - Sid: CloudWatchLogsAccess
               Effect: Allow

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -22,6 +22,9 @@ CRI_STATE:
       targetState: PYI_NO_MATCH
     end:
       targetState: IPV_SUCCESS_PAGE
+      checkFeatureFlag:
+        gpg45ScoresAtEnd:
+          targetState: EVALUATE_GPG45_SCORES
     pyi-no-match:
       targetState: PYI_NO_MATCH
     pyi-kbv-fail:
@@ -279,6 +282,18 @@ CORE_SESSION_TIMEOUT:
     pageId: pyi-timeout-unrecoverable
   parent: END_JOURNEY
 
+EVALUATE_GPG45_SCORES:
+  response:
+    type: process
+    lambda: evaluate-gpg45-scores
+  events:
+    end:
+      targetState:
+        IPV_SUCCESS_PAGE
+    next:
+      targetState:
+        PYI_NO_MATCH
+
 IPV_SUCCESS_PAGE:
   response:
     type: page
@@ -307,6 +322,9 @@ CRI_EXPERIAN_KBV:
   events:
     end:
       targetState: IPV_SUCCESS_PAGE
+      checkFeatureFlag:
+        gpg45ScoresAtEnd:
+          targetState: EVALUATE_GPG45_SCORES
     fail-with-no-ci:
       targetState: PYI_CRI_ESCAPE
       checkIfDisabled:
@@ -337,6 +355,9 @@ ADDRESS_AND_FRAUD_J1:
   exitEvents:
     end:
       targetState: IPV_SUCCESS_PAGE
+      checkFeatureFlag:
+        gpg45ScoresAtEnd:
+          targetState: EVALUATE_GPG45_SCORES
     next:
       targetState: PYI_NO_MATCH
 
@@ -443,6 +464,9 @@ POST_DCMAW_SUCCESS_PAGE_J5:
   events:
     next:
       targetState: IPV_SUCCESS_PAGE
+      checkFeatureFlag:
+        gpg45ScoresAtEnd:
+          targetState: EVALUATE_GPG45_SCORES
 
 # HMRC KBV journey (J6)
 CRI_NINO_J6:
@@ -464,6 +488,9 @@ CRI_HMRC_KBV_J6:
   events:
     end:
       targetState: IPV_SUCCESS_PAGE
+      checkFeatureFlag:
+        gpg45ScoresAtEnd:
+          targetState: EVALUATE_GPG45_SCORES
     fail-with-no-ci:
       targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
     next:


### PR DESCRIPTION
## Proposed changes

### What changed

- Added a lambda call to the end, where it would normally go straight to IPV_SUCCESS_PAGE
  - Add new CHECK_GPG45_SCORES state behind gpg45ScoresAtEnd flag
- (mirrored changes in common-infra: https://github.com/govuk-one-login/ipv-core-common-infra/pull/759)

<img width="1219" alt="Screenshot 2023-11-07 at 16 49 46" src="https://github.com/govuk-one-login/ipv-core-back/assets/144116535/0361cf35-aca2-4462-9f3d-0fc8e65df780">

<img width="538" alt="Screenshot 2023-11-07 at 16 51 36" src="https://github.com/govuk-one-login/ipv-core-back/assets/144116535/0e76a42f-9695-4962-b223-21d58755a48d">

Tests on this (^) deployment pass:
<img width="982" alt="Screenshot 2023-11-07 at 16 52 29" src="https://github.com/govuk-one-login/ipv-core-back/assets/144116535/0b76261f-e78e-440b-81c8-f3b3b49bbc0c">

### Why did it change

- Because we're trying to make the only call of the evaluate gpg45 call at the end, to evaluate a profile

### Issue tracking

- [PYIC-3796](https://govukverify.atlassian.net/browse/PYIC-3796)

## Checklists

### Environment variables or secrets

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository



[PYIC-3796]: https://govukverify.atlassian.net/browse/PYIC-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ