### PR TITLE
PYIC-4168: Add returnCode to ContraIndicatorConfig

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorConfig.java
@@ -12,4 +12,5 @@ public class ContraIndicatorConfig {
     private Integer detectedScore;
     private Integer checkedScore;
     private String exitCode;
+    private String returnCode;
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorsTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorsTest.java
@@ -29,11 +29,11 @@ class ContraIndicatorsTest {
     private static final Map<String, ContraIndicatorConfig> CONTRA_INDICATOR_CONFIG_MAP =
             Map.of(
                     TEST_CI1,
-                    new ContraIndicatorConfig(TEST_CI1, 4, -3, "1"),
+                    new ContraIndicatorConfig(TEST_CI1, 4, -3, "1", "1"),
                     TEST_CI2,
-                    new ContraIndicatorConfig(TEST_CI2, 3, -3, "2"),
+                    new ContraIndicatorConfig(TEST_CI2, 3, -3, "2", "2"),
                     TEST_CI3,
-                    new ContraIndicatorConfig(TEST_CI3, 2, -1, "3"));
+                    new ContraIndicatorConfig(TEST_CI3, 2, -1, "3", "3"));
 
     @BeforeEach
     void setup() {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
@@ -40,8 +40,10 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD))
                 .thenReturn(String.valueOf(ciScoreThreshold));
 
-        ContraIndicatorConfig ciConfig1 = new ContraIndicatorConfig(null, ciScore1, null, null);
-        ContraIndicatorConfig ciConfig2 = new ContraIndicatorConfig(null, ciScore2, null, null);
+        ContraIndicatorConfig ciConfig1 =
+                new ContraIndicatorConfig(null, ciScore1, null, null, null);
+        ContraIndicatorConfig ciConfig2 =
+                new ContraIndicatorConfig(null, ciScore2, null, null, null);
 
         Map<String, ContraIndicatorConfig> ciConfigMap = new HashMap<>();
         ciConfigMap.put("ci_1", ciConfig1);
@@ -77,8 +79,10 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD))
                 .thenReturn(String.valueOf(ciScoreThreshold));
 
-        ContraIndicatorConfig ciConfig1 = new ContraIndicatorConfig(null, ciScore1, null, null);
-        ContraIndicatorConfig ciConfig2 = new ContraIndicatorConfig(null, ciScore2, null, null);
+        ContraIndicatorConfig ciConfig1 =
+                new ContraIndicatorConfig(null, ciScore1, null, null, null);
+        ContraIndicatorConfig ciConfig2 =
+                new ContraIndicatorConfig(null, ciScore2, null, null, null);
 
         Map<String, ContraIndicatorConfig> ciConfigMap = new HashMap<>();
         ciConfigMap.put("ci_1", ciConfig1);
@@ -119,8 +123,8 @@ class CiMitUtilityServiceTest {
                         .build();
         Map<String, ContraIndicatorConfig> ciConfigMap =
                 Map.of(
-                        "ciCode1", new ContraIndicatorConfig("ciCode", 4, -3, "X"),
-                        "ciCode2", new ContraIndicatorConfig("ciCode", 9, -5, "X"));
+                        "ciCode1", new ContraIndicatorConfig("ciCode", 4, -3, "X", "X"),
+                        "ciCode2", new ContraIndicatorConfig("ciCode", 9, -5, "X", "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("9");
 
@@ -140,8 +144,8 @@ class CiMitUtilityServiceTest {
                         .build();
         Map<String, ContraIndicatorConfig> ciConfigMap =
                 Map.of(
-                        "ciCode1", new ContraIndicatorConfig("ciCode", 5, -5, "X"),
-                        "ciCode2", new ContraIndicatorConfig("ciCode", 5, -5, "X"));
+                        "ciCode1", new ContraIndicatorConfig("ciCode", 5, -5, "X", "X"),
+                        "ciCode2", new ContraIndicatorConfig("ciCode", 5, -5, "X", "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
@@ -157,7 +161,7 @@ class CiMitUtilityServiceTest {
         var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
         when(mockConfigService.getCimitConfig()).thenReturn(Map.of(code, "some_mitigation"));
         Map<String, ContraIndicatorConfig> ciConfigMap =
-                Map.of(code, new ContraIndicatorConfig(code, 7, -5, "X"));
+                Map.of(code, new ContraIndicatorConfig(code, 7, -5, "X", "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
@@ -213,7 +217,7 @@ class CiMitUtilityServiceTest {
         var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
         when(mockConfigService.getCimitConfig()).thenReturn(Map.of(code, "some_mitigation"));
         Map<String, ContraIndicatorConfig> ciConfigMap =
-                Map.of(code, new ContraIndicatorConfig(code, 7, -1, "X"));
+                Map.of(code, new ContraIndicatorConfig(code, 7, -1, "X", "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -518,7 +518,7 @@ class ConfigServiceTest {
     @Test
     void shouldGetContraIndicatorConfigMap() {
         String scoresJsonString =
-                "[{\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"exitCode\":\"1\"},{\"ci\":\"Z03\",\"detectedScore\":5,\"checkedScore\":-3,\"exitCode\":\"1\"}]";
+                "[{\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"exitCode\":\"1\",\"returnCode\":\"1\"},{\"ci\":\"Z03\",\"detectedScore\":5,\"checkedScore\":-3,\"exitCode\":\"1\",\"returnCode\":\"1\"}]";
         when(secretsProvider.get(any())).thenReturn(scoresJsonString);
 
         Map<String, ContraIndicatorConfig> configMap = configService.getContraIndicatorConfigMap();
@@ -535,7 +535,7 @@ class ConfigServiceTest {
     @Test
     void shouldReturnEmptyCollectionOnInvalidContraIndicatorConfigsMap() {
         final String invalidCIConfigJsonString =
-                "[\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"exitCode\":\"1\"}]";
+                "[\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"exitCode\":\"1\",\"returnCode\":\"1\"}]";
         when(secretsProvider.get(any())).thenReturn(invalidCIConfigJsonString);
         Map<String, ContraIndicatorConfig> configMap = configService.getContraIndicatorConfigMap();
         assertTrue(configMap.isEmpty());

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -1171,9 +1171,9 @@ class UserIdentityServiceTest {
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(
                         Map.of(
-                                "X01", new ContraIndicatorConfig("X01", 4, -3, "🦆"),
-                                "X02", new ContraIndicatorConfig("X02", 4, -3, "2"),
-                                "Z03", new ContraIndicatorConfig("Z03", 4, -3, "3")));
+                                "X01", new ContraIndicatorConfig("X01", 4, -3, "🦆", "🦆"),
+                                "X02", new ContraIndicatorConfig("X02", 4, -3, "2", "2"),
+                                "Z03", new ContraIndicatorConfig("Z03", 4, -3, "3", "3")));
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
@@ -1207,7 +1207,7 @@ class UserIdentityServiceTest {
     void generateUserIdentityShouldThrowWhenP2AndCiCodeNotFound() {
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockConfigService.getContraIndicatorConfigMap())
-                .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1")));
+                .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1", "1")));
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
@@ -1228,9 +1228,9 @@ class UserIdentityServiceTest {
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(
                         Map.of(
-                                "X01", new ContraIndicatorConfig("X01", 4, -3, "1"),
-                                "X02", new ContraIndicatorConfig("X02", 4, -3, "2"),
-                                "Z03", new ContraIndicatorConfig("Z03", 4, -3, "3")));
+                                "X01", new ContraIndicatorConfig("X01", 4, -3, "1", "1"),
+                                "X02", new ContraIndicatorConfig("X02", 4, -3, "2", "2"),
+                                "Z03", new ContraIndicatorConfig("Z03", 4, -3, "3", "3")));
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
@@ -1260,7 +1260,7 @@ class UserIdentityServiceTest {
     void generateUserIdentityShouldThrowWhenBreachingAndCiCodeNotFound() {
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockConfigService.getContraIndicatorConfigMap())
-                .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1")));
+                .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1", "1")));
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
@@ -1281,10 +1281,10 @@ class UserIdentityServiceTest {
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(
                         Map.of(
-                                "X01", new ContraIndicatorConfig("X01", 4, -3, "1"),
-                                "X02", new ContraIndicatorConfig("X02", 4, -3, "2"),
-                                "Z03", new ContraIndicatorConfig("Z03", 4, -3, "3"),
-                                "Z04", new ContraIndicatorConfig("Z04", 4, -3, "2")));
+                                "X01", new ContraIndicatorConfig("X01", 4, -3, "1", "1"),
+                                "X02", new ContraIndicatorConfig("X02", 4, -3, "2", "2"),
+                                "Z03", new ContraIndicatorConfig("Z03", 4, -3, "3", "3"),
+                                "Z04", new ContraIndicatorConfig("Z04", 4, -3, "2", "2")));
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
@@ -1311,7 +1311,7 @@ class UserIdentityServiceTest {
         when(mockConfigService.getSsmParameter(EXIT_CODES_NON_CI_BREACHING_P0)).thenReturn("🐧");
 
         when(mockConfigService.getContraIndicatorConfigMap())
-                .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1")));
+                .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1", "1")));
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add returnCode to ContraIndicatorConfig

### Why did it change

We've extened the CI config to include returnCode as well as exitCode. To be able to deserialize this we need to add returnCode to the ContraIndicatorConfig object

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4168](https://govukverify.atlassian.net/browse/PYIC-4168)


[PYIC-4168]: https://govukverify.atlassian.net/browse/PYIC-4168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ