### PR TITLE
PYIC-4124: Added consumer side contract test suite for BAV CRI

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
@@ -27,8 +27,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
+import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.FixedTimeJWTClaimsVerifier;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
@@ -262,7 +262,7 @@ class ContractTest {
 
         when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
                 .thenReturn("900");
-        when(mockConfigService.getCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getOauthCriConfig(any())).thenReturn(credentialIssuerConfig);
         when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
 
         // Fix the signature here as mocking out the AWSKMS class inside the real signer would be
@@ -318,13 +318,13 @@ class ContractTest {
     @Test
     @PactTestFor(pactMethod = "invalidAuthCodeReturns401")
     void fetchAccessToken_whenCalledAgainstBavCriWithInvalidAuthCode_throwsAnException(
-            MockServer mockServer) throws URISyntaxException, JOSEException, CriApiException {
+            MockServer mockServer) throws URISyntaxException, JOSEException {
         // Arrange
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
 
         when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
                 .thenReturn("900");
-        when(mockConfigService.getCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getOauthCriConfig(any())).thenReturn(credentialIssuerConfig);
         when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
 
         // Fix the signature here as mocking out the AWSKMS class inside the real signer would be
@@ -560,7 +560,7 @@ class ContractTest {
     @Test
     @PactTestFor(pactMethod = "invalidAccessTokenReturns404")
     void fetchVerifiableCredential_whenCalledAgainstBavCriWithInvalidAuthCode_throwsAnException(
-            MockServer mockServer) throws URISyntaxException, CriApiException {
+            MockServer mockServer) throws URISyntaxException {
         // Arrange
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         configureMockConfigService(credentialIssuerConfig);
@@ -596,7 +596,7 @@ class ContractTest {
 
     @NotNull
     private static CriCallbackRequest getCallbackRequest(
-            String authCode, CredentialIssuerConfig credentialIssuerConfig) {
+            String authCode, OauthCriConfig credentialIssuerConfig) {
         return new CriCallbackRequest(
                 authCode,
                 credentialIssuerConfig.getClientId(),
@@ -620,12 +620,12 @@ class ContractTest {
                                 Date.from(CURRENT_TIME.instant()))));
     }
 
-    private void configureMockConfigService(CredentialIssuerConfig credentialIssuerConfig) {
+    private void configureMockConfigService(OauthCriConfig credentialIssuerConfig) {
         ContraIndicatorConfig ciConfig1 = new ContraIndicatorConfig(null, 4, null, null);
         Map<String, ContraIndicatorConfig> ciConfigMap = new HashMap<>();
         ciConfigMap.put("D02", ciConfig1);
 
-        when(mockConfigService.getCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getOauthCriConfig(any())).thenReturn(credentialIssuerConfig);
         when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
         // This mock doesn't get reached in error cases, but it would be messy to explicitly not set
         // it
@@ -635,19 +635,21 @@ class ContractTest {
     }
 
     @NotNull
-    private static CredentialIssuerConfig getMockCredentialIssuerConfig(MockServer mockServer)
+    private static OauthCriConfig getMockCredentialIssuerConfig(MockServer mockServer)
             throws URISyntaxException {
-        return new CredentialIssuerConfig(
-                new URI("http://localhost:" + mockServer.getPort() + "/token"),
-                new URI("http://localhost:" + mockServer.getPort() + "/credential"),
-                new URI("http://localhost:" + mockServer.getPort() + "/authorize"),
-                IPV_CORE_CLIENT_ID,
-                CRI_SIGNING_PRIVATE_KEY_JWK,
-                CRI_RSA_ENCRYPTION_PUBLIC_JWK,
-                TEST_ISSUER,
-                URI.create(
-                        "https://identity.staging.account.gov.uk/credential-issuer/callback?id=bav"),
-                true,
-                false);
+        return OauthCriConfig.builder()
+                .tokenUrl(new URI("http://localhost:" + mockServer.getPort() + "/token"))
+                .credentialUrl(new URI("http://localhost:" + mockServer.getPort() + "/credential"))
+                .authorizeUrl(new URI("http://localhost:" + mockServer.getPort() + "/authorize"))
+                .clientId(IPV_CORE_CLIENT_ID)
+                .signingKey(CRI_SIGNING_PRIVATE_KEY_JWK)
+                .encryptionKey(CRI_RSA_ENCRYPTION_PUBLIC_JWK)
+                .componentId("dummyBavComponentId")
+                .clientCallbackUrl(
+                        URI.create(
+                                "https://identity.staging.account.gov.uk/credential-issuer/callback?id=bav"))
+                .requiresApiKey(true)
+                .requiresAdditionalEvidence(false)
+                .build();
     }
 }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
@@ -178,7 +178,7 @@ class ContractTest {
                          "validityScore": 0,
                          "strengthScore": 3,
                          "ci": [
-                           "D02"
+                           "D15"
                             ],
                          "txn": "dummyTxn",
                          "type": "IdentityCheck"
@@ -219,7 +219,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_BAV_VC_SIGNATURE =
-            "tl8zA_YC6J64PqseVN7ITAWabKb5Xoa9I9bDUzzElrGXjc2i1A7NOG0j_yglZT1Q15syH76UmfSa3FMa7Sfkew";
+            "V9CEL4TCIGFeSJgY9-UePbmm2ot9G3pRTmf4edmHknBfmhL1bum5FeJr69JTVX-CWZ51uXWun9lkHwy1jYuaaQ";
 
     @Mock private ConfigService mockConfigService;
     @Mock private JWSSigner mockSigner;
@@ -458,7 +458,7 @@ class ContractTest {
                 .given("dummyBavComponentId is a valid issuer")
                 .given("VC evidence failedCheckDetails identityCheckPolicy is none")
                 .given("VC evidence failedCheckDetails checkMethod is data")
-                .given("VC evidence has a CI of D02")
+                .given("VC evidence has a CI of D15")
                 .given("VC evidence validityScore is 0")
                 .given("VC evidence strengthScore is 3")
                 .given("VC evidence txn is dummyTxn")
@@ -523,7 +523,7 @@ class ContractTest {
                                         credentialSubject.get("name").get(0).get("nameParts");
                                 JsonNode birthDateNode = credentialSubject.get("birthDate").get(0);
 
-                                assertEquals("D02", ciNode.get(0).asText());
+                                assertEquals("D15", ciNode.get(0).asText());
 
                                 JsonNode bankAccountNode =
                                         credentialSubject.get("bankAccount").get(0);
@@ -631,7 +631,7 @@ class ContractTest {
     private void configureMockConfigService(OauthCriConfig credentialIssuerConfig) {
         ContraIndicatorConfig ciConfig1 = new ContraIndicatorConfig(null, 4, null, null);
         Map<String, ContraIndicatorConfig> ciConfigMap = new HashMap<>();
-        ciConfigMap.put("D02", ciConfig1);
+        ciConfigMap.put("D15", ciConfig1);
 
         when(mockConfigService.getOauthCriConfig(any())).thenReturn(credentialIssuerConfig);
         when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
@@ -1,0 +1,653 @@
+package uk.gov.di.ipv.core.processcricallback.pact.bavCri;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.dto.CredentialIssuerConfig;
+import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
+import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.helpers.FixedTimeJWTClaimsVerifier;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
+import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialJwtValidator;
+import uk.gov.di.ipv.core.processcricallback.exception.CriApiException;
+import uk.gov.di.ipv.core.processcricallback.pact.PactJwtIgnoreSignatureBodyBuilder;
+import uk.gov.di.ipv.core.processcricallback.service.CriApiService;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Date;
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@Disabled("PACT tests should not be run in build pipelines at this time")
+@ExtendWith(PactConsumerTestExt.class)
+@ExtendWith(MockitoExtension.class)
+@PactTestFor(providerName = "BavCriProvider")
+@MockServerConfig(hostInterface = "localhost", port = "1234")
+class ContractTest {
+    private static final String TEST_USER = "test-subject";
+    private static final String TEST_ISSUER = "dummyBavComponentId";
+    private static final String IPV_CORE_CLIENT_ID = "ipv-core";
+    private static final String PRIVATE_API_KEY = "dummyApiKey";
+    private static final Clock CURRENT_TIME =
+            Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
+    private static final String CRI_SIGNING_PRIVATE_KEY_JWK =
+            """
+            {"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}
+            """;
+    private static final String CRI_RSA_ENCRYPTION_PUBLIC_JWK =
+            """
+            {"kty":"RSA","e":"AQAB","n":"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q"}
+            """;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String CLIENT_ASSERTION_HEADER = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9";
+    private static final String CLIENT_ASSERTION_BODY =
+            "eyJpc3MiOiJpcHYtY29yZSIsInN1YiI6Imlwdi1jb3JlIiwiYXVkIjoiZHVtbXlCYXZDb21wb25lbnRJZCIsImV4cCI6NDA3MDkwOTcwMCwianRpIjoiU2NuRjRkR1h0aFpZWFNfNWs4NU9iRW9TVTA0Vy1IM3FhX3A2bnB2MlpVWSJ9";
+    // Signature generated using JWT.io
+    private static final String CLIENT_ASSERTION_SIGNATURE =
+            "Cg7VaW9q94XBCp3XhYRyifqAEASrg1HIYxhHdcJ949lqpFjmvuDM5T1Dh4OzNAQWe5LqoWpA4IGwhklnuKcilA";
+
+    // We hardcode the VC headers and bodies like this so that it is easy to update them from JSON
+    // sent by the CRI team
+    private static final String VALID_VC_HEADER =
+            """
+            {
+              "typ": "JWT",
+              "alg": "ES256"
+            }
+            """;
+    // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
+    private static final String VALID_BAV_VC_BODY =
+            """
+            {
+              "sub": "test-subject",
+              "iss": "dummyBavComponentId",
+              "nbf": 4070908800,
+              "exp": 4070909400,
+              "vc": {
+                "evidence": [
+                  {
+                    "validityScore": 2,
+                    "strengthScore": 3,
+                    "txn": "dummyTxn",
+                    "type": "IdentityCheck"
+                  }
+                ],
+                "credentialSubject": {
+                  "bankAccount": [
+                    {
+                      "accountNumber": "12345678",
+                      "sortCode": "103233"
+                    }
+                  ],
+                  "name": [
+                    {
+                      "nameParts": [
+                        {
+                          "type": "GivenName",
+                          "value": "Kenneth"
+                        },
+                        {
+                          "type": "FamilyName",
+                          "value": "Decerqueira"
+                        }
+                      ]
+                    }
+                  ],
+                  "birthDate": [
+                    {
+                      "value": "1962-10-11"
+                    }
+                  ]
+                },
+                "jti": "dummyJti"
+                }
+            }
+            """;
+    // If we generate the signature in code it will be different each time, so we need to generate a
+    // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
+    // change each time we run the tests.
+    private static final String VALID_BAV_VC_SIGNATURE =
+            "ARHudEXt_OpGqJPP603JvjjmykiibzIUiKD9YvaqLlFAokimzRVDxS3lmu19UMpumLxdXxyz_MMb0ZyB3xgo-A";
+
+    private static final String FAILED_BAV_VC_BODY =
+            """
+                {
+                   "sub": "test-subject",
+                   "iss": "dummyBavComponentId",
+                   "nbf": 4070908800,
+                   "exp": 4070909400,
+                   "vc": {
+                     "evidence": [
+                       {
+                         "failedCheckDetails": [
+                           {
+                             "identityCheckPolicy": "none",
+                             "checkMethod": "data"
+                           }
+                            ],
+                         "validityScore": 0,
+                         "strengthScore": 3,
+                         "ci": [
+                           "D02"
+                            ],
+                         "txn": "dummyTxn",
+                         "type": "IdentityCheck"
+                          }
+                        ],
+                     "credentialSubject": {
+                       "bankAccount": [
+                         {
+                           "accountNumber": "12345678",
+                           "sortCode": "103233"
+                         }
+                       ],
+                       "name": [
+                         {
+                           "nameParts": [
+                             {
+                               "type": "GivenName",
+                               "value": "Kenneth"
+                             },
+                             {
+                               "type": "FamilyName",
+                               "value": "Decerqueira"
+                             }
+                           ]
+                         }
+                       ],
+                       "birthDate": [
+                         {
+                           "value": "1962-10-11"
+                         }
+                       ]
+                     },
+                     "jti": "dummyJti"
+                 }
+             }
+            """;
+    // If we generate the signature in code it will be different each time, so we need to generate a
+    // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
+    // change each time we run the tests.
+    private static final String FAILED_BAV_VC_SIGNATURE =
+            "tl8zA_YC6J64PqseVN7ITAWabKb5Xoa9I9bDUzzElrGXjc2i1A7NOG0j_yglZT1Q15syH76UmfSa3FMa7Sfkew";
+
+    @Mock private ConfigService mockConfigService;
+    @Mock private JWSSigner mockSigner;
+    @Mock private SecureTokenHelper mockSecureTokenHelper;
+
+    @Pact(provider = "BavCriProvider", consumer = "IpvCoreBack")
+    public RequestResponsePact validRequestReturnsValidAccessToken(PactDslWithProvider builder) {
+        return builder.given("dummyAuthCode is a valid authorization code")
+                .given("dummyApiKey is a valid api key")
+                .given("dummyBavComponentId is the BAV CRI component ID")
+                .given("BAV CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
+                .uponReceiving("Valid auth code")
+                .path("/token")
+                .method("POST")
+                .body(
+                        "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3Dbav&client_assertion="
+                                + CLIENT_ASSERTION_HEADER
+                                + "."
+                                + CLIENT_ASSERTION_BODY
+                                + "."
+                                + CLIENT_ASSERTION_SIGNATURE)
+                .headers(
+                        "x-api-key",
+                        PRIVATE_API_KEY,
+                        "Content-Type",
+                        "application/x-www-form-urlencoded; charset=UTF-8")
+                .willRespondWith()
+                .status(200)
+                .body(
+                        newJsonBody(
+                                        (body) -> {
+                                            body.stringType("access_token");
+                                            body.stringValue("token_type", "Bearer");
+                                            body.integerType("expires_in");
+                                        })
+                                .build())
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "validRequestReturnsValidAccessToken")
+    void fetchAccessToken_whenCalledAgainstBavCri_retrievesAValidAccessToken(MockServer mockServer)
+            throws URISyntaxException, JOSEException, CriApiException {
+        // Arrange
+        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
+
+        when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
+                .thenReturn("900");
+        when(mockConfigService.getCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
+
+        // Fix the signature here as mocking out the AWSKMS class inside the real signer would be
+        // painful.
+        when(mockSigner.sign(any(), any())).thenReturn(new Base64URL(CLIENT_ASSERTION_SIGNATURE));
+        when(mockSigner.supportedJWSAlgorithms()).thenReturn(Set.of(JWSAlgorithm.ES256));
+        when(mockSecureTokenHelper.generate())
+                .thenReturn("ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY");
+
+        // We need to generate a fixed request, so we set the secure token and expiry to constant
+        // values.
+        var underTest =
+                new CriApiService(
+                        mockConfigService, mockSigner, mockSecureTokenHelper, CURRENT_TIME);
+
+        // Act
+        BearerAccessToken accessToken =
+                underTest.fetchAccessToken(
+                        getCallbackRequest("dummyAuthCode", credentialIssuerConfig),
+                        getCriOAuthSessionItem());
+        // Assert
+        assertThat(accessToken.getType(), is(AccessTokenType.BEARER));
+        assertThat(accessToken.getValue(), notNullValue());
+        assertThat(accessToken.getLifetime(), greaterThan(0L));
+    }
+
+    @Pact(provider = "BavCriProvider", consumer = "IpvCoreBack")
+    public RequestResponsePact invalidAuthCodeReturns401(PactDslWithProvider builder) {
+        return builder.given("dummyInvalidAuthCode is an invalid authorization code")
+                .given("dummyApiKey is a valid api key")
+                .given("dummyBavComponentId is the BAV CRI component ID")
+                .given("BAV CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
+                .uponReceiving("Invalid auth code")
+                .path("/token")
+                .method("POST")
+                .body(
+                        "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyInvalidAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3Dbav&client_assertion="
+                                + CLIENT_ASSERTION_HEADER
+                                + "."
+                                + CLIENT_ASSERTION_BODY
+                                + "."
+                                + CLIENT_ASSERTION_SIGNATURE)
+                .headers(
+                        "x-api-key",
+                        PRIVATE_API_KEY,
+                        "Content-Type",
+                        "application/x-www-form-urlencoded; charset=UTF-8")
+                .willRespondWith()
+                .status(401)
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "invalidAuthCodeReturns401")
+    void fetchAccessToken_whenCalledAgainstBavCriWithInvalidAuthCode_throwsAnException(
+            MockServer mockServer) throws URISyntaxException, JOSEException, CriApiException {
+        // Arrange
+        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
+
+        when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
+                .thenReturn("900");
+        when(mockConfigService.getCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
+
+        // Fix the signature here as mocking out the AWSKMS class inside the real signer would be
+        // painful.
+        when(mockSigner.sign(any(), any())).thenReturn(new Base64URL(CLIENT_ASSERTION_SIGNATURE));
+        when(mockSigner.supportedJWSAlgorithms()).thenReturn(Set.of(JWSAlgorithm.ES256));
+        when(mockSecureTokenHelper.generate())
+                .thenReturn("ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY");
+
+        // We need to generate a fixed request, so we set the secure token and expiry to constant
+        // values.
+        var underTest =
+                new CriApiService(
+                        mockConfigService, mockSigner, mockSecureTokenHelper, CURRENT_TIME);
+
+        // Act
+        CriApiException exception =
+                assertThrows(
+                        CriApiException.class,
+                        () ->
+                                underTest.fetchAccessToken(
+                                        getCallbackRequest(
+                                                "dummyInvalidAuthCode", credentialIssuerConfig),
+                                        getCriOAuthSessionItem()));
+
+        // Assert
+        assertThat(exception.getErrorResponse(), is(ErrorResponse.INVALID_TOKEN_REQUEST));
+        assertThat(exception.getHttpStatusCode(), is(HTTPResponse.SC_BAD_REQUEST));
+    }
+
+    @Pact(provider = "BavCriProvider", consumer = "IpvCoreBack")
+    public RequestResponsePact validRequestReturnsBavIssuedCredential(PactDslWithProvider builder) {
+        return builder.given("dummyApiKey is a valid api key")
+                .given("dummyAccessToken is a valid access token")
+                .given("test-subject is a valid subject")
+                .given("dummyBavComponentId is a valid issuer")
+                .given("VC evidence validityScore is 2")
+                .given("VC evidence strengthScore is 3")
+                .given("VC evidence txn is dummyTxn")
+                .given("VC evidence credentialSubject contains bankAccount")
+                .given("VC bankAccount accountNumber is 12345678")
+                .given("VC bankAccount sortCode is 103233")
+                .given("VC is for Kenneth Decerqueira")
+                .given("VC birthDate is 1962-10-11")
+                .uponReceiving("Valid POST request")
+                .path("/credential")
+                .method("POST")
+                .headers("x-api-key", PRIVATE_API_KEY, "Authorization", "Bearer dummyAccessToken")
+                .willRespondWith()
+                .status(200)
+                .body(
+                        new PactJwtIgnoreSignatureBodyBuilder(
+                                VALID_VC_HEADER, VALID_BAV_VC_BODY, VALID_BAV_VC_SIGNATURE))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "validRequestReturnsBavIssuedCredential")
+    void fetchVerifiableCredential_whenCalledAgainstBavCri_retrievesAValidVc(MockServer mockServer)
+            throws URISyntaxException, CriApiException {
+        // Arrange
+        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
+        configureMockConfigService(credentialIssuerConfig);
+
+        // We need to generate a fixed request, so we set the secure token and expiry to constant
+        // values.
+        var underTest =
+                new CriApiService(
+                        mockConfigService, mockSigner, mockSecureTokenHelper, CURRENT_TIME);
+
+        // Act
+        var verifiableCredentialResponse =
+                underTest.fetchVerifiableCredential(
+                        new BearerAccessToken("dummyAccessToken"),
+                        getCallbackRequest("dummyAuthCode", credentialIssuerConfig),
+                        getCriOAuthSessionItem());
+
+        // Assert
+        var verifiableCredentialJwtValidator = getVerifiableCredentialJwtValidator();
+        verifiableCredentialResponse
+                .getVerifiableCredentials()
+                .forEach(
+                        credential -> {
+                            try {
+                                verifiableCredentialJwtValidator.validate(
+                                        credential, credentialIssuerConfig, TEST_USER);
+
+                                JsonNode credentialSubject =
+                                        objectMapper
+                                                .readTree(credential.getJWTClaimsSet().toString())
+                                                .get("vc")
+                                                .get("credentialSubject");
+
+                                JsonNode bankAccountNode =
+                                        credentialSubject.get("bankAccount").get(0);
+                                JsonNode nameParts =
+                                        credentialSubject.get("name").get(0).get("nameParts");
+                                JsonNode birthDateNode = credentialSubject.get("birthDate").get(0);
+
+                                assertEquals(
+                                        "12345678", bankAccountNode.get("accountNumber").asText());
+                                assertEquals("103233", bankAccountNode.get("sortCode").asText());
+
+                                assertEquals("GivenName", nameParts.get(0).get("type").asText());
+                                assertEquals("FamilyName", nameParts.get(1).get("type").asText());
+                                assertEquals("Kenneth", nameParts.get(0).get("value").asText());
+                                assertEquals("Decerqueira", nameParts.get(1).get("value").asText());
+
+                                assertEquals("1962-10-11", birthDateNode.get("value").asText());
+                            } catch (VerifiableCredentialException
+                                    | ParseException
+                                    | JsonProcessingException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+    }
+
+    @Pact(provider = "BavCriProvider", consumer = "IpvCoreBack")
+    public RequestResponsePact validRequestReturnsBavResponseWithCi(PactDslWithProvider builder) {
+        return builder.given("dummyApiKey is a valid api key")
+                .given("dummyAccessToken is a valid access token")
+                .given("test-subject is a valid subject")
+                .given("dummyBavComponentId is a valid issuer")
+                .given("VC evidence failedCheckDetails identityCheckPolicy is none")
+                .given("VC evidence failedCheckDetails checkMethod is data")
+                .given("VC evidence has a CI of D02")
+                .given("VC evidence validityScore is 0")
+                .given("VC evidence strengthScore is 3")
+                .given("VC evidence txn is dummyTxn")
+                .given("VC evidence credentialSubject contains bankAccount")
+                .given("VC bankAccount accountNumber is 12345678")
+                .given("VC bankAccount sortCode is 103233")
+                .given("VC is for Kenneth Decerqueira")
+                .given("VC birthDate is 1962-10-11")
+                .uponReceiving("Valid POST request")
+                .path("/credential")
+                .method("POST")
+                .headers("x-api-key", PRIVATE_API_KEY, "Authorization", "Bearer dummyAccessToken")
+                .willRespondWith()
+                .status(200)
+                .body(
+                        new PactJwtIgnoreSignatureBodyBuilder(
+                                VALID_VC_HEADER, FAILED_BAV_VC_BODY, FAILED_BAV_VC_SIGNATURE))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "validRequestReturnsBavResponseWithCi")
+    void fetchVerifiableCredential_whenCalledAgainstBavCri_retrievesAVcWithACi(
+            MockServer mockServer) throws URISyntaxException, CriApiException {
+        // Arrange
+        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
+        configureMockConfigService(credentialIssuerConfig);
+
+        // We need to generate a fixed request, so we set the secure token and expiry to constant
+        // values.
+        var underTest =
+                new CriApiService(
+                        mockConfigService, mockSigner, mockSecureTokenHelper, CURRENT_TIME);
+
+        // Act
+        var verifiableCredentialResponse =
+                underTest.fetchVerifiableCredential(
+                        new BearerAccessToken("dummyAccessToken"),
+                        getCallbackRequest("dummyAuthCode", credentialIssuerConfig),
+                        getCriOAuthSessionItem());
+
+        // Assert
+        var verifiableCredentialJwtValidator = getVerifiableCredentialJwtValidator();
+        verifiableCredentialResponse
+                .getVerifiableCredentials()
+                .forEach(
+                        credential -> {
+                            try {
+                                verifiableCredentialJwtValidator.validate(
+                                        credential, credentialIssuerConfig, TEST_USER);
+
+                                JsonNode vc =
+                                        objectMapper
+                                                .readTree(credential.getJWTClaimsSet().toString())
+                                                .get("vc");
+
+                                JsonNode credentialSubject = vc.get("credentialSubject");
+                                JsonNode evidence = vc.get("evidence").get(0);
+
+                                JsonNode ciNode = evidence.get("ci");
+                                JsonNode nameParts =
+                                        credentialSubject.get("name").get(0).get("nameParts");
+                                JsonNode birthDateNode = credentialSubject.get("birthDate").get(0);
+
+                                assertEquals("D02", ciNode.get(0).asText());
+
+                                JsonNode bankAccountNode =
+                                        credentialSubject.get("bankAccount").get(0);
+
+                                assertEquals(
+                                        "12345678", bankAccountNode.get("accountNumber").asText());
+                                assertEquals("103233", bankAccountNode.get("sortCode").asText());
+
+                                assertEquals("GivenName", nameParts.get(0).get("type").asText());
+                                assertEquals("FamilyName", nameParts.get(1).get("type").asText());
+                                assertEquals("Kenneth", nameParts.get(0).get("value").asText());
+                                assertEquals("Decerqueira", nameParts.get(1).get("value").asText());
+
+                                assertEquals("1962-10-11", birthDateNode.get("value").asText());
+                            } catch (VerifiableCredentialException
+                                    | ParseException
+                                    | JsonProcessingException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+    }
+
+    @Pact(provider = "BavCriProvider", consumer = "IpvCoreBack")
+    public RequestResponsePact invalidAccessTokenReturns404(PactDslWithProvider builder) {
+        return builder.given("dummyApiKey is a valid api key")
+                .given("dummyInvalidAccessToken is an invalid access token")
+                .given("test-subject is a valid subject")
+                .given("dummyBavComponentId is a valid issuer")
+                .uponReceiving("Invalid POST request due to invalid access token")
+                .path("/credential")
+                .method("POST")
+                .headers(
+                        "x-api-key",
+                        PRIVATE_API_KEY,
+                        "Authorization",
+                        "Bearer dummyInvalidAccessToken")
+                .willRespondWith()
+                .status(404)
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "invalidAccessTokenReturns404")
+    void fetchVerifiableCredential_whenCalledAgainstBavCriWithInvalidAuthCode_throwsAnException(
+            MockServer mockServer) throws URISyntaxException, CriApiException {
+        // Arrange
+        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
+        configureMockConfigService(credentialIssuerConfig);
+
+        // We need to generate a fixed request, so we set the secure token and expiry to constant
+        // values.
+        var underTest =
+                new CriApiService(
+                        mockConfigService, mockSigner, mockSecureTokenHelper, CURRENT_TIME);
+
+        // Act
+        CriApiException exception =
+                assertThrows(
+                        CriApiException.class,
+                        () ->
+                                underTest.fetchVerifiableCredential(
+                                        new BearerAccessToken("dummyInvalidAccessToken"),
+                                        getCallbackRequest("dummyAuthCode", credentialIssuerConfig),
+                                        getCriOAuthSessionItem()));
+
+        // Assert
+        assertThat(
+                exception.getErrorResponse(),
+                is(ErrorResponse.FAILED_TO_GET_CREDENTIAL_FROM_ISSUER));
+        assertThat(exception.getHttpStatusCode(), is(HTTPResponse.SC_SERVER_ERROR));
+    }
+
+    @NotNull
+    private static CriOAuthSessionItem getCriOAuthSessionItem() {
+        return new CriOAuthSessionItem(
+                "dummySessionId", "dummyOAuthSessionId", "dummyCriId", "dummyConnection", 900);
+    }
+
+    @NotNull
+    private static CriCallbackRequest getCallbackRequest(
+            String authCode, CredentialIssuerConfig credentialIssuerConfig) {
+        return new CriCallbackRequest(
+                authCode,
+                credentialIssuerConfig.getClientId(),
+                "dummySessionId",
+                "https://identity.staging.account.gov.uk/credential-issuer/callback?id=bav",
+                "dummyState",
+                null,
+                null,
+                "dummyIpAddress",
+                "dummyFeatureSet");
+    }
+
+    @NotNull
+    private VerifiableCredentialJwtValidator getVerifiableCredentialJwtValidator() {
+        return new VerifiableCredentialJwtValidator(
+                mockConfigService,
+                ((exactMatchClaims, requiredClaims) ->
+                        new FixedTimeJWTClaimsVerifier<>(
+                                exactMatchClaims,
+                                requiredClaims,
+                                Date.from(CURRENT_TIME.instant()))));
+    }
+
+    private void configureMockConfigService(CredentialIssuerConfig credentialIssuerConfig) {
+        ContraIndicatorConfig ciConfig1 = new ContraIndicatorConfig(null, 4, null, null);
+        Map<String, ContraIndicatorConfig> ciConfigMap = new HashMap<>();
+        ciConfigMap.put("D02", ciConfig1);
+
+        when(mockConfigService.getCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
+        // This mock doesn't get reached in error cases, but it would be messy to explicitly not set
+        // it
+        Mockito.lenient()
+                .when(mockConfigService.getContraIndicatorConfigMap())
+                .thenReturn(ciConfigMap);
+    }
+
+    @NotNull
+    private static CredentialIssuerConfig getMockCredentialIssuerConfig(MockServer mockServer)
+            throws URISyntaxException {
+        return new CredentialIssuerConfig(
+                new URI("http://localhost:" + mockServer.getPort() + "/token"),
+                new URI("http://localhost:" + mockServer.getPort() + "/credential"),
+                new URI("http://localhost:" + mockServer.getPort() + "/authorize"),
+                IPV_CORE_CLIENT_ID,
+                CRI_SIGNING_PRIVATE_KEY_JWK,
+                CRI_RSA_ENCRYPTION_PUBLIC_JWK,
+                TEST_ISSUER,
+                URI.create(
+                        "https://identity.staging.account.gov.uk/credential-issuer/callback?id=bav"),
+                true,
+                false);
+    }
+}

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
@@ -110,6 +110,12 @@ class ContractTest {
               "vc": {
                 "evidence": [
                   {
+                  "checkDetails": [
+                           {
+                             "identityCheckPolicy": "none",
+                             "checkMethod": "data"
+                       }
+                    ],
                     "validityScore": 2,
                     "strengthScore": 3,
                     "txn": "dummyTxn",
@@ -151,7 +157,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_BAV_VC_SIGNATURE =
-            "ARHudEXt_OpGqJPP603JvjjmykiibzIUiKD9YvaqLlFAokimzRVDxS3lmu19UMpumLxdXxyz_MMb0ZyB3xgo-A";
+            "eux8ArXcqYGPoAkQIafcs_DobUI9GfYc4L5eQIl_pMIieHdevWoa2ExxoaaeVgXQ-9SFeLn0Ai01_xrAyJLtOw";
 
     private static final String FAILED_BAV_VC_BODY =
             """
@@ -361,6 +367,8 @@ class ContractTest {
                 .given("dummyAccessToken is a valid access token")
                 .given("test-subject is a valid subject")
                 .given("dummyBavComponentId is a valid issuer")
+                .given("VC evidence checkDetails identityCheckPolicy is none")
+                .given("VC evidence checkDetails checkMethod is data")
                 .given("VC evidence validityScore is 2")
                 .given("VC evidence strengthScore is 3")
                 .given("VC evidence txn is dummyTxn")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added consumer side contract test suite for BAV CRI

### Why did it change

To build up contract test coverage for NINO CRI service, and unblock producer side tests for BAV CRI

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4124](https://govukverify.atlassian.net/browse/PYIC-4124)



[PYIC-4124]: https://govukverify.atlassian.net/browse/PYIC-4124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ