### PR TITLE
PYIC-3991: Fix exit code breaching threshold logic

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CiScoreThresholdChecker.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CiScoreThresholdChecker.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.core.library.domain;
+
+public class CiScoreThresholdChecker {
+    private CiScoreThresholdChecker() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static boolean ciScoreBreachesThreshold(int ciScore, String threshold) {
+        return ciScore > Integer.parseInt(threshold);
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/CiScoreThresholdCheckerTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/CiScoreThresholdCheckerTest.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.ipv.core.library.domain.CiScoreThresholdChecker.ciScoreBreachesThreshold;
+
+class CiScoreThresholdCheckerTest {
+    @Test
+    void ciScoreBreachesThresholdShouldReturnTrueIfScoreAboveThreshold() {
+        assertTrue(ciScoreBreachesThreshold(101, "100"));
+    }
+
+    @Test
+    void ciScoreBreachesThresholdShouldReturnFalseIfScoreEqualsThreshold() {
+        assertFalse(ciScoreBreachesThreshold(100, "100"));
+    }
+
+    @Test
+    void ciScoreBreachesThresholdShouldReturnFalseIfScoreBelowThreshold() {
+        assertFalse(ciScoreBreachesThreshold(99, "100"));
+    }
+}

--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
+import static uk.gov.di.ipv.core.library.domain.CiScoreThresholdChecker.ciScoreBreachesThreshold;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CI_SCORE;
@@ -69,7 +70,8 @@ public class Gpg45ProfileEvaluator {
                         .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "Calculated user's CI score.")
                         .with(LOG_CI_SCORE.getFieldName(), ciScore));
 
-        if (ciScore <= Integer.parseInt(configService.getSsmParameter(CI_SCORING_THRESHOLD))) {
+        if (!ciScoreBreachesThreshold(
+                ciScore, configService.getSsmParameter(CI_SCORING_THRESHOLD))) {
             ipvSession.setCiFail(false);
             ipvSessionService.updateIpvSession(ipvSession);
             return Optional.empty();

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -48,6 +48,7 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_C
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.EXIT_CODES_ALWAYS_REQUIRED;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.EXIT_CODES_NON_CI_BREACHING_P0;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.USER_ISSUED_CREDENTIALS_TABLE_NAME;
+import static uk.gov.di.ipv.core.library.domain.CiScoreThresholdChecker.ciScoreBreachesThreshold;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.BAV_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
@@ -217,8 +218,10 @@ public class UserIdentityService {
     }
 
     private boolean breachingCiThreshold(ContraIndicators contraIndicators) {
-        return contraIndicators.getContraIndicatorScore(configService.getContraIndicatorConfigMap())
-                >= Integer.parseInt(configService.getSsmParameter(CI_SCORING_THRESHOLD));
+        return ciScoreBreachesThreshold(
+                contraIndicators.getContraIndicatorScore(
+                        configService.getContraIndicatorConfigMap()),
+                configService.getSsmParameter(CI_SCORING_THRESHOLD));
     }
 
     private List<VcStoreItem> getSuccessfulVCStoreItems(List<VcStoreItem> vcStoreItems)


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix exit code breaching threshold logic

### Why did it change

When we check a users CI scores against the threshold we only fail them if the score is *greater* than the threshold. Equal to is ok.

When calculating the exit code we were deciding the scores were breaching if they were greater than *or* equal to. Which is wrong.

This pulls the logic for determining if CI scores are breaching to a shared place. This will ensure that we're always determining it the same way.

The exit codes are not being consumed yet, so this isn't a wider problem.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3991](https://govukverify.atlassian.net/browse/PYIC-3991)


[PYIC-3991]: https://govukverify.atlassian.net/browse/PYIC-3991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ