### PR TITLE
BAU: Run gradle tasks in parallel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.parallel=true


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Run gradle tasks in parallel

### Why did it change

Our gradle project consists of lots of separate sub-projects, without too many dependencies on each other. This makes it a good candidate to run separate sub-project tasks in parallel.

Currently, on my machine, running `gradlew clean build` takes 2m12s. Applying the parallel config reduces that to 59s.

We'd need to keep an eye on how this affects build in GHA for the pipeline, but hopefully it should be fine.

See the gradle docs for this config here: https://docs.gradle.org/current/userguide/performance.html#parallel_execution

