### PR TITLE
Group some dependabot updates for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,14 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-patch" ]
+    groups:
+      aws:
+        patterns:
+          - "@aws-*"
+      babel:
+        patterns:
+          - "@babel/*"
+      eslint:
+        patterns:
+          - "eslint-*"
+          - "@typescript-eslint/*"


### PR DESCRIPTION
Try to group some of the common groups of dependencies, to reduce the volume of dependabot PRs