### PR TITLE
PYIC-3932: Added reset-identity event to reuse page

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -76,9 +76,6 @@ CHECK_EXISTING_IDENTITY:
       targetState: RESET_IDENTITY
     reuse:
       targetState: IPV_IDENTITY_REUSE_PAGE
-      checkFeatureFlag:
-        deleteDetailsEnabled:
-          targetState: IPV_IDENTITY_REUSE_PAGE_TEST
     pending:
       targetState: IPV_IDENTITY_PENDING_PAGE
     fail-with-ci:
@@ -332,16 +329,6 @@ CRI_EXPERIAN_KBV:
           targetState: MITIGATION_02_OPTIONS
 
 # User initiated details delete
-IPV_IDENTITY_REUSE_PAGE_TEST:
-  response:
-    type: page
-    pageId: page-ipv-reuse
-  parent: END_JOURNEY
-  events:
-    next:
-      targetState:
-        PYI_NEW_DETAILS_PAGE
-
 PYI_NEW_DETAILS_PAGE:
   response:
     type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -107,6 +107,9 @@ IPV_IDENTITY_REUSE_PAGE:
   events:
     next:
       targetState: END
+    reset-identity:
+      targetState:
+        PYI_NEW_DETAILS_PAGE
 
 IPV_IDENTITY_PENDING_PAGE:
   response:


### PR DESCRIPTION
========== DO NOT MERGE IN UNLESS READY TO GO LIVE ===========

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added reset-identity event to reuse page

### Why did it change

To allow core-front to route from reuse-identity page into the user initiated VC reset flow

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3932](https://govukverify.atlassian.net/browse/PYIC-3932)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed



[PYIC-3932]: https://govukverify.atlassian.net/browse/PYIC-3932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ