### PR TITLE
PYIC-3860: Added journey map config for reset user identity flow

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -73,7 +73,8 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "isUserInitiated.$": "$.lambdaInput.isUserInitiated"
       },
       "Next": "ProcessNextJourney"
     },

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -370,12 +370,12 @@ PYI_CONFIRM_DELETE_DETAILS_PAGE:
   events:
     next:
       targetState:
-        RESET_IDENTITY_V2
+        RESET_IDENTITY_USER_INITIATED
     end:
       targetState:
         IPV_IDENTITY_REUSE_PAGE
 
-RESET_IDENTITY_V2:
+RESET_IDENTITY_USER_INITIATED:
   response:
     type: process
     lambda: reset-identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -83,6 +83,10 @@ CHECK_EXISTING_IDENTITY:
       targetState: RESET_IDENTITY
     reuse:
       targetState: IPV_IDENTITY_REUSE_PAGE
+      checkFeatureFlag:
+        deleteDetailsEnabled:
+          targetState: IPV_IDENTITY_REUSE_PAGE_TEST
+
     pending:
       targetState: IPV_IDENTITY_PENDING_PAGE
     pyi-no-match:
@@ -100,13 +104,26 @@ RESET_IDENTITY:
     lambda: reset-identity
   events:
     next:
-      targetState: IPV_IDENTITY_START_PAGE
+      targetState: PYI_DETAILS_DELETED_PAGE
 
 IPV_IDENTITY_REUSE_PAGE:
   response:
     type: page
     pageId: page-ipv-reuse
   parent: END_JOURNEY
+
+IPV_IDENTITY_REUSE_PAGE_TEST:
+  response:
+    type: page
+    pageId: page-ipv-reuse
+  parent: END_JOURNEY
+  events:
+    next:
+      targetState:
+        END_JOURNEY
+    reset:
+      targetState:
+        PYI_NEW_DETAILS_PAGE
 
 IPV_IDENTITY_PENDING_PAGE:
   response:
@@ -126,11 +143,6 @@ IPV_IDENTITY_START_PAGE:
           checkIfDisabled:
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
-    end:
-      targetState: F2F_START_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: PYI_ANOTHER_WAY
 
 CRI_F2F:
   response:
@@ -293,6 +305,39 @@ IPV_SUCCESS_PAGE:
     type: page
     pageId: page-ipv-success
   parent: END_JOURNEY
+
+PYI_NEW_DETAILS_PAGE:
+  response:
+    type: page
+    pageId: pyi-new-details
+  events:
+    next:
+      targetState:
+        PYI_CONFIRM_DELETE_DETAILS_PAGE
+    end:
+      targetState:
+        IPV_IDENTITY_REUSE_PAGE
+
+PYI_CONFIRM_DELETE_DETAILS_PAGE:
+  response:
+    type: page
+    pageId: pyi-confirm-delete-details
+  events:
+    reset:
+      targetState:
+        RESET_IDENTITY
+    end:
+      targetState:
+        IPV_IDENTITY_REUSE_PAGE
+
+PYI_DETAILS_DELETED_PAGE:
+  response:
+    type: page
+    pageId: pyi-details-deleted
+  events:
+    next:
+      targetState:
+        IPV_IDENTITY_START_PAGE
 
 END:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -86,7 +86,6 @@ CHECK_EXISTING_IDENTITY:
       checkFeatureFlag:
         deleteDetailsEnabled:
           targetState: IPV_IDENTITY_REUSE_PAGE_TEST
-
     pending:
       targetState: IPV_IDENTITY_PENDING_PAGE
     pyi-no-match:
@@ -102,9 +101,11 @@ RESET_IDENTITY:
   response:
     type: process
     lambda: reset-identity
+    lambdaInput:
+      isUserInitiated: false
   events:
     next:
-      targetState: PYI_DETAILS_DELETED_PAGE
+      targetState: IPV_IDENTITY_START_PAGE
 
 IPV_IDENTITY_REUSE_PAGE:
   response:
@@ -114,16 +115,6 @@ IPV_IDENTITY_REUSE_PAGE:
   events:
     next:
       targetState: END_JOURNEY
-
-IPV_IDENTITY_REUSE_PAGE_TEST:
-  response:
-    type: page
-    pageId: page-ipv-reuse
-  parent: END_JOURNEY
-  events:
-    next:
-      targetState:
-        PYI_NEW_DETAILS_PAGE
 
 IPV_IDENTITY_PENDING_PAGE:
   response:
@@ -311,39 +302,6 @@ IPV_SUCCESS_PAGE:
     pageId: page-ipv-success
   parent: END_JOURNEY
 
-PYI_NEW_DETAILS_PAGE:
-  response:
-    type: page
-    pageId: pyi-new-details
-  events:
-    next:
-      targetState:
-        PYI_CONFIRM_DELETE_DETAILS_PAGE
-    end:
-      targetState:
-        IPV_IDENTITY_REUSE_PAGE
-
-PYI_CONFIRM_DELETE_DETAILS_PAGE:
-  response:
-    type: page
-    pageId: pyi-confirm-delete-details
-  events:
-    next:
-      targetState:
-        RESET_IDENTITY
-    end:
-      targetState:
-        IPV_IDENTITY_REUSE_PAGE
-
-PYI_DETAILS_DELETED_PAGE:
-  response:
-    type: page
-    pageId: pyi-details-deleted
-  events:
-    next:
-      targetState:
-        IPV_IDENTITY_START_PAGE
-
 END:
   response:
     type: process
@@ -381,6 +339,61 @@ CRI_EXPERIAN_KBV:
       checkIfDisabled:
         f2f:
           targetState: MITIGATION_02_OPTIONS
+
+# User initiated details delete
+IPV_IDENTITY_REUSE_PAGE_TEST:
+  response:
+    type: page
+    pageId: page-ipv-reuse
+  parent: END_JOURNEY
+  events:
+    next:
+      targetState:
+        PYI_NEW_DETAILS_PAGE
+
+PYI_NEW_DETAILS_PAGE:
+  response:
+    type: page
+    pageId: pyi-new-details
+  events:
+    next:
+      targetState:
+        PYI_CONFIRM_DELETE_DETAILS_PAGE
+    end:
+      targetState:
+        IPV_IDENTITY_REUSE_PAGE
+
+PYI_CONFIRM_DELETE_DETAILS_PAGE:
+  response:
+    type: page
+    pageId: pyi-confirm-delete-details
+  events:
+    next:
+      targetState:
+        RESET_IDENTITY_V2
+    end:
+      targetState:
+        IPV_IDENTITY_REUSE_PAGE
+
+RESET_IDENTITY_V2:
+  response:
+    type: process
+    lambda: reset-identity
+    lambdaInput:
+      isUserInitiated: true
+  events:
+    next:
+      targetState: PYI_DETAILS_DELETED_PAGE
+
+PYI_DETAILS_DELETED_PAGE:
+  response:
+    type: page
+    pageId: pyi-details-deleted
+  events:
+    next:
+      targetState:
+        IPV_IDENTITY_START_PAGE
+
 
 # DCMAW journey (J1)
 POST_DCMAW_SUCCESS_PAGE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -328,7 +328,7 @@ PYI_CONFIRM_DELETE_DETAILS_PAGE:
     type: page
     pageId: pyi-confirm-delete-details
   events:
-    reset:
+    next:
       targetState:
         RESET_IDENTITY
     end:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -120,9 +120,6 @@ IPV_IDENTITY_REUSE_PAGE_TEST:
   events:
     next:
       targetState:
-        END_JOURNEY
-    reset:
-      targetState:
         PYI_NEW_DETAILS_PAGE
 
 IPV_IDENTITY_PENDING_PAGE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -111,6 +111,9 @@ IPV_IDENTITY_REUSE_PAGE:
     type: page
     pageId: page-ipv-reuse
   parent: END_JOURNEY
+  events:
+    next:
+      targetState: END_JOURNEY
 
 IPV_IDENTITY_REUSE_PAGE_TEST:
   response:
@@ -140,6 +143,11 @@ IPV_IDENTITY_START_PAGE:
           checkIfDisabled:
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
+    end:
+      targetState: F2F_START_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_ANOTHER_WAY
 
 CRI_F2F:
   response:

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -71,9 +71,7 @@ public class ResetIdentityHandler implements RequestHandler<JourneyRequest, Map<
         try {
             String ipvSessionId = getIpvSessionId(event);
             String featureSet = RequestHelper.getFeatureSet(event);
-
             Boolean isUserInitiated = RequestHelper.getIsUserInitiated(event);
-            LogHelper.attachIsUserInitiatedToLogs(isUserInitiated);
 
             configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
@@ -84,7 +82,7 @@ public class ResetIdentityHandler implements RequestHandler<JourneyRequest, Map<
             String govukSigninJourneyId = clientOAuthSessionItem.getGovukSigninJourneyId();
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
-            userIdentityService.deleteVcStoreItems(userId);
+            userIdentityService.deleteVcStoreItems(userId, isUserInitiated);
             criResponseService.deleteCriResponseItem(userId, F2F_CRI);
 
             return JOURNEY_NEXT;

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -71,6 +71,10 @@ public class ResetIdentityHandler implements RequestHandler<JourneyRequest, Map<
         try {
             String ipvSessionId = getIpvSessionId(event);
             String featureSet = RequestHelper.getFeatureSet(event);
+
+            Boolean isUserInitiated = RequestHelper.getIsUserInitiated(event);
+            LogHelper.attachIsUserInitiatedToLogs(isUserInitiated);
+
             configService.setFeatureSet(featureSet);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             ClientOAuthSessionItem clientOAuthSessionItem =

--- a/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
+++ b/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
@@ -36,6 +36,7 @@ public class ResetIdentityHandlerTest {
     private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
     private static final String TEST_FEATURE_SET = "test-feature-set";
     private static final String TEST_JOURNEY = "journey/reset-identity";
+    private static final Boolean IS_USER_INITIATED = true;
     private static final JourneyRequest event =
             JourneyRequest.builder()
                     .ipvSessionId(TEST_SESSION_ID)
@@ -43,6 +44,7 @@ public class ResetIdentityHandlerTest {
                     .clientOAuthSessionId(TEST_CLIENT_SOURCE_IP)
                     .journey(TEST_JOURNEY)
                     .featureSet(TEST_FEATURE_SET)
+                    .isUserInitiated(IS_USER_INITIATED)
                     .build();
     @Mock private Context context;
     @Mock private UserIdentityService userIdentityService;
@@ -83,7 +85,7 @@ public class ResetIdentityHandlerTest {
                 objectMapper.convertValue(
                         resetIdentityHandler.handleRequest(event, context), JourneyResponse.class);
 
-        verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID);
+        verify(userIdentityService).deleteVcStoreItems(TEST_USER_ID, IS_USER_INITIATED);
         verify(criResponseService).deleteCriResponseItem(TEST_USER_ID, F2F_CRI);
         assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -72,7 +72,7 @@ public enum ErrorResponse {
     UNKNOWN_SCORE_TYPE(1060, "Unknown score type in request"),
     FAILED_TO_PARSE_SUCCESSFUL_VC_STORE_ITEMS(1061, "Failed to parse successful VC Store items."),
     FAILED_TO_GENERATE_NINO_CLAIM(1062, "Failed to generate the NINO claim"),
-    MISSING_IS_USER_INITIATED_PARAMETER(1059, "Missing isUserInitiated in request");
+    MISSING_IS_USER_INITIATED_PARAMETER(1059, "Missing isUserInitiated in request"),
     MISSING_VTR(1063, "The 'vtr' claim is required and was not provided in the request.");
 
     @JsonProperty("code")

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -71,7 +71,8 @@ public enum ErrorResponse {
     MISSING_SCORE_THRESHOLD(1059, "Missing score type in request"),
     UNKNOWN_SCORE_TYPE(1060, "Unknown score type in request"),
     FAILED_TO_PARSE_SUCCESSFUL_VC_STORE_ITEMS(1061, "Failed to parse successful VC Store items."),
-    FAILED_TO_GENERATE_NINO_CLAIM(1062, "Failed to generate the NINO claim");
+    FAILED_TO_GENERATE_NINO_CLAIM(1062, "Failed to generate the NINO claim"),
+    MISSING_IS_USER_INITIATED_PARAMETER(1059, "Missing isUserInitiated in request");
 
     @JsonProperty("code")
     private final int code;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -15,4 +15,5 @@ public class JourneyRequest {
     private String clientOAuthSessionId;
     private String journey;
     private String featureSet;
+    private Boolean isUserInitiated;
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
@@ -23,7 +23,7 @@ public class ProcessRequest extends JourneyRequest {
             String scoreType,
             Integer scoreThreshold,
             Boolean isUserInitiated) {
-        super(ipvSessionId, ipAddress, clientOAuthSessionId, journey, featureSet);
+        super(ipvSessionId, ipAddress, clientOAuthSessionId, journey, featureSet, isUserInitiated);
         this.scoreType = scoreType;
         this.scoreThreshold = scoreThreshold;
         this.isUserInitiated = isUserInitiated;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 public class ProcessRequest extends JourneyRequest {
     private String scoreType;
     private Integer scoreThreshold;
+    private Boolean isUserInitiated;
 
     @Builder(builderMethodName = "processRequestBuilder")
     public ProcessRequest(
@@ -20,9 +21,11 @@ public class ProcessRequest extends JourneyRequest {
             String journey,
             String featureSet,
             String scoreType,
-            Integer scoreThreshold) {
+            Integer scoreThreshold,
+            Boolean isUserInitiated) {
         super(ipvSessionId, ipAddress, clientOAuthSessionId, journey, featureSet);
         this.scoreType = scoreType;
         this.scoreThreshold = scoreThreshold;
+        this.isUserInitiated = isUserInitiated;
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -31,6 +31,7 @@ public class LogHelper {
         LOG_ERROR_JOURNEY_RESPONSE("errorJourneyResponse"),
         LOG_FEATURE_SET("featureSet"),
         LOG_GOVUK_SIGNIN_JOURNEY_ID("govuk_signin_journey_id"),
+        LOG_IS_USER_INITIATED("isUserInitiated"),
         LOG_IPV_SESSION_ID("ipvSessionId"),
         LOG_IS_VC_SUCCESSFUL("isVCSuccessful"),
         LOG_JOURNEY_EVENT("journeyEvent"),
@@ -106,6 +107,10 @@ public class LogHelper {
         } else {
             attachFieldToLogs(LogField.LOG_GOVUK_SIGNIN_JOURNEY_ID, govukSigninJourneyId);
         }
+    }
+
+    public static void attachIsUserInitiatedToLogs(Boolean isUserInitiated) {
+        attachFieldToLogs(LogField.LOG_IS_USER_INITIATED, isUserInitiated.toString());
     }
 
     public static void logErrorMessage(String message, String errorDescription) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -144,6 +144,17 @@ public class RequestHelper {
         return scoreThreshold;
     }
 
+    public static Boolean getIsUserInitiated(JourneyRequest request)
+            throws HttpResponseExceptionWithErrorBody {
+        Boolean isUserInitiated = request.getIsUserInitiated();
+        if (isUserInitiated == null) {
+            LOGGER.error("Missing isUserInitiated parameter in request");
+            throw new HttpResponseExceptionWithErrorBody(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IS_USER_INITIATED_PARAMETER);
+        }
+        return isUserInitiated;
+    }
+
     private static String getIpvSessionId(Map<String, String> headers, boolean allowNull)
             throws HttpResponseExceptionWithErrorBody {
         String ipvSessionId = RequestHelper.getHeaderByKey(headers, IPV_SESSION_ID_HEADER);

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -117,7 +117,7 @@ public class UserIdentityService {
         return vcStoreItems.stream().map(VcStoreItem::getCredential).toList();
     }
 
-    public void deleteVcStoreItems(String userId) {
+    public void deleteVcStoreItems(String userId, Boolean isUserInitiated) {
         List<VcStoreItem> vcStoreItems = dataStore.getItems(userId);
         if (!vcStoreItems.isEmpty()) {
             var message =
@@ -127,7 +127,11 @@ public class UserIdentityService {
                                     "Deleting existing issued VCs.")
                             .with(
                                     LogHelper.LogField.LOG_NUMBER_OF_VCS.getFieldName(),
-                                    String.valueOf(vcStoreItems.size()));
+                                    String.valueOf(vcStoreItems.size()))
+                            .with(
+                                    LogHelper.LogField.LOG_IS_USER_INITIATED.getFieldName(),
+                                    String.valueOf(isUserInitiated)
+                            );
             LOGGER.info(message);
         }
         for (VcStoreItem item : vcStoreItems) {

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -129,8 +129,7 @@ public class UserIdentityService {
                                     String.valueOf(vcStoreItems.size()))
                             .with(
                                     LogHelper.LogField.LOG_IS_USER_INITIATED.getFieldName(),
-                                    String.valueOf(isUserInitiated)
-                            );
+                                    String.valueOf(isUserInitiated));
             LOGGER.info(message);
         }
         for (VcStoreItem item : vcStoreItems) {

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -950,7 +950,7 @@ class UserIdentityServiceTest {
 
         when(mockDataStore.getItems("a-users-id")).thenReturn(vcStoreItems);
 
-        userIdentityService.deleteVcStoreItems("a-users-id");
+        userIdentityService.deleteVcStoreItems("a-users-id", true);
 
         verify(mockDataStore).delete("a-users-id", PASSPORT_CRI);
         verify(mockDataStore).delete("a-users-id", FRAUD_CRI);

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
@@ -306,6 +306,7 @@ public class LambdaHandler {
                 .journey((String) processJourneyEventOutput.get(JOURNEY))
                 .scoreType((String) lambdaInput.get("scoreType"))
                 .scoreThreshold((int) lambdaInput.get("scoreThreshold"))
+                .isUserInitiated((boolean) lambdaInput.get("isUserInitiated"))
                 .build();
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added journey map config for delete-details flow 

### Why did it change

Integrating the new delete user details pages into a journey flow.

Added a test route that can be enabled by feature set, to start the flow from the existing reuse details page

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3860](https://govukverify.atlassian.net/browse/PYIC-3860)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-3860]: https://govukverify.atlassian.net/browse/PYIC-3860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ