### PR TITLE
PYIC-3799: Direct cri callback traffic to new process cri callback lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1524,12 +1524,19 @@ Resources:
                         - !Ref AWS::AccountId
                         - cimitEnvironment
       Events:
-        IPVCorePrivateAPI:
+        IPVCoreJourneyCallback:
           Type: Api
           Properties:
             RestApiId:
               Ref: IPVCorePrivateAPI
             Path: /journey/cri/callback
+            Method: POST
+        IPVCoreCriCallback:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: IPVCorePrivateAPI
+            Path: /cri/callback
             Method: POST
       AutoPublishAlias: live
       ProvisionedConcurrencyConfig:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -20,15 +20,8 @@ CRI_STATE:
       targetState: ERROR
     temporarily-unavailable:
       targetState: PYI_NO_MATCH
-    end:
-      targetState: IPV_SUCCESS_PAGE
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: ERROR
     pyi-no-match:
       targetState: PYI_NO_MATCH
-    pyi-kbv-fail:
-      targetState: PYI_KBV_FAIL
 
 # Shared states
 INITIAL_IPV_JOURNEY:
@@ -222,12 +215,6 @@ PYI_NO_MATCH:
     pageId: pyi-no-match
   parent: END_JOURNEY
 
-PYI_KBV_FAIL:
-  response:
-    type: page
-    pageId: pyi-kbv-fail
-  parent: END_JOURNEY
-
 PYI_F2F_TECHNICAL:
   response:
     type: page
@@ -288,10 +275,10 @@ EVALUATE_GPG45_SCORES:
     type: process
     lambda: evaluate-gpg45-scores
   events:
-    end:
+    met:
       targetState:
         IPV_SUCCESS_PAGE
-    next:
+    unmet:
       targetState:
         PYI_NO_MATCH
 
@@ -321,21 +308,13 @@ CRI_EXPERIAN_KBV:
     criId: kbv
   parent: CRI_STATE
   events:
-    end:
-      targetState: IPV_SUCCESS_PAGE
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: ERROR
     fail-with-no-ci:
       targetState: PYI_CRI_ESCAPE
       checkIfDisabled:
         f2f:
           targetState: PYI_CRI_ESCAPE_NO_F2F
     next:
-      targetState: PYI_NO_MATCH
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: EVALUATE_GPG45_SCORES
+      targetState: EVALUATE_GPG45_SCORES
     enhanced-verification:
       targetState: MITIGATION_02_OPTIONS_WITH_F2F
       checkIfDisabled:
@@ -409,16 +388,8 @@ POST_DCMAW_SUCCESS_PAGE:
 ADDRESS_AND_FRAUD_J1:
   nestedJourney: ADDRESS_AND_FRAUD
   exitEvents:
-    end:
-      targetState: IPV_SUCCESS_PAGE
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: ERROR
     next:
-      targetState: PYI_NO_MATCH
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: EVALUATE_GPG45_SCORES
+      targetState: EVALUATE_GPG45_SCORES
     enhanced-verification:
       targetState: PYI_NO_MATCH
 
@@ -445,8 +416,6 @@ ADDRESS_AND_FRAUD_J2:
       checkIfDisabled:
         hmrcKbv:
           targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    end:
-      targetState: ERROR
     enhanced-verification:
       targetState: CRI_NINO_J6
       checkIfDisabled:
@@ -473,8 +442,6 @@ ADDRESS_AND_FRAUD_J3:
   exitEvents:
     next:
       targetState: CHECK_FRAUD_SCORE_J3
-    end:
-      targetState: ERROR
     enhanced-verification:
       targetState: CHECK_FRAUD_SCORE_J3
 
@@ -511,8 +478,6 @@ ADDRESS_AND_FRAUD_J4:
   exitEvents:
     next:
       targetState: CRI_F2F
-    end:
-      targetState: ERROR
     enhanced-verification:
       targetState: CRI_F2F
 
@@ -534,18 +499,10 @@ CRI_HMRC_KBV_J6:
     criId: hmrcKbv
   parent: CRI_STATE
   events:
-    end:
-      targetState: IPV_SUCCESS_PAGE
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: ERROR
     fail-with-no-ci:
       targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
     next:
-      targetState: PYI_NO_MATCH
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: EVALUATE_GPG45_SCORES
+      targetState: EVALUATE_GPG45_SCORES
 
 # No photo id journey (M2B)
 CRI_CLAIMED_IDENTITY_M2B:
@@ -587,8 +544,6 @@ ADDRESS_AND_FRAUD_M2B:
       checkIfDisabled:
         hmrcKbv:
           targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
-    end:
-      targetState: ERROR
     enhanced-verification:
       targetState: CRI_HMRC_KBV_J6
       checkIfDisabled:
@@ -609,11 +564,6 @@ CRI_EXPERIAN_KBV_M2B:
     criId: kbv
   parent: CRI_STATE
   events:
-    end:
-      targetState: IPV_SUCCESS_PAGE
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: EVALUATE_GPG45_SCORES
     fail-with-no-ci:
       targetState: PYI_CRI_ESCAPE
       checkIfDisabled:
@@ -733,10 +683,7 @@ CRI_DCMAW_PYI_ESCAPE:
   parent: CRI_STATE
   events:
     next:
-      targetState: ERROR
-      checkFeatureFlag:
-        gpg45ScoresAtEnd:
-          targetState: EVALUATE_GPG45_SCORES
+      targetState: EVALUATE_GPG45_SCORES
     not-found:
       targetState: PYI_POST_OFFICE
       checkIfDisabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -275,10 +275,10 @@ EVALUATE_GPG45_SCORES:
     type: process
     lambda: evaluate-gpg45-scores
   events:
-    met:
+    end:
       targetState:
         IPV_SUCCESS_PAGE
-    unmet:
+    next:
       targetState:
         PYI_NO_MATCH
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -21,8 +21,6 @@ ADDRESS_AND_FRAUD:
         criId: fraud
       parent: CRI_STATE
       events:
-        end:
-          exitEventToEmit: end
         next:
           exitEventToEmit: next
         enhanced-verification:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -21,6 +21,25 @@ paths:
         passthroughBehavior: "when_no_match"
         type: "aws_proxy"
 
+  /cri/callback:
+    post:
+      description: |
+        Called when a user comes back to core on the frontend's callback endpoint, after visiting a CRI. Triggers a step
+        function that orchestrates lambdas for validating the oauth callback, retrieving the access token, and fetching
+        the credential.
+      responses:
+        200:
+          description: "Returns a journey or error response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/journeyType"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ProcessCriCallbackFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
   /journey/cri/callback:
     post:
       description: |
@@ -35,50 +54,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/journeyType"
       x-amazon-apigateway-integration:
-        'Fn::If':
-          - IsDevOrBuild
-          - type: "aws_proxy"
-            httpMethod: "POST"
-            uri:
-              Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ProcessCriCallbackFunction.Arn}:live/invocations
-            passthroughBehavior: "when_no_match"
-          - type: "aws"
-            credentials:
-              Fn::GetAtt: CriReturnStepFunctionApiGateWayIamRole.Arn
-            httpMethod: "POST"
-            uri:
-              Fn::Sub: arn:aws:apigateway:${AWS::Region}:states:action/StartSyncExecution
-            passthroughBehavior: "when_no_match"
-            requestTemplates:
-              application/json:
-                Fn::Sub: |
-                  #set($inputRoot = $input.path('$'))
-                  {
-                    "input": "{\"ipvSessionId\": \"$input.params('ipv-session-id')\", \"featureSet\": \"$input.params('feature-set')\", \"ipAddress\": \"$input.params('ip-address')\"#foreach($key in $inputRoot.keySet()), \"$key\": \"$inputRoot.get($key)\"#end}",
-                    "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${CriReturnStepFunction.Name}"
-                  }
-            responses:
-              default:
-                statusCode: 200
-                responseTemplates:
-                  application/json: |
-                    #set ($bodyObj = $util.parseJson($input.body))
-    
-                    #if ($bodyObj.status == "SUCCEEDED")
-                      #set($lambdaOutputObj = $util.parseJson($bodyObj.output))
-                      #set($context.responseOverride.status = $lambdaOutputObj.statusCode)
-                      $bodyObj.output
-    
-                    #elseif ($bodyObj.status == "FAILED")
-                      #set($context.responseOverride.status = 500)
-                      {
-                        "cause": "$bodyObj.cause",
-                        "error": "$bodyObj.error"
-                      }
-                    #else
-                      #set($context.responseOverride.status = 504)
-                      $bodyObj
-                    #end
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ProcessCriCallbackFunction.Arn}:live/invocations
+        passthroughBehavior: "when_no_match"
 
   /journey/{journeyStep}:
     post:


### PR DESCRIPTION
## Proposed changes

### What changed

- Open Api spec edited to allow /journey/cri/callback and /cri/callback to only set off the new ProcessCriCallback lambda
- This will allow us to remove the gpg45ScoresAtEnd featrue flag in core-common-infra

### Why did it change

- So users are pointed away from soon-to-be deleted resources

### Issue tracking

- [PYIC-3799](https://govukverify.atlassian.net/browse/PYIC-3799)

[PYIC-3799]: https://govukverify.atlassian.net/browse/PYIC-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ