### PR TITLE
BAU: Only fetch ci-config if required when validating VC

### DIFF
--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidator.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialJwtValidator.java
@@ -18,7 +18,6 @@ import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -30,7 +29,6 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
@@ -163,9 +161,6 @@ public class VerifiableCredentialJwtValidator {
 
     private void validateCiCodes(SignedJWT verifiableCredential)
             throws VerifiableCredentialException {
-        Map<String, ContraIndicatorConfig> contraIndicatorConfigMap =
-                configService.getContraIndicatorConfigMap();
-
         try {
             JSONObject vcClaim =
                     (JSONObject) verifiableCredential.getJWTClaimsSet().getClaim(VC_CLAIM);
@@ -184,8 +179,9 @@ public class VerifiableCredentialJwtValidator {
                                 cis.stream()
                                         .anyMatch(
                                                 ciCode ->
-                                                        !contraIndicatorConfigMap.containsKey(
-                                                                ciCode));
+                                                        !configService
+                                                                .getContraIndicatorConfigMap()
+                                                                .containsKey(ciCode));
                         if (anyUnrecognisedCiCodes) {
                             break;
                         }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Only fetch ci-config if required when validating VC

### Why did it change

When validating VCs we validate that any CI codes contained within are valid. If the VC doesn't have any CIs we don't need to fetch the config.

This has become an issue due to the validation of inherited identity VCs which won't contain CIs. Without this change the initialise-ipv-session lambda would need to have read access to the ci-config secret, even though it doesn't actually require that access.