### PR TITLE
PYIC-4184: Added passportCri pact test token and credential issue

### DIFF
--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -37,8 +37,9 @@ public class DataStoreIpvSessionIT {
     private static final String IPV_SESSION_ID = "ipvSessionId";
     private static final String USER_STATE = "userState";
     private static final String CREATION_DATE_TIME = "creationDateTime";
-    private static final String CRI_OAUTH_SESSION_ID = SecureTokenHelper.generate();
-    private static final String CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String CRI_OAUTH_SESSION_ID = SecureTokenHelper.getInstance().generate();
+    private static final String CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
 
     private static List<String> createdItemIds = new ArrayList<>();
     private static final String INITIAL_IPV_JOURNEY_STATE = "INITIAL_IPV_JOURNEY";
@@ -105,7 +106,7 @@ public class DataStoreIpvSessionIT {
 
     private IpvSessionItem setUpIpvSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setUserState(INITIAL_IPV_JOURNEY_STATE);
         ipvSessionItem.setCreationDateTime(new Date().toString());
         ipvSessionItem.setCriOAuthSessionId(CRI_OAUTH_SESSION_ID);

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -55,7 +55,8 @@ import static org.mockito.Mockito.when;
 class BuildClientOauthResponseHandlerTest {
     private static final String TEST_SESSION_ID = "test-session-id";
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
-    private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
     public static final String TEST_FEATURE_SET = "fs-001";
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -356,7 +357,7 @@ class BuildClientOauthResponseHandlerTest {
 
     private IpvSessionItem generateIpvSessionItem() {
         IpvSessionItem item = new IpvSessionItem();
-        item.setIpvSessionId(SecureTokenHelper.generate());
+        item.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         item.setUserState("test-state");
         item.setCreationDateTime(new Date().toString());
         return item;
@@ -364,7 +365,7 @@ class BuildClientOauthResponseHandlerTest {
 
     private ClientOAuthSessionItem getClientOAuthSessionItem() {
         ClientOAuthSessionItem clientOAuthSessionItem = new ClientOAuthSessionItem();
-        clientOAuthSessionItem.setClientOAuthSessionId(SecureTokenHelper.generate());
+        clientOAuthSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
         clientOAuthSessionItem.setResponseType("code");
         clientOAuthSessionItem.setClientId("test-client-id");
         clientOAuthSessionItem.setRedirectUri("https://example.com");

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -190,7 +190,7 @@ public class BuildCriOauthRequestHandler
 
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
-            String oauthState = SecureTokenHelper.generate();
+            String oauthState = SecureTokenHelper.getInstance().generate();
             JWEObject jweObject =
                     signEncryptJar(
                             ipvSessionItem,

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -126,7 +126,8 @@ class BuildCriOauthRequestHandlerTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
     public static final String MAIN_CONNECTION = "main";
 
     @Mock private Context context;

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -77,7 +77,7 @@ class AuthorizationRequestHelperTest {
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String TEST_SHARED_CLAIMS = "shared_claims";
     private static final String TEST_EMAIL_ADDRESS = "test@hotmail.com";
-    private static final String OAUTH_STATE = SecureTokenHelper.generate();
+    private static final String OAUTH_STATE = SecureTokenHelper.getInstance().generate();
 
     private final SharedClaimsResponse sharedClaims =
             new SharedClaimsResponse(

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -55,7 +55,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
 
     private static final String SESSION_ID = "the-session-id";
     private static final String TEST_USER_ID = "test-user-id";
-    private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static final CredentialIssuerConfig ISSUER_CONFIG_ADDRESS =
             createCredentialIssuerConfig("https://review-a.integration.account.gov.uk");

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -69,11 +69,12 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_IND
 @ExtendWith(MockitoExtension.class)
 class BuildUserIdentityHandlerTest {
 
-    private static final String TEST_IPV_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_IPV_SESSION_ID = SecureTokenHelper.getInstance().generate();
     private static final String TEST_ACCESS_TOKEN = "test-access-token";
     private static final String VTM = "http://www.example.com/vtm";
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
-    private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
 
     @Mock private Context mockContext;
     @Mock private UserIdentityService mockUserIdentityService;

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -89,7 +89,8 @@ class CheckExistingIdentityHandlerTest {
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
     private static final String TEST_FEATURE_SET = "test-feature-set";
-    private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
     private static final String TEST_JOURNEY = "journey/check-existing-identity";
     private static final List<String> CREDENTIALS =
             List.of(

--- a/lambdas/check-gpg45-score/src/test/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandlerTest.java
+++ b/lambdas/check-gpg45-score/src/test/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandlerTest.java
@@ -52,7 +52,8 @@ class CheckGpg45ScoreHandlerTest {
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final JourneyResponse JOURNEY_MET = new JourneyResponse("/journey/met");
     private static final JourneyResponse JOURNEY_UNMET = new JourneyResponse("/journey/unmet");
-    private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
     private static final List<String> CREDENTIALS =
             List.of(
                     M1A_PASSPORT_VC,

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -87,7 +87,8 @@ class EvaluateGpg45ScoresHandlerTest {
     private static final JourneyResponse JOURNEY_MET = new JourneyResponse("/journey/met");
     private static final JourneyResponse JOURNEY_UNMET = new JourneyResponse("/journey/unmet");
     private static final String JOURNEY_VCS_NOT_CORRELATED = "/journey/vcs-not-correlated";
-    private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
     private static final ObjectMapper mapper = new ObjectMapper();
 
     static {

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -142,7 +142,7 @@ public class InitialiseIpvSessionHandler
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_VTR);
             }
 
-            String clientOAuthSessionId = SecureTokenHelper.generate();
+            String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
 
             IpvSessionItem ipvSessionItem =
                     ipvSessionService.generateIpvSession(clientOAuthSessionId, null, emailAddress);
@@ -194,7 +194,7 @@ public class InitialiseIpvSessionHandler
             LogHelper.logErrorMessage(
                     "Recoverable Jar validation failed.", e.getErrorObject().getDescription());
 
-            String clientOAuthSessionId = SecureTokenHelper.generate();
+            String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
 
             IpvSessionItem ipvSessionItem =
                     ipvSessionService.generateIpvSession(

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -174,8 +174,6 @@ public class InitialiseIpvSessionHandler
                             auditEventUser,
                             reproveAuditExtension);
 
-            LOGGER.warn("Audit Event: " + auditEvent.getExtensions());
-
             auditService.sendAuditEvent(auditEvent);
 
             Map<String, String> response =

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -70,7 +70,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
 class InitialiseIpvSessionHandlerTest {
 
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
-    public static final String CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    public static final String CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.getInstance().generate();
     @Mock private Context mockContext;
 
     @Mock private IpvSessionService mockIpvSessionService;
@@ -114,10 +114,10 @@ class InitialiseIpvSessionHandlerTest {
                         signedJWT);
 
         ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setClientOAuthSessionId(CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
 
         clientOAuthSessionItem = new ClientOAuthSessionItem();
         clientOAuthSessionItem.setClientOAuthSessionId(CLIENT_OAUTH_SESSION_ID);

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java
@@ -374,7 +374,7 @@ class IssueClientAccessTokenHandlerTest {
     private ClientOAuthSessionItem getClientOAuthSessionItem() {
         ClientOAuthSessionItem clientOAuthSessionItem =
                 ClientOAuthSessionItem.builder()
-                        .clientOAuthSessionId(SecureTokenHelper.generate())
+                        .clientOAuthSessionId(SecureTokenHelper.getInstance().generate())
                         .responseType("code")
                         .state("test-state")
                         .redirectUri("https://example.com/redirect")

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -26,8 +26,6 @@ dependencies {
 			project(":libs:user-identity-service"),
 			project(":libs:verifiable-credentials")
 
-	testImplementation 'junit:junit:4.13.1'
-
 	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
 			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
 	aspect('org.aspectj:aspectjrt') {

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
 			"org.mockito:mockito-junit-jupiter:5.8.0",
+			"au.com.dius.pact.consumer:junit5:4.6.3",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -29,6 +29,7 @@ import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
 import uk.gov.di.ipv.core.library.kmses256signer.KmsEs256Signer;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -52,6 +53,7 @@ import uk.gov.di.ipv.core.processcricallback.service.CriApiService;
 import uk.gov.di.ipv.core.processcricallback.service.CriCheckingService;
 
 import java.text.ParseException;
+import java.time.Clock;
 
 import static uk.gov.di.ipv.core.library.domain.CriConstants.DCMAW_CRI;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -113,7 +115,12 @@ public class ProcessCriCallbackHandler
         signer.setKeyId(configService.getSigningKeyId());
         VcHelper.setConfigService(configService);
 
-        criApiService = new CriApiService(configService, signer);
+        criApiService =
+                new CriApiService(
+                        configService,
+                        signer,
+                        SecureTokenHelper.getInstance(),
+                        Clock.systemDefaultZone());
         criCheckingService =
                 new CriCheckingService(
                         configService,

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java
@@ -38,6 +38,7 @@ import uk.gov.di.ipv.core.library.verifiablecredential.dto.VerifiableCredentialR
 import uk.gov.di.ipv.core.processcricallback.exception.CriApiException;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -54,11 +55,19 @@ public class CriApiService {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final ConfigService configService;
     private final JWSSigner signer;
+    private final SecureTokenHelper secureTokenHelper;
+    private final Clock clock;
 
     @ExcludeFromGeneratedCoverageReport
-    public CriApiService(ConfigService configService, JWSSigner signer) {
+    public CriApiService(
+            ConfigService configService,
+            JWSSigner signer,
+            SecureTokenHelper secureTokenHelper,
+            Clock clock) {
         this.configService = configService;
         this.signer = signer;
+        this.secureTokenHelper = secureTokenHelper;
+        this.clock = clock;
     }
 
     private String getApiKey(
@@ -75,7 +84,7 @@ public class CriApiService {
         var criConfig = configService.getCriConfig(criOAuthSessionItem);
 
         try {
-            var httpRequest = buildfetchAccessTokenRequest(callbackRequest, criOAuthSessionItem);
+            var httpRequest = buildFetchAccessTokenRequest(callbackRequest, criOAuthSessionItem);
             var httpResponse = httpRequest.send();
             var tokenResponse = TokenResponse.parse(httpResponse);
 
@@ -107,7 +116,7 @@ public class CriApiService {
         }
     }
 
-    public HTTPRequest buildfetchAccessTokenRequest(
+    public HTTPRequest buildFetchAccessTokenRequest(
             CriCallbackRequest callbackRequest, CriOAuthSessionItem criOAuthSessionItem)
             throws CriApiException {
         var criId = callbackRequest.getCredentialIssuerId();
@@ -117,7 +126,7 @@ public class CriApiService {
         var authorizationCode = new AuthorizationCode(authorisationCode);
 
         try {
-            var dateTime = OffsetDateTime.now();
+            var dateTime = OffsetDateTime.now(clock);
             var clientAuthClaims =
                     new ClientAuthClaims(
                             criConfig.getClientId(),
@@ -128,7 +137,7 @@ public class CriApiService {
                                                     configService.getSsmParameter(
                                                             ConfigurationVariable.JWT_TTL_SECONDS)))
                                     .toEpochSecond(),
-                            SecureTokenHelper.generate());
+                            secureTokenHelper.generate());
             var signedClientJwt = JwtHelper.createSignedJwtFromObject(clientAuthClaims, signer);
             var clientAuthentication = new PrivateKeyJWT(signedClientJwt);
             var redirectionUri = criConfig.getClientCallbackUrl();
@@ -170,6 +179,10 @@ public class CriApiService {
                 buildFetchVerifiableCredentialRequest(
                         accessToken, callbackRequest, criOAuthSessionItem);
 
+        LOGGER.warn(credentialRequest.toString());
+        LOGGER.warn(callbackRequest.toString());
+        LOGGER.warn(criId);
+
         try {
             var response = credentialRequest.send();
 
@@ -188,6 +201,8 @@ public class CriApiService {
                         HTTPResponse.SC_SERVER_ERROR,
                         ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
             }
+
+            LOGGER.warn(response.toString());
 
             var responseContentType = response.getHeaderValue(HttpHeaders.CONTENT_TYPE);
             if (ContentType.APPLICATION_JWT.matches(ContentType.parse(responseContentType))) {
@@ -234,6 +249,8 @@ public class CriApiService {
         var apiKey = getApiKey(criConfig, criOAuthSessionItem);
 
         var request = new HTTPRequest(HTTPRequest.Method.POST, criConfig.getCredentialUrl());
+
+        LOGGER.warn(criConfig.getCredentialUrl());
 
         if (apiKey != null) {
             LOGGER.info(

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java
@@ -179,10 +179,6 @@ public class CriApiService {
                 buildFetchVerifiableCredentialRequest(
                         accessToken, callbackRequest, criOAuthSessionItem);
 
-        LOGGER.warn(credentialRequest.toString());
-        LOGGER.warn(callbackRequest.toString());
-        LOGGER.warn(criId);
-
         try {
             var response = credentialRequest.send();
 
@@ -201,8 +197,6 @@ public class CriApiService {
                         HTTPResponse.SC_SERVER_ERROR,
                         ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
             }
-
-            LOGGER.warn(response.toString());
 
             var responseContentType = response.getHeaderValue(HttpHeaders.CONTENT_TYPE);
             if (ContentType.APPLICATION_JWT.matches(ContentType.parse(responseContentType))) {
@@ -249,8 +243,6 @@ public class CriApiService {
         var apiKey = getApiKey(criConfig, criOAuthSessionItem);
 
         var request = new HTTPRequest(HTTPRequest.Method.POST, criConfig.getCredentialUrl());
-
-        LOGGER.warn(criConfig.getCredentialUrl());
 
         if (apiKey != null) {
             LOGGER.info(

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
@@ -102,12 +102,9 @@ public class ContractTest {
     @Pact(provider = "PassportCriProvider", consumer = "IpvCoreBack")
     public RequestResponsePact validRequestReturnsIssuedCredential(PactDslWithProvider builder)
             throws Exception {
-        return builder.given("dummyAuthCode is a valid authorization code")
-                .given("dummyApiKey is a valid api key")
-                .given("dummyPassportComponentId is the passport CRI component ID")
-                .given(
-                        "Passport CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
-                .uponReceiving("Valid auth code")
+        return builder.given("dummyApiKey is a valid api key")
+                .given("dummyAccessToken is a valid access token")
+                .uponReceiving("Valid POST request")
                 .path("/credential")
                 .method("POST")
                 .headers("x-api-key", PRIVATE_API_KEY, "Authorization", "Bearer dummyAccessToken")

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
@@ -1,0 +1,160 @@
+package uk.gov.di.ipv.core.processcricallback.pact.passportCri;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
+import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.processcricallback.exception.CriApiException;
+import uk.gov.di.ipv.core.processcricallback.service.CriApiService;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Set;
+
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@Disabled("PACT tests should not be run in build pipelines at this time")
+@ExtendWith(PactConsumerTestExt.class)
+@ExtendWith(MockitoExtension.class)
+@PactTestFor(providerName = "PassportCriProvider")
+@MockServerConfig(hostInterface = "localhost", port = "1234")
+public class ContractTest {
+
+    public static final String IPV_CORE_CLIENT_ID = "ipv-core";
+    public static final String PRIVATE_API_KEY = "dummyApiKey";
+    public static final String CRI_SIGNING_PRIVATE_KEY_JWK =
+            "{\"kty\":\"EC\",\"d\":\"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
+    public static final String CRI_RSA_ENCRYPTION_PUBLIC_JWK =
+            "{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}";
+    @Mock private ConfigService mockConfigService;
+    @Mock private JWSSigner mockSigner;
+    @Mock private SecureTokenHelper mockSecureTokenHelper;
+
+    @Pact(provider = "PassportCriProvider", consumer = "IpvCoreBack")
+    public RequestResponsePact validRequestReturnsValidAccessToken(PactDslWithProvider builder) {
+        return builder.given("dummyAuthCode is a valid authorization code")
+                .given("dummyApiKey is a valid api key")
+                .given("dummyPassportComponentId is the passport CRI component ID")
+                .given(
+                        "Passport CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
+                .uponReceiving("Valid auth code")
+                .path("/token")
+                .method("POST")
+                .body(
+                        "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3DukPassport&client_assertion=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJpcHYtY29yZSIsInN1YiI6Imlwdi1jb3JlIiwiYXVkIjoiZHVtbXlQYXNzcG9ydENvbXBvbmVudElkIiwiZXhwIjo0MDcwOTA5NzAwLCJqdGkiOiJTY25GNGRHWHRoWllYU181azg1T2JFb1NVMDRXLUgzcWFfcDZucHYyWlVZIn0.hXYrKJ_W9YItUbZxu3T63gQgScVoSMqHZ43UPfdB8im8L4d0mZPLC6BlwMJSsfjiAyU1y3c37vm-rV8kZo2uyw")
+                .headers(
+                        "x-api-key",
+                        PRIVATE_API_KEY,
+                        "Content-Type",
+                        "application/x-www-form-urlencoded; charset=UTF-8")
+                .willRespondWith()
+                .status(200)
+                .body(
+                        newJsonBody(
+                                        (body) -> {
+                                            body.stringType("access_token");
+                                            body.stringValue("token_type", "Bearer");
+                                            body.integerType("expires_in");
+                                        })
+                                .build())
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "validRequestReturnsValidAccessToken")
+    void testCallToDummyPassportCri(MockServer mockServer)
+            throws URISyntaxException, JOSEException, CriApiException {
+        // Arrange
+        var credentialIssuerConfig =
+                new CredentialIssuerConfig(
+                        new URI("http://localhost:" + mockServer.getPort() + "/token"),
+                        new URI("http://localhost:" + mockServer.getPort() + "/credential"),
+                        new URI("http://localhost:" + mockServer.getPort() + "/authorize"),
+                        IPV_CORE_CLIENT_ID,
+                        CRI_SIGNING_PRIVATE_KEY_JWK,
+                        CRI_RSA_ENCRYPTION_PUBLIC_JWK,
+                        "dummyPassportComponentId",
+                        URI.create(
+                                "https://identity.staging.account.gov.uk/credential-issuer/callback?id=ukPassport"),
+                        true,
+                        false);
+
+        when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
+                .thenReturn("900");
+        when(mockConfigService.getCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
+
+        // Signature generated by jwt.io by debugging the test and getting the client assertion JWT
+        // generated by the test as mocking out the AWSKMS class inside the real signer would be
+        // painful.
+        when(mockSigner.sign(any(), any()))
+                .thenReturn(
+                        new Base64URL(
+                                "hXYrKJ_W9YItUbZxu3T63gQgScVoSMqHZ43UPfdB8im8L4d0mZPLC6BlwMJSsfjiAyU1y3c37vm-rV8kZo2uyw"));
+        when(mockSigner.supportedJWSAlgorithms()).thenReturn(Set.of(JWSAlgorithm.ES256));
+        when(mockSecureTokenHelper.generate())
+                .thenReturn("ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY");
+
+        // We need to generate a fixed request, so we set the secure token and expiry to constant
+        // values.
+        var underTest =
+                new CriApiService(
+                        mockConfigService,
+                        mockSigner,
+                        mockSecureTokenHelper,
+                        Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC));
+
+        // Act
+        BearerAccessToken accessToken =
+                underTest.fetchAccessToken(
+                        new CriCallbackRequest(
+                                "dummyAuthCode",
+                                credentialIssuerConfig.getClientId(),
+                                "dummySessionId",
+                                "https://identity.staging.account.gov.uk/credential-issuer/callback?id=ukPassport",
+                                "dummyState",
+                                null,
+                                null,
+                                "dummyIpAddress",
+                                "dummyFeatureSet"),
+                        new CriOAuthSessionItem(
+                                "dummySessionId",
+                                "dummyOAuthSessionId",
+                                "dummyCriId",
+                                "dummyConnection",
+                                900));
+        // Assert
+        assertThat(accessToken.getType(), is(AccessTokenType.BEARER));
+        assertThat(accessToken.getValue(), notNullValue());
+        assertThat(accessToken.getLifetime(), greaterThan(0L));
+    }
+}

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
@@ -110,6 +110,8 @@ public class ContractTest {
             throws Exception {
         return builder.given("dummyApiKey is a valid api key")
                 .given("dummyAccessToken is a valid access token")
+                .given("test-subject is a valid subject")
+                .given("dummyPassportComponentId is a valid issuer" )
                 .given("VC givenName is Mary")
                 .given("VC familyName is Watson")
                 .given("VC birthDate is 1932-02-25")

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
@@ -111,7 +111,7 @@ public class ContractTest {
         return builder.given("dummyApiKey is a valid api key")
                 .given("dummyAccessToken is a valid access token")
                 .given("test-subject is a valid subject")
-                .given("dummyPassportComponentId is a valid issuer" )
+                .given("dummyPassportComponentId is a valid issuer")
                 .given("VC givenName is Mary")
                 .given("VC familyName is Watson")
                 .given("VC birthDate is 1932-02-25")

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -195,10 +195,10 @@ class ProcessJourneyEventHandlerTest {
                 Map.of(JOURNEY, ProcessJourneyStepEvents.JOURNEY_NEXT, IPV_SESSION_ID, "1234");
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(ProcessJourneyStepStates.CORE_SESSION_TIMEOUT_STATE);
-        ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setJourneyType(IPV_CORE_MAIN_JOURNEY);
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
@@ -292,10 +292,10 @@ class ProcessJourneyEventHandlerTest {
 
     private void mockIpvSessionItemAndTimeout(String userState) {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setUserState(userState);
-        ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setJourneyType(IPV_CORE_MAIN_JOURNEY);
 
         when(mockConfigService.getSsmParameter(COMPONENT_ID)).thenReturn("core");
@@ -307,7 +307,7 @@ class ProcessJourneyEventHandlerTest {
 
     private ClientOAuthSessionItem getClientOAuthSessionItem() {
         return ClientOAuthSessionItem.builder()
-                .clientOAuthSessionId(SecureTokenHelper.generate())
+                .clientOAuthSessionId(SecureTokenHelper.getInstance().generate())
                 .responseType("code")
                 .state("teststate")
                 .redirectUri("https://example.com/redirect")

--- a/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
+++ b/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
@@ -38,7 +38,8 @@ public class ResetIdentityHandlerTest {
     private static final String TEST_SESSION_ID = "test-session-id";
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_JOURNEY_ID = "test-journey-id";
-    private static final String TEST_CLIENT_OAUTH_SESSION_ID = SecureTokenHelper.generate();
+    private static final String TEST_CLIENT_OAUTH_SESSION_ID =
+            SecureTokenHelper.getInstance().generate();
     private static final String TEST_CLIENT_SOURCE_IP = "test-client-source-ip";
     private static final String TEST_FEATURE_SET = "test-feature-set";
     private static final String TEST_JOURNEY = "journey/reset-identity";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/SecureTokenHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/SecureTokenHelper.java
@@ -1,22 +1,20 @@
 package uk.gov.di.ipv.core.library.helpers;
 
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import lombok.Getter;
 
 import java.security.SecureRandom;
 import java.util.Base64;
 
 public class SecureTokenHelper {
-
-    @ExcludeFromGeneratedCoverageReport
-    private SecureTokenHelper() {
-        throw new IllegalStateException("Utility class");
-    }
+    private SecureTokenHelper() {}
 
     private static final int BYTES_OF_ENTROPY = 32;
     private static final SecureRandom random = new SecureRandom();
     private static final Base64.Encoder b64Encoder = Base64.getUrlEncoder().withoutPadding();
 
-    public static String generate() {
+    @Getter private static final SecureTokenHelper instance = new SecureTokenHelper();
+
+    public String generate() {
         // Returns a B64 encoded random string with 256 bits of entropy
         // For example: ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY
         byte[] buffer = new byte[BYTES_OF_ENTROPY];

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -95,7 +95,7 @@ public class IpvSessionService {
             String clientOAuthSessionId, ErrorObject errorObject, String emailAddress) {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setClientOAuthSessionId(clientOAuthSessionId);
         LogHelper.attachIpvSessionIdToLogs(ipvSessionItem.getIpvSessionId());
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java
@@ -243,6 +243,23 @@ public interface TestFixtures {
                                     "addressCountry", "GB",
                                     "validFrom", "2018-06-23")));
 
+    Map<String, Object> PASSPORT_CREDENTIAL_ATTRIBUTES =
+            Map.of(
+                    "name",
+                    List.of(
+                            Map.of(
+                                    "nameParts",
+                                    List.of(
+                                            Map.of("value", "Mary", "type", "GivenName"),
+                                            Map.of("value", "Watson", "type", "FamilyName")))),
+                    "birthDate",
+                    List.of(Map.of("value", "1932-02-25")),
+                    "passport",
+                    List.of(
+                            Map.of(
+                                    "documentNumber", "824159121",
+                                    "expiryDate", "2030-01-01")));
+
     String ADDRESS_JSON_1 =
             "{\"buildingNumber\":10,\"streetName\":\"DowningStreet\",\"dependentAddressLocality\":\"Westminster\",\"addressLocality\":\"London\",\"postalCode\":\"SW1A2AA\",\"addressCountry\":\"GB\",\"validFrom\":\"2019-07-24\"}";
     String ADDRESS_JSON_2 =

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/SecureTokenHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/SecureTokenHelperTest.java
@@ -12,7 +12,7 @@ class SecureTokenHelperTest {
 
     @Test
     void generateShouldGiveAB64StringOfKnownLength() {
-        String token = SecureTokenHelper.generate();
+        String token = SecureTokenHelper.getInstance().generate();
 
         byte[] bytes = assertDoesNotThrow(() -> Base64.getUrlDecoder().decode(token));
         assertEquals(BYTES_OF_ENTROPY, bytes.length);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
@@ -31,7 +31,7 @@ class ClientOAuthSessionDetailsServiceTest {
 
     @Test
     void shouldReturnClientOAuthSessionItem() {
-        String clientOAuthSessionId = SecureTokenHelper.generate();
+        String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
 
         ClientOAuthSessionItem clientOAuthSessionItem = new ClientOAuthSessionItem();
         clientOAuthSessionItem.setClientOAuthSessionId(clientOAuthSessionId);
@@ -64,7 +64,7 @@ class ClientOAuthSessionDetailsServiceTest {
 
     @Test
     void shouldCreateClientOAuthSessionItem() throws ParseException {
-        String clientOAuthSessionId = SecureTokenHelper.generate();
+        String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
         JWTClaimsSet testClaimSet =
                 new JWTClaimsSet.Builder()
                         .claim("response_type", "test-type")
@@ -104,7 +104,7 @@ class ClientOAuthSessionDetailsServiceTest {
 
     @Test
     void shouldCreateSessionItemWithErrorObject() {
-        String clientOAuthSessionId = SecureTokenHelper.generate();
+        String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
         ClientOAuthSessionItem clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.generateErrorClientSessionDetails(
                         clientOAuthSessionId,

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -39,7 +39,7 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldReturnSessionItem() {
-        String ipvSessionID = SecureTokenHelper.generate();
+        String ipvSessionID = SecureTokenHelper.getInstance().generate();
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
@@ -60,7 +60,7 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldReturnSessionItemByAuthorizationCode() {
-        String ipvSessionID = SecureTokenHelper.generate();
+        String ipvSessionID = SecureTokenHelper.getInstance().generate();
         String authorizationCode = "12345";
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -77,7 +77,7 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldReturnSessionItemByAccessToken() {
-        String ipvSessionID = SecureTokenHelper.generate();
+        String ipvSessionID = SecureTokenHelper.getInstance().generate();
         String accessToken = "56789";
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -94,7 +94,7 @@ class IpvSessionServiceTest {
 
     @Test
     void shouldRetryGettingSessionItemByAccessToken() {
-        String ipvSessionID = SecureTokenHelper.generate();
+        String ipvSessionID = SecureTokenHelper.getInstance().generate();
         String accessToken = "56789";
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -114,7 +114,8 @@ class IpvSessionServiceTest {
         when(mockConfigService.getSsmParameter(ConfigurationVariable.JOURNEY_TYPE))
                 .thenReturn("IPV_CORE_MAIN_JOURNEY");
         IpvSessionItem ipvSessionItem =
-                ipvSessionService.generateIpvSession(SecureTokenHelper.generate(), null, null);
+                ipvSessionService.generateIpvSession(
+                        SecureTokenHelper.getInstance().generate(), null, null);
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -136,7 +137,7 @@ class IpvSessionServiceTest {
                 .thenReturn("IPV_CORE_MAIN_JOURNEY");
         IpvSessionItem ipvSessionItem =
                 ipvSessionService.generateIpvSession(
-                        SecureTokenHelper.generate(), null, "test@test.com");
+                        SecureTokenHelper.getInstance().generate(), null, "test@test.com");
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -160,7 +161,7 @@ class IpvSessionServiceTest {
         ErrorObject testErrorObject = new ErrorObject("server_error", "Test error");
         IpvSessionItem ipvSessionItem =
                 ipvSessionService.generateIpvSession(
-                        SecureTokenHelper.generate(), testErrorObject, null);
+                        SecureTokenHelper.getInstance().generate(), testErrorObject, null);
 
         ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(IpvSessionItem.class);
@@ -183,7 +184,7 @@ class IpvSessionServiceTest {
     @Test
     void shouldUpdateSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setUserState(INITIAL_IPV_JOURNEY_STATE);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -196,7 +197,7 @@ class IpvSessionServiceTest {
     void shouldSetAuthorizationCodeAndMetadataOnSessionItem() {
         AuthorizationCode testCode = new AuthorizationCode();
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setUserState(IPV_SUCCESS_PAGE_STATE);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -214,7 +215,7 @@ class IpvSessionServiceTest {
     void shouldSetAccessTokenAndMetadataOnSessionItem() {
         BearerAccessToken accessToken = new BearerAccessToken("test-access-token");
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setUserState(IPV_SUCCESS_PAGE_STATE);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -231,7 +232,7 @@ class IpvSessionServiceTest {
     void shouldRevokeAccessTokenOnSessionItem() {
         BearerAccessToken accessToken = new BearerAccessToken("test-access-token");
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.generate());
+        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setAccessToken(accessToken.getValue());
         ipvSessionItem.setAccessTokenMetadata(new AccessTokenMetadata());
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added pact test framework, as well as initial contract tests covering PassportCri - both token and credential issuer endpoint calls.

### Why did it change

So we can start building contract test coverage for points of integration between IPV Core and other services.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4184](https://govukverify.atlassian.net/browse/PYIC-4184)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-4184]: https://govukverify.atlassian.net/browse/PYIC-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ