### PR TITLE
BAU: Add TICF CRI stub to local running setup

### DIFF
--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 			project(":lambdas:build-cri-oauth-request"),
 			project(":lambdas:build-proven-user-identity-details"),
 			project(":lambdas:build-user-identity"),
+			project(":lambdas:call-ticf-cri"),
 			project(":lambdas:check-existing-identity"),
 			project(":lambdas:check-gpg45-score"),
 			project(":lambdas:evaluate-gpg45-scores"),

--- a/local-running/setConfigForLocalOrCloudRunning.py
+++ b/local-running/setConfigForLocalOrCloudRunning.py
@@ -28,6 +28,7 @@ def get_local_running_params(environment, dev_account):
         Param(f"/{environment}/core/credentialIssuers/nino/activeConnection", "local"),
         Param(f"/{environment}/core/credentialIssuers/hmrcKbv/activeConnection", "local"),
         Param(f"/{environment}/core/credentialIssuers/bav/activeConnection", "local"),
+        Param(f"/{environment}/core/credentialIssuers/ticf/activeConnection", "stub"),
 
         Param(f'/{environment}/core/credentialIssuers/dcmaw/connections/local', f'''{{
             "authorizeUrl":"http://localhost:3003/authorize",

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.ipv.core.buildclientoauthresponse.BuildClientOauthResponseHandl
 import uk.gov.di.ipv.core.buildcrioauthrequest.BuildCriOauthRequestHandler;
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.BuildProvenUserIdentityDetailsHandler;
 import uk.gov.di.ipv.core.builduseridentity.BuildUserIdentityHandler;
+import uk.gov.di.ipv.core.callticfcri.CallTicfCriHandler;
 import uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler;
 import uk.gov.di.ipv.core.checkgpg45score.CheckGpg45ScoreHandler;
 import uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler;
@@ -54,6 +55,7 @@ public class LambdaHandler {
     private EvaluateGpg45ScoresHandler evaluateGpg45ScoresHandler;
     private IssueClientAccessTokenHandler issueClientAccessTokenHandler;
     private BuildUserIdentityHandler buildUserIdentityHandler;
+    private CallTicfCriHandler callTicfCriHandler;
 
     public LambdaHandler() throws IOException {
         this.initialiseIpvSessionHandler = new InitialiseIpvSessionHandler();
@@ -68,6 +70,7 @@ public class LambdaHandler {
         this.evaluateGpg45ScoresHandler = new EvaluateGpg45ScoresHandler();
         this.issueClientAccessTokenHandler = new IssueClientAccessTokenHandler();
         this.buildUserIdentityHandler = new BuildUserIdentityHandler();
+        this.callTicfCriHandler = new CallTicfCriHandler();
     }
 
     private final Route initialiseSession =
@@ -148,6 +151,15 @@ public class LambdaHandler {
                                 buildProcessRequest(request, processJourneyEventOutput);
                         lambdaOutput =
                                 checkGpg45ScoreHandler.handleRequest(processRequest, EMPTY_CONTEXT);
+                        if (!lambdaOutput.containsKey(JOURNEY)) {
+                            return gson.toJson(lambdaOutput);
+                        }
+                        journey = (String) lambdaOutput.get(JOURNEY);
+                    } else if ("/journey/call-ticf-cri".equals(journey)) {
+                        ProcessRequest processRequest =
+                                buildProcessRequest(request, processJourneyEventOutput);
+                        lambdaOutput =
+                                callTicfCriHandler.handleRequest(processRequest, EMPTY_CONTEXT);
                         if (!lambdaOutput.containsKey(JOURNEY)) {
                             return gson.toJson(lambdaOutput);
                         }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add TICF CRI stub to local running setup

### Why did it change

As the TICF CRI is not OAuth based (and so no callbacks to worry about), we can just use the deployed stub when running locally, rather than running it as another container like the other stubs.
