### PR TITLE
PYIC-4384: Add check for existing inherited identity with stronger vot

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -394,12 +394,11 @@ public class InitialiseIpvSessionHandler
                                 existingInheritedIdentityVot, incomingInheritedIdentityVot));
             }
 
-            return indexOfExistingVot - indexOfIncomingVot < 0;
+            return indexOfIncomingVot > indexOfExistingVot;
         } catch (ParseException | IllegalArgumentException e) {
             throw new CredentialParseException(
-                    String.format(
-                            "Encountered a parsing error while attempting to parse or compare credentials: %s",
-                            e.getMessage()));
+                    "Encountered a parsing error while attempting to parse or compare credentials: %s",
+                    e);
         }
     }
 

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsReproveIdent
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
@@ -72,6 +73,8 @@ public class InitialiseIpvSessionHandler
     private static final String REQUEST_GOV_UK_SIGN_IN_JOURNEY_ID_KEY = "govuk_signin_journey_id";
     private static final String REQUEST_EMAIL_ADDRESS_KEY = "email_address";
     private static final String REQUEST_VTR_KEY = "vtr";
+    private static final List<VectorOfTrust> HMRC_PROFILES_BY_STRENGTH =
+            List.of(VectorOfTrust.PCL250, VectorOfTrust.PCL200);
 
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
@@ -379,11 +382,24 @@ public class InitialiseIpvSessionHandler
             var incomingInheritedIdentityVot =
                     userIdentityService.getVot(incomingInheritedIdentity);
 
-            return existingInheritedIdentityVot.compareTo(incomingInheritedIdentityVot) > 0;
-        } catch (JsonProcessingException | ParseException | IllegalArgumentException e) {
+            var indexOfExistingVot =
+                    HMRC_PROFILES_BY_STRENGTH.indexOf(existingInheritedIdentityVot);
+            var indexOfIncomingVot =
+                    HMRC_PROFILES_BY_STRENGTH.indexOf(incomingInheritedIdentityVot);
+
+            if (indexOfExistingVot == -1 || indexOfIncomingVot == -1) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "At least one of the existing (%s) or incoming (%s) VoTs from hmrc aren't expected",
+                                existingInheritedIdentityVot, incomingInheritedIdentityVot));
+            }
+
+            return indexOfExistingVot - indexOfIncomingVot < 0;
+        } catch (ParseException | IllegalArgumentException e) {
             throw new CredentialParseException(
-                    "Encountered a parsing error while attempting to parse credentials: "
-                            + e.getMessage());
+                    String.format(
+                            "Encountered a parsing error while attempting to parse or compare credentials: %s",
+                            e.getMessage()));
         }
     }
 

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -397,7 +397,7 @@ public class InitialiseIpvSessionHandler
             return indexOfIncomingVot > indexOfExistingVot;
         } catch (ParseException | IllegalArgumentException e) {
             throw new CredentialParseException(
-                    "Encountered a parsing error while attempting to parse or compare credentials: %s",
+                    "Encountered a parsing error while attempting to parse or compare credentials",
                     e);
         }
     }

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsReproveIdent
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -46,6 +47,7 @@ import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
+import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialJwtValidator;
 
@@ -74,6 +76,7 @@ public class InitialiseIpvSessionHandler
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionService;
+    private final UserIdentityService userIdentityService;
     private final VerifiableCredentialJwtValidator verifiableCredentialJwtValidator;
     private final VerifiableCredentialService verifiableCredentialService;
 
@@ -86,6 +89,7 @@ public class InitialiseIpvSessionHandler
         this.configService = new ConfigService();
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
+        this.userIdentityService = new UserIdentityService(configService);
         this.verifiableCredentialJwtValidator = new VerifiableCredentialJwtValidator(configService);
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.kmsRsaDecrypter = new KmsRsaDecrypter();
@@ -95,17 +99,19 @@ public class InitialiseIpvSessionHandler
 
     @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public InitialiseIpvSessionHandler(
+            ConfigService configService,
             IpvSessionService ipvSessionService,
             ClientOAuthSessionDetailsService clientOAuthSessionService,
-            ConfigService configService,
+            UserIdentityService userIdentityService,
             VerifiableCredentialJwtValidator verifiableCredentialJwtValidator,
             VerifiableCredentialService verifiableCredentialService,
             KmsRsaDecrypter kmsRsaDecrypter,
             JarValidator jarValidator,
             AuditService auditService) {
+        this.configService = configService;
         this.ipvSessionService = ipvSessionService;
         this.clientOAuthSessionService = clientOAuthSessionService;
-        this.configService = configService;
+        this.userIdentityService = userIdentityService;
         this.verifiableCredentialJwtValidator = verifiableCredentialJwtValidator;
         this.verifiableCredentialService = verifiableCredentialService;
         this.kmsRsaDecrypter = kmsRsaDecrypter;
@@ -236,6 +242,7 @@ public class InitialiseIpvSessionHandler
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, response);
         } catch (ParseException e) {
+            // Doesn't match all the potential causes
             LOGGER.error(LogHelper.buildErrorMessage("Failed to parse the decrypted JWE.", e));
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_REQUEST);
@@ -258,6 +265,11 @@ public class InitialiseIpvSessionHandler
             LOGGER.error(LogHelper.buildErrorMessage("Failed to parse request body.", e));
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IP_ADDRESS);
+        } catch (CredentialParseException e) {
+            LOGGER.error(
+                    LogHelper.buildErrorMessage("Failed to check if stronger vot vc present.", e));
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
         }
     }
 
@@ -284,12 +296,15 @@ public class InitialiseIpvSessionHandler
             InheritedIdentityJwtClaim inheritedIdentityJwtClaim,
             JWTClaimsSet claimsSet,
             IpvSessionItem ipvSessionItem)
-            throws RecoverableJarValidationException, ParseException {
+            throws RecoverableJarValidationException, ParseException, CredentialParseException {
         try {
             var signedInheritedIdentityJWT =
                     validateHmrcInheritedIdentity(userId, inheritedIdentityJwtClaim);
-            storeHmrcInheritedIdentity(
-                    userId, claimsSet, ipvSessionItem, signedInheritedIdentityJWT);
+            if (!isHmrcInheritedIdentityWithStrongerVotPresent(
+                    signedInheritedIdentityJWT, userId)) {
+                storeHmrcInheritedIdentity(
+                        userId, claimsSet, ipvSessionItem, signedInheritedIdentityJWT);
+            }
         } catch (VerifiableCredentialException | ParseException e) {
             throw new RecoverableJarValidationException(
                     OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
@@ -349,6 +364,26 @@ public class InitialiseIpvSessionHandler
                             "Failed to persist inherited identity JWT"),
                     claimsSet,
                     e);
+        }
+    }
+
+    private boolean isHmrcInheritedIdentityWithStrongerVotPresent(
+            SignedJWT incomingInheritedIdentity, String userId) throws CredentialParseException {
+        try {
+            var vcStoreItem =
+                    verifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, userId);
+            SignedJWT existingInheritedIdentity = SignedJWT.parse(vcStoreItem.getCredential());
+
+            var existingInheritedIdentityVot =
+                    userIdentityService.getVot(existingInheritedIdentity);
+            var incomingInheritedIdentityVot =
+                    userIdentityService.getVot(incomingInheritedIdentity);
+
+            return existingInheritedIdentityVot.compareTo(incomingInheritedIdentityVot) > 0;
+        } catch (JsonProcessingException | ParseException | IllegalArgumentException e) {
+            throw new CredentialParseException(
+                    "Encountered a parsing error while attempting to parse credentials: "
+                            + e.getMessage());
         }
     }
 

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -528,7 +528,7 @@ class InitialiseIpvSessionHandlerTest {
     }
 
     @Test
-    void shouldHandleJsonProcessingExceptionFromCheckingInheritedIdentityVotStrength()
+    void shouldHandleParseExceptionFromCheckingInheritedIdentityVotStrength()
             throws Exception {
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
@@ -560,7 +560,7 @@ class InitialiseIpvSessionHandlerTest {
                                 existingInheritedIdentityJwt.serialize(),
                                 Instant.now(),
                                 Instant.now()));
-        doThrow(new JsonProcessingException("") {}).when(mockUserIdentityService).getVot(any());
+        doThrow(new ParseException("", 0) {}).when(mockUserIdentityService).getVot(any());
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams =

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -147,14 +147,12 @@ class InitialiseIpvSessionHandlerTest {
                                             INHERITED_IDENTITY_JWT_CLAIM_NAME,
                                                     Map.of(VALUES, List.of()),
                                             PASSPORT_CLAIM_NAME, "test-passport-claim")));
-    private static SignedJWT inheritedIdentityJWT;
     private static String serialisedInheritedIdentityJWT;
 
     @BeforeAll
     static void setUpBeforeAll()
             throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
-        inheritedIdentityJWT = getInheritedIdentityJWT();
-        serialisedInheritedIdentityJWT = inheritedIdentityJWT.serialize();
+        serialisedInheritedIdentityJWT = getInheritedIdentityJWT().serialize();
     }
 
     @BeforeEach

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -528,8 +528,7 @@ class InitialiseIpvSessionHandlerTest {
     }
 
     @Test
-    void shouldHandleParseExceptionFromCheckingInheritedIdentityVotStrength()
-            throws Exception {
+    void shouldHandleParseExceptionFromCheckingInheritedIdentityVotStrength() throws Exception {
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
                 .thenReturn(ipvSessionItem);

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.VectorOfTrust;
 import uk.gov.di.ipv.core.library.dto.CriConfig;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
@@ -48,6 +49,7 @@ import uk.gov.di.ipv.core.library.fixtures.TestFixtures;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -145,12 +147,14 @@ class InitialiseIpvSessionHandlerTest {
                                             INHERITED_IDENTITY_JWT_CLAIM_NAME,
                                                     Map.of(VALUES, List.of()),
                                             PASSPORT_CLAIM_NAME, "test-passport-claim")));
-    private static String inheritedIdentityJWT;
+    private static SignedJWT inheritedIdentityJWT;
+    private static String serialisedInheritedIdentityJWT;
 
     @BeforeAll
     static void setUpBeforeAll()
             throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
-        inheritedIdentityJWT = getInheritedIdentityJWT().serialize();
+        inheritedIdentityJWT = getInheritedIdentityJWT();
+        serialisedInheritedIdentityJWT = inheritedIdentityJWT.serialize();
     }
 
     @BeforeEach
@@ -228,7 +232,7 @@ class InitialiseIpvSessionHandlerTest {
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);
 
-        // Assrt
+        // Assert
         Map<String, Object> responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
@@ -411,11 +415,24 @@ class InitialiseIpvSessionHandlerTest {
                                                         INHERITED_IDENTITY_JWT_CLAIM_NAME,
                                                         Map.of(
                                                                 VALUES,
-                                                                List.of(inheritedIdentityJWT)))))
+                                                                List.of(
+                                                                        serialisedInheritedIdentityJWT)))))
                                 .build());
         when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY))
                 .thenReturn(true); // Mock enabled inherited identity feature flag
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+        SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(VectorOfTrust.PCL200);
+        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+                .thenReturn(
+                        new VcStoreItem(
+                                "test-user-id",
+                                HMRC_MIGRATION_CRI,
+                                existingInheritedIdentityJwt.serialize(),
+                                Instant.now(),
+                                Instant.now()));
+        when(mockUserIdentityService.getVot(any()))
+                .thenReturn(VectorOfTrust.PCL200)
+                .thenReturn(VectorOfTrust.PCL200);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams =
@@ -430,19 +447,142 @@ class InitialiseIpvSessionHandlerTest {
         verify(mockVerifiableCredentialJwtValidator, times(1))
                 .validate(
                         signedJWTArgumentCaptor.capture(), eq(TEST_CRI_CONFIG), eq("test-user-id"));
-        assertEquals(inheritedIdentityJWT, signedJWTArgumentCaptor.getValue().serialize());
+        assertEquals(
+                serialisedInheritedIdentityJWT, signedJWTArgumentCaptor.getValue().serialize());
 
         verify(mockVerifiableCredentialService, times(1))
                 .persistUserCredentials(
                         signedJWTArgumentCaptor.capture(),
                         eq(HMRC_MIGRATION_CRI),
                         eq("test-user-id"));
-        assertEquals(inheritedIdentityJWT, signedJWTArgumentCaptor.getValue().serialize());
+        assertEquals(
+                serialisedInheritedIdentityJWT, signedJWTArgumentCaptor.getValue().serialize());
 
         verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
         assertEquals(
                 ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
-                List.of(inheritedIdentityJWT));
+                List.of(serialisedInheritedIdentityJWT));
+    }
+
+    @Test
+    void shouldNotStoreInheritedIdentityWhenVotWeakerThanExisting() throws Exception {
+        // Arrange
+        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
+                .thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockJarValidator.validateRequestJwt(any(), any()))
+                .thenReturn(
+                        claimsBuilder
+                                .claim(
+                                        CLAIMS,
+                                        Map.of(
+                                                USER_INFO,
+                                                Map.of(
+                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                        Map.of(
+                                                                VALUES,
+                                                                List.of(
+                                                                        serialisedInheritedIdentityJWT)))))
+                                .build());
+        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
+        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+        SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(VectorOfTrust.PCL250);
+        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+                .thenReturn(
+                        new VcStoreItem(
+                                "test-user-id",
+                                HMRC_MIGRATION_CRI,
+                                existingInheritedIdentityJwt.serialize(),
+                                Instant.now(),
+                                Instant.now()));
+        when(mockUserIdentityService.getVot(any()))
+                .thenReturn(VectorOfTrust.PCL250)
+                .thenReturn(VectorOfTrust.PCL200);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, Object> sessionParams =
+                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
+        event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+
+        // Act
+        initialiseIpvSessionHandler.handleRequest(event, mockContext);
+
+        // Assert
+        verify(mockVerifiableCredentialJwtValidator, times(1))
+                .validate(
+                        signedJWTArgumentCaptor.capture(), eq(TEST_CRI_CONFIG), eq("test-user-id"));
+        verify(mockUserIdentityService, times(2)).getVot(signedJWTArgumentCaptor.capture());
+
+        List<SignedJWT> capturedArguments = signedJWTArgumentCaptor.getAllValues();
+        assertEquals(3, capturedArguments.size());
+        assertEquals(serialisedInheritedIdentityJWT, capturedArguments.get(0).serialize());
+        // Used for comparing vots of inherited identities
+        assertEquals(
+                existingInheritedIdentityJwt.serialize(), capturedArguments.get(1).serialize());
+        assertEquals(serialisedInheritedIdentityJWT, capturedArguments.get(2).serialize());
+
+        verify(mockVerifiableCredentialService, times(0))
+                .persistUserCredentials(any(), any(), any());
+    }
+
+    @Test
+    void shouldHandleJsonProcessingExceptionFromCheckingInheritedIdentityVotStrength()
+            throws Exception {
+        // Arrange
+        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
+                .thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockJarValidator.validateRequestJwt(any(), any()))
+                .thenReturn(
+                        claimsBuilder
+                                .claim(
+                                        CLAIMS,
+                                        Map.of(
+                                                USER_INFO,
+                                                Map.of(
+                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                        Map.of(
+                                                                VALUES,
+                                                                List.of(
+                                                                        serialisedInheritedIdentityJWT)))))
+                                .build());
+        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
+        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+        SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(VectorOfTrust.PCL200);
+        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+                .thenReturn(
+                        new VcStoreItem(
+                                "test-user-id",
+                                HMRC_MIGRATION_CRI,
+                                existingInheritedIdentityJwt.serialize(),
+                                Instant.now(),
+                                Instant.now()));
+        doThrow(new JsonProcessingException("") {}).when(mockUserIdentityService).getVot(any());
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, Object> sessionParams =
+                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
+        event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+
+        // Act
+        APIGatewayProxyResponseEvent response =
+                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+
+        // Assert
+        Map<String, Object> responseBody =
+                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getCode(),
+                responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(),
+                responseBody.get("message"));
     }
 
     @Test
@@ -536,9 +676,11 @@ class InitialiseIpvSessionHandlerTest {
         event.setBody(objectMapper.writeValueAsString(sessionParams));
         event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
+        // Act
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(event, mockContext);
 
+        // Assert
         Map<String, Object> responseBody =
                 objectMapper.readValue(response.getBody(), new TypeReference<>() {});
 
@@ -571,7 +713,8 @@ class InitialiseIpvSessionHandlerTest {
                                                         INHERITED_IDENTITY_JWT_CLAIM_NAME,
                                                         Map.of(
                                                                 VALUES,
-                                                                List.of(inheritedIdentityJWT)))))
+                                                                List.of(
+                                                                        serialisedInheritedIdentityJWT)))))
                                 .build());
         when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
@@ -625,7 +768,8 @@ class InitialiseIpvSessionHandlerTest {
                                                         INHERITED_IDENTITY_JWT_CLAIM_NAME,
                                                         Map.of(
                                                                 VALUES,
-                                                                List.of(inheritedIdentityJWT)))))
+                                                                List.of(
+                                                                        serialisedInheritedIdentityJWT)))))
                                 .build());
         when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
         CriConfig testCriConfig =
@@ -634,6 +778,18 @@ class InitialiseIpvSessionHandlerTest {
                         .signingKey("test-signing-key")
                         .build();
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(testCriConfig);
+        SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(VectorOfTrust.PCL200);
+        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+                .thenReturn(
+                        new VcStoreItem(
+                                "test-user-id",
+                                HMRC_MIGRATION_CRI,
+                                existingInheritedIdentityJwt.serialize(),
+                                Instant.now(),
+                                Instant.now()));
+        when(mockUserIdentityService.getVot(any()))
+                .thenReturn(VectorOfTrust.PCL200)
+                .thenReturn(VectorOfTrust.PCL200);
         doThrow(
                         new VerifiableCredentialException(
                                 HTTPResponse.SC_SERVER_ERROR,
@@ -689,6 +845,11 @@ class InitialiseIpvSessionHandlerTest {
 
     private static SignedJWT getInheritedIdentityJWT()
             throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException {
+        return getInheritedIdentityJWT(VectorOfTrust.PCL200);
+    }
+
+    private static SignedJWT getInheritedIdentityJWT(VectorOfTrust vot)
+            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException {
         SignedJWT inheritedIdentityJWT =
                 new SignedJWT(
                         new JWSHeader.Builder(JWSAlgorithm.ES256).type(JOSEObjectType.JWT).build(),
@@ -696,7 +857,7 @@ class InitialiseIpvSessionHandlerTest {
                                 .subject("test-user-id")
                                 .issuer("<https://oidc.hmrc.gov.uk/migration/v1>")
                                 .notBeforeTime(new Date(1694430000L * 1000))
-                                .claim("vot", "PCL200")
+                                .claim("vot", vot.toString())
                                 .claim("vtm", "<https://hmrc.gov.uk/trustmark>")
                                 .claim(
                                         "vc",

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VectorOfTrust.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VectorOfTrust.java
@@ -1,9 +1,9 @@
 package uk.gov.di.ipv.core.library.domain;
 
-// In order of strength
 public enum VectorOfTrust {
     P0,
+    P1,
+    P2,
     PCL200,
-    PCL250,
-    P2
+    PCL250
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VectorOfTrust.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VectorOfTrust.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
 public enum VectorOfTrust {
     P0,
     P1,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VectorOfTrust.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VectorOfTrust.java
@@ -1,6 +1,9 @@
 package uk.gov.di.ipv.core.library.domain;
 
+// In order of strength
 public enum VectorOfTrust {
     P0,
+    PCL200,
+    PCL250,
     P2
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/CredentialParseException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/CredentialParseException.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.core.library.exceptions;
 
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
 public class CredentialParseException extends Exception {
     public CredentialParseException(String message) {
         super(message);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/CredentialParseException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/CredentialParseException.java
@@ -4,4 +4,8 @@ public class CredentialParseException extends Exception {
     public CredentialParseException(String message) {
         super(message);
     }
+
+    public CredentialParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -483,11 +483,8 @@ public class UserIdentityService {
     }
 
     public VectorOfTrust getVot(SignedJWT credential)
-            throws JsonProcessingException, IllegalArgumentException {
-        var votJson =
-                objectMapper.readTree(credential.getPayload().toString()).path(VOT_CLAIM_NAME);
-
-        return VectorOfTrust.valueOf(votJson.asText());
+            throws IllegalArgumentException, ParseException {
+        return VectorOfTrust.valueOf(credential.getJWTClaimsSet().getStringClaim(VOT_CLAIM_NAME));
     }
 
     private Optional<JsonNode> generateAddressClaim(List<VcStoreItem> vcStoreItems)

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -78,6 +78,7 @@ public class UserIdentityService {
             List.of(ADDRESS_CRI, BAV_CRI, TICF_CRI);
 
     private static final Logger LOGGER = LogManager.getLogger();
+    private static final String VOT_CLAIM_NAME = "vot";
     private static final String ADDRESS_PROPERTY_NAME = "address";
     private static final String NINO_PROPERTY_NAME = "socialSecurityRecord";
     private static final String PASSPORT_PROPERTY_NAME = "passport";
@@ -479,6 +480,14 @@ public class UserIdentityService {
                                 .constructCollectionType(List.class, BirthDate.class));
 
         return new IdentityClaim(names, birthDates);
+    }
+
+    public VectorOfTrust getVot(SignedJWT credential)
+            throws JsonProcessingException, IllegalArgumentException {
+        var votJson =
+                objectMapper.readTree(credential.getPayload().toString()).path(VOT_CLAIM_NAME);
+
+        return VectorOfTrust.valueOf(votJson.asText());
     }
 
     private Optional<JsonNode> generateAddressClaim(List<VcStoreItem> vcStoreItems)

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEObjectType;
@@ -41,6 +40,7 @@ import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
 
 import java.net.URI;
+import java.text.ParseException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -789,7 +789,7 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void shouldGetCorrectVot() throws JsonProcessingException {
+    void shouldGetCorrectVot() throws ParseException {
         // Arrange
         JWTClaimsSet claims =
                 new JWTClaimsSet.Builder().claim("vot", VectorOfTrust.PCL200.toString()).build();

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEObjectType;
@@ -149,6 +150,7 @@ class UserIdentityServiceTest {
     @Test
     void shouldReturnCredentialsFromDataStore()
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -162,10 +164,12 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         assertEquals(VC_PASSPORT_NON_DCMAW_SUCCESSFUL, credentials.getVcs().get(0));
         assertEquals(VC_FRAUD_SCORE_1, credentials.getVcs().get(1));
         assertEquals("test-sub", credentials.getSub());
@@ -173,6 +177,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldSetVotClaimToP2OnSuccessfulIdentityCheck() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -188,15 +193,18 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         assertEquals(VectorOfTrust.P2.toString(), credentials.getVot());
     }
 
     @Test
     void areVCsCorrelatedReturnsTrueWhenVcAreCorrelated() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -220,11 +228,13 @@ class UserIdentityServiceTest {
                         createVcStoreItem(USER_ID_1, TICF_CRI, VC_TICF, Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
     void areVCsCorrelatedReturnFalseWhenNamesDiffer() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -248,11 +258,13 @@ class UserIdentityServiceTest {
                         createVcStoreItem(USER_ID_1, TICF_CRI, VC_TICF, Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
     void areVCsCorrelatedReturnFalseWhenNameDifferentForBavCRI() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -269,6 +281,7 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
@@ -276,6 +289,7 @@ class UserIdentityServiceTest {
     @NullAndEmptySource
     void areVCsCorrelatedShouldThrowExceptionWhenVcHasMissingGivenName(String missingName)
             throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -292,6 +306,7 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
@@ -310,6 +325,7 @@ class UserIdentityServiceTest {
     @NullAndEmptySource
     void areVCsCorrelatedShouldThrowExceptionWhenVcHasMissingFamilyName(String missingName)
             throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -326,6 +342,7 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
@@ -344,6 +361,7 @@ class UserIdentityServiceTest {
     @NullAndEmptySource
     void areVCsCorrelatedShouldReturnTrueWhenAddressVcHasMissingName(String missing)
             throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -360,6 +378,7 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
@@ -367,6 +386,7 @@ class UserIdentityServiceTest {
     @NullAndEmptySource
     void areVCsCorrelatedShouldReturnFalseWhenMissingNameCredentialForBAVCRI(String missing)
             throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -388,6 +408,7 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
@@ -404,6 +425,7 @@ class UserIdentityServiceTest {
 
     @Test
     void areVCsCorrelatedShouldReturnFalseIfExtraGivenNameInVc() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -426,11 +448,13 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
     void areVCsCorrelatedReturnsFalseWhenBirthDatesDiffer() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -453,6 +477,7 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
@@ -460,6 +485,7 @@ class UserIdentityServiceTest {
     @NullAndEmptySource
     void areVCsCorrelatedShouldThrowExceptionWhenMissingBirthDateProperty(String missing)
             throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -481,6 +507,7 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
@@ -499,6 +526,7 @@ class UserIdentityServiceTest {
     @NullAndEmptySource
     void areVCsCorrelatedShouldReturnTrueWhenAddressHasMissingBirthDate(String missing)
             throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -520,6 +548,7 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
@@ -527,6 +556,7 @@ class UserIdentityServiceTest {
     @NullAndEmptySource
     void areVCsCorrelatedShouldReturnTrueWhenBavHasMissingBirthDate(String missing)
             throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -548,11 +578,13 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
     void areVCsCorrelatedShouldReturnFalseIfBavHasDifferentBirthDate() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -575,11 +607,13 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
     void areVCsCorrelatedShouldNotIncludeVCsForNameNotDeemedSuccessful() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -602,11 +636,13 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
     void areVCsCorrelatedShouldNotIncludeVCsForDOBNotDeemedSuccessful() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -629,11 +665,13 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertTrue(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
     void areVCsCorrelatedReturnsFalseWhenExtraBirthDateInVc() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -656,11 +694,13 @@ class UserIdentityServiceTest {
                                 Instant.now()));
         mockCredentialIssuerConfig();
 
+        // Act & Assert
         assertFalse(userIdentityService.areVCsCorrelated(vcStoreItems));
     }
 
     @Test
     void shouldSetIdentityClaimWhenVotIsP2() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -676,10 +716,12 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         IdentityClaim identityClaim = credentials.getIdentityClaim();
 
         assertEquals("GivenName", identityClaim.getName().get(0).getNameParts().get(0).getType());
@@ -690,6 +732,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldSetIdentityClaimWhenVotIsP2MissingName() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -707,10 +750,12 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         IdentityClaim identityClaim = credentials.getIdentityClaim();
 
         assertEquals("GivenName", identityClaim.getName().get(0).getNameParts().get(0).getType());
@@ -721,6 +766,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldNotSetIdentityClaimWhenVotIsP0() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -733,15 +779,50 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
         mockParamStoreCalls(paramsToMockForP0WithNoCi);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P0", emptyContraIndicators);
 
+        // Assert
         assertNull(credentials.getIdentityClaim());
     }
 
     @Test
+    void shouldGetCorrectVot() throws JsonProcessingException {
+        // Arrange
+        JWTClaimsSet claims =
+                new JWTClaimsSet.Builder().claim("vot", VectorOfTrust.PCL200.toString()).build();
+        SignedJWT signedJWT = new SignedJWT(JWS_HEADER, claims);
+
+        // Act
+        VectorOfTrust vot = userIdentityService.getVot(signedJWT);
+
+        // Assert
+        assertEquals(VectorOfTrust.PCL200, vot);
+    }
+
+    @Test
+    void shouldThrowForInvalidVot() {
+        // Arrange
+        JWTClaimsSet claims = new JWTClaimsSet.Builder().claim("vot", "not a vot value").build();
+        SignedJWT signedJWT = new SignedJWT(JWS_HEADER, claims);
+
+        // Act
+        IllegalArgumentException thrownException =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> userIdentityService.getVot(signedJWT));
+
+        // Assert
+        assertEquals(
+                "No enum constant uk.gov.di.ipv.core.library.domain.VectorOfTrust.not a vot value",
+                thrownException.getMessage());
+    }
+
+    @Test
     void shouldThrowExceptionWhenMissingNameProperty() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -753,6 +834,7 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act & Assert
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
@@ -771,6 +853,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldThrowExceptionWhenMissingBirthDateProperty() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -785,6 +868,7 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act & Assert
         HttpResponseExceptionWithErrorBody thrownError =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
@@ -803,6 +887,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldSetPassportClaimWhenVotIsP2() throws Exception {
+        // Arrange
         mockParamStoreCalls(paramsToMockForP2);
         mockCredentialIssuerConfig();
 
@@ -819,10 +904,12 @@ class UserIdentityServiceTest {
 
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         JsonNode passportClaim = credentials.getPassportClaim();
 
         assertEquals("123456789", passportClaim.get(0).get("documentNumber").asText());
@@ -831,6 +918,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldNotSetPassportClaimWhenVotIsP0() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -843,15 +931,18 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
         mockParamStoreCalls(paramsToMockForP0WithNoCi);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P0", emptyContraIndicators);
 
+        // Assert
         assertNull(credentials.getPassportClaim());
     }
 
     @Test
     void shouldReturnEmptyWhenMissingPassportProperty() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -867,10 +958,12 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         assertNull(credentials.getPassportClaim());
     }
 
@@ -1008,28 +1101,35 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldSetSubClaimOnUserIdentity() throws Exception {
+        // Arrange
         mockParamStoreCalls(paramsToMockForP2);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         assertEquals("test-sub", credentials.getSub());
     }
 
     @Test
     void shouldSetVtmClaimOnUserIdentity() throws Exception {
+        // Arrange
         mockParamStoreCalls(paramsToMockForP2);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         assertEquals("mock-vtm-claim", credentials.getVtm());
     }
 
     @Test
     void generateUserIdentityShouldSetAddressClaimOnUserIdentity() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1045,10 +1145,12 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity userIdentity =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         JsonNode userIdentityJsonNode =
                 objectMapper.readTree(objectMapper.writeValueAsString(userIdentity));
         JsonNode address = userIdentityJsonNode.get(ADDRESS_CLAIM_NAME).get(0);
@@ -1062,6 +1164,7 @@ class UserIdentityServiceTest {
 
     @Test
     void generateUserIdentityShouldThrowIfAddressVCIsMissingAddressProperty() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1081,6 +1184,7 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act & Assert
         HttpResponseExceptionWithErrorBody thrownException =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
@@ -1099,6 +1203,7 @@ class UserIdentityServiceTest {
 
     @Test
     void generateUserIdentityShouldThrowIfAddressVCCanNotBeParsed() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1114,6 +1219,7 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act & Assert
         assertThrows(
                 CredentialParseException.class,
                 () ->
@@ -1123,6 +1229,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldNotSetAddressClaimWhenVotIsP0() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(USER_ID_1, FRAUD_CRI, VC_FRAUD_SCORE_1, Instant.now()),
@@ -1132,15 +1239,18 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
         mockParamStoreCalls(paramsToMockForP0WithNoCi);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P0", emptyContraIndicators);
 
+        // Assert
         assertNull(credentials.getAddressClaim());
     }
 
     @Test
     void shouldReturnListOfVcsForSharedAttributes() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1150,14 +1260,17 @@ class UserIdentityServiceTest {
                                 Instant.now()),
                         createVcStoreItem(USER_ID_1, FRAUD_CRI, VC_FRAUD_SCORE_1, Instant.now()));
 
+        // Act
         List<String> vcList = userIdentityService.getIdentityCredentials(vcStoreItems);
 
+        // Assert
         assertEquals(VC_PASSPORT_NON_DCMAW_SUCCESSFUL, vcList.get(0));
         assertEquals(VC_FRAUD_SCORE_1, vcList.get(1));
     }
 
     @Test
     void shouldSetDrivingPermitClaimWhenVotIsP2() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1169,10 +1282,12 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         JsonNode drivingPermitClaim = credentials.getDrivingPermitClaim();
 
         assertEquals("MORGA753116SM9IJ", drivingPermitClaim.get(0).get("personalNumber").asText());
@@ -1182,6 +1297,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldNotSetDrivingPermitClaimWhenVotIsP0() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1192,10 +1308,12 @@ class UserIdentityServiceTest {
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
         mockParamStoreCalls(paramsToMockForP0WithNoCi);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P0", emptyContraIndicators);
 
+        // Assert
         JsonNode drivingPermitClaim = credentials.getDrivingPermitClaim();
 
         assertNull(drivingPermitClaim);
@@ -1203,6 +1321,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldNotSetDrivingPermitClaimWhenDrivingPermitVCIsMissing() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1218,10 +1337,12 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         JsonNode drivingPermitClaim = credentials.getDrivingPermitClaim();
 
         assertNull(drivingPermitClaim);
@@ -1229,6 +1350,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldNotSetDrivingPermitClaimWhenDrivingPermitVCFailed() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1249,10 +1371,12 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         JsonNode drivingPermitClaim = credentials.getDrivingPermitClaim();
 
         assertNull(drivingPermitClaim);
@@ -1260,6 +1384,7 @@ class UserIdentityServiceTest {
 
     @Test
     void shouldReturnEmptyWhenMissingDrivingPermitProperty() throws Exception {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1272,15 +1397,18 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act
         UserIdentity credentials =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
 
+        // Assert
         assertNull(credentials.getDrivingPermitClaim());
     }
 
     @Test
     void generateUserIdentityShouldThrowIfDcmawVCCanNotBeParsed() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(
@@ -1297,6 +1425,7 @@ class UserIdentityServiceTest {
         mockCredentialIssuerConfig();
         when(mockDataStore.getItems(anyString())).thenReturn(vcStoreItems);
 
+        // Act & Assert
         CredentialParseException thrownException =
                 assertThrows(
                         CredentialParseException.class,
@@ -1310,6 +1439,7 @@ class UserIdentityServiceTest {
 
     @Test
     void generateUserIdentityShouldSetExitCodeWhenP2AndAlwaysRequiredCiPresent() throws Exception {
+        // Arrange
         mockParamStoreCalls(paramsToMockForP2);
         when(mockConfigService.getSsmParameter(RETURN_CODES_ALWAYS_REQUIRED)).thenReturn("🦆,🐧");
         when(mockDataStore.getItems(anyString())).thenReturn(List.of());
@@ -1329,18 +1459,22 @@ class UserIdentityServiceTest {
                                         "Z03", ContraIndicator.builder().code("Z03").build()))
                         .build();
 
+        // Act
         UserIdentity userIdentity =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", contraIndicators);
 
+        // Assert
         assertEquals(List.of(new ReturnCode("🦆")), userIdentity.getReturnCode());
     }
 
     @Test
     void generateUserIdentityShouldSetEmptyExitCodeWhenP2AndAlwaysRequiredCiNotPresent()
             throws Exception {
+        // Arrange
         mockParamStoreCalls(paramsToMockForP2);
 
+        // Act
         UserIdentity userIdentity =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P2", emptyContraIndicators);
@@ -1350,6 +1484,7 @@ class UserIdentityServiceTest {
 
     @Test
     void generateUserIdentityShouldThrowWhenP2AndCiCodeNotFound() {
+        // Arrange
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1")));
@@ -1360,6 +1495,7 @@ class UserIdentityServiceTest {
                                 Map.of("wat", ContraIndicator.builder().code("wat").build()))
                         .build();
 
+        // Act & Assert
         assertThrows(
                 UnrecognisedCiException.class,
                 () ->
@@ -1369,6 +1505,7 @@ class UserIdentityServiceTest {
 
     @Test
     void generateUserIdentityShouldSetExitCodeWhenBreachingCiThreshold() throws Exception {
+        // Arrange
         mockParamStoreCalls(paramsToMockForP0);
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(
@@ -1394,10 +1531,12 @@ class UserIdentityServiceTest {
                                         "Z03", ContraIndicator.builder().code("Z03").build()))
                         .build();
 
+        // Act
         UserIdentity userIdentity =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P0", contraIndicators);
 
+        // Assert
         assertEquals(
                 List.of(new ReturnCode("1"), new ReturnCode("2"), new ReturnCode("3")),
                 userIdentity.getReturnCode());
@@ -1405,6 +1544,7 @@ class UserIdentityServiceTest {
 
     @Test
     void generateUserIdentityShouldThrowWhenBreachingAndCiCodeNotFound() {
+        // Arrange
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(Map.of("X01", new ContraIndicatorConfig("X01", 4, -3, "1")));
@@ -1424,6 +1564,7 @@ class UserIdentityServiceTest {
 
     @Test
     void generateUserIdentityShouldDeduplicateExitCodes() throws Exception {
+        // Arrange
         mockParamStoreCalls(paramsToMockForP0);
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(
@@ -1443,10 +1584,12 @@ class UserIdentityServiceTest {
                                         "Z04", ContraIndicator.builder().code("Z04").build()))
                         .build();
 
+        // Act
         UserIdentity userIdentity =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P0", contraIndicators);
 
+        // Assert
         assertEquals(
                 List.of(new ReturnCode("1"), new ReturnCode("2"), new ReturnCode("3")),
                 userIdentity.getReturnCode());
@@ -1455,6 +1598,7 @@ class UserIdentityServiceTest {
     @Test
     void generateUserIdentityShouldSetRequiredExitCodeWhenP0AndNotBreachingCiThreshold()
             throws Exception {
+        // Arrange
         when(mockConfigService.getSsmParameter(CORE_VTM_CLAIM)).thenReturn("mock-vtm-claim");
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("10");
         when(mockConfigService.getSsmParameter(RETURN_CODES_NON_CI_BREACHING_P0)).thenReturn("🐧");
@@ -1468,10 +1612,12 @@ class UserIdentityServiceTest {
                                 Map.of("X01", ContraIndicator.builder().code("X01").build()))
                         .build();
 
+        // Act
         UserIdentity userIdentity =
                 userIdentityService.generateUserIdentity(
                         USER_ID_1, "test-sub", "P0", contraIndicators);
 
+        // Assert
         assertEquals(List.of(new ReturnCode("🐧")), userIdentity.getReturnCode());
         verify(mockConfigService, never()).getSsmParameter(RETURN_CODES_ALWAYS_REQUIRED);
     }
@@ -1502,11 +1648,14 @@ class UserIdentityServiceTest {
 
     @Test
     void isVcSuccessfulShouldThrowIfNoStatusFoundForIssuer() {
+        // Arrange
         List<VcStatusDto> vcStatusDtos =
                 List.of(
                         new VcStatusDto("issuer1", true),
                         new VcStatusDto("issuer2", true),
                         new VcStatusDto("issuer3", true));
+
+        // Act & Assert
         assertThrows(
                 NoVcStatusForIssuerException.class,
                 () -> userIdentityService.isVcSuccessful(vcStatusDtos, "badIssuer"));
@@ -1514,47 +1663,58 @@ class UserIdentityServiceTest {
 
     @Test
     void getCredentialsWithSingleCredentialAndOnlyOneValidEvidence() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(createVcStoreItem(USER_ID_1, BAV_CRI, M1B_DCMAW_VC, Instant.now()));
         claimedIdentityConfig.setRequiresAdditionalEvidence(true);
         when(mockConfigService.getOauthCriActiveConnectionConfig(any()))
                 .thenReturn(claimedIdentityConfig);
 
+        // Act & Assert
         assertTrue(userIdentityService.checkRequiresAdditionalEvidence(vcStoreItems));
     }
 
     @Test
     void
             getCredentialsWithSingleCredentialWithOnlyOneValidEvidenceAndRequiresAdditionalEvidencesFalse() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(createVcStoreItem(USER_ID_1, BAV_CRI, M1B_DCMAW_VC, Instant.now()));
         claimedIdentityConfig.setRequiresAdditionalEvidence(false);
         when(mockConfigService.getOauthCriActiveConnectionConfig(any()))
                 .thenReturn(claimedIdentityConfig);
 
+        // Act & Assert
         assertFalse(userIdentityService.checkRequiresAdditionalEvidence(vcStoreItems));
     }
 
     @Test
     void getCredentialsWithMultipleCredentialsAndAllValidEvidence() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(USER_ID_1, BAV_CRI, M1B_DCMAW_VC, Instant.now()),
                         createVcStoreItem(USER_ID_1, F2F_CRI, M1A_F2F_VC, Instant.now()));
+
+        // Act & Assert
         assertFalse(userIdentityService.checkRequiresAdditionalEvidence(vcStoreItems));
     }
 
     @Test
     void getCredentialsWithMultipleCredentialsAndAllInValidEvidence() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(USER_ID_1, BAV_CRI, VC_FRAUD_SCORE_1, Instant.now()),
                         createVcStoreItem(USER_ID_1, F2F_CRI, VC_KBV_SCORE_2, Instant.now()));
+
+        // Act & Assert
         assertFalse(userIdentityService.checkRequiresAdditionalEvidence(vcStoreItems));
     }
 
     @Test
     void getCredentialsWithMultipleCredentialsAndValidAndInValidEvidence() {
+        // Arrange
         List<VcStoreItem> vcStoreItems =
                 List.of(
                         createVcStoreItem(USER_ID_1, BAV_CRI, M1B_DCMAW_VC, Instant.now()),
@@ -1564,6 +1724,7 @@ class UserIdentityServiceTest {
         when(mockConfigService.getOauthCriActiveConnectionConfig(any()))
                 .thenReturn(claimedIdentityConfig);
 
+        // Act & Assert
         assertTrue(userIdentityService.checkRequiresAdditionalEvidence(vcStoreItems));
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Added `getVot` method to user identity service to get a VC's vot value and parse as a VectorOfTrust
- Added `isHmrcInheritedIdentityWithStrongerVotPresent` to check if existing vc exists for `userId` and `HMRC_MIGRATION_CRI` which has a stronger vot than the incoming vc
- Added PCL200 and PCL250 enum values to VectorOfTrust enum - which is now ordered for logic on strength

### Why did it change

- We want to prevent writing new VCs to the vc store for the cri hmrcMigration and userId when am inherited identity with a stronger vot already exists

### Issue tracking

- [PYIC-4384](https://govukverify.atlassian.net/browse/PYIC-4384)

[PYIC-4384]: https://govukverify.atlassian.net/browse/PYIC-4384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ