### PR TITLE
PYIC-4217: Fix NPE when name parts are null

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialConstants.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialConstants.java
@@ -8,17 +8,21 @@ public class VerifiableCredentialConstants {
         throw new IllegalStateException("Utility class");
     }
 
-    public static final String VC_CONTEXT = "@context";
-    public static final String W3_BASE_CONTEXT = "https://www.w3.org/2018/credentials/v1";
     public static final String DI_CONTEXT =
             "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld";
-    public static final String VC_TYPE = "type";
-    public static final String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
     public static final String IDENTITY_CHECK_CREDENTIAL_TYPE = "IdentityCheckCredential";
+    public static final String VC_BIRTH_DATE = "birthDate";
+    public static final String VC_CLAIM = "vc";
+    public static final String VC_CONTEXT = "@context";
     public static final String VC_CREDENTIAL_SUBJECT = "credentialSubject";
     public static final String VC_EVIDENCE = "evidence";
-    public static final String VC_EVIDENCE_VALIDITY = "validityScore";
     public static final String VC_EVIDENCE_STRENGTH = "strengthScore";
     public static final String VC_EVIDENCE_TXN = "txn";
-    public static final String VC_CLAIM = "vc";
+    public static final String VC_EVIDENCE_VALIDITY = "validityScore";
+    public static final String VC_FAMILY_NAME = "FamilyName";
+    public static final String VC_GIVEN_NAME = "GivenName";
+    public static final String VC_NAME = "name";
+    public static final String VC_TYPE = "type";
+    public static final String VERIFIABLE_CREDENTIAL_TYPE = "VerifiableCredential";
+    public static final String W3_BASE_CONTEXT = "https://www.w3.org/2018/credentials/v1";
 }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -329,31 +329,25 @@ public class UserIdentityService {
 
     private List<String> getFullNamesFromCredentials(List<IdentityClaim> identityClaims) {
         return identityClaims.stream()
-                .flatMap(id -> id.getName().stream())
+                .flatMap(claim -> claim.getName().stream())
                 .map(Name::getNameParts)
                 .map(
                         nameParts -> {
                             String givenNames =
                                     nameParts.stream()
                                             .filter(
-                                                    nameParts1 ->
+                                                    namePart ->
                                                             GIVEN_NAME_PROPERTY_NAME.equals(
-                                                                            nameParts1.getType())
-                                                                    && !nameParts1
-                                                                            .getValue()
-                                                                            .equals(""))
+                                                                    namePart.getType()))
                                             .map(NameParts::getValue)
                                             .collect(Collectors.joining(" "));
 
                             String familyNames =
                                     nameParts.stream()
                                             .filter(
-                                                    nameParts1 ->
+                                                    namePart ->
                                                             FAMILY_NAME_PROPERTY_NAME.equals(
-                                                                            nameParts1.getType())
-                                                                    && !nameParts1
-                                                                            .getValue()
-                                                                            .equals(""))
+                                                                    namePart.getType()))
                                             .map(NameParts::getValue)
                                             .collect(Collectors.joining(" "));
 
@@ -672,7 +666,7 @@ public class UserIdentityService {
                 || names.stream()
                         .flatMap(name -> name.getNameParts().stream())
                         .map(NameParts::getValue)
-                        .allMatch(StringUtils::isEmpty);
+                        .anyMatch(StringUtils::isBlank);
     }
 
     private void addLogMessage(VcStoreItem item, String error) {

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -2,16 +2,29 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
+import uk.gov.di.ipv.core.library.domain.Name;
+import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.domain.ReturnCode;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
@@ -27,8 +40,8 @@ import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +70,13 @@ import static uk.gov.di.ipv.core.library.domain.CriConstants.NINO_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.NON_EVIDENCE_CRI_TYPES;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
 import static uk.gov.di.ipv.core.library.domain.UserIdentity.ADDRESS_CLAIM_NAME;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_BIRTH_DATE;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_FAMILY_NAME;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_GIVEN_NAME;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_NAME;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_F2F_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1B_DCMAW_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_ADDRESS;
@@ -73,13 +93,15 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_NINO_UNSUCCESS
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_PASSPORT_MISSING_BIRTH_DATE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_PASSPORT_MISSING_NAME;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_PASSPORT_MISSING_PASSPORT;
-import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_PASSPORT_NON_DCMAW_FULL_NAME_SUCCESSFUL;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_PASSPORT_NON_DCMAW_SUCCESSFUL;
 
 @ExtendWith(MockitoExtension.class)
 class UserIdentityServiceTest {
+    public static final JWSHeader JWS_HEADER =
+            new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build();
     private static final String USER_ID_1 = "user-id-1";
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static ECDSASigner jwtSigner;
     @Mock private ConfigService mockConfigService;
     @Mock private DataStore<VcStoreItem> mockDataStore;
     private final ContraIndicators emptyContraIndicators =
@@ -97,27 +119,24 @@ class UserIdentityServiceTest {
                     "0",
                     RETURN_CODES_NON_CI_BREACHING_P0,
                     "🐧");
-    public static CredentialIssuerConfig claimedIdentityConfig = null;
+    public static CredentialIssuerConfig claimedIdentityConfig;
 
-    static {
-        try {
-            claimedIdentityConfig =
-                    CredentialIssuerConfig.builder()
-                            .tokenUrl(new URI("http://example.com/token"))
-                            .credentialUrl(new URI("http://example.com/credential"))
-                            .authorizeUrl(new URI("http://example.com/authorize"))
-                            .clientId("ipv-core")
-                            .signingKey("test-jwk")
-                            .encryptionKey("test-encryption-jwk")
-                            .componentId("https://review-a.integration.account.gov.uk")
-                            .clientCallbackUrl(new URI("http://example.com/redirect"))
-                            .requiresApiKey(true)
-                            .requiresAdditionalEvidence(false)
-                            .build();
-
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        }
+    @BeforeAll
+    static void beforeAllSetUp() throws Exception {
+        jwtSigner = new ECDSASigner(ECKey.parse(EC_PRIVATE_KEY_JWK).toECPrivateKey());
+        claimedIdentityConfig =
+                CredentialIssuerConfig.builder()
+                        .tokenUrl(new URI("http://example.com/token"))
+                        .credentialUrl(new URI("http://example.com/credential"))
+                        .authorizeUrl(new URI("http://example.com/authorize"))
+                        .clientId("ipv-core")
+                        .signingKey("test-jwk")
+                        .encryptionKey("test-encryption-jwk")
+                        .componentId("https://review-a.integration.account.gov.uk")
+                        .clientCallbackUrl(new URI("http://example.com/redirect"))
+                        .requiresApiKey(true)
+                        .requiresAdditionalEvidence(false)
+                        .build();
     }
 
     @BeforeEach
@@ -175,103 +194,194 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void checkBirthDateCorrelationInCredentialsReturnsTrueWhenBirthDatesSame() throws Exception {
+    void areVCsCorrelatedReturnsTrueWhenVcAreCorrelated() throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
-                        createVcStoreItem(USER_ID_1, PASSPORT_CRI, VC_FRAUD_SCORE_1, Instant.now()),
-                        createVcStoreItem(USER_ID_1, DCMAW_CRI, VC_KBV_SCORE_2, Instant.now()));
+                        createVcStoreItem(
+                                USER_ID_1,
+                                ADDRESS_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                BAV_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()));
         mockCredentialIssuerConfig();
 
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
-
-        assertTrue(isValid);
+        assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
-    void checkNameCorrelationInCredentialsReturnTrueWhenSameName() throws Exception {
+    void areVCsCorrelatedReturnFalseWhenNamesDiffer() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                ADDRESS_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Corky", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
+
+    @Test
+    void areVCsCorrelatedReturnFalseWhenNameDifferentForBavCRI() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                DCMAW_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                BAV_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimmy", "Jones", ""), // BAV cri doesn't provide birthdate
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void areVCsCorrelatedShouldThrowExceptionWhenVcHasMissingGivenName(String missingName)
+            throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
                                 USER_ID_1,
                                 PASSPORT_CRI,
-                                VC_PASSPORT_NON_DCMAW_FULL_NAME_SUCCESSFUL,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
                                 Instant.now()),
                         createVcStoreItem(
                                 USER_ID_1,
-                                DCMAW_CRI,
-                                VC_PASSPORT_NON_DCMAW_FULL_NAME_SUCCESSFUL,
-                                Instant.now()),
-                        createVcStoreItem(
-                                USER_ID_1,
-                                BAV_CRI,
-                                VC_PASSPORT_NON_DCMAW_FULL_NAME_SUCCESSFUL,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        missingName, "Jones", "1000-01-01"),
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
+        HttpResponseExceptionWithErrorBody thrownError =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> userIdentityService.areVCsCorrelated(vcStoreItems));
 
-        assertTrue(isValid);
+        assertEquals(500, thrownError.getResponseCode());
+        assertEquals(
+                ErrorResponse.FAILED_NAME_CORRELATION.getCode(),
+                thrownError.getErrorBody().get("error"));
+        assertEquals(
+                ErrorResponse.FAILED_NAME_CORRELATION.getMessage(),
+                thrownError.getErrorBody().get("error_description"));
     }
 
-    @Test
-    void checkBirthDateCorrelationInCredentialsReturnsFalseWhenBirthDatesDiffer() throws Exception {
+    @ParameterizedTest
+    @NullAndEmptySource
+    void areVCsCorrelatedShouldThrowExceptionWhenVcHasMissingFamilyName(String missingName)
+            throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
                                 USER_ID_1,
                                 PASSPORT_CRI,
-                                VC_PASSPORT_NON_DCMAW_SUCCESSFUL,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", missingName, "1000-01-01"),
                                 Instant.now()),
-                        createVcStoreItem(USER_ID_1, DCMAW_CRI, VC_KBV_SCORE_2, Instant.now()));
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()));
         mockCredentialIssuerConfig();
 
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
+        HttpResponseExceptionWithErrorBody thrownError =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> userIdentityService.areVCsCorrelated(vcStoreItems));
 
-        assertFalse(isValid);
+        assertEquals(500, thrownError.getResponseCode());
+        assertEquals(
+                ErrorResponse.FAILED_NAME_CORRELATION.getCode(),
+                thrownError.getErrorBody().get("error"));
+        assertEquals(
+                ErrorResponse.FAILED_NAME_CORRELATION.getMessage(),
+                thrownError.getErrorBody().get("error_description"));
     }
 
-    @Test
-    void checkNameCorrelationInCredentialsReturnFalseWhenNameDiffer() throws Exception {
+    @ParameterizedTest
+    @NullAndEmptySource
+    void areVCsCorrelatedShouldReturnTrueWhenAddressVcHasMissingName(String missing)
+            throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
-                        createVcStoreItem(USER_ID_1, PASSPORT_CRI, VC_FRAUD_SCORE_1, Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                ADDRESS_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        missing, missing, "1000-01-01"),
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void areVCsCorrelatedShouldReturnFalseWhenMissingNameCredentialForBAVCRI(String missing)
+            throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
                         createVcStoreItem(
                                 USER_ID_1,
                                 DCMAW_CRI,
-                                VC_PASSPORT_NON_DCMAW_FULL_NAME_SUCCESSFUL,
-                                Instant.now()));
-        mockCredentialIssuerConfig();
-
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
-
-        assertFalse(isValid);
-    }
-
-    @Test
-    void checkNameCorrelationInCredentialsReturnFalseWhenNameDifferForBavCRI() throws Exception {
-        List<VcStoreItem> vcStoreItems =
-                List.of(
-                        createVcStoreItem(USER_ID_1, PASSPORT_CRI, VC_FRAUD_SCORE_1, Instant.now()),
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
                         createVcStoreItem(
                                 USER_ID_1,
                                 BAV_CRI,
-                                VC_PASSPORT_NON_DCMAW_SUCCESSFUL,
+                                createCredentialWithNameAndBirthDate(missing, "Jones", missing),
                                 Instant.now()));
-        mockCredentialIssuerConfig();
-
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
-
-        assertFalse(isValid);
-    }
-
-    @Test
-    void shouldThrowExceptionWhenMissingNamePropertyFromCheckNameCorrelation() {
-        List<VcStoreItem> vcStoreItems =
-                List.of(
-                        createVcStoreItem(
-                                USER_ID_1, PASSPORT_CRI, VC_PASSPORT_MISSING_NAME, Instant.now()),
-                        createVcStoreItem(
-                                USER_ID_1, BAV_CRI, VC_PASSPORT_MISSING_NAME, Instant.now()));
         mockCredentialIssuerConfig();
 
         HttpResponseExceptionWithErrorBody thrownError =
@@ -289,50 +399,81 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void checkNameCorrelationWithMissingNameWithAddressCredentialsForReturnTrue() throws Exception {
-        List<VcStoreItem> vcStoreItems =
-                List.of(
-                        createVcStoreItem(
-                                USER_ID_1, ADDRESS_CRI, VC_PASSPORT_MISSING_NAME, Instant.now()));
-        mockCredentialIssuerConfig();
-
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
-
-        assertTrue(isValid);
-    }
-
-    @Test
-    void checkNameCorrelationWithMissingNameCredentialsForOnlyBAVCRIReturnFalse() throws Exception {
-        List<VcStoreItem> vcStoreItems =
-                List.of(
-                        createVcStoreItem(
-                                USER_ID_1,
-                                PASSPORT_CRI,
-                                VC_PASSPORT_NON_DCMAW_SUCCESSFUL,
-                                Instant.now()),
-                        createVcStoreItem(USER_ID_1, DCMAW_CRI, VC_KBV_SCORE_2, Instant.now()),
-                        createVcStoreItem(
-                                USER_ID_1, BAV_CRI, VC_PASSPORT_MISSING_BIRTH_DATE, Instant.now()));
-        mockCredentialIssuerConfig();
-
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
-
-        assertFalse(isValid);
-    }
-
-    @Test
-    void shouldThrowExceptionWhenMissingBirthDatePropertyFromCheckBirthDateCorrelation() {
+    void areVCsCorrelatedShouldReturnFalseIfExtraGivenNameInVc() throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
                                 USER_ID_1,
                                 ADDRESS_CRI,
-                                VC_PASSPORT_MISSING_BIRTH_DATE,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
                                 Instant.now()),
                         createVcStoreItem(
                                 USER_ID_1,
                                 PASSPORT_CRI,
-                                VC_PASSPORT_MISSING_BIRTH_DATE,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jimmy", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                BAV_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
+
+    @Test
+    void areVCsCorrelatedReturnsFalseWhenBirthDatesDiffer() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                DCMAW_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "2000-01-01"),
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void areVCsCorrelatedShouldThrowExceptionWhenMissingBirthDateProperty(String missing)
+            throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                ADDRESS_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate("Jimbo", "Jones", missing),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
@@ -350,75 +491,168 @@ class UserIdentityServiceTest {
                 thrownError.getErrorBody().get("error_description"));
     }
 
-    @Test
-    void checkBirthDateCorrelationWithMissingBirthDateFromAddressAndBavCredentialsForReturnTrue()
+    @ParameterizedTest
+    @NullAndEmptySource
+    void areVCsCorrelatedShouldReturnTrueWhenAddressHasMissingBirthDate(String missing)
             throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
                                 USER_ID_1,
                                 ADDRESS_CRI,
-                                VC_PASSPORT_MISSING_BIRTH_DATE,
+                                createCredentialWithNameAndBirthDate("Jimbo", "Jones", missing),
                                 Instant.now()),
                         createVcStoreItem(
-                                USER_ID_1, BAV_CRI, VC_PASSPORT_MISSING_BIRTH_DATE, Instant.now()));
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()));
         mockCredentialIssuerConfig();
 
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
+        assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
 
-        assertTrue(isValid);
+    @ParameterizedTest
+    @NullAndEmptySource
+    void areVCsCorrelatedShouldReturnTrueWhenBavHasMissingBirthDate(String missing)
+            throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                BAV_CRI,
+                                createCredentialWithNameAndBirthDate("Jimbo", "Jones", missing),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
-    void checkBirthDateCorrelationWithMissingBirthDateForOnlyBAVCRIAndReturnTrue()
-            throws Exception {
+    void areVCsCorrelatedShouldReturnFalseIfBavHasDifferentBirthDate() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                ADDRESS_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                BAV_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "2000-01-01"),
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
+
+    @Test
+    void areVCsCorrelatedShouldNotIncludeVCsForNameNotDeemedSuccessful() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                ADDRESS_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Corky", "Jones", "1000-01-01", false),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
+
+    @Test
+    void areVCsCorrelatedShouldNotIncludeVCsForDOBNotDeemedSuccessful() throws Exception {
+        List<VcStoreItem> vcStoreItems =
+                List.of(
+                        createVcStoreItem(
+                                USER_ID_1,
+                                ADDRESS_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                PASSPORT_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
+                        createVcStoreItem(
+                                USER_ID_1,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "2000-01-01", false),
+                                Instant.now()));
+        mockCredentialIssuerConfig();
+
+        assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
+    }
+
+    @Test
+    void areVCsCorrelatedReturnsFalseWhenExtraBirthDateInVc() throws Exception {
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
                                 USER_ID_1,
                                 PASSPORT_CRI,
-                                VC_PASSPORT_NON_DCMAW_SUCCESSFUL,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
                                 Instant.now()),
                         createVcStoreItem(
-                                USER_ID_1, BAV_CRI, VC_PASSPORT_MISSING_BIRTH_DATE, Instant.now()));
-        mockCredentialIssuerConfig();
-
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
-
-        assertTrue(isValid);
-    }
-
-    @Test
-    void checkBirthDateCorrelationWithBirthDateIsNotEmptyForBAVCRIAndReturnTrue() throws Exception {
-        List<VcStoreItem> vcStoreItems =
-                List.of(
-                        createVcStoreItem(USER_ID_1, PASSPORT_CRI, VC_FRAUD_SCORE_1, Instant.now()),
-                        createVcStoreItem(USER_ID_1, DCMAW_CRI, VC_KBV_SCORE_2, Instant.now()),
-                        createVcStoreItem(USER_ID_1, BAV_CRI, VC_FRAUD_SCORE_1, Instant.now()));
-        mockCredentialIssuerConfig();
-
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
-
-        assertTrue(isValid);
-    }
-
-    @Test
-    void checkBirthDateCorrelationWithBirthDateIsNotEmptyButDifferentDOBForBAVCRIAndReturnFalse()
-            throws Exception {
-        List<VcStoreItem> vcStoreItems =
-                List.of(
-                        createVcStoreItem(USER_ID_1, PASSPORT_CRI, VC_FRAUD_SCORE_1, Instant.now()),
-                        createVcStoreItem(USER_ID_1, DCMAW_CRI, VC_KBV_SCORE_2, Instant.now()),
+                                USER_ID_1,
+                                DCMAW_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01"),
+                                Instant.now()),
                         createVcStoreItem(
                                 USER_ID_1,
-                                BAV_CRI,
-                                VC_PASSPORT_NON_DCMAW_SUCCESSFUL,
+                                FRAUD_CRI,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", List.of("1000-01-01", "2000-01-01")),
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
-        boolean isValid = userIdentityService.areVCsCorrelated(vcStoreItems);
-
-        assertFalse(isValid);
+        assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
@@ -1239,7 +1473,7 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void getFullNamesFromCredentialsValidateSpecialCharactersSuccessScenarios() {
+    void checkNamesForCorrelationValidateSpecialCharactersSuccessScenarios() {
         List<String> fullNames = List.of("Alice JANE DOE", "AlIce Ja-ne Do-e", "ALiCE JA'-ne Do'e");
         assertTrue(userIdentityService.checkNamesForCorrelation(fullNames));
 
@@ -1248,7 +1482,7 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void getFullNamesFromCredentialsValidateSpecialCharactersFailScenarios() {
+    void checkNamesForCorrelationValidateSpecialCharactersFailScenarios() {
         List<String> fullNames = List.of("Alice JANE DOE", "Alce JANE DOE", "Alëce JANE DOE");
         assertFalse(userIdentityService.checkNamesForCorrelation(fullNames));
 
@@ -1351,5 +1585,75 @@ class UserIdentityServiceTest {
     private void mockParamStoreCalls(Map<ConfigurationVariable, String> params) {
         params.forEach(
                 (key, value) -> when(mockConfigService.getSsmParameter(key)).thenReturn(value));
+    }
+
+    private String createCredentialWithNameAndBirthDate(
+            String givenName, String familyName, String birthDate) throws Exception {
+        var birthDateList = new ArrayList<String>();
+        birthDateList.add(birthDate);
+        return createCredentialWithNameAndBirthDate(
+                givenName, null, familyName, birthDateList, true);
+    }
+
+    private String createCredentialWithNameAndBirthDate(
+            String givenName, String middleName, String familyName, String birthDate)
+            throws Exception {
+        var birthDateList = new ArrayList<String>();
+        birthDateList.add(birthDate);
+        return createCredentialWithNameAndBirthDate(
+                givenName, middleName, familyName, birthDateList, true);
+    }
+
+    private String createCredentialWithNameAndBirthDate(
+            String givenName, String familyName, String birthDate, boolean isSuccessful)
+            throws Exception {
+        var birthDateList = new ArrayList<String>();
+        birthDateList.add(birthDate);
+        return createCredentialWithNameAndBirthDate(
+                givenName, null, familyName, birthDateList, isSuccessful);
+    }
+
+    private String createCredentialWithNameAndBirthDate(
+            String givenName, String familyName, List<String> birthDates) throws Exception {
+        return createCredentialWithNameAndBirthDate(givenName, null, familyName, birthDates, true);
+    }
+
+    private String createCredentialWithNameAndBirthDate(
+            String givenName,
+            String middleName,
+            String familyName,
+            List<String> birthDates,
+            boolean isSuccessful)
+            throws Exception {
+        var credentialSubject = new HashMap<String, Object>();
+        var vcClaim = new HashMap<String, Object>();
+
+        vcClaim.put(VC_CREDENTIAL_SUBJECT, credentialSubject);
+        List<NameParts> nameParts =
+                new ArrayList<>(
+                        List.of(
+                                new NameParts(givenName, VC_GIVEN_NAME),
+                                new NameParts(familyName, VC_FAMILY_NAME)));
+        if (middleName != null) {
+            nameParts.add(1, new NameParts(middleName, VC_GIVEN_NAME));
+        }
+
+        credentialSubject.put(VC_NAME, List.of(new Name(nameParts)));
+
+        credentialSubject.put(VC_BIRTH_DATE, birthDates.stream().map(BirthDate::new).toList());
+
+        JWTClaimsSet claims =
+                new JWTClaimsSet.Builder()
+                        .claim(VC_CLAIM, vcClaim)
+                        .issuer(
+                                // address VC are always considered "successful" even without
+                                // evidence
+                                isSuccessful ? ADDRESS_CRI : PASSPORT_CRI)
+                        .build();
+
+        SignedJWT signedJWT = new SignedJWT(JWS_HEADER, claims);
+        signedJWT.sign(jwtSigner);
+
+        return signedJWT.serialize();
     }
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix NPE when name parts are null

### Why did it change
The code we had to create a full name from a VC's name parts was throwing NPEs. This would happen if one of the name parts was null. We were calling equals on it when trying to filter out values that were equal to an empty string.

We've determined that it is not currently acceptable for a VC to have a missing name part, so we should be catching and logging this scenario in advance of getting to the stage of throwing this NPE.

And we were infact already attemting to do this when retrieving the name parts from the VC. We were only throwing though if ALL name parts were missing. This updates that check to catch if ANY of the name parts are missing. It also refines that check to check for null, empty string OR pure whitespace.

This change also removes the code that was originally throwing the NPE as it was unnecessary. We should have already caught any of these values. And if we hadn't, we'd still want to fail correlation for this.

This also updates the tests to be more flexible. Rather than relying on hardcoded VCs, which can be difficult to understand what they're doing, it allows VCs to be constructed with specific names and DOBs.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4217](https://govukverify.atlassian.net/browse/PYIC-4217)

[PYIC-4217]: https://govukverify.atlassian.net/browse/PYIC-4217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ