### PR TITLE
PYIC-4331: Track VCs to submit to TICF

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -138,8 +138,7 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet",
-        "lambdaInput.$": "$.lambdaInput"
+        "featureSet.$": "$$.Execution.Input.featureSet"
       },
       "Next": "ProcessNextJourney"
     },

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -306,9 +306,10 @@ public class ProcessCriCallbackHandler
             criStoringService.storeVcs(
                     callbackRequest.getCredentialIssuerId(),
                     callbackRequest.getIpAddress(),
-                    callbackRequest.getIpvSessionId(),
                     vcResponse.getVerifiableCredentials(),
-                    clientOAuthSessionItem);
+                    clientOAuthSessionItem,
+                    ipvSessionItem);
+            ipvSessionService.updateIpvSession(ipvSessionItem);
         }
 
         return criCheckingService.checkVcResponse(

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
@@ -118,9 +118,9 @@ public class ProcessCriCallbackHandlerTest {
                 .storeVcs(
                         callbackRequest.getCredentialIssuerId(),
                         callbackRequest.getIpAddress(),
-                        callbackRequest.getIpvSessionId(),
                         vcResponse.getVerifiableCredentials(),
-                        clientOAuthSessionItem);
+                        clientOAuthSessionItem,
+                        ipvSessionItem);
     }
 
     @Test

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -333,8 +333,6 @@ CALL_TICF_CRI:
   response:
     type: process
     lambda: call-ticf-cri
-    lambdaInput:
-      journeyType: main
   events:
     next:
       targetState: IPV_SUCCESS_PAGE
@@ -347,8 +345,6 @@ CALL_TICF_CRI_ON_REUSE:
   response:
     type: process
     lambda: call-ticf-cri
-    lambdaInput:
-      journeyType: reuse
   events:
     next:
       targetState: IPV_IDENTITY_REUSE_PAGE

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -76,8 +76,7 @@ public enum ErrorResponse {
     MISSING_VTR(1064, "The 'vtr' claim is required and was not provided in the request."),
     NO_IPV_FOR_CRI_OAUTH_SESSION(1065, "No ipvSession for existing CriOAuthSession."),
     FAILED_TO_PARSE_CRI_CALLBACK_REQUEST(1066, "Failed to parse cri callback request."),
-    ERROR_PROCESSING_TICF_CRI_RESPONSE(1067, "Error processing response from the TICF CRI"),
-    MISSING_JOURNEY_TYPE(1068, "Missing journey type in request");
+    ERROR_PROCESSING_TICF_CRI_RESPONSE(1067, "Error processing response from the TICF CRI");
 
     @JsonProperty("code")
     private final int code;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -135,12 +135,6 @@ public class RequestHelper {
                 request, "scoreThreshold", ErrorResponse.MISSING_SCORE_THRESHOLD, Integer.class);
     }
 
-    public static String getJourneyType(ProcessRequest request)
-            throws HttpResponseExceptionWithErrorBody {
-        return extractValueFromLambdaInput(
-                request, "journeyType", ErrorResponse.MISSING_JOURNEY_TYPE, String.class);
-    }
-
     public static Boolean getIsUserInitiated(ProcessRequest request)
             throws HttpResponseExceptionWithErrorBody {
         return extractValueFromLambdaInput(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -35,6 +35,7 @@ public class IpvSessionItem implements DynamodbItem {
     // Only for passing the featureSet to the external API lambdas at the end of the user journey.
     // Not for general use.
     private String featureSet;
+    private List<String> vcReceivedThisSession;
 
     @DynamoDbPartitionKey
     public String getIpvSessionId() {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -322,28 +322,4 @@ class RequestHelperTest {
                 ErrorResponse.MISSING_SCORE_THRESHOLD.getMessage(),
                 exception.getErrorResponse().getMessage());
     }
-
-    @Test
-    void getJourneyTypeShouldReturnJourneyType() throws HttpResponseExceptionWithErrorBody {
-        ProcessRequest processRequest =
-                ProcessRequest.processRequestBuilder()
-                        .lambdaInput(Map.of("journeyType", "reuse"))
-                        .build();
-        assertEquals("reuse", RequestHelper.getJourneyType(processRequest));
-    }
-
-    @Test
-    void getJourneyTypeShouldThrowIfJourneyTypeIsNull() {
-        ProcessRequest processRequest = new ProcessRequest();
-
-        var exception =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () -> RequestHelper.getJourneyType(processRequest));
-
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
-        assertEquals(
-                ErrorResponse.MISSING_JOURNEY_TYPE.getMessage(),
-                exception.getErrorResponse().getMessage());
-    }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Track VCs to submit to TICF

### Why did it change
We want to simplify the journey map when invoking the call-ticf-cri lambda by not having to supply a journey type. The journey type was being used to determine if we should send all the users VC (an IPV journey), or none (a reuse journey).

What we're actually interested in sending to the TICF VC is the VC gathered during the users current session. The previous behaviour was just a proxy for that.

This change keeps track of the VC the user has received in the current session, and then only sends those to the TICF CRI when appropriate.

I had originally planned to just store the JTI from the VC in the users session, and use that to filter the users VCs from the store. However not all CRIs currently provide a JTI claim (even thought they should), so have fallen back to storing the entire serialized VC in the session.

I've maintained the filtering behaviour - the VC in the users session are compared against the VC from the VC store before sending. We could in theory just use the VC in the store directly and skip the check of the VC in the store - this would save a round trip to the DB. It feels safer however to do the check, although I don't have a good example of why this is beneficial.

One consequence of this change is that on a reuse journey, where the user decides to reset their identity (an upcoming feature) we could send TICF their own VC. Hopefully this is ok.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4331](https://govukverify.atlassian.net/browse/PYIC-4331)


[PYIC-4331]: https://govukverify.atlassian.net/browse/PYIC-4331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ