### PR TITLE
PYIC-4252: use boolean instead of string to fetch reprove identity flag

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -160,7 +160,7 @@ public class InitialiseIpvSessionHandler
                             govukSigninJourneyId,
                             ipAddress);
 
-            String reproveIdentity = claimsSet.getStringClaim(REPROVE_IDENTITY_KEY);
+            Boolean reproveIdentity = claimsSet.getBooleanClaim(REPROVE_IDENTITY_KEY);
 
             AuditExtensionsReproveIdentity reproveAuditExtension =
                     reproveIdentity == null

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsReproveIdentity.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsReproveIdentity.java
@@ -15,7 +15,7 @@ public class AuditExtensionsReproveIdentity implements AuditExtensions {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final Boolean reproveIdentity;
 
-    public AuditExtensionsReproveIdentity(String reproveIdentity) {
-        this.reproveIdentity = Boolean.valueOf(reproveIdentity);
+    public AuditExtensionsReproveIdentity(Boolean reproveIdentity) {
+        this.reproveIdentity = reproveIdentity;
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -51,8 +51,7 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setGovukSigninJourneyId(
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
         clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
-        Boolean reproveIdentity =
-                Boolean.parseBoolean(claimsSet.getStringClaim("reprove_identity"));
+        Boolean reproveIdentity = claimsSet.getBooleanClaim("reprove_identity");
         clientOAuthSessionItem.setReproveIdentity(reproveIdentity);
 
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import java.text.ParseException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
@@ -41,6 +42,7 @@ class ClientOAuthSessionDetailsServiceTest {
         clientOAuthSessionItem.setState("test-state");
         clientOAuthSessionItem.setUserId("test-user-id");
         clientOAuthSessionItem.setGovukSigninJourneyId("test-journey-id");
+        clientOAuthSessionItem.setReproveIdentity(true);
 
         when(mockDataStore.getItem(clientOAuthSessionId)).thenReturn(clientOAuthSessionItem);
 
@@ -60,6 +62,7 @@ class ClientOAuthSessionDetailsServiceTest {
         assertEquals(clientOAuthSessionItem.getUserId(), result.getUserId());
         assertEquals(
                 clientOAuthSessionItem.getGovukSigninJourneyId(), result.getGovukSigninJourneyId());
+        assertEquals(clientOAuthSessionItem.getReproveIdentity(), result.getReproveIdentity());
     }
 
     @Test
@@ -71,6 +74,7 @@ class ClientOAuthSessionDetailsServiceTest {
                         .claim("redirect_uri", "http://example.com")
                         .claim("state", "test-state")
                         .claim("govuk_signin_journey_id", "test-journey-id")
+                        .claim("reprove_identity", false)
                         .subject("test-user-id")
                         .build();
         ClientOAuthSessionItem clientOAuthSessionItem =
@@ -100,6 +104,7 @@ class ClientOAuthSessionDetailsServiceTest {
         assertEquals(
                 clientOAuthSessionItem.getGovukSigninJourneyId(),
                 clientOAuthSessionItemArgumentCaptor.getValue().getGovukSigninJourneyId());
+        assertFalse(clientOAuthSessionItem.getReproveIdentity());
     }
 
     @Test
@@ -133,5 +138,6 @@ class ClientOAuthSessionDetailsServiceTest {
         assertEquals(
                 clientOAuthSessionItem.getGovukSigninJourneyId(),
                 clientOAuthSessionItemArgumentCaptor.getValue().getGovukSigninJourneyId());
+        assertNull(clientOAuthSessionItem.getReproveIdentity());
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Update reprove identity flag to boolean from String

### What changed

- Updated reprove identity flag to boolean from String

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To match with auth, fraud service claim.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4252](https://govukverify.atlassian.net/browse/PYIC-4252)


[PYIC-4252]: https://govukverify.atlassian.net/browse/PYIC-4252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ