### PR TITLE
BAU: Remove DDB TTL from UserIssuedCredentialsV2Table

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2315,12 +2315,6 @@ Resources:
           KeyType: "HASH"
         - AttributeName: "credentialIssuer"
           KeyType: "RANGE"
-      TimeToLiveSpecification:
-        AttributeName: "ttl"
-        Enabled: !If
-          - IsProduction
-          - true #false set to true until user privacy notice is updated
-          - true
       SSESpecification:
         SSEEnabled: true
         SSEType: KMS

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -65,6 +65,10 @@ public class DataStore<T extends DynamodbItem> {
                 Instant.now()
                         .plusSeconds(Long.parseLong(configService.getSsmParameter(tableTtl)))
                         .getEpochSecond());
+        create(item);
+    }
+
+    public void create(T item) {
         table.putItem(item);
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/VcStoreItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/VcStoreItem.java
@@ -24,7 +24,6 @@ public class VcStoreItem implements DynamodbItem {
     private String credential;
     private Instant dateCreated;
     private Instant expirationTime;
-    private long ttl;
 
     @DynamoDbPartitionKey
     public String getUserId() {
@@ -34,5 +33,10 @@ public class VcStoreItem implements DynamodbItem {
     @DynamoDbSortKey
     public String getCredentialIssuer() {
         return credentialIssuer;
+    }
+
+    @Override
+    public void setTtl(long ttl) {
+        throw new UnsupportedOperationException("VC store items do not use TTL");
     }
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -51,7 +50,7 @@ public class VerifiableCredentialService {
             throws VerifiableCredentialException {
         try {
             VcStoreItem vcStoreItem = createVcStoreItem(credential, credentialIssuerId, userId);
-            dataStore.create(vcStoreItem, ConfigurationVariable.VC_TTL);
+            dataStore.create(vcStoreItem);
         } catch (Exception e) {
             LOGGER.error("Error persisting user credential: {}", e.getMessage(), e);
             throw new VerifiableCredentialException(

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
@@ -30,18 +30,15 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.VC_TTL;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.FRAUD_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
@@ -73,7 +70,7 @@ class VerifiableCredentialServiceTest {
 
         verifiableCredentialService.persistUserCredentials(
                 SignedJWT.parse(VC_PASSPORT_NON_DCMAW_SUCCESSFUL), credentialIssuerId, userId);
-        verify(mockDataStore).create(userIssuedCredentialsItemCaptor.capture(), eq(VC_TTL));
+        verify(mockDataStore).create(userIssuedCredentialsItemCaptor.capture());
         VcStoreItem vcStoreItem = userIssuedCredentialsItemCaptor.getValue();
         assertEquals(userId, vcStoreItem.getUserId());
         assertEquals(credentialIssuerId, vcStoreItem.getCredentialIssuer());
@@ -100,14 +97,13 @@ class VerifiableCredentialServiceTest {
 
         verifiableCredentialService.persistUserCredentials(signedJwt, credentialIssuerId, userId);
 
-        verify(mockDataStore).create(userIssuedCredentialsItemCaptor.capture(), eq(VC_TTL));
+        verify(mockDataStore).create(userIssuedCredentialsItemCaptor.capture());
         VcStoreItem vcStoreItem = userIssuedCredentialsItemCaptor.getValue();
 
         assertNull(vcStoreItem.getExpirationTime());
         assertEquals(userId, vcStoreItem.getUserId());
         assertEquals(credentialIssuerId, vcStoreItem.getCredentialIssuer());
         assertEquals(signedJwt.serialize(), vcStoreItem.getCredential());
-        verify(mockDataStore, Mockito.times(1)).create(any(), any());
     }
 
     @Test


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove DDB TTL from UserIssuedCredentialsV2Table

### Why did it change

This removes the config from the SAM template that enables the DynamoDB TTL feature for the UserIssuedCredentialsV2Table table. This will have the effect of no more VCs being removed automatically from the table once the timestamp in the ttl attribute of the record has been reached.

It also removes the writing of the ttl timestamp for any future VCs stored in the table as this is no longer required.
