### PR TITLE
PYIC-4138: Adds dateCreated as sort index for VC table

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2410,15 +2410,18 @@ Resources:
           AttributeType: "S"
         - AttributeName: "credentialIssuer"
           AttributeType: "S"
-        - AttributeName: "dateCreated"
-          AttributeType: "S"
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
         - AttributeName: "credentialIssuer"
           KeyType: "RANGE"
-        - AttributeName: "dateCreated"
-          KeyType: "RANGE"
+      GlobalSecondaryIndexes:
+        - IndexName: "dateCreated"
+          KeySchema:
+            - AttributeName: "dateCreated"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: "ALL"
       TimeToLiveSpecification:
         AttributeName: "ttl"
         Enabled: !If

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2410,10 +2410,14 @@ Resources:
           AttributeType: "S"
         - AttributeName: "credentialIssuer"
           AttributeType: "S"
+        - AttributeName: "dateCreated"
+          AttributeType: "S"
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
         - AttributeName: "credentialIssuer"
+          KeyType: "RANGE"
+        - AttributeName: "dateCreated"
           KeyType: "RANGE"
       TimeToLiveSpecification:
         AttributeName: "ttl"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2410,6 +2410,8 @@ Resources:
           AttributeType: "S"
         - AttributeName: "credentialIssuer"
           AttributeType: "S"
+        - AttributeName: "dateCreated"
+          AttributeType: "S"
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2421,7 +2421,7 @@ Resources:
         - IndexName: "dateCreated"
           KeySchema:
             - AttributeName: "dateCreated"
-              KeyType: "HASH"
+              KeyType: "RANGE"
           Projection:
             ProjectionType: "ALL"
       TimeToLiveSpecification:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2420,6 +2420,8 @@ Resources:
       GlobalSecondaryIndexes:
         - IndexName: "dateCreated"
           KeySchema:
+            - AttributeName: "userId"
+              KeyType: "HASH"
             - AttributeName: "dateCreated"
               KeyType: "RANGE"
           Projection:


### PR DESCRIPTION
## Proposed changes

### What changed

Adds `AttributeDefinitions` & `KeySchema` to the `dateCreated` field on the VC table

### Why did it change

Allows quick filter of VCs by `dateCreated`

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4138](https://govukverify.atlassian.net/browse/PYIC-4138)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-4138]: https://govukverify.atlassian.net/browse/PYIC-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ