### PR TITLE
PYIC-4139: Handle case where retrieved VC store item has a null creden…

### DIFF
--- a/lambdas/replay-cimit-vcs/src/main/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandler.java
+++ b/lambdas/replay-cimit-vcs/src/main/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandler.java
@@ -92,12 +92,12 @@ public class ReplayCimitVcsHandler implements RequestStreamHandler {
             VcStoreItem vcStoreItem =
                     this.verifiableCredentialService.getVcStoreItem(
                             item.getUserId().get("S"), item.getCredentialIssuer().get("S"));
-            if (vcStoreItem.getCredential() != null) {
+            if (vcStoreItem != null) {
                 SignedJWT vc = SignedJWT.parse(vcStoreItem.getCredential());
                 ciMitService.submitVC(vc, null, null);
                 submittedVcs.add(vc.serialize());
             } else {
-                LOGGER.warn("Null credential in VC");
+                LOGGER.warn("VC not found");
             }
         }
         ciMitService.submitMitigatingVcList(submittedVcs, null, null);

--- a/lambdas/replay-cimit-vcs/src/main/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandler.java
+++ b/lambdas/replay-cimit-vcs/src/main/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandler.java
@@ -65,7 +65,7 @@ public class ReplayCimitVcsHandler implements RequestStreamHandler {
             LOGGER.info("Retrieving {} VCs", requestItems.size());
             List<List<ReplayItem>> batchedRequest = ListHelper.getBatches(requestItems, 100);
             for (int i = 0; i < batchedRequest.size(); i++) {
-                LOGGER.info("Processing batch {} of {}", i, requestItems.size());
+                LOGGER.info("Processing batch {} of {}", i, batchedRequest.size());
                 List<ReplayItem> batch = batchedRequest.get(i);
                 handleBatch(batch);
             }
@@ -92,9 +92,13 @@ public class ReplayCimitVcsHandler implements RequestStreamHandler {
             VcStoreItem vcStoreItem =
                     this.verifiableCredentialService.getVcStoreItem(
                             item.getUserId().get("S"), item.getCredentialIssuer().get("S"));
-            SignedJWT vc = SignedJWT.parse(vcStoreItem.getCredential());
-            ciMitService.submitVC(vc, null, null);
-            submittedVcs.add(vc.serialize());
+            if (vcStoreItem.getCredential() != null) {
+                SignedJWT vc = SignedJWT.parse(vcStoreItem.getCredential());
+                ciMitService.submitVC(vc, null, null);
+                submittedVcs.add(vc.serialize());
+            } else {
+                LOGGER.warn("Null credential in VC");
+            }
         }
         ciMitService.submitMitigatingVcList(submittedVcs, null, null);
     }

--- a/lambdas/replay-cimit-vcs/src/test/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandlerTest.java
+++ b/lambdas/replay-cimit-vcs/src/test/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandlerTest.java
@@ -71,11 +71,11 @@ class ReplayCimitVcsHandlerTest {
     }
 
     @Test
-    void shouldNotAttemptSubmitOnNullCredential() throws CiPutException {
+    void shouldNotAttemptSubmitOnNullVc() throws CiPutException {
         InputStream inputStream =
                 ReplayCimitVcsHandlerTest.class.getResourceAsStream("/testReplayRequest.json");
         when(mockVerifiableCredentialService.getVcStoreItem(TEST_USER_ID, TEST_CRI_ID))
-                .thenReturn(createNullCredentialVcStoreItem());
+                .thenReturn(null);
 
         this.replayCimitVcsHandler.handleRequest(inputStream, null, null);
 
@@ -143,15 +143,6 @@ class ReplayCimitVcsHandlerTest {
         VcStoreItem vcStoreItem = new VcStoreItem();
         vcStoreItem.setUserId(TEST_USER_ID);
         vcStoreItem.setCredential("invalid-credential");
-        vcStoreItem.setDateCreated(dateCreated);
-        vcStoreItem.setExpirationTime(dateCreated.plusSeconds(1000L));
-        return vcStoreItem;
-    }
-
-    private VcStoreItem createNullCredentialVcStoreItem() {
-        Instant dateCreated = Instant.now();
-        VcStoreItem vcStoreItem = new VcStoreItem();
-        vcStoreItem.setUserId(TEST_USER_ID);
         vcStoreItem.setDateCreated(dateCreated);
         vcStoreItem.setExpirationTime(dateCreated.plusSeconds(1000L));
         return vcStoreItem;

--- a/lambdas/replay-cimit-vcs/src/test/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandlerTest.java
+++ b/lambdas/replay-cimit-vcs/src/test/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandlerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,6 +68,18 @@ class ReplayCimitVcsHandlerTest {
         List<String> ciIpAddresses = ipAddressCaptor.getAllValues();
         assertEquals(1, ciIpAddresses.size());
         assertNull(ciIpAddresses.get(0));
+    }
+
+    @Test
+    void shouldNotAttemptSubmitOnNullCredential() throws CiPutException {
+        InputStream inputStream =
+                ReplayCimitVcsHandlerTest.class.getResourceAsStream("/testReplayRequest.json");
+        when(mockVerifiableCredentialService.getVcStoreItem(TEST_USER_ID, TEST_CRI_ID))
+                .thenReturn(createNullCredentialVcStoreItem());
+
+        this.replayCimitVcsHandler.handleRequest(inputStream, null, null);
+
+        verify(ciMitService, never()).submitVC(any(), any(), any());
     }
 
     @Test
@@ -130,6 +143,15 @@ class ReplayCimitVcsHandlerTest {
         VcStoreItem vcStoreItem = new VcStoreItem();
         vcStoreItem.setUserId(TEST_USER_ID);
         vcStoreItem.setCredential("invalid-credential");
+        vcStoreItem.setDateCreated(dateCreated);
+        vcStoreItem.setExpirationTime(dateCreated.plusSeconds(1000L));
+        return vcStoreItem;
+    }
+
+    private VcStoreItem createNullCredentialVcStoreItem() {
+        Instant dateCreated = Instant.now();
+        VcStoreItem vcStoreItem = new VcStoreItem();
+        vcStoreItem.setUserId(TEST_USER_ID);
         vcStoreItem.setDateCreated(dateCreated);
         vcStoreItem.setExpirationTime(dateCreated.plusSeconds(1000L));
         return vcStoreItem;


### PR DESCRIPTION
…tial field

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Adds null check against the credential field for retrieved VC store items
- Adds warning when VC found without credential field

### Why did it change

- A few VC store items appear to have null credentials, this was causing the replay lambda to error and not continue when finding a VC in this state

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4139](https://govukverify.atlassian.net/browse/PYIC-4139)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-4139]: https://govukverify.atlassian.net/browse/PYIC-4139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ