### PR TITLE
PYIC-3939: Added CIC CRI to BAV M2B journey map

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -68,7 +68,7 @@ BANK_ACCOUNT_START_PAGE:
     pageId: page-ipv-bank-account-start
   events:
     next:
-      targetState: CRI_BANK_ACCOUNT_J7
+      targetState: CRI_CLAIMED_IDENTITY_J7
     end:
       targetState: PYI_ESCAPE
 
@@ -497,6 +497,17 @@ CRI_HMRC_KBV_J6:
       targetState: PYI_NO_MATCH
 
 # No photo id M2B journey (J7)
+CRI_CLAIMED_IDENTITY_J7:
+  response:
+    type: cri
+    criId: claimedIdentity
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: CRI_BANK_ACCOUNT_J7
+    enhanced-verification:
+      targetState: CRI_BANK_ACCOUNT_J7
+
 CRI_BANK_ACCOUNT_J7:
   response:
     type: cri


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added CIC CRI to BAV M2B journey map as the first page.

### Why did it change

This was missed off the initial implementation of the E2E M2B journey config

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3939](https://govukverify.atlassian.net/browse/PYIC-3939)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-3939]: https://govukverify.atlassian.net/browse/PYIC-3939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ