### PR TITLE
PYIC-4167: Clean up exitCode cruft

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ContraIndicatorConfig.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +7,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ContraIndicatorConfig {
     private String ci;
     private Integer detectedScore;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -518,7 +518,7 @@ class ConfigServiceTest {
     @Test
     void shouldGetContraIndicatorConfigMap() {
         String scoresJsonString =
-                "[{\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"exitCode\":\"1\",\"returnCode\":\"1\"},{\"ci\":\"Z03\",\"detectedScore\":5,\"checkedScore\":-3,\"exitCode\":\"1\",\"returnCode\":\"1\"}]";
+                "[{\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"returnCode\":\"1\"},{\"ci\":\"Z03\",\"detectedScore\":5,\"checkedScore\":-3,\"returnCode\":\"1\"}]";
         when(secretsProvider.get(any())).thenReturn(scoresJsonString);
 
         Map<String, ContraIndicatorConfig> configMap = configService.getContraIndicatorConfigMap();
@@ -535,7 +535,7 @@ class ConfigServiceTest {
     @Test
     void shouldReturnEmptyCollectionOnInvalidContraIndicatorConfigsMap() {
         final String invalidCIConfigJsonString =
-                "[\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"exitCode\":\"1\",\"returnCode\":\"1\"}]";
+                "[\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"returnCode\":\"1\"}]";
         when(secretsProvider.get(any())).thenReturn(invalidCIConfigJsonString);
         Map<String, ContraIndicatorConfig> configMap = configService.getContraIndicatorConfigMap();
         assertTrue(configMap.isEmpty());


### PR DESCRIPTION
**Not to be merged before https://github.com/govuk-one-login/ipv-core-common-infra/pull/805**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Clean up exitCode cruft

### Why did it change

This removes the last remnants of the exitCodes.

The ContraIndicatorConfig no longer needs to ignore unknown properties, as the exitCode property has been removed from the config.

Also, we can update some test data.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4167](https://govukverify.atlassian.net/browse/PYIC-4167)


[PYIC-4167]: https://govukverify.atlassian.net/browse/PYIC-4167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ