### PR TITLE
PYIC-3748: change default error state for journey map events

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -7,19 +7,19 @@ END_JOURNEY:
 CRI_STATE:
   events:
     next:
-      targetState: ERROR
+      targetState: UNEXPECTED_EVENT
     not-found:
-      targetState: ERROR
+      targetState: PYI_NO_MATCH
     fail-with-no-ci:
-      targetState: ERROR
+      targetState: PYI_NO_MATCH
     error:
       targetState: ERROR
     access-denied:
       targetState: PYI_NO_MATCH
     enhanced-verification:
-      targetState: ERROR
-    temporarily-unavailable:
       targetState: PYI_NO_MATCH
+    temporarily-unavailable:
+      targetState: ERROR
     fail-with-ci:
       targetState: PYI_NO_MATCH
 
@@ -258,6 +258,13 @@ PYI_CRI_ESCAPE_NO_F2F:
       targetState: END
 
 ERROR:
+  response:
+    type: error
+    pageId: pyi-technical
+    statusCode: 500
+  parent: END_JOURNEY
+
+UNEXPECTED_EVENT:
   response:
     type: error
     pageId: pyi-technical


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Change defaults to CRI journey map events, change error maps.

### What changed

- Changed defaults journey map for the cri state errors.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To trace error correctly in logs.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3748](https://govukverify.atlassian.net/browse/PYIC-3748)


[PYIC-3748]: https://govukverify.atlassian.net/browse/PYIC-3748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ