### PR TITLE
PYIC-3799: Remove option for old CRI callback endpoint

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1184,13 +1184,6 @@ Resources:
                         - !Ref AWS::AccountId
                         - cimitEnvironment
       Events:
-        IPVCoreJourneyCallback:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCorePrivateAPI
-            Path: /journey/cri/callback
-            Method: POST
         IPVCoreCriCallback:
           Type: Api
           Properties:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -40,25 +40,6 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ProcessCriCallbackFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
-  /journey/cri/callback:
-    post:
-      description: |
-        Called when a user comes back to core on the frontend's callback endpoint, after visiting a CRI. Triggers a step
-        function that orchestrates lambdas for validating the oauth callback, retrieving the access token, and fetching
-        the credential.
-      responses:
-        200:
-          description: "Returns a journey or error response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/journeyType"
-      x-amazon-apigateway-integration:
-        type: "aws_proxy"
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ProcessCriCallbackFunction.Arn}:live/invocations
-        passthroughBehavior: "when_no_match"
 
   /journey/{journeyStep}:
     post:


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove the flexibility to take CRI callback traffic at multiple endpoints to just the `/cri/callback` endpoint

### Why did it change

- The `/journey` prefix made the endpoint misleadingly similar to an event URL

### Issue tracking

- [PYIC-3799](https://govukverify.atlassian.net/browse/PYIC-3799)


[PYIC-3799]: https://govukverify.atlassian.net/browse/PYIC-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ