### PR TITLE
PYIC-3943: Moved bank_account context to CIC_CRI from BAV

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -501,6 +501,7 @@ CRI_CLAIMED_IDENTITY_J7:
   response:
     type: cri
     criId: claimedIdentity
+    context: bank_account
   parent: CRI_STATE
   events:
     next:
@@ -512,7 +513,6 @@ CRI_BANK_ACCOUNT_J7:
   response:
     type: cri
     criId: bav
-    context: bank_account
   parent: CRI_STATE
   events:
     next:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Moved bank_account context to CIC_CRI from BAV

### Why did it change

Corrected mistaken implementation of bank_account context field - should be sent to CIC_CRI, not BAV

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3943](https://govukverify.atlassian.net/browse/PYIC-3943)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-3943]: https://govukverify.atlassian.net/browse/PYIC-3943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ