### PR TITLE
PYIC-4086: add delete pending identity journey map for f2f journey

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -402,6 +402,7 @@ PYI_F2F_DELETE_PAGE:
 PYI_F2F_CONFIRM_DELETE_DETAILS_PAGE:
   response:
     type: page
+    context: f2f
     pageId: pyi-confirm-delete-details
   events:
     next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -85,6 +85,9 @@ CHECK_EXISTING_IDENTITY:
           targetState: IPV_IDENTITY_REUSE_PAGE_TEST
     pending:
       targetState: IPV_IDENTITY_PENDING_PAGE
+      checkFeatureFlag:
+        deleteDetailsEnabled:
+          targetState: IPV_IDENTITY_PENDING_PAGE_TEST
     fail-with-ci:
       targetState: PYI_NO_MATCH
     f2f-fail:
@@ -112,13 +115,19 @@ IPV_IDENTITY_REUSE_PAGE:
     next:
       targetState: END
 
-IPV_IDENTITY_PENDING_PAGE:
+IPV_IDENTITY_PENDING_PAGE_TEST:
   response:
     type: page
+    context: f2f-delete-details
     pageId: page-ipv-pending
   events:
     next:
       targetState: PYI_F2F_DELETE_PAGE
+
+IPV_IDENTITY_PENDING_PAGE:
+  response:
+    type: page
+    pageId: page-ipv-pending
 
 IPV_IDENTITY_START_PAGE:
   response:
@@ -397,7 +406,7 @@ PYI_F2F_DELETE_PAGE:
         PYI_F2F_CONFIRM_DELETE_DETAILS_PAGE
     end:
       targetState:
-        IPV_IDENTITY_PENDING_PAGE
+        IPV_IDENTITY_PENDING_PAGE_TEST
 
 PYI_F2F_CONFIRM_DELETE_DETAILS_PAGE:
   response:
@@ -410,7 +419,7 @@ PYI_F2F_CONFIRM_DELETE_DETAILS_PAGE:
         RESET_IDENTITY_USER_INITIATED
     end:
       targetState:
-        IPV_IDENTITY_PENDING_PAGE
+        IPV_IDENTITY_PENDING_PAGE_TEST
 
 PYI_NEW_DETAILS_PAGE:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -420,7 +420,7 @@ PYI_F2F_CONFIRM_DELETE_DETAILS_PAGE:
   events:
     next:
       targetState:
-        RESET_IDENTITY_USER_INITIATED
+        RESET_IDENTITY_USER_INITIATED_F2F
     end:
       targetState:
         IPV_IDENTITY_PENDING_PAGE_TEST
@@ -460,6 +460,26 @@ RESET_IDENTITY_USER_INITIATED:
 PYI_DETAILS_DELETED_PAGE:
   response:
     type: page
+    pageId: pyi-details-deleted
+  events:
+    next:
+      targetState:
+        IPV_IDENTITY_START_PAGE
+
+RESET_IDENTITY_USER_INITIATED_F2F:
+  response:
+    type: process
+    lambda: reset-identity
+    lambdaInput:
+      isUserInitiated: true
+  events:
+    next:
+      targetState: PYI_DETAILS_DELETED_PAGE_F2F
+
+PYI_DETAILS_DELETED_PAGE_F2F:
+  response:
+    type: page
+    context: f2f
     pageId: pyi-details-deleted
   events:
     next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -116,6 +116,9 @@ IPV_IDENTITY_PENDING_PAGE:
   response:
     type: page
     pageId: page-ipv-pending
+  events:
+    next:
+      targetState: PYI_F2F_DELETE_PAGE
 
 IPV_IDENTITY_START_PAGE:
   response:
@@ -382,6 +385,31 @@ IPV_IDENTITY_REUSE_PAGE_TEST:
     next:
       targetState:
         PYI_NEW_DETAILS_PAGE
+
+PYI_F2F_DELETE_PAGE:
+  response:
+    type: page
+    pageId: pyi-f2f-delete-details
+    parent: END_JOURNEY
+  events:
+    next:
+      targetState:
+        PYI_CONFIRM_DELETE_DETAILS_PAGE
+    end:
+      targetState:
+        IPV_IDENTITY_PENDING_PAGE
+
+PYI_F2F_CONFIRM_DELETE_DETAILS_PAGE:
+  response:
+    type: page
+    pageId: pyi-confirm-delete-details
+  events:
+    next:
+      targetState:
+        RESET_IDENTITY_USER_INITIATED
+    end:
+      targetState:
+        IPV_IDENTITY_PENDING_PAGE
 
 PYI_NEW_DETAILS_PAGE:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -390,11 +390,11 @@ PYI_F2F_DELETE_PAGE:
   response:
     type: page
     pageId: pyi-f2f-delete-details
-    parent: END_JOURNEY
+  parent: END_JOURNEY
   events:
     next:
       targetState:
-        PYI_CONFIRM_DELETE_DETAILS_PAGE
+        PYI_F2F_CONFIRM_DELETE_DETAILS_PAGE
     end:
       targetState:
         IPV_IDENTITY_PENDING_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -115,6 +115,7 @@ IPV_IDENTITY_REUSE_PAGE:
     next:
       targetState: END
 
+# User initiated details delete for f2f journey. Hidden behind deleteDetailsEnabled feature flag.
 IPV_IDENTITY_PENDING_PAGE_TEST:
   response:
     type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -128,6 +128,9 @@ IPV_IDENTITY_PENDING_PAGE:
   response:
     type: page
     pageId: page-ipv-pending
+  events:
+    next:
+      targetState: END
 
 IPV_IDENTITY_START_PAGE:
   response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Add journey map for deleting pending f2f details.

### What changed

- Added new journey map for f2f delete details

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To allow user to delete their pending f2f identity verification and use another way to prove it.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4086](https://govukverify.atlassian.net/browse/PYIC-4086)


[PYIC-4086]: https://govukverify.atlassian.net/browse/PYIC-4086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ