### PR TITLE
PYIC-4033: Add mitigation route to HMRC_KBV

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -513,6 +513,22 @@ CRI_HMRC_KBV_J6:
     next:
       targetState: EVALUATE_GPG45_SCORES
     enhanced-verification:
+      targetState: MITIGATION_02_OPTIONS_WITH_F2F
+      checkIfDisabled:
+        f2f:
+          targetState: MITIGATION_02_OPTIONS
+
+CRI_HMRC_KBV_M2B:
+  response:
+    type: cri
+    criId: hmrcKbv
+  parent: CRI_STATE
+  events:
+    fail-with-no-ci:
+      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
       targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
       checkIfDisabled:
         f2f:
@@ -554,12 +570,12 @@ ADDRESS_AND_FRAUD_M2B:
   nestedJourney: ADDRESS_AND_FRAUD
   exitEvents:
     next:
-      targetState: CRI_HMRC_KBV_J6
+      targetState: CRI_HMRC_KBV_M2B
       checkIfDisabled:
         hmrcKbv:
           targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
     enhanced-verification:
-      targetState: CRI_HMRC_KBV_J6
+      targetState: CRI_HMRC_KBV_M2B
       checkIfDisabled:
         hmrcKbv:
           targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -513,7 +513,10 @@ CRI_HMRC_KBV_J6:
     next:
       targetState: EVALUATE_GPG45_SCORES
     enhanced-verification:
-      targetState: CRI_F2F
+      targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+      checkIfDisabled:
+        f2f:
+          targetState: MITIGATION_02_OPTIONS
 
 # No photo id journey (M2B)
 CRI_CLAIMED_IDENTITY_M2B:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -512,6 +512,8 @@ CRI_HMRC_KBV_J6:
       targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
     next:
       targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
+      targetState: CRI_F2F
 
 # No photo id journey (M2B)
 CRI_CLAIMED_IDENTITY_M2B:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add mitigation route to HMRC_KBV for V03 CI

### Why did it change

To provide users who have received a V03 CI an opportunity to mitigate their score, thus avoiding a 2-year bar from government services.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4033](https://govukverify.atlassian.net/browse/PYIC-4033)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-4033]: https://govukverify.atlassian.net/browse/PYIC-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ