### PR TITLE
INCIDENT-599: Stop parsing reprove identity claim

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsReproveIdentity.REPROVE_IDENTITY_KEY;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JAR_KMS_ENCRYPTION_KEY_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
@@ -160,7 +159,9 @@ public class InitialiseIpvSessionHandler
                             govukSigninJourneyId,
                             ipAddress);
 
-            String reproveIdentity = claimsSet.getStringClaim(REPROVE_IDENTITY_KEY);
+            //            Hardcoding to null to temporarily address INCIDENT-599
+            //            String reproveIdentity = claimsSet.getStringClaim(REPROVE_IDENTITY_KEY);
+            String reproveIdentity = null;
 
             AuditExtensionsReproveIdentity reproveAuditExtension =
                     reproveIdentity == null

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -104,6 +104,7 @@ class InitialiseIpvSessionHandlerTest {
                         .claim("state", "test-state")
                         .claim("client_id", "test-client")
                         .claim("vtr", List.of("Cl.Cm.P2", "Cl.Cm.PCL200"))
+                        .claim("reprove_identity", false)
                         .build();
 
         signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsSet);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Stop parsing reprove identity claim

### Why did it change

A change has been made in Orch that has meant that the value coming through is no longer a string - possibly a boolean.

This is causing the `getStringClaim()` method to throw. This has caused a P1 outage.

The change on orch side is being reverted - this change is a backup just in case to return functionality.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [INCIDENT-599](https://govukverify.atlassian.net/browse/INCIDENT-599)
