### PR TITLE
PYIC-4429: Put reprove_identity audit event parsing behind feature flag

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -195,7 +195,7 @@ public class InitialiseIpvSessionHandler
             }
 
             Boolean reproveIdentity =
-                    configService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_AUDIT_ENABLED)
+                    configService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_ENABLED)
                             ? claimsSet.getBooleanClaim(REPROVE_IDENTITY_KEY)
                             : null;
 

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -194,9 +194,10 @@ public class InitialiseIpvSessionHandler
                 }
             }
 
-            Boolean reproveIdentity = configService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_AUDIT_ENABLED)
-                    ? claimsSet.getBooleanClaim(REPROVE_IDENTITY_KEY)
-                    : null;
+            Boolean reproveIdentity =
+                    configService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_AUDIT_ENABLED)
+                            ? claimsSet.getBooleanClaim(REPROVE_IDENTITY_KEY)
+                            : null;
 
             AuditExtensionsReproveIdentity reproveAuditExtension =
                     reproveIdentity == null

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -194,7 +194,9 @@ public class InitialiseIpvSessionHandler
                 }
             }
 
-            Boolean reproveIdentity = claimsSet.getBooleanClaim(REPROVE_IDENTITY_KEY);
+            Boolean reproveIdentity = configService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_AUDIT_ENABLED)
+                    ? claimsSet.getBooleanClaim(REPROVE_IDENTITY_KEY)
+                    : null;
 
             AuditExtensionsReproveIdentity reproveAuditExtension =
                     reproveIdentity == null

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -4,7 +4,7 @@ public enum CoreFeatureFlag implements FeatureFlag {
     UNUSED_PLACEHOLDER("unusedPlaceHolder"),
     RESET_IDENTITY("resetIdentity"),
     INHERITED_IDENTITY("inheritedIdentity"),
-    REPROVE_IDENTITY_AUDIT_ENABLED("reproveIdentityAuditEnabled");
+    REPROVE_IDENTITY_ENABLED("reproveIdentityEnabled");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -3,7 +3,8 @@ package uk.gov.di.ipv.core.library.config;
 public enum CoreFeatureFlag implements FeatureFlag {
     UNUSED_PLACEHOLDER("unusedPlaceHolder"),
     RESET_IDENTITY("resetIdentity"),
-    INHERITED_IDENTITY("inheritedIdentity");
+    INHERITED_IDENTITY("inheritedIdentity"),
+    REPROVE_IDENTITY_AUDIT_ENABLED("reproveIdentityAuditEnabled");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 
@@ -51,7 +52,12 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setGovukSigninJourneyId(
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
         clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
-        Boolean reproveIdentity = claimsSet.getBooleanClaim("reprove_identity");
+
+        Boolean reproveIdentity =
+                configService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_ENABLED)
+                        ? claimsSet.getBooleanClaim("reprove_identity")
+                        : null;
+
         clientOAuthSessionItem.setReproveIdentity(reproveIdentity);
 
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -68,6 +69,9 @@ class ClientOAuthSessionDetailsServiceTest {
     @Test
     void shouldCreateClientOAuthSessionItem() throws ParseException {
         String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
+
+        when(mockConfigService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_ENABLED)).thenReturn(true);
+
         JWTClaimsSet testClaimSet =
                 new JWTClaimsSet.Builder()
                         .claim("response_type", "test-type")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Put reprove_identity audit event parsing behind feature flag

### Why did it change

To avoid similar incidents to the P1 we had a few months back, where another team merged some work in before it was expected. This resulted in core-back trying to parse an audit variable that wasn't been sent yet, and caused a prod outage.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4429](https://govukverify.atlassian.net/browse/PYIC-4429)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-4429]: https://govukverify.atlassian.net/browse/PYIC-4429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ