### PR TITLE
PYIC-4548: Allow IPV_IDENTITY_REUSE_COMPLETE audit event and simplify profile check methods

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/domain/VotProfilePair.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/domain/VotProfilePair.java
@@ -1,5 +1,0 @@
-package uk.gov.di.ipv.core.checkexistingidentity.domain;
-
-import uk.gov.di.ipv.core.library.enums.Vot;
-
-public record VotProfilePair(Vot attainedVot, String profileName) {}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

[PYIC-4548: Allow IPV_IDENTITY_REUSE_COMPLETE audit event](https://github.com/govuk-one-login/ipv-core-back/pull/1560/commits/741d4eee0032891eb300957f54ff113a706d7826)

We can allow this audit event of an inherited identity reuse scenario.
The profile used is logged elsewhere, so we've caught all the info we
need.


[PYIC-4548: Simplify attainedVot logic](https://github.com/govuk-one-login/ipv-core-back/pull/1560/commits/233162dac90339c894029b66e000b2fef0598e7f)

This simplifies the return values of the methods used to check if a user
has attained a gpg45 VOT or an operational VOT. We were returning a
VotProfilePair and only using the pair for some logging.

This removes that record, and just returns a boolean for if the
requested VOT being checked has been met or not.


