### PR TITLE
PYIC-2892: Temporarily handle ClassCastException and force old behaviour

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -269,7 +269,7 @@ public class ConfigService {
         try {
             String parameter = getSsmParameter(resolvePath(pathTemplate, criId, connection));
             return objectMapper.readValue(parameter, CredentialIssuerConfig.class);
-        } catch (ParameterNotFoundException e) {
+        } catch (ParameterNotFoundException | ClassCastException e) {
             Map<String, String> parameters =
                     getSsmParameters(pathTemplate, false, criId, connection);
             if (parameters != null && !parameters.isEmpty()) {


### PR DESCRIPTION
Temporary workaround to fix `ClassCastException` errors in build

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
