### PR TITLE
PYIC-4425 Revise log helper so it is more extensible and does not lose context

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -188,16 +188,18 @@ public class BuildClientOauthResponseHandler
 
             return clientResponse.toObjectMap();
         } catch (ParseException e) {
-            LogHelper.logErrorMessage("Authentication request could not be parsed", e);
+            LOGGER.error(
+                    LogHelper.buildErrorMessage("Authentication request could not be parsed", e));
             return buildJourneyErrorResponse(
                     HttpStatus.SC_BAD_REQUEST,
                     ErrorResponse.FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS);
         } catch (SqsException e) {
-            LogHelper.logErrorMessage("Failed to send audit event to SQS queue.", e.getMessage());
+            LOGGER.error(
+                    LogHelper.buildErrorMessage("Failed to send audit event to SQS queue.", e));
             return buildJourneyErrorResponse(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
         } catch (URISyntaxException e) {
-            LogHelper.logErrorMessage("Failed to construct redirect uri.", e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to construct redirect uri.", e));
             return buildJourneyErrorResponse(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_CONSTRUCT_REDIRECT_URI);

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/validation/AuthRequestValidator.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/validation/AuthRequestValidator.java
@@ -38,13 +38,16 @@ public class AuthRequestValidator {
     public ValidationResult<ErrorResponse> validateRequest(
             Map<String, List<String>> queryStringParameters, Map<String, String> requestHeaders) {
         if (queryStringParamsMissing(queryStringParameters)) {
-            LogHelper.logErrorMessage(
-                    "Missing required query parameters for authorisation request");
+            LOGGER.error(
+                    LogHelper.buildLogMessage(
+                            "Missing required query parameters for authorisation request"));
             return new ValidationResult<>(false, ErrorResponse.MISSING_QUERY_PARAMETERS);
         }
 
         if (sessionIdMissing(requestHeaders) && clientSessionIdMissing(requestHeaders)) {
-            LogHelper.logErrorMessage("Missing IPV session and client session ID from headers");
+            LOGGER.error(
+                    LogHelper.buildLogMessage(
+                            "Missing IPV session and client session ID from headers"));
             return new ValidationResult<>(false, ErrorResponse.MISSING_SESSION_ID);
         }
 
@@ -91,7 +94,7 @@ public class AuthRequestValidator {
             }
             return Optional.empty();
         } catch (IllegalArgumentException e) {
-            LogHelper.logErrorMessage(e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage("Invalid auth request parameters", e));
             return Optional.of(ErrorResponse.INVALID_REQUEST_PARAM);
         }
     }

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -13,7 +13,6 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -235,14 +234,16 @@ public class BuildCriOauthRequestHandler
                                 JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                         .toObjectMap();
             }
-            LogHelper.logErrorMessage("Failed to create cri JAR", e.getErrorReason());
+            LOGGER.error(
+                    LogHelper.buildErrorMessage("Failed to create cri JAR", e.getErrorReason()));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,
                             e.getErrorResponse())
                     .toObjectMap();
         } catch (SqsException e) {
-            LogHelper.logErrorMessage("Failed to send audit event to SQS queue.", e.getMessage());
+            LOGGER.error(
+                    LogHelper.buildErrorMessage("Failed to send audit event to SQS queue.", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,
@@ -250,14 +251,14 @@ public class BuildCriOauthRequestHandler
                             e.getMessage())
                     .toObjectMap();
         } catch (ParseException | JOSEException e) {
-            LogHelper.logErrorMessage("Failed to parse encryption public JWK.", e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to parse encryption public JWK.", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_BAD_REQUEST,
                             ErrorResponse.FAILED_TO_PARSE_CREDENTIAL_ISSUER_CONFIG)
                     .toObjectMap();
         } catch (URISyntaxException e) {
-            LogHelper.logErrorMessage("Failed to construct redirect uri.", e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to construct redirect uri.", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,
@@ -265,7 +266,7 @@ public class BuildCriOauthRequestHandler
                             e.getMessage())
                     .toObjectMap();
         } catch (UnknownEvidenceTypeException e) {
-            LogHelper.logErrorMessage("Unable to determine type of credential.", e);
+            LOGGER.error(LogHelper.buildErrorMessage("Unable to determine type of credential.", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,
@@ -363,8 +364,9 @@ public class BuildCriOauthRequestHandler
                         .min();
 
         if (minViableStrengthOpt.isEmpty()) {
-            LogHelper.logMessage(
-                    Level.WARN, "Minimum strength evidence required cannot be attained.");
+            LOGGER.warn(
+                    LogHelper.buildLogMessage(
+                            "Minimum strength evidence required cannot be attained."));
             return null;
         }
 
@@ -415,8 +417,9 @@ public class BuildCriOauthRequestHandler
                                     .path(VC_CLAIM)
                                     .path(VC_CREDENTIAL_SUBJECT);
                     if (credentialSubject.isMissingNode()) {
-                        LogHelper.logErrorMessage(
-                                ErrorResponse.CREDENTIAL_SUBJECT_MISSING.getMessage());
+                        LOGGER.error(
+                                LogHelper.buildLogMessage(
+                                        ErrorResponse.CREDENTIAL_SUBJECT_MISSING.getMessage()));
                         throw new HttpResponseExceptionWithErrorBody(
                                 500, ErrorResponse.CREDENTIAL_SUBJECT_MISSING);
                     }
@@ -434,11 +437,11 @@ public class BuildCriOauthRequestHandler
                     sharedClaimsSet.add(credentialsSharedClaims);
                 }
             } catch (JsonProcessingException e) {
-                LogHelper.logErrorMessage("Failed to get Shared Attributes.", e.getMessage());
+                LOGGER.error(LogHelper.buildErrorMessage("Failed to get Shared Attributes.", e));
                 throw new HttpResponseExceptionWithErrorBody(
                         500, ErrorResponse.FAILED_TO_GET_SHARED_ATTRIBUTES);
             } catch (ParseException e) {
-                LogHelper.logErrorMessage("Failed to parse issued credentials.", e.getMessage());
+                LOGGER.error(LogHelper.buildErrorMessage("Failed to parse issued credentials.", e));
                 throw new HttpResponseExceptionWithErrorBody(
                         500, ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
             }

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -11,7 +11,6 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -174,14 +173,15 @@ public class BuildUserIdentityHandler
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HTTPResponse.SC_OK, userIdentity);
         } catch (ParseException e) {
-            LogHelper.logErrorMessage("Failed to parse access token");
+            LOGGER.error(LogHelper.buildLogMessage("Failed to parse access token"));
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getErrorObject().getHTTPStatusCode(), e.getErrorObject().toJSONObject());
         } catch (SqsException e) {
             return serverErrorJsonResponse("Failed to send audit event to SQS queue.", e);
         } catch (HttpResponseExceptionWithErrorBody e) {
-            LogHelper.logErrorMessage(
-                    "Failed to generate the user identity output.", e.getErrorReason());
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Failed to generate the user identity output.", e.getErrorReason()));
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     e.getResponseCode(), e.getErrorBody());
         } catch (CiRetrievalException e) {
@@ -216,7 +216,7 @@ public class BuildUserIdentityHandler
                         contraIndicators.hasMitigations(),
                         auditEventReturnCodes);
 
-        LogHelper.logMessage(Level.INFO, "Sending audit event IPV_IDENTITY_ISSUED message.");
+        LOGGER.info(LogHelper.buildLogMessage("Sending audit event IPV_IDENTITY_ISSUED message."));
         auditService.sendAuditEvent(
                 new AuditEvent(
                         AuditEventTypes.IPV_IDENTITY_ISSUED,
@@ -267,8 +267,9 @@ public class BuildUserIdentityHandler
     }
 
     private APIGatewayProxyResponseEvent getUnknownAccessTokenApiGatewayProxyResponseEvent() {
-        LogHelper.logErrorMessage(
-                "User credential could not be retrieved. The supplied access token was not found in the database.");
+        LOGGER.error(
+                LogHelper.buildLogMessage(
+                        "User credential could not be retrieved. The supplied access token was not found in the database."));
         return ApiGatewayResponseGenerator.proxyJsonResponse(
                 OAuth2Error.ACCESS_DENIED.getHTTPStatusCode(),
                 OAuth2Error.ACCESS_DENIED
@@ -285,7 +286,7 @@ public class BuildUserIdentityHandler
     }
 
     private APIGatewayProxyResponseEvent serverErrorJsonResponse(String errorHeader, Exception e) {
-        LogHelper.logErrorMessage(errorHeader, e.getMessage());
+        LOGGER.error(LogHelper.buildErrorMessage(errorHeader, e));
         return ApiGatewayResponseGenerator.proxyJsonResponse(
                 OAuth2Error.SERVER_ERROR.getHTTPStatusCode(),
                 OAuth2Error.SERVER_ERROR

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -3,7 +3,8 @@ package uk.gov.di.ipv.core.callticfcri.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
-import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.callticfcri.dto.TicfCriDto;
 import uk.gov.di.ipv.core.callticfcri.exception.TicfCriHttpResponseException;
@@ -27,6 +28,7 @@ import java.util.List;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.TICF_CRI;
 
 public class TicfCriService {
+    private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final String TRUSTMARK = "https://oidc.account.gov.uk/trustmark";
     public static final String X_API_KEY_HEADER = "x-api-key";
@@ -110,8 +112,9 @@ public class TicfCriService {
                 Thread.currentThread().interrupt();
             }
             // In the case of unavailability, the TICF CRI is deemed optional.
-            LogHelper.logErrorMessage(
-                    "Request to TICF CRI failed. Allowing user journey to continue", e);
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Request to TICF CRI failed. Allowing user journey to continue", e));
             return List.of();
         }
     }
@@ -123,13 +126,13 @@ public class TicfCriService {
                     String.format(
                             "Non 200 HTTP status code: '%s'", ticfCriHttpResponse.statusCode()));
         }
-        LogHelper.logMessage(Level.INFO, "Successful HTTP response from TICF CRI");
+        LOGGER.info(LogHelper.buildLogMessage("Successful HTTP response from TICF CRI"));
     }
 
     @Tracing
     private HttpResponse<String> sendHttpRequest(HttpRequest ticfCriHttpRequest)
             throws IOException, InterruptedException {
-        LogHelper.logMessage(Level.INFO, "Sending HTTP request to TICF CRI");
+        LOGGER.info(LogHelper.buildLogMessage("Sending HTTP request to TICF CRI"));
         return httpClient.send(ticfCriHttpRequest, HttpResponse.BodyHandlers.ofString());
     }
 }

--- a/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
+++ b/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
@@ -106,26 +106,28 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
                 return new JourneyResponse(JOURNEY_UNMET_PATH).toObjectMap();
             }
         } catch (HttpResponseExceptionWithErrorBody e) {
-            LogHelper.logErrorMessage("Received HTTP response exception", e);
+            LOGGER.error(LogHelper.buildErrorMessage("Received HTTP response exception", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();
         } catch (ParseException e) {
-            LogHelper.logErrorMessage("Unable to parse GPG45 scores from existing credentials", e);
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Unable to parse GPG45 scores from existing credentials", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,
                             ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS)
                     .toObjectMap();
         } catch (UnknownEvidenceTypeException e) {
-            LogHelper.logErrorMessage("Unable to determine type of credential", e);
+            LOGGER.error(LogHelper.buildErrorMessage("Unable to determine type of credential", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,
                             ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE)
                     .toObjectMap();
         } catch (UnknownScoreTypeException e) {
-            LogHelper.logErrorMessage("Unable to process score type", e);
+            LOGGER.error(LogHelper.buildErrorMessage("Unable to process score type", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -145,21 +145,23 @@ public class EvaluateGpg45ScoresHandler
                             ipAddress)
                     .toObjectMap();
         } catch (HttpResponseExceptionWithErrorBody e) {
-            LogHelper.logErrorMessage("Received HTTP response exception", e);
+            LOGGER.error(LogHelper.buildErrorMessage("Received HTTP response exception", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();
         } catch (ParseException e) {
-            LogHelper.logErrorMessage("Unable to parse GPG45 scores from existing credentials", e);
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Unable to parse GPG45 scores from existing credentials", e));
             return buildJourneyErrorResponse(ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
         } catch (UnknownEvidenceTypeException e) {
-            LogHelper.logErrorMessage("Unable to determine type of credential", e);
+            LOGGER.error(LogHelper.buildErrorMessage("Unable to determine type of credential", e));
             return buildJourneyErrorResponse(ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE);
         } catch (SqsException e) {
-            LogHelper.logErrorMessage("Failed to send audit event to SQS queue.", e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to send audit event to SQS queue", e));
             return buildJourneyErrorResponse(ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
         } catch (CredentialParseException e) {
-            LogHelper.logErrorMessage("Unable to parse credential", e);
+            LOGGER.error(LogHelper.buildErrorMessage("Unable to parse credential", e));
             return buildJourneyErrorResponse(
                     ErrorResponse.FAILED_TO_PARSE_SUCCESSFUL_VC_STORE_ITEMS);
         }

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
@@ -57,7 +57,7 @@ public class JarValidator {
 
             return jweObject.getPayload().toSignedJWT();
         } catch (JOSEException e) {
-            LogHelper.logErrorMessage("Failed to decrypt the JWE");
+            LOGGER.error(LogHelper.buildLogMessage("Failed to decrypt the JWE"));
             throw new JarValidationException(
                     OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
                             "Failed to decrypt the contents of the JAR"));
@@ -135,13 +135,15 @@ public class JarValidator {
                                             .toECPublicKey()));
 
             if (!valid) {
-                LogHelper.logErrorMessage("JWT signature validation failed");
+                LOGGER.error(LogHelper.buildLogMessage("JWT signature validation failed"));
                 throw new JarValidationException(
                         OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
                                 "JWT signature validation failed"));
             }
         } catch (JOSEException | ParseException e) {
-            LogHelper.logErrorMessage("Failed to parse JWT when attempting signature validation");
+            LOGGER.error(
+                    LogHelper.buildLogMessage(
+                            "Failed to parse JWT when attempting signature validation"));
             throw new JarValidationException(
                     OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
                             "Failed to parse JWT when attempting signature validation"));
@@ -175,7 +177,7 @@ public class JarValidator {
 
             return signedJWT.getJWTClaimsSet();
         } catch (BadJWTException | ParseException e) {
-            LogHelper.logErrorMessage("Claim set validation failed");
+            LOGGER.error(LogHelper.buildLogMessage("Claim set validation failed"));
             throw new JarValidationException(
                     OAuth2Error.INVALID_GRANT.setDescription(e.getMessage()));
         }
@@ -189,7 +191,8 @@ public class JarValidator {
                 LocalDateTime.ofInstant(claimsSet.getExpirationTime().toInstant(), ZoneOffset.UTC);
 
         if (expirationTime.isAfter(maximumExpirationTime)) {
-            LogHelper.logErrorMessage("Client JWT expiry date is too far in the future");
+            LOGGER.error(
+                    LogHelper.buildLogMessage("Client JWT expiry date is too far in the future"));
             throw new JarValidationException(
                     OAuth2Error.INVALID_GRANT.setDescription(
                             "The client JWT expiry date has surpassed the maximum allowed ttl value"));
@@ -216,8 +219,9 @@ public class JarValidator {
             }
             return redirectUri;
         } catch (ParseException e) {
-            LogHelper.logErrorMessage(
-                    "Failed to parse JWT claim set in order to access to the redirect_uri claim");
+            LOGGER.error(
+                    LogHelper.buildLogMessage(
+                            "Failed to parse JWT claim set in order to access to the redirect_uri claim"));
             throw new JarValidationException(
                     OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
                             "Failed to parse JWT claim set in order to access redirect_uri claim"));

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -92,8 +92,7 @@ public class IssueClientAccessTokenHandler
                     accessTokenService.validateAuthorizationGrant(authorizationGrant);
             if (!validationResult.isValid()) {
                 ErrorObject error = validationResult.getError();
-                LogHelper.logOauthError(
-                        "Invalid auth grant received.", error.getCode(), error.getDescription());
+                LOGGER.error(LogHelper.buildErrorMessage("Invalid auth grant received.", error));
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         getHttpStatusCodeForErrorResponse(validationResult.getError()),
                         validationResult.getError().toJSONObject());
@@ -116,10 +115,9 @@ public class IssueClientAccessTokenHandler
 
             if (ipvSessionItem.getAccessToken() != null) {
                 ErrorObject error = revokeAccessToken(ipvSessionItem);
-                LogHelper.logOauthError(
-                        "Auth code has been used multiple times",
-                        error.getCode(),
-                        error.getDescription());
+                LOGGER.error(
+                        LogHelper.buildErrorMessage(
+                                "Auth code has been used multiple times", error));
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         error.getHTTPStatusCode(), error.toJSONObject());
             }
@@ -133,14 +131,14 @@ public class IssueClientAccessTokenHandler
                                     ConfigurationVariable.AUTH_CODE_EXPIRY_SECONDS)))) {
                 ErrorObject error =
                         OAuth2Error.INVALID_GRANT.setDescription("Authorization code expired");
-                LogHelper.logOauthError(
-                        String.format(
-                                "Access Token could not be issued. The supplied authorization code has expired. Created at: %s",
-                                ipvSessionItem
-                                        .getAuthorizationCodeMetadata()
-                                        .getCreationDateTime()),
-                        error.getCode(),
-                        error.getDescription());
+                LOGGER.error(
+                        LogHelper.buildErrorMessage(
+                                String.format(
+                                        "Access Token could not be issued. The supplied authorization code has expired. Created at: %s",
+                                        ipvSessionItem
+                                                .getAuthorizationCodeMetadata()
+                                                .getCreationDateTime()),
+                                error));
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         error.getHTTPStatusCode(), error.toJSONObject());
             }
@@ -150,12 +148,12 @@ public class IssueClientAccessTokenHandler
                         OAuth2Error.INVALID_GRANT.setDescription(
                                 "Redirect URL in token request does not match redirect URL received in auth code request");
 
-                LogHelper.logOauthError(
-                        String.format(
-                                "Invalid redirect URL value received. Session ID: %s",
-                                ipvSessionItem.getIpvSessionId()),
-                        error.getCode(),
-                        error.getDescription());
+                LOGGER.error(
+                        LogHelper.buildErrorMessage(
+                                String.format(
+                                        "Invalid redirect URL value received. Session ID: %s",
+                                        ipvSessionItem.getIpvSessionId()),
+                                error));
 
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         error.getHTTPStatusCode(), error.toJSONObject());
@@ -192,10 +190,9 @@ public class IssueClientAccessTokenHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_OK, accessTokenResponse.toJSONObject());
         } catch (ParseException e) {
-            LogHelper.logOauthError(
-                    "Token request could not be parsed",
-                    e.getErrorObject().getCode(),
-                    e.getErrorObject().getDescription());
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Token request could not be parsed", e.getErrorObject()));
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     getHttpStatusCodeForErrorResponse(e.getErrorObject()),
                     e.getErrorObject().toJSONObject());
@@ -204,16 +201,14 @@ public class IssueClientAccessTokenHandler
                     OAuth2Error.INVALID_GRANT.setDescription(
                             "The supplied authorization code was not found in the database");
 
-            LogHelper.logOauthError(
-                    "Access Token could not be issued", error.getCode(), error.getDescription());
+            LOGGER.error(LogHelper.buildErrorMessage("Access Token could not be issued", error));
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     error.getHTTPStatusCode(), error.toJSONObject());
         } catch (ClientAuthenticationException e) {
             ErrorObject error = OAuth2Error.INVALID_CLIENT.setDescription(e.getMessage());
 
-            LogHelper.logOauthError(
-                    "Client authentication failed", error.getCode(), error.getDescription());
+            LOGGER.error(LogHelper.buildErrorMessage("Client authentication failed", error));
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     error.getHTTPStatusCode(), error.toJSONObject());
@@ -254,7 +249,7 @@ public class IssueClientAccessTokenHandler
             return OAuth2Error.INVALID_GRANT.setDescription(
                     "Authorization code used too many times");
         } catch (IllegalArgumentException e) {
-            LogHelper.logErrorMessage("Failed to revoke access token.", e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to revoke access token.", e));
             return OAuth2Error.INVALID_GRANT.setDescription("Failed to revoke access token");
         }
     }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.jwt.SignedJWT;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -113,7 +112,8 @@ public class ProcessAsyncCriCredentialHandler
                     | CiPutException
                     | AsyncVerifiableCredentialException
                     | CiPostMitigationsException e) {
-                LogHelper.logErrorMessage("Failed to process VC response message.", e.getMessage());
+                LOGGER.error(
+                        LogHelper.buildErrorMessage("Failed to process VC response message.", e));
                 failedRecords.add(new SQSBatchResponse.BatchItemFailure(message.getMessageId()));
             } catch (VerifiableCredentialException e) {
                 LOGGER.error(
@@ -213,15 +213,16 @@ public class ProcessAsyncCriCredentialHandler
                         successAsyncCriResponse.getUserId(),
                         successAsyncCriResponse.getCredentialIssuer());
         if (criResponseItem == null) {
-            LogHelper.logErrorMessage("No response item found");
+            LOGGER.error(LogHelper.buildLogMessage("No response item found"));
             throw new AsyncVerifiableCredentialException(UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL);
         }
         if (criResponseItem.getOauthState() == null
                 || !criResponseItem
                         .getOauthState()
                         .equals(successAsyncCriResponse.getOauthState())) {
-            LogHelper.logErrorMessage(
-                    "State mismatch between response item and async response message");
+            LOGGER.error(
+                    LogHelper.buildLogMessage(
+                            "State mismatch between response item and async response message"));
             throw new AsyncVerifiableCredentialException(UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL);
         }
     }
@@ -270,7 +271,7 @@ public class ProcessAsyncCriCredentialHandler
                         configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
                         auditEventUser,
                         extensionErrorParams);
-        LogHelper.logMessage(Level.INFO, "Sending audit event IPV_F2F_CRI_VC_ERROR message.");
+        LOGGER.info(LogHelper.buildLogMessage("Sending audit event IPV_F2F_CRI_VC_ERROR message."));
         auditService.sendAuditEvent(auditEvent);
     }
 

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/helpers/AsyncCriResponseHelper.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/helpers/AsyncCriResponseHelper.java
@@ -2,7 +2,8 @@ package uk.gov.di.ipv.core.processasynccricredential.helpers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.domain.CriConstants;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.processasynccricredential.domain.BaseAsyncCriResponse;
@@ -11,6 +12,7 @@ import uk.gov.di.ipv.core.processasynccricredential.domain.SuccessAsyncCriRespon
 import uk.gov.di.ipv.core.processasynccricredential.dto.CriResponseMessageDto;
 
 public class AsyncCriResponseHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
     public static final String DEFAULT_CREDENTIAL_ISSUER = CriConstants.F2F_CRI;
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -22,9 +24,10 @@ public class AsyncCriResponseHelper {
         final CriResponseMessageDto criResponseMessageDto =
                 MAPPER.readerFor(CriResponseMessageDto.class).readValue(criResponseMessage);
         if (criResponseMessageDto.getCredentialIssuer() == null) {
-            LogHelper.logMessage(
-                    Level.WARN,
-                    "Credential Issuer not set, defaulting to " + DEFAULT_CREDENTIAL_ISSUER);
+            LOGGER.warn(
+                    LogHelper.buildLogMessage(
+                            "Credential Issuer not set, defaulting to "
+                                    + DEFAULT_CREDENTIAL_ISSUER));
             criResponseMessageDto.setCredentialIssuer(DEFAULT_CREDENTIAL_ISSUER);
         }
         if (criResponseMessageDto.getError() == null) {

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -215,8 +215,9 @@ public class ProcessCriCallbackHandler
         } catch (CriApiException e) {
             if (DCMAW_CRI.equals(callbackRequest.getCredentialIssuerId())
                     && e.getHttpStatusCode() == HTTPResponse.SC_NOT_FOUND) {
-                LogHelper.logErrorMessage(
-                        "404 received from DCMAW CRI", e.getErrorResponse().getMessage());
+                LOGGER.error(
+                        LogHelper.buildErrorMessage(
+                                "404 received from DCMAW CRI", e.getErrorResponse().getMessage()));
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         HttpStatus.SC_OK, JOURNEY_NOT_FOUND);
             }
@@ -312,7 +313,7 @@ public class ProcessCriCallbackHandler
 
     private APIGatewayProxyResponseEvent buildErrorResponse(
             Exception e, int status, ErrorResponse errorResponse) {
-        LogHelper.logErrorMessage(errorResponse.getMessage(), e);
+        LOGGER.error(LogHelper.buildErrorMessage(errorResponse.getMessage(), e));
         return ApiGatewayResponseGenerator.proxyJsonResponse(
                 status,
                 new JourneyErrorResponse(

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java
@@ -18,7 +18,6 @@ import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.http.HttpHeaders;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -107,7 +106,7 @@ public class CriApiService {
             }
 
             var token = tokenResponse.toSuccessResponse().getTokens().getBearerAccessToken();
-            LogHelper.logMessage(Level.INFO, "Auth Code exchanged for Access Token.");
+            LOGGER.info(LogHelper.buildLogMessage("Auth Code exchanged for Access Token."));
             return token;
         } catch (IOException | ParseException e) {
             LOGGER.error("Error exchanging token: {}", e.getMessage(), e);
@@ -184,10 +183,11 @@ public class CriApiService {
             var response = credentialRequest.send();
 
             if (!response.indicatesSuccess()) {
-                LogHelper.logErrorMessage(
-                        "Error retrieving credential",
-                        response.getStatusCode(),
-                        response.getStatusMessage());
+                LOGGER.error(
+                        LogHelper.buildErrorMessage(
+                                "Error retrieving credential",
+                                response.getStatusMessage(),
+                                response.getStatusCode()));
                 if (DCMAW_CRI.equals(criId)
                         && response.getStatusCode() == HTTPResponse.SC_NOT_FOUND) {
                     throw new CriApiException(
@@ -206,15 +206,17 @@ public class CriApiService {
                         VerifiableCredentialResponse.builder()
                                 .verifiableCredentials(Collections.singletonList(vcJwt))
                                 .build();
-                LogHelper.logMessage(
-                        Level.INFO, "Verifiable Credential retrieved from JWT response.");
+                LOGGER.info(
+                        LogHelper.buildLogMessage(
+                                "Verifiable Credential retrieved from JWT response."));
                 return verifiableCredentialResponse;
             } else if (ContentType.APPLICATION_JSON.matches(
                     ContentType.parse(responseContentType))) {
                 var verifiableCredentialResponse =
                         getVerifiableCredentialResponseForApplicationJson(response.getContent());
-                LogHelper.logMessage(
-                        Level.INFO, "Verifiable Credential retrieved from json response.");
+                LOGGER.info(
+                        LogHelper.buildLogMessage(
+                                "Verifiable Credential retrieved from json response."));
                 return verifiableCredentialResponse;
             } else {
                 LOGGER.error(
@@ -230,7 +232,7 @@ public class CriApiService {
                         ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);
             }
         } catch (IOException | ParseException | java.text.ParseException e) {
-            LogHelper.logErrorMessage("Error retrieving credential.", e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage("Error retrieving credential.", e));
             throw new CriApiException(
                     HTTPResponse.SC_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER);

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -104,7 +104,7 @@ public class ProcessJourneyEventHandler
             // Get/ set session items/ config
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
             if (ipvSessionItem == null) {
-                LogHelper.logErrorMessage("Failed to find ipv-session");
+                LOGGER.error(LogHelper.buildLogMessage("Failed to find ipv-session"));
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_ID);
             }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/ApiGatewayResponseGenerator.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/ApiGatewayResponseGenerator.java
@@ -5,11 +5,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpHeaders;
 import org.apache.http.entity.ContentType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.Map;
 
 public class ApiGatewayResponseGenerator {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -23,7 +26,9 @@ public class ApiGatewayResponseGenerator {
         try {
             return proxyResponse(statusCode, generateResponseBody(body), responseHeaders);
         } catch (JsonProcessingException e) {
-            LogHelper.logErrorMessage("Unable to generateApiGatewayProxyErrorResponse", e);
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Unable to generateApiGatewayProxyErrorResponse", e));
             return proxyResponse(500, "Internal server error", Collections.emptyMap());
         }
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -5,7 +5,6 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -148,12 +147,13 @@ public class RequestHelper {
             throws HttpResponseExceptionWithErrorBody {
         Map<String, Object> lambdaInput = request.getLambdaInput();
         if (lambdaInput == null) {
-            LogHelper.logErrorMessage("Missing lambdaInput map");
+            LOGGER.error(LogHelper.buildLogMessage("Missing lambdaInput map"));
             throw new HttpResponseExceptionWithErrorBody(HttpStatus.SC_BAD_REQUEST, errorResponse);
         }
         T value = (T) lambdaInput.get(key);
         if (value == null) {
-            LogHelper.logErrorMessage(String.format("Missing '%s' in lambdaInput", key));
+            LOGGER.error(
+                    LogHelper.buildLogMessage(String.format("Missing '%s' in lambdaInput", key)));
             throw new HttpResponseExceptionWithErrorBody(HttpStatus.SC_BAD_REQUEST, errorResponse);
         }
         return value;
@@ -175,9 +175,9 @@ public class RequestHelper {
             throws HttpResponseExceptionWithErrorBody {
         if (ipvSessionId == null) {
             if (allowNull) {
-                LogHelper.logMessage(Level.WARN, errorMessage);
+                LOGGER.warn(LogHelper.buildLogMessage(errorMessage));
             } else {
-                LogHelper.logErrorMessage(errorMessage);
+                LOGGER.error(LogHelper.buildLogMessage(errorMessage));
                 throw new HttpResponseExceptionWithErrorBody(
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
             }
@@ -194,7 +194,7 @@ public class RequestHelper {
     private static void validateIpAddress(String ipAddress, String errorMessage)
             throws HttpResponseExceptionWithErrorBody {
         if (ipAddress == null) {
-            LogHelper.logErrorMessage(errorMessage, IP_ADDRESS_HEADER);
+            LOGGER.error(LogHelper.buildErrorMessage(errorMessage, IP_ADDRESS_HEADER));
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IP_ADDRESS);
         }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -48,7 +48,6 @@ import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.IS_LOCAL;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.SIGNING_KEY_ID_PARAM;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CONNECTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
-import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_FEATURE_SET;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_PARAMETER_PATH;
@@ -288,7 +287,7 @@ public class ConfigService {
             }
             return configMap;
         } catch (JsonProcessingException e) {
-            LogHelper.logErrorMessage("Failed to parse contra-indicator config");
+            LOGGER.error(LogHelper.buildLogMessage("Failed to parse contra-indicator config"));
             return Collections.emptyMap();
         }
     }
@@ -322,29 +321,31 @@ public class ConfigService {
         try {
             return secretsProvider.get(secretId);
         } catch (DecryptionFailureException e) {
-            LogHelper.logErrorMessage(
-                    "Secrets manager failed to decrypt the protected secret using the configured KMS key",
-                    e.getMessage());
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Secrets manager failed to decrypt the protected secret using the configured KMS key",
+                            e));
         } catch (InternalServiceErrorException e) {
-            LogHelper.logErrorMessage(
-                    "Internal server error occurred with Secrets manager", e.getMessage());
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Internal server error occurred with Secrets manager", e));
         } catch (InvalidParameterException e) {
             LOGGER.error(
-                    "An invalid value was provided for the param value: {}, details: {}",
-                    secretId,
-                    e.getMessage());
+                    LogHelper.buildErrorMessage(
+                            String.format(
+                                    "An invalid value was provided for the param value: %s",
+                                    secretId),
+                            e));
         } catch (InvalidRequestException e) {
-            LogHelper.logErrorMessage(
-                    "Parameter value is not valid for the current state of the resource",
-                    e.getMessage());
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Parameter value is not valid for the current state of the resource",
+                            e));
         } catch (ResourceNotFoundException e) {
             LOGGER.error(
-                    new StringMapMessage()
-                            .with(
-                                    LOG_MESSAGE_DESCRIPTION.getFieldName(),
-                                    "Failed to find the resource within Secrets manager.")
-                            .with(LOG_SECRET_ID.getFieldName(), secretId)
-                            .with(LOG_ERROR_DESCRIPTION.getFieldName(), e.getMessage()));
+                    LogHelper.buildErrorMessage(
+                                    "Failed to find the resource within Secrets manager.", e)
+                            .with(LOG_SECRET_ID.getFieldName(), secretId));
         }
         return null;
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -4,7 +4,8 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
@@ -22,6 +23,7 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SE
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.IPV_SESSIONS_TABLE_NAME;
 
 public class IpvSessionService {
+    private static final Logger LOGGER = LogManager.getLogger();
     private static final String INITIAL_IPV_JOURNEY_STATE = "INITIAL_IPV_JOURNEY";
     private static final String FAILED_CLIENT_JAR_STATE = "FAILED_CLIENT_JAR";
     private static final String VOT_P0 = "P0";
@@ -73,9 +75,9 @@ public class IpvSessionService {
                 try {
                     Thread.sleep(backoff);
                 } catch (InterruptedException e) {
-                    LogHelper.logMessage(
-                            Level.WARN,
-                            "getIpvSessionByAccessToken() backoff and retry sleep was interrupted");
+                    LOGGER.warn(
+                            LogHelper.buildLogMessage(
+                                    "getIpvSessionByAccessToken() backoff and retry sleep was interrupted"));
                     Thread.currentThread().interrupt();
                 }
             } else {
@@ -84,7 +86,7 @@ public class IpvSessionService {
         }
 
         if (attempts > 0) {
-            LogHelper.logMessage(Level.WARN, "getIpvSessionByAccessToken() required retries");
+            LOGGER.warn(LogHelper.buildLogMessage("getIpvSessionByAccessToken() required retries"));
         }
         return Optional.ofNullable(ipvSessionItem);
     }

--- a/libs/email-service/src/main/java/uk/gov/di/ipv/core/library/service/EmailService.java
+++ b/libs/email-service/src/main/java/uk/gov/di/ipv/core/library/service/EmailService.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.service;
 
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -42,8 +41,9 @@ public class EmailService {
         Map<String, Object> templateParameters = new HashMap<>();
         templateParameters.put("fullName", fullName);
 
-        LogHelper.logMessage(
-                Level.INFO, "Attempting to send user triggered identity reset confirmation email");
+        LOGGER.info(
+                LogHelper.buildLogMessage(
+                        "Attempting to send user triggered identity reset confirmation email"));
         // This template ID can vary between production and the other environments, so it can't be
         // hardcoded
         final String templateId =
@@ -61,9 +61,9 @@ public class EmailService {
 
         while (true) {
             try {
-                LogHelper.logMessage(Level.DEBUG, "About to send email");
+                LOGGER.debug(LogHelper.buildLogMessage("About to send email"));
                 notificationClient.sendEmail(templateId, toAddress, personalisation, null, null);
-                LogHelper.logMessage(Level.DEBUG, "Email sent");
+                LOGGER.debug(LogHelper.buildLogMessage("Email sent"));
                 return;
             } catch (NotificationClientException e) {
                 LOGGER.warn(
@@ -75,14 +75,17 @@ public class EmailService {
 
                 if (httpResult == 400 || httpResult == 403) {
                     // A 400 or 403 is not going to be fixed by retrying so don't bother.
-                    LogHelper.logErrorMessage(
-                            "Error sending email is not retryable. Email has NOT been sent");
+                    LOGGER.error(
+                            LogHelper.buildLogMessage(
+                                    "Error sending email is not retryable. Email has NOT been sent"));
                     return;
                 }
             }
 
             if (retries >= NUMBER_OF_RETRIES) {
-                LogHelper.logErrorMessage("Number of retries exceeded. Email has NOT been sent");
+                LOGGER.error(
+                        LogHelper.buildLogMessage(
+                                "Number of retries exceeded. Email has NOT been sent"));
                 return;
             }
             retries++;
@@ -93,8 +96,9 @@ public class EmailService {
                 // Set the interruption flag
                 Thread.currentThread().interrupt();
                 // If we're interrupted then give up on sending the email
-                LogHelper.logErrorMessage(
-                        "Interrupted while waiting to retry email. Email has NOT been sent");
+                LOGGER.error(
+                        LogHelper.buildLogMessage(
+                                "Interrupted while waiting to retry email. Email has NOT been sent"));
                 return;
             }
         }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -10,7 +10,6 @@ import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.util.CollectionUtils;
 import org.apache.http.HttpStatus;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -177,7 +176,7 @@ public class UserIdentityService {
         }
 
         if (identityClaims.isEmpty()) {
-            LogHelper.logMessage(Level.WARN, "Failed to find any identity claims in VCs");
+            LOGGER.warn(LogHelper.buildLogMessage("Failed to find any identity claims in VCs"));
             return Optional.empty();
         }
 
@@ -190,7 +189,7 @@ public class UserIdentityService {
                         .filter(identityClaim -> !identityClaim.getBirthDate().isEmpty())
                         .findFirst();
         if (claimWithName.isEmpty() || claimWithBirthDate.isEmpty()) {
-            LogHelper.logErrorMessage("Failed to generate identity claim");
+            LOGGER.error(LogHelper.buildLogMessage("Failed to generate identity claim"));
             throw new HttpResponseExceptionWithErrorBody(
                     500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
         }
@@ -447,7 +446,7 @@ public class UserIdentityService {
             try {
                 return objectMapper.readValue(new JSONArray().toJSONString(), valueType);
             } catch (JsonProcessingException e) {
-                LogHelper.logErrorMessage("Failed to generate empty list", e.getMessage());
+                LOGGER.error(LogHelper.buildErrorMessage("Failed to generate empty list", e));
                 throw new HttpResponseExceptionWithErrorBody(
                         500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
             }
@@ -455,7 +454,7 @@ public class UserIdentityService {
         try {
             return objectMapper.treeToValue(propertyNode, valueType);
         } catch (JsonProcessingException e) {
-            LogHelper.logErrorMessage("Failed to parse VC JWT", e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to parse VC JWT", e));
             throw new HttpResponseExceptionWithErrorBody(
                     500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
         }
@@ -487,7 +486,7 @@ public class UserIdentityService {
         var addressStoreItem = findStoreItem(ADDRESS_CRI, vcStoreItems);
 
         if (addressStoreItem.isEmpty()) {
-            LogHelper.logMessage(Level.WARN, "Failed to find Address CRI credential");
+            LOGGER.warn(LogHelper.buildLogMessage("Failed to find Address CRI credential"));
             return Optional.empty();
         }
 
@@ -499,7 +498,7 @@ public class UserIdentityService {
                         ErrorResponse.FAILED_TO_GENERATE_ADDRESS_CLAIM);
 
         if (addressNode.isMissingNode()) {
-            LogHelper.logErrorMessage("Address property is missing from address VC");
+            LOGGER.error(LogHelper.buildLogMessage("Address property is missing from address VC"));
             throw new HttpResponseExceptionWithErrorBody(
                     500, ErrorResponse.FAILED_TO_GENERATE_ADDRESS_CLAIM);
         }
@@ -512,7 +511,7 @@ public class UserIdentityService {
         var ninoStoreItem = findStoreItem(NINO_CRI, successfulVCStoreItems);
 
         if (ninoStoreItem.isEmpty()) {
-            LogHelper.logMessage(Level.WARN, "Failed to find Nino CRI credential");
+            LOGGER.warn(LogHelper.buildLogMessage("Failed to find Nino CRI credential"));
             return Optional.empty();
         }
 
@@ -545,7 +544,7 @@ public class UserIdentityService {
         var passportVc = findStoreItem(PASSPORT_CRI_TYPES, successfulVCStoreItems);
 
         if (passportVc.isEmpty()) {
-            LogHelper.logMessage(Level.WARN, "Failed to find Passport CRI credential");
+            LOGGER.warn(LogHelper.buildLogMessage("Failed to find Passport CRI credential"));
             return Optional.empty();
         }
 
@@ -578,7 +577,7 @@ public class UserIdentityService {
         var drivingPermitVc = findStoreItem(DRIVING_PERMIT_CRI_TYPES, successfulVCStoreItems);
 
         if (drivingPermitVc.isEmpty()) {
-            LogHelper.logMessage(Level.WARN, "Failed to find Driving Permit CRI credential");
+            LOGGER.warn(LogHelper.buildLogMessage("Failed to find Driving Permit CRI credential"));
             return Optional.empty();
         }
 
@@ -634,7 +633,7 @@ public class UserIdentityService {
             return getVCClaimNode(credentialItem.getCredential(), VC_CREDENTIAL_SUBJECT)
                     .path(detailName);
         } catch (CredentialParseException e) {
-            LogHelper.logErrorMessage(errorLog, e.getMessage());
+            LOGGER.error(LogHelper.buildErrorMessage(errorLog, e));
             throw new HttpResponseExceptionWithErrorBody(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse);
         }

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsPoller.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsPoller.java
@@ -3,15 +3,18 @@ package uk.gov.di.ipv.coreback.sqs;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class SqsPoller {
+    private static final Logger LOGGER = LogManager.getLogger();
+
     public void start(RequestHandler<SQSEvent, SQSBatchResponse> sqsHandler) {
-        LogHelper.logMessage(Level.INFO, "SQS poller starting up");
+        LOGGER.info(LogHelper.buildLogMessage("SQS poller starting up"));
         ScheduledThreadPoolExecutor threadPool = new ScheduledThreadPoolExecutor(2);
         threadPool.scheduleAtFixedRate(new SqsReader(sqsHandler), 2, 2, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
## Proposed changes

### What changed

LogHelper methods now only build the log messages, but do not perform the logging themselves.

### Why did it change

Putting all the log messages in a helper means that all the messages appear to come from `LogHelper.java`, which makes it much harder to identify which piece of code the log originates from.

### Issue tracking

- [PYIC-4425](https://govukverify.atlassian.net/browse/PYIC-4425)

[PYIC-4425]: https://govukverify.atlassian.net/browse/PYIC-4425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ