### PR TITLE
PYIC-4043: force identity reset if reprove identity flag is true

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -202,8 +202,10 @@ public class CheckExistingIdentityHandler
             }
 
             // Reset identity if reprove is true.
-            Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
-            if (configService.enabled(ACCOUNT_INTERVENTIONS.getName()) && reproveIdentity) {
+            String reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
+            if (configService.enabled(ACCOUNT_INTERVENTIONS.getName())
+                    && !Objects.isNull(reproveIdentity)
+                    && reproveIdentity.equals("true")) {
                 return buildForceResetResponse();
             }
 

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -200,6 +200,12 @@ public class CheckExistingIdentityHandler
                         : buildNotCorrelatedResponse(auditEventUser);
             }
 
+            // Reset identity if reprove is true.
+            Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
+            if (reproveIdentity) {
+                return buildForceResetResponse();
+            }
+
             // Force reset
             if (configService.enabled(RESET_IDENTITY.getName())) {
                 return buildForceResetResponse();

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.ACCOUNT_INTERVENTIONS;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.RESET_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
@@ -202,7 +203,7 @@ public class CheckExistingIdentityHandler
 
             // Reset identity if reprove is true.
             Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
-            if (reproveIdentity) {
+            if (configService.enabled(ACCOUNT_INTERVENTIONS.getName()) && reproveIdentity) {
                 return buildForceResetResponse();
             }
 

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -55,7 +55,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.ACCOUNT_INTERVENTIONS;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.RESET_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
@@ -203,9 +202,7 @@ public class CheckExistingIdentityHandler
 
             // Reset identity if reprove is true.
             String reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
-            if (configService.enabled(ACCOUNT_INTERVENTIONS.getName())
-                    && !Objects.isNull(reproveIdentity)
-                    && reproveIdentity.equals("true")) {
+            if (!Objects.isNull(reproveIdentity) && reproveIdentity.equals("true")) {
                 return buildForceResetResponse();
             }
 

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -160,6 +160,12 @@ public class CheckExistingIdentityHandler
                             ipvSessionItem.getClientOAuthSessionId());
             String userId = clientOAuthSessionItem.getUserId();
 
+            // Reset identity if reprove is true.
+            Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
+            if (!Objects.isNull(reproveIdentity) && reproveIdentity) {
+                return buildForceResetResponse();
+            }
+
             String govukSigninJourneyId = clientOAuthSessionItem.getGovukSigninJourneyId();
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
@@ -198,12 +204,6 @@ public class CheckExistingIdentityHandler
                 return isF2FComplete
                         ? buildF2FNotCorrelatedResponse(auditEventUser)
                         : buildNotCorrelatedResponse(auditEventUser);
-            }
-
-            // Reset identity if reprove is true.
-            String reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
-            if (!Objects.isNull(reproveIdentity) && reproveIdentity.equals("true")) {
-                return buildForceResetResponse();
             }
 
             // Force reset

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -197,6 +197,7 @@ class CheckExistingIdentityHandlerTest {
                         .userId(TEST_USER_ID)
                         .clientId("test-client")
                         .govukSigninJourneyId(TEST_JOURNEY_ID)
+                        .reproveIdentity(false)
                         .build();
     }
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -91,12 +91,9 @@ class CheckExistingIdentityHandlerTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
-
     private static final String TEST_FEATURE_SET = "test-feature-set";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
-
     private static final String TEST_JOURNEY = "journey/check-existing-identity";
-
     private static final List<String> CREDENTIALS =
             List.of(
                     M1A_PASSPORT_VC,
@@ -107,7 +104,6 @@ class CheckExistingIdentityHandlerTest {
     private static CredentialIssuerConfig addressConfig = null;
     private static CredentialIssuerConfig claimedIdentityConfig = null;
     private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
-
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B);
     private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse(JOURNEY_REUSE_PATH);
@@ -197,7 +193,7 @@ class CheckExistingIdentityHandlerTest {
                         .userId(TEST_USER_ID)
                         .clientId("test-client")
                         .govukSigninJourneyId(TEST_JOURNEY_ID)
-                        .reproveIdentity("false")
+                        .reproveIdentity(false)
                         .build();
     }
 
@@ -268,15 +264,9 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnJourneyResetIdentityIfReApproveFlagIsReceived() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getUserIssuedCredentials(TEST_USER_ID)).thenReturn(CREDENTIALS);
-        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(null);
-        when(userIdentityService.checkNameAndFamilyNameCorrelationInCredentials(TEST_USER_ID))
-                .thenReturn(true);
-        when(userIdentityService.checkBirthDateCorrelationInCredentials(TEST_USER_ID))
-                .thenReturn(true);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        clientOAuthSessionItem.setReproveIdentity("true");
+        clientOAuthSessionItem.setReproveIdentity(true);
 
         JourneyResponse journeyResponse =
                 toResponseClass(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -69,6 +69,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler.VOT_P2;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.ACCOUNT_INTERVENTIONS;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.RESET_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_ADDRESS_VC;
@@ -213,6 +214,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1A));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
+        when(configService.enabled(ACCOUNT_INTERVENTIONS.getName())).thenReturn(false);
         when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
 
         JourneyResponse journeyResponse =
@@ -251,6 +253,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(true);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
+        when(configService.enabled(ACCOUNT_INTERVENTIONS.getName())).thenReturn(false);
         when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(true);
 
         JourneyResponse journeyResponse =
@@ -278,6 +281,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(Gpg45Profile.M1B));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
+        when(configService.enabled(ACCOUNT_INTERVENTIONS.getName())).thenReturn(false);
         when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
 
         JourneyResponse journeyResponse =

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -198,7 +198,7 @@ class CheckExistingIdentityHandlerTest {
                         .userId(TEST_USER_ID)
                         .clientId("test-client")
                         .govukSigninJourneyId(TEST_JOURNEY_ID)
-                        .reproveIdentity(false)
+                        .reproveIdentity("false")
                         .build();
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -2,7 +2,8 @@ package uk.gov.di.ipv.core.library.config;
 
 public enum CoreFeatureFlag implements FeatureFlag {
     UNUSED_PLACEHOLDER("unusedPlaceHolder"),
-    RESET_IDENTITY("resetIdentity");
+    RESET_IDENTITY("resetIdentity"),
+    ACCOUNT_INTERVENTIONS("accountInterventions");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -2,8 +2,7 @@ package uk.gov.di.ipv.core.library.config;
 
 public enum CoreFeatureFlag implements FeatureFlag {
     UNUSED_PLACEHOLDER("unusedPlaceHolder"),
-    RESET_IDENTITY("resetIdentity"),
-    ACCOUNT_INTERVENTIONS("accountInterventions");
+    RESET_IDENTITY("resetIdentity");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
@@ -24,7 +24,7 @@ public class ClientOAuthSessionItem implements DynamodbItem {
     private String state;
     private String userId;
     private String govukSigninJourneyId;
-    private String reproveIdentity;
+    private Boolean reproveIdentity;
     private List<String> vtr;
     private long ttl;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
@@ -24,6 +24,7 @@ public class ClientOAuthSessionItem implements DynamodbItem {
     private String state;
     private String userId;
     private String govukSigninJourneyId;
+    private Boolean reproveIdentity;
     private List<String> vtr;
     private long ttl;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
@@ -24,7 +24,7 @@ public class ClientOAuthSessionItem implements DynamodbItem {
     private String state;
     private String userId;
     private String govukSigninJourneyId;
-    private Boolean reproveIdentity;
+    private String reproveIdentity;
     private List<String> vtr;
     private long ttl;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -51,7 +51,9 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setGovukSigninJourneyId(
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
         clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
-        clientOAuthSessionItem.setReproveIdentity(claimsSet.getStringClaim("reprove_identity"));
+        Boolean reproveIdentity =
+                Boolean.parseBoolean(claimsSet.getStringClaim("reprove_identity"));
+        clientOAuthSessionItem.setReproveIdentity(reproveIdentity);
 
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import java.text.ParseException;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.ACCOUNT_INTERVENTIONS;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CLIENT_OAUTH_SESSIONS_TABLE_NAME;
 
 public class ClientOAuthSessionDetailsService {
@@ -48,10 +49,14 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setRedirectUri(claimsSet.getStringClaim("redirect_uri"));
         clientOAuthSessionItem.setState(claimsSet.getStringClaim("state"));
         clientOAuthSessionItem.setUserId(claimsSet.getSubject());
-        clientOAuthSessionItem.setReproveIdentity(claimsSet.getBooleanClaim("reprove_identity"));
         clientOAuthSessionItem.setGovukSigninJourneyId(
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
         clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
+
+        if (configService.enabled(ACCOUNT_INTERVENTIONS.getName())) {
+            clientOAuthSessionItem.setReproveIdentity(
+                    claimsSet.getBooleanClaim("reprove_identity"));
+        }
 
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -8,7 +8,6 @@ import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import java.text.ParseException;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.ACCOUNT_INTERVENTIONS;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CLIENT_OAUTH_SESSIONS_TABLE_NAME;
 
 public class ClientOAuthSessionDetailsService {
@@ -52,10 +51,7 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setGovukSigninJourneyId(
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
         clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
-
-        if (configService.enabled(ACCOUNT_INTERVENTIONS.getName())) {
-            clientOAuthSessionItem.setReproveIdentity(claimsSet.getStringClaim("reprove_identity"));
-        }
+        clientOAuthSessionItem.setReproveIdentity(claimsSet.getStringClaim("reprove_identity"));
 
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -54,8 +54,7 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
 
         if (configService.enabled(ACCOUNT_INTERVENTIONS.getName())) {
-            clientOAuthSessionItem.setReproveIdentity(
-                    claimsSet.getBooleanClaim("reprove_identity"));
+            clientOAuthSessionItem.setReproveIdentity(claimsSet.getStringClaim("reprove_identity"));
         }
 
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);
@@ -77,7 +76,7 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionErrorItem.setState(state);
         clientOAuthSessionErrorItem.setUserId(null);
         clientOAuthSessionErrorItem.setGovukSigninJourneyId(govukSigninJourneyId);
-        clientOAuthSessionErrorItem.setReproveIdentity(false);
+        clientOAuthSessionErrorItem.setReproveIdentity(null);
 
         dataStore.create(clientOAuthSessionErrorItem, BACKEND_SESSION_TTL);
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -48,6 +48,7 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setRedirectUri(claimsSet.getStringClaim("redirect_uri"));
         clientOAuthSessionItem.setState(claimsSet.getStringClaim("state"));
         clientOAuthSessionItem.setUserId(claimsSet.getSubject());
+        clientOAuthSessionItem.setReproveIdentity(claimsSet.getBooleanClaim("reprove_identity"));
         clientOAuthSessionItem.setGovukSigninJourneyId(
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
         clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
@@ -71,6 +72,7 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionErrorItem.setState(state);
         clientOAuthSessionErrorItem.setUserId(null);
         clientOAuthSessionErrorItem.setGovukSigninJourneyId(govukSigninJourneyId);
+        clientOAuthSessionErrorItem.setReproveIdentity(false);
 
         dataStore.create(clientOAuthSessionErrorItem, BACKEND_SESSION_TTL);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Reset users identity when `reprove_identity` flag is `true`.

### What changed

- Resetting users identity when `reprove_identity` flag is `true`. Allowing user to prove identity again.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- When orch API passes `reprove_identity: "true"` claim we let user to prove identity.
- In case if its false or not present user can continue journey as it is.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4043](https://govukverify.atlassian.net/browse/PYIC-4043)

## Checklists


[PYIC-4043]: https://govukverify.atlassian.net/browse/PYIC-4043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ