### PR TITLE
PYIC-4152: exitCode -> returnCode

### DIFF
--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -200,7 +200,7 @@ public class BuildUserIdentityHandler
                         ipvSessionItem.getVot(),
                         ciMitUtilityService.isBreachingCiThreshold(contraIndicators),
                         contraIndicators.hasMitigations(),
-                        userIdentity.getExitCode());
+                        userIdentity.getReturnCode());
 
         LOGGER.info(
                 new StringMapMessage()

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -27,6 +27,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.Name;
 import uk.gov.di.ipv.core.library.domain.NameParts;
+import uk.gov.di.ipv.core.library.domain.ReturnCode;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
@@ -111,7 +112,7 @@ class BuildUserIdentityHandlerTest {
                         "test-sub",
                         VectorOfTrust.P2.toString(),
                         VTM,
-                        List.of("1", "2", "3"));
+                        List.of(new ReturnCode("1"), new ReturnCode("2"), new ReturnCode("3")));
 
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
@@ -188,7 +189,7 @@ class BuildUserIdentityHandlerTest {
         assertEquals(userIdentity.getAddressClaim(), responseBody.getAddressClaim());
         assertEquals(userIdentity.getDrivingPermitClaim(), responseBody.getDrivingPermitClaim());
         assertEquals(userIdentity.getNinoClaim(), responseBody.getNinoClaim());
-        assertEquals(userIdentity.getExitCode(), responseBody.getExitCode());
+        assertEquals(userIdentity.getReturnCode(), responseBody.getReturnCode());
 
         verify(mockIpvSessionService).revokeAccessToken(ipvSessionItem);
 
@@ -202,7 +203,7 @@ class BuildUserIdentityHandlerTest {
         assertEquals(VectorOfTrust.P2.toString(), extensions.levelOfConfidence());
         assertFalse(extensions.ciFail());
         assertTrue(extensions.hasMitigations());
-        assertEquals(extensions.exitCode(), responseBody.getExitCode());
+        assertEquals(extensions.returnCode(), responseBody.getReturnCode());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
         verify(mockCiMitService, times(1)).getContraIndicatorsVCJwt(any(), any(), any());
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsUserIdentity.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsUserIdentity.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.library.auditing.extension;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.ReturnCode;
 
 import java.util.List;
 
@@ -11,5 +12,5 @@ public record AuditExtensionsUserIdentity(
         @JsonProperty String levelOfConfidence,
         @JsonProperty boolean ciFail,
         @JsonProperty boolean hasMitigations,
-        @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty List<String> exitCode)
+        @JsonInclude(JsonInclude.Include.NON_NULL) @JsonProperty List<ReturnCode> returnCode)
         implements AuditExtensions {}

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
@@ -161,7 +161,7 @@ class AuditServiceTest {
                 AuditEventTypes.IPV_JOURNEY_START.toString(),
                 messageBody.get("event_name").asText());
         JsonNode auditExtensionsUserIdentity = messageBody.get("extensions");
-        assertNull(auditExtensionsUserIdentity.get("exitCode"));
+        assertNull(auditExtensionsUserIdentity.get("returnCode"));
     }
 
     @Test
@@ -185,7 +185,7 @@ class AuditServiceTest {
                 AuditEventTypes.IPV_JOURNEY_START.toString(),
                 messageBody.get("event_name").asText());
         JsonNode auditExtensionsUserIdentity = messageBody.get("extensions");
-        assertNotNull(auditExtensionsUserIdentity.get("exitCode"));
+        assertNotNull(auditExtensionsUserIdentity.get("returnCode"));
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -23,8 +23,8 @@ public enum ConfigurationVariable {
     CIMIT_SIGNING_KEY("cimit/signingKey"),
     CIMIT_COMPONENT_ID("cimit/componentId"),
     CIMIT_CONFIG("cimit/config"),
-    EXIT_CODES_ALWAYS_REQUIRED("self/exitCodes/alwaysRequired"),
-    EXIT_CODES_NON_CI_BREACHING_P0("self/exitCodes/nonCiBreachingP0");
+    RETURN_CODES_ALWAYS_REQUIRED("self/returnCodes/alwaysRequired"),
+    RETURN_CODES_NON_CI_BREACHING_P0("self/returnCodes/nonCiBreachingP0");
 
     private final String path;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,10 +8,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ContraIndicatorConfig {
     private String ci;
     private Integer detectedScore;
     private Integer checkedScore;
-    private String exitCode;
     private String returnCode;
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReturnCode.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReturnCode.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.core.library.domain;
+
+public record ReturnCode(String code) {}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -26,7 +26,7 @@ public class UserIdentity {
             "https://vocab.account.gov.uk/v1/drivingPermit";
     private static final String NINO_CLAIM_NAME =
             "https://vocab.account.gov.uk/v1/socialSecurityRecord";
-    public static final String EXIT_CODE_NAME = "exit_code";
+    public static final String RETURN_CODE_NAME = "https://vocab.account.gov.uk/v1/returnCode";
 
     @JsonProperty(VCS_CLAIM_NAME)
     private List<String> vcs;
@@ -52,8 +52,8 @@ public class UserIdentity {
 
     @JsonProperty private String vtm;
 
-    @JsonProperty(EXIT_CODE_NAME)
-    private List<String> exitCode;
+    @JsonProperty(RETURN_CODE_NAME)
+    private List<ReturnCode> returnCode;
 
     @JsonCreator
     public UserIdentity(
@@ -66,7 +66,7 @@ public class UserIdentity {
             @JsonProperty(value = "sub", required = true) String sub,
             @JsonProperty(value = "vot", required = true) String vot,
             @JsonProperty(value = "vtm", required = true) String vtm,
-            @JsonProperty(value = EXIT_CODE_NAME) List<String> exitCode) {
+            @JsonProperty(value = RETURN_CODE_NAME) List<ReturnCode> returnCode) {
         this.vcs = new ArrayList<>(vcs);
         this.identityClaim = identityClaim;
         this.addressClaim = addressClaim;
@@ -76,6 +76,6 @@ public class UserIdentity {
         this.sub = sub;
         this.vot = vot;
         this.vtm = vtm;
-        this.exitCode = exitCode;
+        this.returnCode = returnCode;
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorsTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorsTest.java
@@ -29,11 +29,11 @@ class ContraIndicatorsTest {
     private static final Map<String, ContraIndicatorConfig> CONTRA_INDICATOR_CONFIG_MAP =
             Map.of(
                     TEST_CI1,
-                    new ContraIndicatorConfig(TEST_CI1, 4, -3, "1", "1"),
+                    new ContraIndicatorConfig(TEST_CI1, 4, -3, "1"),
                     TEST_CI2,
-                    new ContraIndicatorConfig(TEST_CI2, 3, -3, "2", "2"),
+                    new ContraIndicatorConfig(TEST_CI2, 3, -3, "2"),
                     TEST_CI3,
-                    new ContraIndicatorConfig(TEST_CI3, 2, -1, "3", "3"));
+                    new ContraIndicatorConfig(TEST_CI3, 2, -1, "3"));
 
     @BeforeEach
     void setup() {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
@@ -40,10 +40,8 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD))
                 .thenReturn(String.valueOf(ciScoreThreshold));
 
-        ContraIndicatorConfig ciConfig1 =
-                new ContraIndicatorConfig(null, ciScore1, null, null, null);
-        ContraIndicatorConfig ciConfig2 =
-                new ContraIndicatorConfig(null, ciScore2, null, null, null);
+        ContraIndicatorConfig ciConfig1 = new ContraIndicatorConfig(null, ciScore1, null, null);
+        ContraIndicatorConfig ciConfig2 = new ContraIndicatorConfig(null, ciScore2, null, null);
 
         Map<String, ContraIndicatorConfig> ciConfigMap = new HashMap<>();
         ciConfigMap.put("ci_1", ciConfig1);
@@ -79,10 +77,8 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD))
                 .thenReturn(String.valueOf(ciScoreThreshold));
 
-        ContraIndicatorConfig ciConfig1 =
-                new ContraIndicatorConfig(null, ciScore1, null, null, null);
-        ContraIndicatorConfig ciConfig2 =
-                new ContraIndicatorConfig(null, ciScore2, null, null, null);
+        ContraIndicatorConfig ciConfig1 = new ContraIndicatorConfig(null, ciScore1, null, null);
+        ContraIndicatorConfig ciConfig2 = new ContraIndicatorConfig(null, ciScore2, null, null);
 
         Map<String, ContraIndicatorConfig> ciConfigMap = new HashMap<>();
         ciConfigMap.put("ci_1", ciConfig1);
@@ -123,8 +119,8 @@ class CiMitUtilityServiceTest {
                         .build();
         Map<String, ContraIndicatorConfig> ciConfigMap =
                 Map.of(
-                        "ciCode1", new ContraIndicatorConfig("ciCode", 4, -3, "X", "X"),
-                        "ciCode2", new ContraIndicatorConfig("ciCode", 9, -5, "X", "X"));
+                        "ciCode1", new ContraIndicatorConfig("ciCode", 4, -3, "X"),
+                        "ciCode2", new ContraIndicatorConfig("ciCode", 9, -5, "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("9");
 
@@ -144,8 +140,8 @@ class CiMitUtilityServiceTest {
                         .build();
         Map<String, ContraIndicatorConfig> ciConfigMap =
                 Map.of(
-                        "ciCode1", new ContraIndicatorConfig("ciCode", 5, -5, "X", "X"),
-                        "ciCode2", new ContraIndicatorConfig("ciCode", 5, -5, "X", "X"));
+                        "ciCode1", new ContraIndicatorConfig("ciCode", 5, -5, "X"),
+                        "ciCode2", new ContraIndicatorConfig("ciCode", 5, -5, "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
@@ -161,7 +157,7 @@ class CiMitUtilityServiceTest {
         var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
         when(mockConfigService.getCimitConfig()).thenReturn(Map.of(code, "some_mitigation"));
         Map<String, ContraIndicatorConfig> ciConfigMap =
-                Map.of(code, new ContraIndicatorConfig(code, 7, -5, "X", "X"));
+                Map.of(code, new ContraIndicatorConfig(code, 7, -5, "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
@@ -217,7 +213,7 @@ class CiMitUtilityServiceTest {
         var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
         when(mockConfigService.getCimitConfig()).thenReturn(Map.of(code, "some_mitigation"));
         Map<String, ContraIndicatorConfig> ciConfigMap =
-                Map.of(code, new ContraIndicatorConfig(code, 7, -1, "X", "X"));
+                Map.of(code, new ContraIndicatorConfig(code, 7, -1, "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -529,7 +529,7 @@ class ConfigServiceTest {
         assertEquals("X01", configMap.get("X01").getCi());
         assertEquals(3, configMap.get("X01").getDetectedScore());
         assertEquals(-3, configMap.get("X01").getCheckedScore());
-        assertEquals("1", configMap.get("X01").getExitCode());
+        assertEquals("1", configMap.get("X01").getReturnCode());
     }
 
     @Test

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -22,6 +22,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.Name;
 import uk.gov.di.ipv.core.library.domain.NameParts;
+import uk.gov.di.ipv.core.library.domain.ReturnCode;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.domain.cimitvc.ContraIndicator;
@@ -44,8 +45,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.EXIT_CODES_ALWAYS_REQUIRED;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.EXIT_CODES_NON_CI_BREACHING_P0;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_ALWAYS_REQUIRED;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_NON_CI_BREACHING_P0;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.USER_ISSUED_CREDENTIALS_TABLE_NAME;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.BAV_CRI;
@@ -181,29 +182,35 @@ public class UserIdentityService {
             Optional<JsonNode> ninoClaim = generateNinoClaim(successfulVCStoreItems);
             ninoClaim.ifPresent(userIdentityBuilder::ninoClaim);
 
-            userIdentityBuilder.exitCode(getSuccessExitCode(contraIndicators));
+            userIdentityBuilder.returnCode(getSuccessReturnCode(contraIndicators));
         } else {
-            userIdentityBuilder.exitCode(getFailExitCode(contraIndicators));
+            userIdentityBuilder.returnCode(getFailReturnCode(contraIndicators));
         }
 
         return userIdentityBuilder.build();
     }
 
-    private List<String> getFailExitCode(ContraIndicators contraIndicators)
+    private List<ReturnCode> getFailReturnCode(ContraIndicators contraIndicators)
             throws UnrecognisedCiException {
         return ciMitUtilityService.isBreachingCiThreshold(contraIndicators)
-                ? mapCisToExitCodes(contraIndicators)
-                : List.of(configService.getSsmParameter(EXIT_CODES_NON_CI_BREACHING_P0));
+                ? mapCisToReturnCodes(contraIndicators)
+                : List.of(
+                        new ReturnCode(
+                                configService.getSsmParameter(RETURN_CODES_NON_CI_BREACHING_P0)));
     }
 
-    private List<String> getSuccessExitCode(ContraIndicators contraIndicators)
+    private List<ReturnCode> getSuccessReturnCode(ContraIndicators contraIndicators)
             throws UnrecognisedCiException {
-        return mapCisToExitCodes(contraIndicators).stream()
-                .filter(configService.getSsmParameter(EXIT_CODES_ALWAYS_REQUIRED)::contains)
+        return mapCisToReturnCodes(contraIndicators).stream()
+                .filter(
+                        returnCode ->
+                                configService
+                                        .getSsmParameter(RETURN_CODES_ALWAYS_REQUIRED)
+                                        .contains(returnCode.code()))
                 .toList();
     }
 
-    private List<String> mapCisToExitCodes(ContraIndicators contraIndicators)
+    private List<ReturnCode> mapCisToReturnCodes(ContraIndicators contraIndicators)
             throws UnrecognisedCiException {
         return contraIndicators.getContraIndicatorsMap().values().stream()
                 .map(ContraIndicator::getCode)
@@ -217,9 +224,10 @@ public class UserIdentityService {
                                                 () ->
                                                         new UnrecognisedCiException(
                                                                 "CI code not found")))
-                .map(ContraIndicatorConfig::getExitCode)
+                .map(ContraIndicatorConfig::getReturnCode)
                 .distinct()
                 .sorted()
+                .map(ReturnCode::new)
                 .toList();
     }
 


### PR DESCRIPTION
**Not to be merged before https://github.com/govuk-one-login/ipv-core-common-infra/pull/804**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

exitCode -> returnCode

### Why did it change

The requirement for the format of the codes returned in the identity bundle has changed.

There will be a follow up PR to this once we've switched over to the new config, and the config repo has been updated.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4152](https://govukverify.atlassian.net/browse/PYIC-4152)


[PYIC-4152]: https://govukverify.atlassian.net/browse/PYIC-4152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ