### PR TITLE
PYIC-4335: Clean up VC_TTL config var

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -15,7 +15,6 @@ public enum ConfigurationVariable {
     CLIENT_VALID_REDIRECT_URLS("clients/%s/validRedirectUrls"),
     CI_CONFIG("self/ci-config"),
     CI_SCORING_THRESHOLD("self/ciScoringThreshold"),
-    VC_TTL("self/vcTtl"),
     CREDENTIAL_ISSUERS("credentialIssuers"),
     FEATURE_FLAGS("featureFlags/%s"),
     CRI_RESPONSE_TTL("self/criResponseTtl"),


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Clean up VC_TTL config var

### Why did it change

We no longer use TTL for the VC store and this config var is redundant.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4335](https://govukverify.atlassian.net/browse/PYIC-4335)


[PYIC-4335]: https://govukverify.atlassian.net/browse/PYIC-4335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ