### PR TITLE
Pyic 3660

### DIFF
--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -96,7 +96,7 @@ class CheckExistingIdentityHandlerTest {
     private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
 
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
-            List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
+            List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B);
     private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse("/journey/reuse");
     private static final JourneyResponse JOURNEY_RESET_IDENTITY =
             new JourneyResponse("/journey/reset-identity");

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -61,7 +61,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1B_DCMAW_VC;
-import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.*;
+import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1A;
+import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1B;
+import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M2B;
 
 @ExtendWith(MockitoExtension.class)
 class EvaluateGpg45ScoresHandlerTest {

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -61,8 +61,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_VERIFICATION_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1B_DCMAW_VC;
-import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1A;
-import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1B;
+import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.*;
 
 @ExtendWith(MockitoExtension.class)
 class EvaluateGpg45ScoresHandlerTest {
@@ -81,7 +80,7 @@ class EvaluateGpg45ScoresHandlerTest {
     public static CredentialIssuerConfig addressConfig = null;
     public static CredentialIssuerConfig claimedIdentityConfig = null;
     private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
-    private static final List<Gpg45Profile> ACCEPTED_PROFILES = List.of(M1A, M1B);
+    private static final List<Gpg45Profile> ACCEPTED_PROFILES = List.of(M1A, M1B, M2B);
     private static final JourneyResponse JOURNEY_END = new JourneyResponse("/journey/end");
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse("/journey/next");
     private static final String JOURNEY_PYI_NO_MATCH = "/journey/pyi-no-match";

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -65,7 +65,7 @@ BANK_ACCOUNT_START_PAGE:
     pageId: page-ipv-bank-account-start
   events:
     next:
-      targetState: CRI_BANK_ACCOUNT
+      targetState: CRI_BANK_ACCOUNT_J7
     end:
       targetState: PYI_ESCAPE
 
@@ -402,16 +402,6 @@ CHECK_FRAUD_SCORE_J3:
     unmet:
       targetState: PYI_NO_MATCH
 
-CRI_BANK_ACCOUNT:
-  response:
-    type: cri
-    criId: bav
-    context: bank_account
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_NINO_WITH_SCOPE_J6
-
 # F2F journey (J4)
 CRI_CLAIMED_IDENTITY_J4:
   response:
@@ -466,16 +456,6 @@ CRI_NINO_J6:
     fail-with-no-ci:
       targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
-CRI_NINO_WITH_SCOPE_J6:
-  response:
-    type: cri
-    criId: nino
-    scope: identityCheck
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J3
-
 CRI_HMRC_KBV_J6:
   response:
     type: cri
@@ -488,6 +468,38 @@ CRI_HMRC_KBV_J6:
       targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
     next:
       targetState: PYI_NO_MATCH
+
+# No photo id M2B journey (J7)
+CRI_BANK_ACCOUNT_J7:
+  response:
+    type: cri
+    criId: bav
+    context: bank_account
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: CRI_NINO_WITH_SCOPE_J7
+
+CRI_NINO_WITH_SCOPE_J7:
+  response:
+    type: cri
+    criId: nino
+    scope: identityCheck
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: ADDRESS_AND_FRAUD_J7
+
+ADDRESS_AND_FRAUD_J7:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
+    next:
+      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      checkFeatureFlag:
+        hmrcKbv:
+          targetState: CRI_HMRC_KBV_J6
+    end:
+      targetState: ERROR
 
 # Mitigation journey (01)
 MITIGATION_01:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -409,7 +409,7 @@ CRI_BANK_ACCOUNT:
   parent: CRI_STATE
   events:
     next:
-      targetState: ADDRESS_AND_FRAUD_J4
+      targetState: CRI_NINO_J6
     enhanced-verification:
       targetState: ADDRESS_AND_FRAUD_J4
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -410,7 +410,7 @@ CRI_BANK_ACCOUNT:
   parent: CRI_STATE
   events:
     next:
-      targetState: CRI_NINO_J6
+      targetState: CRI_NINO_WITH_SCOPE_J6
     enhanced-verification:
       targetState: ADDRESS_AND_FRAUD_J4
 
@@ -462,6 +462,18 @@ CRI_NINO_J6:
   response:
     type: cri
     criId: nino
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: CRI_HMRC_KBV_J6
+    fail-with-no-ci:
+      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+CRI_NINO_WITH_SCOPE_J6:
+  response:
+    type: cri
+    criId: nino
+    scope: identityCheck
   parent: CRI_STATE
   events:
     next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -65,7 +65,7 @@ BANK_ACCOUNT_START_PAGE:
     pageId: page-ipv-bank-account-start
   events:
     next:
-      targetState: PYI_ESCAPE # Todo: Need to replace with CRI.
+      targetState: CRI_BANK_ACCOUNT
     end:
       targetState: PYI_ESCAPE
 
@@ -401,6 +401,18 @@ CHECK_FRAUD_SCORE_J3:
       targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
     unmet:
       targetState: PYI_NO_MATCH
+
+CRI_BANK_ACCOUNT:
+  response:
+    type: cri
+    criId: bav
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: ADDRESS_AND_FRAUD_J4
+    enhanced-verification:
+      targetState: ADDRESS_AND_FRAUD_J4
+
 
 # F2F journey (J4)
 CRI_CLAIMED_IDENTITY_J4:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -406,7 +406,7 @@ CRI_BANK_ACCOUNT:
   response:
     type: cri
     criId: bav
-    scope: identityCheck
+    context: bank_account
   parent: CRI_STATE
   events:
     next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -411,9 +411,6 @@ CRI_BANK_ACCOUNT:
   events:
     next:
       targetState: CRI_NINO_WITH_SCOPE_J6
-    enhanced-verification:
-      targetState: ADDRESS_AND_FRAUD_J4
-
 
 # F2F journey (J4)
 CRI_CLAIMED_IDENTITY_J4:
@@ -477,9 +474,7 @@ CRI_NINO_WITH_SCOPE_J6:
   parent: CRI_STATE
   events:
     next:
-      targetState: CRI_HMRC_KBV_J6
-    fail-with-no-ci:
-      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      targetState: ADDRESS_AND_FRAUD_J3
 
 CRI_HMRC_KBV_J6:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -406,6 +406,7 @@ CRI_BANK_ACCOUNT:
   response:
     type: cri
     criId: bav
+    scope: identityCheck
   parent: CRI_STATE
   events:
     next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -494,10 +494,10 @@ ADDRESS_AND_FRAUD_J7:
   nestedJourney: ADDRESS_AND_FRAUD
   exitEvents:
     next:
-      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      checkFeatureFlag:
+      targetState: CRI_HMRC_KBV_J6
+      checkIfDisabled:
         hmrcKbv:
-          targetState: CRI_HMRC_KBV_J6
+          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
     end:
       targetState: ERROR
 

--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
@@ -38,7 +38,7 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PYI_NO_
 
 public class Gpg45ProfileEvaluator {
     public static final List<Gpg45Profile> CURRENT_ACCEPTED_GPG45_PROFILES =
-            List.of(Gpg45Profile.M1A, Gpg45Profile.M1B);
+            List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B);
     private static final Logger LOGGER = LogManager.getLogger();
     private static final JourneyResponse JOURNEY_RESPONSE_PYI_NO_MATCH =
             new JourneyResponse(JOURNEY_PYI_NO_MATCH_PATH);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added M2B No Photo Id journey to the journey map. Enables the M2B GPG45 score as a valid score that we will check with. 

### Why did it change

So that a user can prove their identity with two pieces of weaker evidence instead of just one stronger one. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3660](https://govukverify.atlassian.net/browse/PYIC-3660)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3660]: https://govukverify.atlassian.net/browse/PYIC-3660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ