### PR TITLE
BAU: Add orphan states option to journey map render

### DIFF
--- a/journey-map/public/index.html
+++ b/journey-map/public/index.html
@@ -73,6 +73,10 @@
                     <div>Expand nested journeys:</div>
                     <input id="expandNestedJourneysInput" name="expandNestedJourneys" type="checkbox">
                 </label>
+                <label>
+                    <div>Only show orphan states:</div>
+                    <input id="onlyOrphanStatesInput" name="onlyOrphanStates" type="checkbox">
+                </label>
             </form>
         </div>
         <div id="diagram"></div>

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -221,12 +221,6 @@ PYI_KBV_FAIL:
     pageId: pyi-kbv-fail
   parent: END_JOURNEY
 
-PYI_KBV_THIN_FILE:
-  response:
-    type: page
-    pageId: pyi-kbv-thin-file
-  parent: END_JOURNEY
-
 PYI_F2F_TECHNICAL:
   response:
     type: page


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add orphan states option to journey map render

### Why did it change

This adds a new option to the rendering of the journey map to show orphan states - states that have no other state targeting them.

We only have two states that we expect to be in this state - the `INITIAL_IPV_JOURNEY` state and the `CORE_SESSION_TIMEOUT` state. Both of these states are set directly in the core back code, rather than being transitioned to in the usual flow.

The `INITIAL_IPV_JOURNEY` state has been handled, but the `CORE_SESSION_TIMEOUT` state has been left in. Perhaps we should also exclude it...

This also removes the `PYI_KBV_THIN_FILE` state, as the new functionality showed it was an orphan.
