### PR TITLE
BAU: Turn off xray logging in local running

### DIFF
--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
+			"org.apache.logging.log4j:log4j-1.2-api:2.22.0",
 			"org.apache.logging.log4j:log4j-api:2.22.0",
 			"org.apache.logging.log4j:log4j-core:2.22.0",
 			project(":lambdas:build-client-oauth-response"),

--- a/local-running/src/main/resources/log4j2.json
+++ b/local-running/src/main/resources/log4j2.json
@@ -16,6 +16,10 @@
         "AppenderRef": {
           "ref": "STDOUT"
         }
+      },
+      "Logger": {
+        "level": "off",
+        "name": "com.amazonaws.xray.contexts.LambdaSegmentContext"
       }
     }
   }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Turn off xray logging in local running

### Why did it change

When using the local running setup X-RAY tracing doesn't work, due to not passing around the correct HTTP headers. We don't really need it to work when running in this environment anyway.

There is no global way to "switch-off" x-ray without removing all the code and the library which isn't practical.

This results in a LOT of annoying log messages from core-back when running locally.

We can just turn off the logger for the x-ray class which is responsible for emitting these messages. Unfortunately x-ray uses log4j 1.2, even though it's been deprecated since 2015. As we're using log4j 2.x, x-rays loggers were falling back to using the default java logger and as such our log4j config file was having no effect on the annoying log messages.

The solution is to include the log4j bridging lib, which allows 3rd part libs using the 1.2 API to work with a 2.x set up.
