### PR TITLE
PYIC-4139: Adjust timeouts and correct indexing

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2301,6 +2301,7 @@ Resources:
       Handler: uk.gov.di.ipv.core.replaycimitvcs.ReplayCimitVcsHandler::handleRequest
       PackageType: Zip
       CodeUri: ../lambdas/replay-cimit-vcs
+      Timeout: 600
       Tracing: Active
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.

--- a/lambdas/replay-cimit-vcs/src/main/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandler.java
+++ b/lambdas/replay-cimit-vcs/src/main/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandler.java
@@ -64,7 +64,7 @@ public class ReplayCimitVcsHandler implements RequestStreamHandler {
             requestItems = mapper.readValue(inputStream, ReplayRequest.class).getItems();
             LOGGER.info("Retrieving {} VCs", requestItems.size());
             List<List<ReplayItem>> batchedRequest = ListHelper.getBatches(requestItems, 100);
-            for (int i = 0; i < requestItems.size(); i++) {
+            for (int i = 0; i < batchedRequest.size(); i++) {
                 LOGGER.info("Processing batch {} of {}", i, requestItems.size());
                 List<ReplayItem> batch = batchedRequest.get(i);
                 handleBatch(batch);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Adjusts timeout property on lambda to 10 minutes
- Adjusts number of times to iterate over batches

### Why did it change

- Longer timeout allows for processing more replay events in one chunk, current lambda take ~3minutes to process 1000 events
- Iterations over the list of batches exceeded size of the list

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
