### PR TITLE
BAU: Add not correlated event

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -30,6 +30,7 @@ import uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile;
 import uk.gov.di.ipv.core.library.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
+import uk.gov.di.ipv.core.library.journeyuris.JourneyUris;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
@@ -53,7 +54,6 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 import static uk.gov.di.ipv.core.library.gpg45.Gpg45ProfileEvaluator.CURRENT_ACCEPTED_GPG45_PROFILES;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_MET_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PYI_NO_MATCH_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_UNMET_PATH;
 
 /** Evaluate the gathered credentials against a desired GPG45 profile. */
@@ -61,8 +61,8 @@ public class EvaluateGpg45ScoresHandler
         implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final JourneyResponse JOURNEY_MET = new JourneyResponse(JOURNEY_MET_PATH);
     private static final JourneyResponse JOURNEY_UNMET = new JourneyResponse(JOURNEY_UNMET_PATH);
-    private static final JourneyResponse JOURNEY_PYI_NO_MATCH =
-            new JourneyResponse(JOURNEY_PYI_NO_MATCH_PATH);
+    private static final JourneyResponse JOURNEY_VCS_NOT_CORRELATED =
+            new JourneyResponse(JourneyUris.JOURNEY_VCS_NOT_CORRELATED);
     private static final Logger LOGGER = LogManager.getLogger();
     private static final int ONLY = 0;
     private final UserIdentityService userIdentityService;
@@ -132,7 +132,7 @@ public class EvaluateGpg45ScoresHandler
                             userIdentityService.getUserIssuedCredentials(vcStoreItems));
 
             if (!userIdentityService.areVCsCorrelated(vcStoreItems)) {
-                return JOURNEY_PYI_NO_MATCH.toObjectMap();
+                return JOURNEY_VCS_NOT_CORRELATED.toObjectMap();
             }
 
             return checkForMatchingGpg45Profile(

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -86,7 +86,7 @@ class EvaluateGpg45ScoresHandlerTest {
     private static final List<Gpg45Profile> ACCEPTED_PROFILES = List.of(M1A, M1B, M2B);
     private static final JourneyResponse JOURNEY_MET = new JourneyResponse("/journey/met");
     private static final JourneyResponse JOURNEY_UNMET = new JourneyResponse("/journey/unmet");
-    private static final String JOURNEY_PYI_NO_MATCH = "/journey/pyi-no-match";
+    private static final String JOURNEY_VCS_NOT_CORRELATED = "/journey/vcs-not-correlated";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -395,7 +395,7 @@ class EvaluateGpg45ScoresHandlerTest {
     }
 
     @Test
-    void shouldReturnPyiNoMatchIfFailedDueToNameCorrelationIssues() throws Exception {
+    void shouldReturnVcsNotCorrelatedIfFailedDueToNameCorrelationIssues() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -406,7 +406,7 @@ class EvaluateGpg45ScoresHandlerTest {
                         evaluateGpg45ScoresHandler.handleRequest(request, context),
                         JourneyResponse.class);
 
-        assertEquals(JOURNEY_PYI_NO_MATCH, response.getJourney());
+        assertEquals(JOURNEY_VCS_NOT_CORRELATED, response.getJourney());
 
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
         verify(userIdentityService, times(1)).areVCsCorrelated(any());

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.journeyuris.JourneyUris;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -45,14 +46,13 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_P
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_NO_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PYI_NO_MATCH_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_TEMPORARILY_UNAVAILABLE_PATH;
 
 public class CriCheckingService {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse(JOURNEY_NEXT_PATH);
-    private static final JourneyResponse JOURNEY_PYI_NO_MATCH =
-            new JourneyResponse(JOURNEY_PYI_NO_MATCH_PATH);
+    private static final JourneyResponse JOURNEY_VCS_NOT_CORRELATED =
+            new JourneyResponse(JourneyUris.JOURNEY_VCS_NOT_CORRELATED);
     private static final JourneyResponse JOURNEY_FAIL_WITH_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
     private static final JourneyResponse JOURNEY_FAIL_WITH_NO_CI =
@@ -226,7 +226,7 @@ public class CriCheckingService {
 
         if (!userIdentityService.areVCsCorrelated(
                 verifiableCredentialService.getVcStoreItems(clientOAuthSessionItem.getUserId()))) {
-            return JOURNEY_PYI_NO_MATCH;
+            return JOURNEY_VCS_NOT_CORRELATED;
         }
 
         if (!VcHelper.isSuccessfulVcs(vcResponse.getVerifiableCredentials())) {

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -54,8 +54,8 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_P
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_NO_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PYI_NO_MATCH_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_TEMPORARILY_UNAVAILABLE_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_VCS_NOT_CORRELATED;
 
 @ExtendWith(MockitoExtension.class)
 public class CriCheckingServiceTest {
@@ -522,7 +522,7 @@ public class CriCheckingServiceTest {
     }
 
     @Test
-    void checkVcResponseShouldReturnPyiNoMatchWhenVcsNotCorrelated() throws Exception {
+    void checkVcResponseShouldReturnVcsNotCorrelatedWhenVcsNotCorrelated() throws Exception {
         // Arrange for VCs not correlated
         var callbackRequest = buildValidCallbackRequest();
         var vcResponse = VerifiableCredentialResponse.builder().userId(TEST_USER_ID).build();
@@ -538,7 +538,7 @@ public class CriCheckingServiceTest {
                         vcResponse, callbackRequest, clientOAuthSessionItem);
 
         // Assert
-        assertEquals(new JourneyResponse(JOURNEY_PYI_NO_MATCH_PATH), result);
+        assertEquals(new JourneyResponse(JOURNEY_VCS_NOT_CORRELATED), result);
         verify(mockVerifiableCredentialService, times(1)).getVcStoreItems(TEST_USER_ID);
     }
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -22,6 +22,8 @@ CRI_STATE:
       targetState: ERROR
     fail-with-ci:
       targetState: PYI_NO_MATCH
+    vcs-not-correlated:
+      targetState: PYI_NO_MATCH
 
 # Shared states
 INITIAL_IPV_JOURNEY:
@@ -283,11 +285,11 @@ EVALUATE_GPG45_SCORES:
     lambda: evaluate-gpg45-scores
   events:
     met:
-      targetState:
-        IPV_SUCCESS_PAGE
+      targetState: IPV_SUCCESS_PAGE
     unmet:
-      targetState:
-        PYI_NO_MATCH
+      targetState: PYI_NO_MATCH
+    vcs-not-correlated:
+      targetState: PYI_NO_MATCH
 
 IPV_SUCCESS_PAGE:
   response:

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -8,17 +8,17 @@ public class JourneyUris {
 
     public static final String JOURNEY_ACCESS_DENIED_PATH = "/journey/access-denied";
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
-    public static final String JOURNEY_NOT_FOUND_PATH = "/journey/not-found";
     public static final String JOURNEY_F2F_FAIL_PATH = "/journey/f2f-fail";
     public static final String JOURNEY_FAIL_WITH_CI_PATH = "/journey/fail-with-ci";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
+    public static final String JOURNEY_MET_PATH = "/journey/met";
     public static final String JOURNEY_NEXT_PATH = "/journey/next";
+    public static final String JOURNEY_VCS_NOT_CORRELATED = "/journey/vcs-not-correlated";
+    public static final String JOURNEY_NOT_FOUND_PATH = "/journey/not-found";
     public static final String JOURNEY_PENDING_PATH = "/journey/pending";
-    public static final String JOURNEY_PYI_NO_MATCH_PATH = "/journey/pyi-no-match";
     public static final String JOURNEY_RESET_IDENTITY_PATH = "/journey/reset-identity";
     public static final String JOURNEY_REUSE_PATH = "/journey/reuse";
     public static final String JOURNEY_TEMPORARILY_UNAVAILABLE_PATH =
             "/journey/temporarily-unavailable";
-    public static final String JOURNEY_MET_PATH = "/journey/met";
     public static final String JOURNEY_UNMET_PATH = "/journey/unmet";
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add not correlated event

### Why did it change

We check a users VCs to ensure the data withing is correlated. We do this in the evaluate-gpg45-scores lambda and the process-cri-callback lambdas. If the data wasn't correlated we would thrown a `/journey/pyi-no-match` event. This is the only place this event is used. We weren't handling it in the journey map on either of the required states.

This removes the old journey event and replaces it with something more descriptive.
