### PR TITLE
BAU: Track VC received for TICF CRI

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -301,7 +301,9 @@ public class ProcessCriCallbackHandler
                     callbackRequest.getIpAddress(),
                     callbackRequest.getIpvSessionId(),
                     vcResponse.getVerifiableCredentials(),
-                    clientOAuthSessionItem);
+                    clientOAuthSessionItem,
+                    ipvSessionItem);
+            ipvSessionService.updateIpvSession(ipvSessionItem);
         }
 
         return criCheckingService.checkVcResponse(

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -317,8 +317,6 @@ CALL_TICF_CRI:
   response:
     type: process
     lambda: call-ticf-cri
-    lambdaInput:
-      journeyType: main
   events:
     next:
       targetState: IPV_SUCCESS_PAGE
@@ -331,8 +329,6 @@ CALL_TICF_CRI_ON_REUSE:
   response:
     type: process
     lambda: call-ticf-cri
-    lambdaInput:
-      journeyType: reuse
   events:
     next:
       targetState: IPV_IDENTITY_REUSE_PAGE

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -76,8 +76,7 @@ public enum ErrorResponse {
     MISSING_VTR(1064, "The 'vtr' claim is required and was not provided in the request."),
     NO_IPV_FOR_CRI_OAUTH_SESSION(1065, "No ipvSession for existing CriOAuthSession."),
     FAILED_TO_PARSE_CRI_CALLBACK_REQUEST(1066, "Failed to parse cri callback request."),
-    ERROR_PROCESSING_TICF_CRI_RESPONSE(1067, "Error processing response from the TICF CRI"),
-    MISSING_JOURNEY_TYPE(1068, "Missing journey type in request");
+    ERROR_PROCESSING_TICF_CRI_RESPONSE(1067, "Error processing response from the TICF CRI");
 
     @JsonProperty("code")
     private final int code;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -134,12 +134,6 @@ public class RequestHelper {
                 request, "scoreThreshold", ErrorResponse.MISSING_SCORE_THRESHOLD, Integer.class);
     }
 
-    public static String getJourneyType(ProcessRequest request)
-            throws HttpResponseExceptionWithErrorBody {
-        return extractValueFromLambdaInput(
-                request, "journeyType", ErrorResponse.MISSING_JOURNEY_TYPE, String.class);
-    }
-
     public static Boolean getIsUserInitiated(ProcessRequest request)
             throws HttpResponseExceptionWithErrorBody {
         return extractValueFromLambdaInput(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -35,6 +35,7 @@ public class IpvSessionItem implements DynamodbItem {
     // Only for passing the featureSet to the external API lambdas at the end of the user journey.
     // Not for general use.
     private String featureSet;
+    private List<String> vcReceivedThisSession;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Track VC received for TICF CRI

### Why did it change

When calling the TICF CRI, what we're actually interested in sending is all the VCs received so far this session. We've modelled this as a reuse/other journey so far, with a reuse journey not sending any VCs, and anything else sending all of them.

Due to how the journey map works and how many places we need to update to integrate the TICF CRI into all journeys it's very fiddly to get this right and not make a mistake.

This is an attempt to alleviate having to think about that. This is a speculative, untested, not even deployed stab at tracking the VCs received in the users session, and then using that to inform which VCs are sent to TICF.
