### PR TITLE
PYIC-4023 Codify mock jwks endpoint into template

### DIFF
--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -59,8 +59,10 @@ paths:
             statusCode: 200
             responseTemplates:
               application/json:
-                Fn::ToJsonString:
-                  Fn::FindInMap: [ EnvironmentConfiguration, !Ref AWS::AccountId, jwksJson ]
+                Fn::FindInMap:
+                  - EnvironmentConfiguration
+                  - Ref: AWS::AccountId
+                  - jwksJson
 
   /healthcheck:
     get:


### PR DESCRIPTION
## Proposed changes

### What changed

Codify mock jwks endpoint into template
Corresponding test in core-tests: https://github.com/govuk-one-login/ipv-core-tests/pull/395

### Why did it change

Following https://govukverify.atlassian.net/browse/INCIDEN-536 on Sunday we had to clickops a change to make the jwks endpoint a mock integration serving the keys json - this is to codify it into the template

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4023](https://govukverify.atlassian.net/browse/PYIC-4023)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-4023]: https://govukverify.atlassian.net/browse/PYIC-4023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ