### PR TITLE
PYIC-2892: Remove handling of old connection config format

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -269,12 +269,7 @@ public class ConfigService {
         try {
             String parameter = getSsmParameter(resolvePath(pathTemplate, criId, connection));
             return objectMapper.readValue(parameter, CredentialIssuerConfig.class);
-        } catch (ParameterNotFoundException | ClassCastException e) {
-            Map<String, String> parameters =
-                    getSsmParameters(pathTemplate, false, criId, connection);
-            if (parameters != null && !parameters.isEmpty()) {
-                return objectMapper.convertValue(parameters, CredentialIssuerConfig.class);
-            }
+        } catch (ParameterNotFoundException e) {
             throw new NoConfigForConnectionException(
                     String.format(
                             "No config found for connection: '%s' and criId: '%s'",

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -187,31 +187,13 @@ class ConfigServiceTest {
         }
 
         @Test
-        void shouldGetCredentialIssuerFromParameterStoreSingleParameter() {
+        void shouldGetCredentialIssuerFromParameterStore() {
             environmentVariables.set("ENVIRONMENT", "test");
 
             when(ssmProvider.get("/test/core/credentialIssuers/passportCri/activeConnection"))
                     .thenReturn("stub");
             when(ssmProvider.get("/test/core/credentialIssuers/passportCri/connections/stub"))
                     .thenReturn(jsonCredentialIssuerConfig);
-
-            CredentialIssuerConfig result =
-                    configService.getCredentialIssuerActiveConnectionConfig("passportCri");
-
-            checkCredentialIssuerConfig(expectedBaseCredentialIssuerConfig, result);
-        }
-
-        @Test
-        void shouldGetCredentialIssuerFromParameterStoreMultipleParameters() {
-            environmentVariables.set("ENVIRONMENT", "test");
-
-            when(ssmProvider.get("/test/core/credentialIssuers/passportCri/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/passportCri/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.builder().build());
-            when(ssmProvider.getMultiple(
-                            "/test/core/credentialIssuers/passportCri/connections/stub"))
-                    .thenReturn(baseCredentialIssuerConfig);
 
             CredentialIssuerConfig result =
                     configService.getCredentialIssuerActiveConnectionConfig("passportCri");
@@ -245,71 +227,6 @@ class ConfigServiceTest {
             assertThrows(
                     NoConfigForConnectionException.class,
                     () -> configService.getCriConfigForConnection("stub", "passportCri"));
-        }
-
-        @Test
-        void shouldApplyFeatureSetOverridesOnActiveConfiguration() {
-            environmentVariables.set("ENVIRONMENT", "test");
-            configService.setFeatureSet("fs01");
-
-            when(ssmProvider.get("/test/core/credentialIssuers/passportCri/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.builder().build());
-            when(ssmProvider.get("/test/core/credentialIssuers/passportCri/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.getMultiple("/test/core/features/fs01/credentialIssuers/passportCri"))
-                    .thenReturn(Map.of());
-            when(ssmProvider.getMultiple(
-                            "/test/core/credentialIssuers/passportCri/connections/stub"))
-                    .thenReturn(baseCredentialIssuerConfig);
-            when(ssmProvider.getMultiple(
-                            "/test/core/features/fs01/credentialIssuers/passportCri/connections/stub"))
-                    .thenReturn(featureSetCredentialIssuerConfig);
-
-            CredentialIssuerConfig result =
-                    configService.getCredentialIssuerActiveConnectionConfig("passportCri");
-
-            checkCredentialIssuerConfig(expectedFeatureSetCredentialIssuerConfig, result);
-        }
-
-        @Test
-        void shouldOverrideActiveConfigurationForAFeatureSet() {
-            environmentVariables.set("ENVIRONMENT", "test");
-            configService.setFeatureSet("fs01");
-
-            when(ssmProvider.get("/test/core/credentialIssuers/passportCri/connections/main"))
-                    .thenThrow(ParameterNotFoundException.builder().build());
-            when(ssmProvider.getMultiple("/test/core/features/fs01/credentialIssuers/passportCri"))
-                    .thenReturn(Map.of("activeConnection", "main"));
-            when(ssmProvider.getMultiple(
-                            "/test/core/credentialIssuers/passportCri/connections/main"))
-                    .thenReturn(baseCredentialIssuerConfig);
-
-            CredentialIssuerConfig result =
-                    configService.getCredentialIssuerActiveConnectionConfig("passportCri");
-
-            checkCredentialIssuerConfig(expectedBaseCredentialIssuerConfig, result);
-        }
-
-        @Test
-        void shouldApplyFeatureSetOverridesOnFeatureSetActiveConfiguration() {
-            environmentVariables.set("ENVIRONMENT", "test");
-            configService.setFeatureSet("fs01");
-
-            when(ssmProvider.get("/test/core/credentialIssuers/passportCri/connections/main"))
-                    .thenThrow(ParameterNotFoundException.builder().build());
-            when(ssmProvider.getMultiple("/test/core/features/fs01/credentialIssuers/passportCri"))
-                    .thenReturn(Map.of("activeConnection", "main"));
-            when(ssmProvider.getMultiple(
-                            "/test/core/credentialIssuers/passportCri/connections/main"))
-                    .thenReturn(baseCredentialIssuerConfig);
-            when(ssmProvider.getMultiple(
-                            "/test/core/features/fs01/credentialIssuers/passportCri/connections/main"))
-                    .thenReturn(featureSetCredentialIssuerConfig);
-
-            CredentialIssuerConfig result =
-                    configService.getCredentialIssuerActiveConnectionConfig("passportCri");
-
-            checkCredentialIssuerConfig(expectedFeatureSetCredentialIssuerConfig, result);
         }
 
         @Test


### PR DESCRIPTION
Removes handling of the old connection format

## Proposed changes

### What changed

- Removes lookup and handling to look up connection config from multiple parameter store values
- Removes redundant unit tests to look up and override multiple parameter values with feature sets

### Why did it change

Updated to support new connection configuration format & reduce number of overall parameters in use

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-2892](https://govukverify.atlassian.net/browse/PYIC-2892)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-2892]: https://govukverify.atlassian.net/browse/PYIC-2892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ