### PR TITLE
PYIC-4121: Fix passport pact test

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/PactJwtIgnoreSignatureBodyBuilder.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/PactJwtIgnoreSignatureBodyBuilder.java
@@ -1,0 +1,79 @@
+package uk.gov.di.ipv.core.processcricallback.pact;
+
+import au.com.dius.pact.consumer.dsl.BodyBuilder;
+import au.com.dius.pact.core.model.ContentType;
+import au.com.dius.pact.core.model.generators.Generators;
+import au.com.dius.pact.core.model.matchingrules.MatchingRuleCategory;
+import au.com.dius.pact.core.model.matchingrules.MatchingRuleGroup;
+import au.com.dius.pact.core.model.matchingrules.RegexMatcher;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.util.Base64URL;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+// This class can generate an example signed JWT for use in a test, but will also tell the PACT
+// framework that the provider signature does not need to match the example signature (as JWT
+// signatures are randomised)
+public class PactJwtIgnoreSignatureBodyBuilder implements BodyBuilder {
+    private final String minifiedHeaderJson;
+    private final String minifiedBodyJson;
+    private final String signature;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public PactJwtIgnoreSignatureBodyBuilder(String headerJson, String bodyJson, String signature) {
+        this.minifiedHeaderJson = minifyJson(headerJson);
+        this.minifiedBodyJson = minifyJson(bodyJson);
+        this.signature = signature;
+    }
+
+    @Override
+    public MatchingRuleCategory getMatchers() {
+        var noSignatureRegex = new RegexMatcher(createJwtRegex());
+        return new MatchingRuleCategory(
+                "full body matcher",
+                Collections.singletonMap(
+                        "ignore JWT signature", new MatchingRuleGroup(List.of(noSignatureRegex))));
+    }
+
+    @Override
+    public Generators getGenerators() {
+        return new Generators();
+    }
+
+    @Override
+    public ContentType getContentType() {
+        return new ContentType("application/jwt; charset=UTF-8");
+    }
+
+    @Override
+    public byte[] buildBody() {
+        return (Base64URL.encode(minifiedHeaderJson)
+                        + "."
+                        + Base64URL.encode(minifiedBodyJson)
+                        + "."
+                        + signature)
+                .getBytes(StandardCharsets.UTF_8);
+    }
+
+    private String createJwtRegex() {
+        return "^"
+                + Base64URL.encode(minifiedHeaderJson)
+                + "\\."
+                + Base64URL.encode(minifiedBodyJson)
+                + "\\..*";
+    }
+
+    private String minifyJson(String prettyJson) {
+        JsonNode jsonNode = null;
+        try {
+            jsonNode = objectMapper.readValue(prettyJson, JsonNode.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonNode.toString();
+    }
+}

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/ContractTest.java
@@ -27,15 +27,18 @@ import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.helpers.FixedTimeJWTClaimsVerifier;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialJwtValidator;
 import uk.gov.di.ipv.core.processcricallback.exception.CriApiException;
+import uk.gov.di.ipv.core.processcricallback.pact.PactJwtIgnoreSignatureBodyBuilder;
 import uk.gov.di.ipv.core.processcricallback.service.CriApiService;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.sql.Date;
 import java.text.ParseException;
 import java.time.Clock;
 import java.time.Instant;
@@ -52,9 +55,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.PASSPORT_CREDENTIAL_ATTRIBUTES;
-import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.generateVerifiableCredential;
-import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.vcClaim;
 
 @Disabled("PACT tests should not be run in build pipelines at this time")
 @ExtendWith(PactConsumerTestExt.class)
@@ -64,13 +64,94 @@ import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.v
 public class ContractTest {
     private static final String TEST_USER = "test-subject";
     private static final String TEST_ISSUER = "dummyPassportComponentId";
-    public static final String IPV_CORE_CLIENT_ID = "ipv-core";
-    public static final String PRIVATE_API_KEY = "dummyApiKey";
-    public static final String CRI_SIGNING_PRIVATE_KEY_JWK =
-            "{\"kty\":\"EC\",\"d\":\"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
-    public static final String CRI_RSA_ENCRYPTION_PUBLIC_JWK =
-            "{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}";
+    private static final String IPV_CORE_CLIENT_ID = "ipv-core";
+    private static final String PRIVATE_API_KEY = "dummyApiKey";
+    private static final Clock CURRENT_TIME =
+            Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
+    private static final String CRI_SIGNING_PRIVATE_KEY_JWK =
+            """
+            {"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}
+            """;
+    private static final String CRI_RSA_ENCRYPTION_PUBLIC_JWK =
+            """
+            {"kty":"RSA","e":"AQAB","n":"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q"}
+            """;
     private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // We hardcode the VC headers and bodies like this so that it is easy to update them from JSON
+    // sent by the CRI team
+    private static final String VALID_VC_HEADER =
+            """
+            {
+              "typ": "JWT",
+              "alg": "ES256"
+            }
+            """;
+    // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
+    private static final String VALID_VC_BODY =
+            """
+            {
+              "iss": "dummyPassportComponentId",
+              "sub": "test-subject",
+              "nbf": 4070908800,
+              "exp": 4070909400,
+              "vc": {
+                "@context": [
+                  "https://www.w3.org/2018/credentials/v1",
+                  "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
+                ],
+                "type": [
+                  "VerifiableCredential",
+                  "IdentityCheckCredential"
+                ],
+                "credentialSubject": {
+                  "passport": [
+                    {
+                      "expiryDate": "2030-01-01",
+                      "documentNumber": "824159121"
+                    }
+                  ],
+                  "birthDate": [
+                    {
+                      "value": "1932-02-25"
+                    }
+                  ],
+                  "name": [
+                    {
+                      "nameParts": [
+                        {
+                          "type": "GivenName",
+                          "value": "Mary"
+                        },
+                        {
+                          "type": "FamilyName",
+                          "value": "Watson"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "evidence": [
+                  {
+                    "verificationScore": "0",
+                    "ci": [
+                      "A02",
+                      "A03"
+                    ],
+                    "txn": "DSJJSEE29392",
+                    "type": "IdentityCheck"
+                  }
+                ]
+              }
+            }
+            """;
+
+    // If we generate the signature in code it will be different each time, so we need to generate a
+    // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
+    // change each time we run the tests.
+    private static final String VALID_VC_SIGNATURE =
+            "lDEi47XWnjyZ20fU-vb02BV1MSan68AqLUEQxCZGM_r8i4bG06uzdpXOJZeg-Kdhsf-NtWbqb-xM0P36YGwIeg";
+
     @Mock private ConfigService mockConfigService;
     @Mock private JWSSigner mockSigner;
     @Mock private SecureTokenHelper mockSecureTokenHelper;
@@ -124,16 +205,15 @@ public class ContractTest {
                 .willRespondWith()
                 .status(200)
                 .body(
-                        generateVerifiableCredential(
-                                vcClaim(PASSPORT_CREDENTIAL_ATTRIBUTES), TEST_USER, TEST_ISSUER),
-                        "application/jwt; charset=UTF-8")
+                        new PactJwtIgnoreSignatureBodyBuilder(
+                                VALID_VC_HEADER, VALID_VC_BODY, VALID_VC_SIGNATURE))
                 .toPact();
     }
 
     @Test
     @PactTestFor(pactMethod = "validRequestReturnsValidAccessToken")
-    void testCallToDummyPassportCri(MockServer mockServer)
-            throws URISyntaxException, JOSEException, CriApiException {
+    void fetchAccessToken_whenCalledAgainstPassportCri_retrievesAValidAccessToken(
+            MockServer mockServer) throws URISyntaxException, JOSEException, CriApiException {
         // Arrange
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
 
@@ -157,10 +237,7 @@ public class ContractTest {
         // values.
         var underTest =
                 new CriApiService(
-                        mockConfigService,
-                        mockSigner,
-                        mockSecureTokenHelper,
-                        Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC));
+                        mockConfigService, mockSigner, mockSecureTokenHelper, CURRENT_TIME);
 
         // Act
         BearerAccessToken accessToken =
@@ -206,16 +283,19 @@ public class ContractTest {
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
 
         var verifiableCredentialJwtValidator =
-                new VerifiableCredentialJwtValidator(mockConfigService);
+                new VerifiableCredentialJwtValidator(
+                        mockConfigService,
+                        ((exactMatchClaims, requiredClaims) ->
+                                new FixedTimeJWTClaimsVerifier<>(
+                                        exactMatchClaims,
+                                        requiredClaims,
+                                        Date.from(CURRENT_TIME.instant()))));
 
         // We need to generate a fixed request, so we set the secure token and expiry to constant
         // values.
         var underTest =
                 new CriApiService(
-                        mockConfigService,
-                        mockSigner,
-                        mockSecureTokenHelper,
-                        Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC));
+                        mockConfigService, mockSigner, mockSecureTokenHelper, CURRENT_TIME);
 
         // Act
         var verifiableCredentialResponse =

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/FixedTimeJWTClaimsVerifier.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/FixedTimeJWTClaimsVerifier.java
@@ -1,0 +1,29 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+
+import java.util.Date;
+import java.util.HashSet;
+
+// When VerifiableCredentialJwtValidator checks a JWT it will normally use the current time to check
+// that the JWT is still valid. In tests where we freeze the JWT contents we have to give the
+// VerifiableCredentialJwtValidator a verifier that is set to match the time of the frozen JWT
+// contents.
+public class FixedTimeJWTClaimsVerifier<T extends SecurityContext>
+        extends DefaultJWTClaimsVerifier<T> {
+
+    private final Date currentTime;
+
+    public FixedTimeJWTClaimsVerifier(
+            JWTClaimsSet exactMatchClaims, HashSet<String> requiredClaims, Date currentTime) {
+        super(exactMatchClaims, requiredClaims);
+        this.currentTime = currentTime;
+    }
+
+    @Override
+    protected Date currentTime() {
+        return currentTime;
+    }
+}

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidatorTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidatorTest.java
@@ -9,7 +9,6 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidatorTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidatorTest.java
@@ -55,11 +55,12 @@ class VerifiableCredentialJwtValidatorTest {
     @Mock private ConfigService mockConfigService;
     private SignedJWT verifiableCredentials;
 
-    @InjectMocks private VerifiableCredentialJwtValidator vcJwtValidator;
+    private VerifiableCredentialJwtValidator vcJwtValidator;
 
     @BeforeEach
     void setUp() throws Exception {
         verifiableCredentials = createTestVerifiableCredentials(TEST_USER, TEST_ISSUER);
+        vcJwtValidator = new VerifiableCredentialJwtValidator(mockConfigService);
     }
 
     @Test


### PR DESCRIPTION
Update passport pact test to not change the pact file each time the test runs, and to ignore the JWT signature in the provider test (because the signature changes each time it is generated)

The changes happened for two reasons
1. The generated VC had a timestamp inside it that changed
2. The JWT signature is generated with a random seed and so changes even if the JWT content is identical

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Change the way that the test VC is created - we now hardcode the JSON string in the test which should make updating it in the future simpler. This also fixes the timestamp.
- Create a fixed valid signature so that the PACT file doesn't change each time the test is run
- Tell the PACT framework to validate the provider response with a regex that will ignore the signature block

### Why did it change

Because our response is a JWT (which the PACT framework doesn't understand) the expected response needs to match the provider response exactly. That means that things like timestamps need to be fixed so the the consumer and provider side tests can both use the same timestamp.
The PACT file should also not change every time we run the test. If it did it would add a lot of noise to the PACT server and the server would probably run lots of unnecessary on tests on pacts that would be functionally identical.

### Issue tracking


- [PYIC-4124](https://govukverify.atlassian.net/browse/PYIC-4121)


[PYIC-4124]: https://govukverify.atlassian.net/browse/PYIC-4124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ