### PR TITLE
PYIC-4007: If the 'vtr' value is empty, a bad request will be returned

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -136,7 +136,10 @@ public class InitialiseIpvSessionHandler
                                         LOG_MESSAGE_DESCRIPTION.getFieldName(),
                                         ErrorResponse.MISSING_VTR.getMessage());
                 LOGGER.error(message);
+                return ApiGatewayResponseGenerator.proxyJsonResponse(
+                        HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_VTR);
             }
+
             String clientOAuthSessionId = SecureTokenHelper.generate();
 
             IpvSessionItem ipvSessionItem =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

If the 'vtr' value is empty, a bad request will be returned

### Why did it change

The request requred a "vtr" in params. Therefore, we should heck for it presence in the request and if the value is empty, throw a Bad Request with and an error message.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4007](https://govukverify.atlassian.net/browse/PYIC-4007)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-4007]: https://govukverify.atlassian.net/browse/PYIC-4007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ