### PR TITLE
PYIC-4258-fix: Makes some fixes to deploy template

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -168,14 +172,14 @@
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
+        "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
         "is_verified": false,
-        "line_number": 728
+        "line_number": 986
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
+        "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
         "line_number": 988
       },
@@ -184,14 +188,14 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1803
+        "line_number": 1801
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7456c32054693a3154d744c6729b2547b63e770c",
         "is_verified": false,
-        "line_number": 2190
+        "line_number": 2188
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -291,6 +295,78 @@
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
         "is_verified": false,
         "line_number": 255
+      }
+    ],
+    "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
+        "is_verified": false,
+        "line_number": 72
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "5a8d6b3d3ca71cb72e3e75294fbb727065ea6681",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "ad302621d832b872af77ecdb58ffb8f0c54395b1",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "0304d615c235e95fbfec9cc4f72bbd76bcc24577",
+        "is_verified": false,
+        "line_number": 160
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "0ab71ed9bc43f957e1b43547c70d345ebbf3a6ed",
+        "is_verified": false,
+        "line_number": 222
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
+        "is_verified": false,
+        "line_number": 279
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java": [
@@ -1242,5 +1318,5 @@
       }
     ]
   },
-  "generated_at": "2024-01-25T09:31:43Z"
+  "generated_at": "2024-01-25T11:11:46Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -685,7 +685,7 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub initialise-ipv-session-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
-          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [1, !Split ['/', !GetAtt UserIssuedCredentialsV2Table.Arn]]
+          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
       VpcConfig:
@@ -724,8 +724,6 @@ Resources:
             ParameterName: !Sub ${Environment}/core/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
-        - AWSSecretsManagerGetSecretValuePolicy:
-            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
         - Statement:
             - Sid: jarKmsEncryptionKeyPermission
               Effect: Allow

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -376,7 +376,7 @@ public class InitialiseIpvSessionHandler
             SignedJWT incomingInheritedIdentity, String userId) throws CredentialParseException {
         try {
             var vcStoreItem =
-                    verifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, userId);
+                    verifiableCredentialService.getVcStoreItem(userId, HMRC_MIGRATION_CRI);
             if (vcStoreItem == null) {
                 return false;
             }

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -135,7 +135,7 @@ class InitialiseIpvSessionHandlerTest {
                     .claim(REDIRECT_URI, "https://example.com")
                     .claim(STATE, "test-state")
                     .claim(CLIENT_ID, "test-client")
-                    .claim(VTR, List.of("Cl.Cm.P2", "Cl.Cm.PCL200"))
+                    .claim(VTR, List.of("P2", "PCL200"))
                     .claim(
                             CLAIMS,
                             Map.of(
@@ -157,6 +157,7 @@ class InitialiseIpvSessionHandlerTest {
 
     @BeforeEach
     void setUp() throws Exception {
+        claimsBuilder.claim(VTR, List.of("P2", "PCL200"));
         signClaims(claimsBuilder);
 
         ipvSessionItem = new IpvSessionItem();
@@ -396,7 +397,7 @@ class InitialiseIpvSessionHandlerTest {
     }
 
     @Test
-    void shouldValidateAndStoreAnyInheritedIdentity() throws Exception {
+    void shouldValidateAndStoreAnyInheritedIdentityWhenStrongerVotThanExisting() throws Exception {
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
                 .thenReturn(ipvSessionItem);
@@ -420,7 +421,7 @@ class InitialiseIpvSessionHandlerTest {
                 .thenReturn(true); // Mock enabled inherited identity feature flag
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
         SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(Vot.PCL200);
-        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+        when(mockVerifiableCredentialService.getVcStoreItem("test-user-id", HMRC_MIGRATION_CRI))
                 .thenReturn(
                         new VcStoreItem(
                                 "test-user-id",
@@ -429,6 +430,62 @@ class InitialiseIpvSessionHandlerTest {
                                 Instant.now(),
                                 Instant.now()));
         when(mockUserIdentityService.getVot(any())).thenReturn(Vot.PCL200).thenReturn(Vot.PCL200);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        Map<String, Object> sessionParams =
+                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
+        event.setBody(objectMapper.writeValueAsString(sessionParams));
+        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+
+        // Act
+        initialiseIpvSessionHandler.handleRequest(event, mockContext);
+
+        // Assert
+        verify(mockVerifiableCredentialJwtValidator, times(1))
+                .validate(
+                        signedJWTArgumentCaptor.capture(), eq(TEST_CRI_CONFIG), eq("test-user-id"));
+        assertEquals(
+                serialisedInheritedIdentityJWT, signedJWTArgumentCaptor.getValue().serialize());
+
+        verify(mockVerifiableCredentialService, times(1))
+                .persistUserCredentials(
+                        signedJWTArgumentCaptor.capture(),
+                        eq(HMRC_MIGRATION_CRI),
+                        eq("test-user-id"));
+        assertEquals(
+                serialisedInheritedIdentityJWT, signedJWTArgumentCaptor.getValue().serialize());
+
+        verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
+        assertEquals(
+                ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
+                List.of(serialisedInheritedIdentityJWT));
+    }
+
+    @Test
+    void shouldValidateAndStoreAnyInheritedIdentityWhenNoExistingIdentity() throws Exception {
+        // Arrange
+        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
+                .thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockJarValidator.validateRequestJwt(any(), any()))
+                .thenReturn(
+                        claimsBuilder
+                                .claim(
+                                        CLAIMS,
+                                        Map.of(
+                                                USER_INFO,
+                                                Map.of(
+                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                        Map.of(
+                                                                VALUES,
+                                                                List.of(
+                                                                        serialisedInheritedIdentityJWT)))))
+                                .build());
+        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
+        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+        when(mockVerifiableCredentialService.getVcStoreItem("test-user-id", HMRC_MIGRATION_CRI))
+                .thenReturn(null);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams =
@@ -484,7 +541,7 @@ class InitialiseIpvSessionHandlerTest {
         when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
         SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(Vot.PCL250);
-        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+        when(mockVerifiableCredentialService.getVcStoreItem("test-user-id", HMRC_MIGRATION_CRI))
                 .thenReturn(
                         new VcStoreItem(
                                 "test-user-id",
@@ -546,7 +603,7 @@ class InitialiseIpvSessionHandlerTest {
                 .thenReturn(true); // Mock enabled inherited identity feature flag
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
         SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(Vot.PCL200);
-        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+        when(mockVerifiableCredentialService.getVcStoreItem("test-user-id", HMRC_MIGRATION_CRI))
                 .thenReturn(null);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -603,7 +660,7 @@ class InitialiseIpvSessionHandlerTest {
         when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
         SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(Vot.PCL200);
-        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+        when(mockVerifiableCredentialService.getVcStoreItem("test-user-id", HMRC_MIGRATION_CRI))
                 .thenReturn(
                         new VcStoreItem(
                                 "test-user-id",
@@ -926,7 +983,7 @@ class InitialiseIpvSessionHandlerTest {
                         .build();
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(testCriConfig);
         SignedJWT existingInheritedIdentityJwt = getInheritedIdentityJWT(Vot.PCL200);
-        when(mockVerifiableCredentialService.getVcStoreItem(HMRC_MIGRATION_CRI, "test-user-id"))
+        when(mockVerifiableCredentialService.getVcStoreItem("test-user-id", HMRC_MIGRATION_CRI))
                 .thenReturn(
                         new VcStoreItem(
                                 "test-user-id",


### PR DESCRIPTION
## Proposed changes

### What changed

- Fixed template so initialiseipvsession has correct permissions and env vars
- Add in a null check to protect against failures

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4258](https://govukverify.atlassian.net/browse/PYIC-4258)

[PYIC-4258]: https://govukverify.atlassian.net/browse/PYIC-4258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ