### PR TITLE
PYIC-3979: Save 'vtr' from Orchestration into the ClientAuthSessionItem

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -41,11 +41,13 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 
 import java.text.ParseException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JAR_KMS_ENCRYPTION_KEY_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 
 public class InitialiseIpvSessionHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -54,6 +56,9 @@ public class InitialiseIpvSessionHandler
     private static final String IPV_SESSION_ID_KEY = "ipvSessionId";
     private static final String CLIENT_ID_PARAM_KEY = "clientId";
     private static final String REQUEST_PARAM_KEY = "request";
+    private static final String REQUEST_GOV_UK_SIGN_IN_JOURNEY_ID_KEY = "govuk_signin_journey_id";
+    private static final String REQUEST_EMAIL_ADDRESS_KEY = "email_address";
+    private static final String REQUEST_VTR_KEY = "vtr";
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
@@ -118,10 +123,23 @@ public class InitialiseIpvSessionHandler
                     jarValidator.validateRequestJwt(
                             signedJWT, sessionParams.get(CLIENT_ID_PARAM_KEY));
 
-            String govukSigninJourneyId = claimsSet.getStringClaim("govuk_signin_journey_id");
-            String emailAddress = claimsSet.getStringClaim("email_address");
+            String govukSigninJourneyId =
+                    claimsSet.getStringClaim(REQUEST_GOV_UK_SIGN_IN_JOURNEY_ID_KEY);
+            String emailAddress = claimsSet.getStringClaim(REQUEST_EMAIL_ADDRESS_KEY);
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
+            List<String> vtr = claimsSet.getStringListClaim(REQUEST_VTR_KEY);
+            if (vtr == null || vtr.isEmpty() || vtr.stream().allMatch(String::isEmpty)) {
+                var message =
+                        new StringMapMessage()
+                                .with(
+                                        LOG_MESSAGE_DESCRIPTION.getFieldName(),
+                                        ErrorResponse.MISSING_VTR.getMessage());
+                LOGGER.error(message);
+
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_VTR);
+            }
             String clientOAuthSessionId = SecureTokenHelper.generate();
 
             IpvSessionItem ipvSessionItem =

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -137,8 +137,6 @@ public class InitialiseIpvSessionHandler
                                         ErrorResponse.MISSING_VTR.getMessage());
                 LOGGER.error(message);
 
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_VTR);
             }
             String clientOAuthSessionId = SecureTokenHelper.generate();
 

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -136,7 +136,6 @@ public class InitialiseIpvSessionHandler
                                         LOG_MESSAGE_DESCRIPTION.getFieldName(),
                                         ErrorResponse.MISSING_VTR.getMessage());
                 LOGGER.error(message);
-
             }
             String clientOAuthSessionId = SecureTokenHelper.generate();
 

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -164,8 +164,8 @@ class InitialiseIpvSessionHandlerTest {
     @MethodSource("getVtrTestValues")
     void shouldReturn200ForAllVtrValues(List<String> vtrList)
             throws JsonProcessingException, InvalidKeySpecException, NoSuchAlgorithmException,
-            JOSEException, ParseException, HttpResponseExceptionWithErrorBody,
-            JarValidationException, SqsException {
+                    JOSEException, ParseException, HttpResponseExceptionWithErrorBody,
+                    JarValidationException, SqsException {
         JWTClaimsSet.Builder claimsSet =
                 new JWTClaimsSet.Builder()
                         .expirationTime(new Date(Instant.now().plusSeconds(1000).getEpochSecond()))

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -162,10 +162,10 @@ class InitialiseIpvSessionHandlerTest {
 
     @ParameterizedTest
     @MethodSource("getVtrTestValues")
-    void shouldReturn400IfMissingVtr(List<String> vtrList)
+    void shouldReturn200ForAllVtrValues(List<String> vtrList)
             throws JsonProcessingException, InvalidKeySpecException, NoSuchAlgorithmException,
-                    JOSEException, ParseException, HttpResponseExceptionWithErrorBody,
-                    JarValidationException {
+            JOSEException, ParseException, HttpResponseExceptionWithErrorBody,
+            JarValidationException, SqsException {
         JWTClaimsSet.Builder claimsSet =
                 new JWTClaimsSet.Builder()
                         .expirationTime(new Date(Instant.now().plusSeconds(1000).getEpochSecond()))
@@ -190,6 +190,10 @@ class InitialiseIpvSessionHandlerTest {
 
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
+        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
+                .thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
+                .thenReturn(clientOAuthSessionItem);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams =
@@ -203,9 +207,11 @@ class InitialiseIpvSessionHandlerTest {
         Map<String, Object> responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        assertEquals(ErrorResponse.MISSING_VTR.getCode(), responseBody.get("code"));
-        assertEquals(ErrorResponse.MISSING_VTR.getMessage(), responseBody.get("message"));
+        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+
+        ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        assertEquals(AuditEventTypes.IPV_JOURNEY_START, auditEventCaptor.getValue().getEventName());
     }
 
     private static Stream<Arguments> getVtrTestValues() {

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.JarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidationException;
+import uk.gov.di.ipv.core.initialiseipvsession.service.KmsRsaDecrypter;
 import uk.gov.di.ipv.core.initialiseipvsession.validation.JarValidator;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
@@ -41,7 +42,9 @@ import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -72,8 +75,11 @@ class InitialiseIpvSessionHandlerTest {
 
     @Mock private IpvSessionService mockIpvSessionService;
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionDetailsService;
+    @Mock private ConfigService mockConfigService;
+    @Mock private KmsRsaDecrypter mockKmsRsaDecrypter;
     @Mock private JarValidator mockJarValidator;
     @Mock private AuditService mockAuditService;
+    @Mock private UserIdentityService mockUserIdentityService;
     @InjectMocks private InitialiseIpvSessionHandler initialiseIpvSessionHandler;
 
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -19,17 +20,20 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.JarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidationException;
-import uk.gov.di.ipv.core.initialiseipvsession.service.KmsRsaDecrypter;
 import uk.gov.di.ipv.core.initialiseipvsession.validation.JarValidator;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.fixtures.TestFixtures;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
@@ -37,9 +41,7 @@ import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
-import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
-import uk.gov.di.ipv.core.library.service.UserIdentityService;
 
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -49,8 +51,11 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -67,11 +72,8 @@ class InitialiseIpvSessionHandlerTest {
 
     @Mock private IpvSessionService mockIpvSessionService;
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionDetailsService;
-    @Mock private ConfigService mockConfigService;
-    @Mock private KmsRsaDecrypter mockKmsRsaDecrypter;
     @Mock private JarValidator mockJarValidator;
     @Mock private AuditService mockAuditService;
-    @Mock private UserIdentityService mockUserIdentityService;
     @InjectMocks private InitialiseIpvSessionHandler initialiseIpvSessionHandler;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -95,6 +97,7 @@ class InitialiseIpvSessionHandlerTest {
                         .claim("redirect_uri", "http://example.com")
                         .claim("state", "test-state")
                         .claim("client_id", "test-client")
+                        .claim("vtr", List.of("Cl.Cm.P2", "Cl.Cm.PCL200"))
                         .build();
 
         signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsSet);
@@ -118,6 +121,7 @@ class InitialiseIpvSessionHandlerTest {
         clientOAuthSessionItem.setState("test-state");
         clientOAuthSessionItem.setUserId("test-user-id");
         clientOAuthSessionItem.setGovukSigninJourneyId("test-journey-id");
+        clientOAuthSessionItem.setVtr(List.of("Cl.Cm.P2", "Cl.Cm.PCL200"));
     }
 
     @Test
@@ -148,6 +152,61 @@ class InitialiseIpvSessionHandlerTest {
         ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
         verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
         assertEquals(AuditEventTypes.IPV_JOURNEY_START, auditEventCaptor.getValue().getEventName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getVtrTestValues")
+    void shouldReturn400IfMissingVtr(List<String> vtrList)
+            throws JsonProcessingException, InvalidKeySpecException, NoSuchAlgorithmException,
+                    JOSEException, ParseException, HttpResponseExceptionWithErrorBody,
+                    JarValidationException {
+        JWTClaimsSet.Builder claimsSet =
+                new JWTClaimsSet.Builder()
+                        .expirationTime(new Date(Instant.now().plusSeconds(1000).getEpochSecond()))
+                        .issueTime(new Date())
+                        .notBeforeTime(new Date())
+                        .subject("test-user-id")
+                        .audience("test-audience")
+                        .issuer("test-issuer")
+                        .claim("response_type", "code")
+                        .claim("redirect_uri", "http://example.com")
+                        .claim("state", "test-state")
+                        .claim("client_id", "test-client");
+        if (vtrList != null) {
+            claimsSet.claim("vtr", vtrList);
+        }
+        signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsSet.build());
+        signedJWT.sign(new ECDSASigner(getPrivateKey()));
+        signedEncryptedJwt =
+                TestFixtures.createJweObject(
+                        new RSAEncrypter(RSAKey.parse(TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK)),
+                        signedJWT);
+
+        when(mockJarValidator.validateRequestJwt(any(), any()))
+                .thenReturn(signedJWT.getJWTClaimsSet());
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, Object> sessionParams =
+                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
+        event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+
+        APIGatewayProxyResponseEvent response =
+                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.MISSING_VTR.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.MISSING_VTR.getMessage(), responseBody.get("message"));
+    }
+
+    private static Stream<Arguments> getVtrTestValues() {
+        return Stream.of(
+                Arguments.of((Object) null),
+                Arguments.of(Collections.emptyList()),
+                Arguments.of(List.of("", "")));
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -72,7 +72,7 @@ public enum ErrorResponse {
     UNKNOWN_SCORE_TYPE(1060, "Unknown score type in request"),
     FAILED_TO_PARSE_SUCCESSFUL_VC_STORE_ITEMS(1061, "Failed to parse successful VC Store items."),
     FAILED_TO_GENERATE_NINO_CLAIM(1062, "Failed to generate the NINO claim"),
-    MISSING_VTR(1063, "The 'vtr' field is required and was not provided in the request.");
+    MISSING_VTR(1063, "The 'vtr' claim is required and was not provided in the request.");
 
     @JsonProperty("code")
     private final int code;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -71,7 +71,8 @@ public enum ErrorResponse {
     MISSING_SCORE_THRESHOLD(1059, "Missing score type in request"),
     UNKNOWN_SCORE_TYPE(1060, "Unknown score type in request"),
     FAILED_TO_PARSE_SUCCESSFUL_VC_STORE_ITEMS(1061, "Failed to parse successful VC Store items."),
-    FAILED_TO_GENERATE_NINO_CLAIM(1062, "Failed to generate the NINO claim");
+    FAILED_TO_GENERATE_NINO_CLAIM(1062, "Failed to generate the NINO claim"),
+    MISSING_VTR(1063, "The 'vtr' field is required and was not provided in the request.");
 
     @JsonProperty("code")
     private final int code;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
@@ -8,6 +8,8 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+import java.util.List;
+
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
 @Data
@@ -22,6 +24,7 @@ public class ClientOAuthSessionItem implements DynamodbItem {
     private String state;
     private String userId;
     private String govukSigninJourneyId;
+    private List<String> vtr;
     private long ttl;
 
     @DynamoDbPartitionKey

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -50,6 +50,7 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setUserId(claimsSet.getSubject());
         clientOAuthSessionItem.setGovukSigninJourneyId(
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
+        clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
 
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The 'vtr' is checked in the coming request. If the vtr is null or empty, a bad request is returned from the Initialise Ipv Session Handler. If the vtr is provided, it it stored in the ClientOAuthSessionItem document. 

### Why did it change

Save 'vtr' from Orchestration into the ClientAuthSessionItem

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3979](https://govukverify.atlassian.net/browse/PYIC-3979)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3979]: https://govukverify.atlassian.net/browse/PYIC-3979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ