### PR TITLE
PYIC-3960: Remove f2fCimit feature flag

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -333,13 +333,10 @@ CRI_EXPERIAN_KBV:
     next:
       targetState: PYI_NO_MATCH
     enhanced-verification:
-      targetState: MITIGATION_02_OPTIONS
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_02_OPTIONS_WITH_F2F
-          checkIfDisabled:
-            f2f:
-              targetState: MITIGATION_02_OPTIONS
+      targetState: MITIGATION_02_OPTIONS_WITH_F2F
+      checkIfDisabled:
+        f2f:
+          targetState: MITIGATION_02_OPTIONS
 
 # DCMAW journey (J1)
 POST_DCMAW_SUCCESS_PAGE:
@@ -556,13 +553,10 @@ MITIGATION_01_IDENTITY_START_PAGE:
     next:
       targetState: MITIGATION_01_CRI_DCMAW
     end:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_01_F2F_START_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_01_F2F_START_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
 
 MITIGATION_01_CRI_DCMAW:
   response:
@@ -575,37 +569,25 @@ MITIGATION_01_CRI_DCMAW:
     not-found:
       targetState: PYI_NO_MATCH
     access-denied:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_01_PYI_POST_OFFICE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
     temporarily-unavailable:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_01_PYI_POST_OFFICE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_01_PYI_POST_OFFICE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
     enhanced-verification:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_01_PYI_POST_OFFICE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
 
 MITIGATION_01_F2F_START_PAGE:
   response:
@@ -647,37 +629,25 @@ MITIGATION_02_CRI_DCMAW:
     not-found:
       targetState: PYI_NO_MATCH
     access-denied:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_02_PYI_POST_OFFICE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_02_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
     temporarily-unavailable:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_02_PYI_POST_OFFICE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_02_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
     fail-with-no-ci:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_02_PYI_POST_OFFICE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_02_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
     enhanced-verification:
-      targetState: PYI_ANOTHER_WAY
-      checkFeatureFlag:
-        f2fCimit:
-          targetState: MITIGATION_02_PYI_POST_OFFICE
-          checkIfDisabled:
-            f2f:
-              targetState: PYI_ANOTHER_WAY
+      targetState: MITIGATION_02_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
 
 MITIGATION_02_OPTIONS_WITH_F2F:
   response:


### PR DESCRIPTION
**Acceptance tests PR here: https://github.com/govuk-one-login/ipv-core-tests/pull/388**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove f2fCimit feature flag

### Why did it change

This flag was just used in the jourey map, not in the java code. The flag is set to true all the way out to prod and we've seen users completing the journey successfully. We can now remove the flag.

This leaves the disabled check on the f2f CRI in case we do want to disable it for any reason (like we already have).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3960](https://govukverify.atlassian.net/browse/PYIC-3960)


[PYIC-3960]: https://govukverify.atlassian.net/browse/PYIC-3960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ