### PR TITLE
PYIC-3803 Change to add exit code in identity issued audit event.

### DIFF
--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -192,9 +192,10 @@ class BuildUserIdentityHandlerTest {
         assertEquals(AuditEventTypes.IPV_IDENTITY_ISSUED, capturedAuditEvent.getEventName());
         AuditExtensionsUserIdentity extensions =
                 (AuditExtensionsUserIdentity) capturedAuditEvent.getExtensions();
-        assertEquals(VectorOfTrust.P2.toString(), extensions.getLevelOfConfidence());
-        assertFalse(extensions.isCiFail());
-        assertTrue(extensions.isHasMitigations());
+        assertEquals(VectorOfTrust.P2.toString(), extensions.levelOfConfidence());
+        assertFalse(extensions.ciFail());
+        assertTrue(extensions.hasMitigations());
+        assertEquals(extensions.exitCode(), responseBody.getExitCode());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
         verify(mockCiMitService, times(1)).getContraIndicatorsVCJwt(any(), any(), any());
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsUserIdentity.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsUserIdentity.java
@@ -1,19 +1,31 @@
 package uk.gov.di.ipv.core.library.auditing.extension;
 
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
-@ExcludeFromGeneratedCoverageReport
-@Getter
-public class AuditExtensionsUserIdentity implements AuditExtensions {
-    private final String levelOfConfidence;
-    private final boolean ciFail;
-    private final boolean hasMitigations;
+import java.util.List;
 
+@ExcludeFromGeneratedCoverageReport
+public record AuditExtensionsUserIdentity(
+        @JsonProperty String levelOfConfidence,
+        @JsonProperty boolean ciFail,
+        @JsonProperty boolean hasMitigations,
+        @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty(EXIT_CODE_NAME)
+                List<String> exitCode)
+        implements AuditExtensions {
+    private static final String EXIT_CODE_NAME = "exit_code";
+
+    @JsonCreator
     public AuditExtensionsUserIdentity(
-            String levelOfConfidence, boolean ciFail, boolean hasMitigations) {
+            @JsonProperty String levelOfConfidence,
+            @JsonProperty boolean ciFail,
+            @JsonProperty boolean hasMitigations,
+            @JsonProperty(value = EXIT_CODE_NAME) List<String> exitCode) {
         this.levelOfConfidence = levelOfConfidence;
         this.ciFail = ciFail;
         this.hasMitigations = hasMitigations;
+        this.exitCode = exitCode;
     }
 }

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsUserIdentity.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsUserIdentity.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.auditing.extension;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -12,20 +11,5 @@ public record AuditExtensionsUserIdentity(
         @JsonProperty String levelOfConfidence,
         @JsonProperty boolean ciFail,
         @JsonProperty boolean hasMitigations,
-        @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty(EXIT_CODE_NAME)
-                List<String> exitCode)
-        implements AuditExtensions {
-    private static final String EXIT_CODE_NAME = "exit_code";
-
-    @JsonCreator
-    public AuditExtensionsUserIdentity(
-            @JsonProperty String levelOfConfidence,
-            @JsonProperty boolean ciFail,
-            @JsonProperty boolean hasMitigations,
-            @JsonProperty(value = EXIT_CODE_NAME) List<String> exitCode) {
-        this.levelOfConfidence = levelOfConfidence;
-        this.ciFail = ciFail;
-        this.hasMitigations = hasMitigations;
-        this.exitCode = exitCode;
-    }
-}
+        @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty List<String> exitCode)
+        implements AuditExtensions {}

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
@@ -161,7 +161,7 @@ class AuditServiceTest {
                 AuditEventTypes.IPV_JOURNEY_START.toString(),
                 messageBody.get("event_name").asText());
         JsonNode auditExtensionsUserIdentity = messageBody.get("extensions");
-        assertNull(auditExtensionsUserIdentity.get("exit_code"));
+        assertNull(auditExtensionsUserIdentity.get("exitCode"));
     }
 
     @Test
@@ -185,7 +185,7 @@ class AuditServiceTest {
                 AuditEventTypes.IPV_JOURNEY_START.toString(),
                 messageBody.get("event_name").asText());
         JsonNode auditExtensionsUserIdentity = messageBody.get("extensions");
-        assertNotNull(auditExtensionsUserIdentity.get("exit_code"));
+        assertNotNull(auditExtensionsUserIdentity.get("exitCode"));
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Update identity issued audit event to include exit codes.

### What changed
Changes made to add exit code in identity issued audit event in BuildUserIdentity lambda.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3803](https://govukverify.atlassian.net/browse/PYIC-3803)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3803]: https://govukverify.atlassian.net/browse/PYIC-3803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ