### PR TITLE
PYIC-3898: Add removal of TCIF VCs to top of check-existing-identity

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -91,7 +91,7 @@ public class CheckExistingIdentityHandler
             new JourneyResponse(JOURNEY_RESET_IDENTITY_PATH).toObjectMap();
     private static final JourneyResponse JOURNEY_FAIL_WITH_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
-    private static final String TCIF_CRI = "tcif";
+    private static final String TICF_CRI = "ticf";
     public static final String VOT_P2 = "P2";
 
     private final ConfigService configService;
@@ -163,8 +163,8 @@ public class CheckExistingIdentityHandler
                             ipvSessionItem.getClientOAuthSessionId());
             String userId = clientOAuthSessionItem.getUserId();
 
-            // Clear TCIF VCs
-            userIdentityService.deleteVcItem(userId, TCIF_CRI);
+            // Clear TICF VCs
+            verifiableCredentialService.deleteVcItem(userId, TICF_CRI);
 
             // Reset identity if reprove is true.
             Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -164,7 +164,7 @@ public class CheckExistingIdentityHandler
             String userId = clientOAuthSessionItem.getUserId();
 
             // Clear TICF VCs
-            verifiableCredentialService.deleteVcItem(userId, TICF_CRI);
+            verifiableCredentialService.deleteVcStoreItem(userId, TICF_CRI);
 
             // Reset identity if reprove is true.
             Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -91,6 +91,7 @@ public class CheckExistingIdentityHandler
             new JourneyResponse(JOURNEY_RESET_IDENTITY_PATH).toObjectMap();
     private static final JourneyResponse JOURNEY_FAIL_WITH_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
+    private static final String TCIF_CRI = "tcif";
     public static final String VOT_P2 = "P2";
 
     private final ConfigService configService;
@@ -161,6 +162,9 @@ public class CheckExistingIdentityHandler
                     clientOAuthSessionDetailsService.getClientOAuthSession(
                             ipvSessionItem.getClientOAuthSessionId());
             String userId = clientOAuthSessionItem.getUserId();
+
+            // Clear TCIF VCs
+            userIdentityService.deleteVcItem(userId, TCIF_CRI);
 
             // Reset identity if reprove is true.
             Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -183,7 +183,7 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
-        verify(mockVerifiableCredentialService).deleteVcItem(TEST_USER_ID, TICF_CRI);
+        verify(mockVerifiableCredentialService).deleteVcStoreItem(TEST_USER_ID, TICF_CRI);
         ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEvent.class);
         verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -98,6 +98,7 @@ class CheckExistingIdentityHandlerTest {
                     M1A_FRAUD_VC,
                     M1A_VERIFICATION_VC,
                     M1B_DCMAW_VC);
+    private static final String TCIF_CRI = "tcif";
     private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B);
@@ -182,6 +183,7 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
+        verify(userIdentityService).deleteVcItem(TEST_USER_ID, TCIF_CRI);
         ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEvent.class);
         verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -98,7 +98,7 @@ class CheckExistingIdentityHandlerTest {
                     M1A_FRAUD_VC,
                     M1A_VERIFICATION_VC,
                     M1B_DCMAW_VC);
-    private static final String TCIF_CRI = "tcif";
+    private static final String TICF_CRI = "ticf";
     private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
     private static final List<Gpg45Profile> ACCEPTED_PROFILES =
             List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B);
@@ -183,7 +183,7 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals(JOURNEY_REUSE, journeyResponse);
 
-        verify(userIdentityService).deleteVcItem(TEST_USER_ID, TCIF_CRI);
+        verify(mockVerifiableCredentialService).deleteVcItem(TEST_USER_ID, TICF_CRI);
         ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEvent.class);
         verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -118,10 +118,6 @@ public class UserIdentityService {
         return vcStoreItems.stream().map(VcStoreItem::getCredential).toList();
     }
 
-    public void deleteVcItem(String userId, String criId) {
-        dataStore.delete(userId, criId);
-    }
-
     public UserIdentity generateUserIdentity(
             String userId, String sub, String vot, ContraIndicators contraIndicators)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException,

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -118,6 +118,10 @@ public class UserIdentityService {
         return vcStoreItems.stream().map(VcStoreItem::getCredential).toList();
     }
 
+    public void deleteVcItem(String userId, String criId) {
+        dataStore.delete(userId, criId);
+    }
+
     public UserIdentity generateUserIdentity(
             String userId, String sub, String vot, ContraIndicators contraIndicators)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException,

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -102,11 +102,11 @@ public class VerifiableCredentialService {
             LOGGER.info(message);
         }
         for (VcStoreItem item : vcStoreItems) {
-            deleteVcItem(item.getUserId(), item.getCredentialIssuer());
+            deleteVcStoreItem(item.getUserId(), item.getCredentialIssuer());
         }
     }
 
-    public void deleteVcItem(String userId, String criId) {
+    public void deleteVcStoreItem(String userId, String criId) {
         dataStore.delete(userId, criId);
     }
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -102,7 +102,11 @@ public class VerifiableCredentialService {
             LOGGER.info(message);
         }
         for (VcStoreItem item : vcStoreItems) {
-            dataStore.delete(item.getUserId(), item.getCredentialIssuer());
+            deleteVcItem(item.getUserId(), item.getCredentialIssuer());
         }
+    }
+
+    public void deleteVcItem(String userId, String criId) {
+        dataStore.delete(userId, criId);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Add call to remove a user's ticf vcs at the start of the check-existing-identity lambda

### Why did it change

- Clearing the old TICF VC is crucial to prevent the accumulation of VCs each time a user reuses their identity. This ensures that IPV Core always works with the latest, most relevant fraud risk assessment information and maintains the integrity and accuracy of the user's identity verification status. 

### Issue tracking

- [PYIC-3898](https://govukverify.atlassian.net/browse/PYIC-3898)


[PYIC-3898]: https://govukverify.atlassian.net/browse/PYIC-3898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ