### PR TITLE
PYIC-3924: Return exit code for non breaching failures

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -23,7 +23,8 @@ public enum ConfigurationVariable {
     CIMIT_SIGNING_KEY("cimit/signingKey"),
     CIMIT_COMPONENT_ID("cimit/componentId"),
     CIMIT_CONFIG("cimit/config"),
-    ALWAYS_REQUIRED_EXIT_CODES("self/alwaysRequiredExitCodes");
+    EXIT_CODES_ALWAYS_REQUIRED("self/exitCodes/alwaysRequired"),
+    EXIT_CODES_NON_CI_BREACHING_P0("self/exitCodes/nonCiBreachingP0");
 
     private final String path;
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -43,9 +43,10 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ALWAYS_REQUIRED_EXIT_CODES;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.EXIT_CODES_ALWAYS_REQUIRED;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.EXIT_CODES_NON_CI_BREACHING_P0;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EXIT_CODES;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.USER_ISSUED_CREDENTIALS_TABLE_NAME;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
@@ -168,22 +169,32 @@ public class UserIdentityService {
                     generateDrivingPermitClaim(successfulVCStoreItems);
             drivingPermitClaim.ifPresent(userIdentityBuilder::drivingPermitClaim);
             if (configService.enabled(EXIT_CODES)) {
-                userIdentityBuilder.exitCode(toAlwaysRequiredExitCode(contraIndicators));
+                userIdentityBuilder.exitCode(getSuccessExitCode(contraIndicators));
             }
         } else {
-            if (configService.enabled(EXIT_CODES)
-                    && contraIndicators.getContraIndicatorScore(
-                                    configService.getContraIndicatorConfigMap())
-                            >= Integer.parseInt(
-                                    configService.getSsmParameter(CI_SCORING_THRESHOLD))) {
-                userIdentityBuilder.exitCode(toExitCode(contraIndicators));
+            if (configService.enabled(EXIT_CODES)) {
+                userIdentityBuilder.exitCode(getFailExitCode(contraIndicators));
             }
         }
 
         return userIdentityBuilder.build();
     }
 
-    private List<String> toExitCode(ContraIndicators contraIndicators)
+    private List<String> getFailExitCode(ContraIndicators contraIndicators)
+            throws UnrecognisedCiException {
+        return breachingCiThreshold(contraIndicators)
+                ? mapCisToExitCodes(contraIndicators)
+                : List.of(configService.getSsmParameter(EXIT_CODES_NON_CI_BREACHING_P0));
+    }
+
+    private List<String> getSuccessExitCode(ContraIndicators contraIndicators)
+            throws UnrecognisedCiException {
+        return mapCisToExitCodes(contraIndicators).stream()
+                .filter(configService.getSsmParameter(EXIT_CODES_ALWAYS_REQUIRED)::contains)
+                .toList();
+    }
+
+    private List<String> mapCisToExitCodes(ContraIndicators contraIndicators)
             throws UnrecognisedCiException {
         return contraIndicators.getContraIndicatorsMap().values().stream()
                 .map(ContraIndicator::getCode)
@@ -203,11 +214,9 @@ public class UserIdentityService {
                 .toList();
     }
 
-    private List<String> toAlwaysRequiredExitCode(ContraIndicators contraIndicators)
-            throws UnrecognisedCiException {
-        return toExitCode(contraIndicators).stream()
-                .filter(configService.getSsmParameter(ALWAYS_REQUIRED_EXIT_CODES)::contains)
-                .toList();
+    private boolean breachingCiThreshold(ContraIndicators contraIndicators) {
+        return contraIndicators.getContraIndicatorScore(configService.getContraIndicatorConfigMap())
+                >= Integer.parseInt(configService.getSsmParameter(CI_SCORING_THRESHOLD));
     }
 
     private List<VcStoreItem> getSuccessfulVCStoreItems(List<VcStoreItem> vcStoreItems)

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -35,11 +35,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.ALWAYS_REQUIRED_EXIT_CODES;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.EXIT_CODES_ALWAYS_REQUIRED;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.EXIT_CODES_NON_CI_BREACHING_P0;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EXIT_CODES;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.BAV_CRI;
@@ -924,7 +926,7 @@ class UserIdentityServiceTest {
                                 "X01", new ContraIndicatorConfig("X01", 4, -3, "1"),
                                 "X02", new ContraIndicatorConfig("X02", 4, -3, "2"),
                                 "Z03", new ContraIndicatorConfig("Z03", 4, -3, "3")));
-        when(mockConfigService.getSsmParameter(ALWAYS_REQUIRED_EXIT_CODES)).thenReturn("1");
+        when(mockConfigService.getSsmParameter(EXIT_CODES_ALWAYS_REQUIRED)).thenReturn("1");
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
@@ -947,7 +949,7 @@ class UserIdentityServiceTest {
             throws Exception {
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockConfigService.enabled(EXIT_CODES)).thenReturn(true);
-        when(mockConfigService.getSsmParameter(ALWAYS_REQUIRED_EXIT_CODES)).thenReturn("1");
+        when(mockConfigService.getSsmParameter(EXIT_CODES_ALWAYS_REQUIRED)).thenReturn("1");
 
         UserIdentity userIdentity =
                 userIdentityService.generateUserIdentity(
@@ -1086,6 +1088,31 @@ class UserIdentityServiceTest {
                         USER_ID_1, "test-sub", "P0", emptyContraIndicators);
 
         assertNull(userIdentity.getExitCode());
+    }
+
+    @Test
+    void generateUserIdentityShouldSetRequiredExitCodeWhenP0AndNotBreachingCiThreshold()
+            throws Exception {
+        when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
+        when(mockConfigService.enabled(EXIT_CODES)).thenReturn(true);
+        when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("10");
+        when(mockConfigService.getSsmParameter(EXIT_CODES_NON_CI_BREACHING_P0)).thenReturn("🐧");
+
+        when(mockConfigService.getContraIndicatorConfigMap())
+                .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1")));
+
+        ContraIndicators contraIndicators =
+                ContraIndicators.builder()
+                        .contraIndicatorsMap(
+                                Map.of("X01", ContraIndicator.builder().code("X01").build()))
+                        .build();
+
+        UserIdentity userIdentity =
+                userIdentityService.generateUserIdentity(
+                        USER_ID_1, "test-sub", "P0", contraIndicators);
+
+        assertEquals(List.of("🐧"), userIdentity.getExitCode());
+        verify(mockConfigService, never()).getSsmParameter(EXIT_CODES_ALWAYS_REQUIRED);
     }
 
     @Test


### PR DESCRIPTION
There is an outstanding question here about if the new scenario should *only* return the specified exit code, or if it should include any details of CIs the user may have that are still below the threshold.
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return exit code for non breaching failures

### Why did it change

This extends the exit code functionality to return a specified exit code in the scenario that a user has failed to prove their identity (`P0`), but is not breaching the CI threshold limit. This would usually indicate that the user has chosen not to finish the journey. Possible reasons being they've go no documents, or don't want to/can't use the app or F2F journeys.

This is distinct from the scenario where a user abandons their journey entirely, which is not in scope.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3924](https://govukverify.atlassian.net/browse/PYIC-3924)


[PYIC-3924]: https://govukverify.atlassian.net/browse/PYIC-3924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ