### PR TITLE
PYIC-4141: Update journey map to use new URLs and to include contexts

### DIFF
--- a/journey-map/package-lock.json
+++ b/journey-map/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "express": "4.18.2",
-        "yaml": "2.3.2"
+        "express": "4.18.2"
       }
     },
     "node_modules/accepts": {
@@ -649,14 +648,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
-      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
-      "engines": {
-        "node": ">= 14"
       }
     }
   }

--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -123,7 +123,10 @@ const setupMermaidClickHandlers = () => {
         if (def.pageId) {
             const link = document.createElement('a');
             link.innerText = 'Click here to view the page in build';
-            link.href = `https://identity.build.account.gov.uk/ipv/page/${encodeURIComponent(def.pageId)}?preview=true&lng=en`;
+            link.href = `https://identity.build.account.gov.uk/dev/template/${encodeURIComponent(def.pageId)}/en`;
+            if (def.context) {
+                link.href += `?context=${def.context}`
+            }
             link.target = '_blank';
             nodeDesc.append(link);
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated the journey map to use the new URLs that will go live on core-front when https://github.com/govuk-one-login/ipv-core-front/pull/1207 is merged.

Also added contexts to the urls in the new format.

### Why did it change

So that the journey map URLs keep working and show the right version of pages that use contexts

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4141](https://govukverify.atlassian.net/browse/PYIC-4141)




[PYIC-4141]: https://govukverify.atlassian.net/browse/PYIC-4141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ