### PR TITLE
PYIC-4126 Use common CRI config to read component id

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -261,11 +261,8 @@ public class ConfigService {
     }
 
     public String getComponentId(String credentialIssuerId) {
-        String activeConnection = getActiveConnection(credentialIssuerId);
-        final String pathTemplate =
-                ConfigurationVariable.CREDENTIAL_ISSUERS.getPath()
-                        + "/%s/connections/%s/componentId";
-        return getSsmParameterWithOverride(pathTemplate, credentialIssuerId, activeConnection);
+        var criConfig = getOauthCriActiveConnectionConfig(credentialIssuerId);
+        return criConfig.getComponentId();
     }
 
     public String getAllowedSharedAttributes(String credentialIssuerId) {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -281,51 +281,17 @@ class ConfigServiceTest {
         @Test
         void shouldGetComponentIdForActiveConnection() {
             environmentVariables.set("ENVIRONMENT", "test");
-            final String testCredentialIssuerId = "address";
+
             final String testComponentId = "testComponentId";
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+            when(ssmProvider.get("/test/core/credentialIssuers/cri/activeConnection"))
                     .thenReturn("stub");
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/address/connections/stub/componentId"))
-                    .thenReturn(testComponentId);
-            assertEquals(testComponentId, configService.getComponentId(testCredentialIssuerId));
-        }
+            when(ssmProvider.get("/test/core/credentialIssuers/cri/connections/stub"))
+                    .thenReturn(
+                            String.format(
+                                    "{\"signingKey\":%s,\"componentId\":\"%s\"}",
+                                    EC_PRIVATE_KEY_JWK_DOUBLE_ENCODED, testComponentId));
 
-        @Test
-        void shouldLookForFeatureSetOverrideOfComponentIdOnActiveConfiguration() {
-            environmentVariables.set("ENVIRONMENT", "test");
-            configService.setFeatureSet("fs01");
-            final String testCredentialIssuerId = "address";
-            final String testComponentId = "testComponentId";
-
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.getMultiple("/test/core/features/fs01/credentialIssuers/address"))
-                    .thenReturn(Map.of());
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/address/connections/stub/componentId"))
-                    .thenReturn(testComponentId);
-            when(ssmProvider.getMultiple(
-                            "/test/core/features/fs01/credentialIssuers/address/connections/stub"))
-                    .thenReturn(Map.of());
-            assertEquals(testComponentId, configService.getComponentId(testCredentialIssuerId));
-        }
-
-        @Test
-        void shouldApplyFeatureSetOverrideOfComponentIdOnActiveConfiguration() {
-            environmentVariables.set("ENVIRONMENT", "test");
-            configService.setFeatureSet("fs01");
-            final String testCredentialIssuerId = "address";
-            final String testComponentId = "testComponentId";
-
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.getMultiple("/test/core/features/fs01/credentialIssuers/address"))
-                    .thenReturn(Map.of());
-            when(ssmProvider.getMultiple(
-                            "/test/core/features/fs01/credentialIssuers/address/connections/stub"))
-                    .thenReturn(Map.of("componentId", "testComponentId"));
-            assertEquals(testComponentId, configService.getComponentId(testCredentialIssuerId));
+            assertEquals(testComponentId, configService.getComponentId("cri"));
         }
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Read the component ID from the new bundled CRI config

### Why did it change

This was an oversight in the original bundling of the CRI config. This only continued to work because we still had the old config values in SSM (but breaks for new deployments).