### PR TITLE
PYIC-4601: Route users depending on reuse type 

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -73,7 +73,7 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_P
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_F2F_FAIL_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_IN_MIGRATION_REUSE_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_IPV_GPG45_MEDIUM_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_OPERATIONAL_PROFILE_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PENDING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_IDENTITY_PATH;
@@ -93,8 +93,8 @@ public class CheckExistingIdentityHandler
             new JourneyResponse(JOURNEY_IN_MIGRATION_REUSE_PATH).toObjectMap();
     private static final Map<String, Object> JOURNEY_PENDING =
             new JourneyResponse(JOURNEY_PENDING_PATH).toObjectMap();
-    private static final Map<String, Object> JOURNEY_NEXT =
-            new JourneyResponse(JOURNEY_NEXT_PATH).toObjectMap();
+    private static final Map<String, Object> JOURNEY_IPV_GPG45_MEDIUM =
+            new JourneyResponse(JOURNEY_IPV_GPG45_MEDIUM_PATH).toObjectMap();
     private static final Map<String, Object> JOURNEY_F2F_FAIL =
             new JourneyResponse(JOURNEY_F2F_FAIL_PATH).toObjectMap();
     private static final Map<String, Object> JOURNEY_RESET_IDENTITY =
@@ -361,8 +361,8 @@ public class CheckExistingIdentityHandler
 
             return JOURNEY_RESET_IDENTITY;
         }
-        LOGGER.info(LogHelper.buildLogMessage("New IPV journey required, returning journey next"));
-        return JOURNEY_NEXT;
+        LOGGER.info(LogHelper.buildLogMessage("New IPV journey required"));
+        return JOURNEY_IPV_GPG45_MEDIUM;
     }
 
     private Map<String, Object> buildReuseResponse(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -4,11 +4,15 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -81,6 +85,7 @@ import static uk.gov.di.ipv.core.library.domain.CriConstants.FRAUD_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.HMRC_MIGRATION_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.KBV_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.PASSPORT_CRI;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_F2F_VC;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.M1A_FRAUD_VC;
@@ -92,7 +97,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_PASSPORT_NON_D
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_F2F_FAIL_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_IN_MIGRATION_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_OPERATIONAL_PROFILE_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PENDING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_IDENTITY_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_PATH;
@@ -126,6 +133,10 @@ class CheckExistingIdentityHandlerTest {
     private static final String TICF_CRI = "ticf";
     private static final List<SignedJWT> PARSED_CREDENTIALS = new ArrayList<>();
     private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse(JOURNEY_REUSE_PATH);
+    private static final JourneyResponse JOURNEY_OP_PROFILE_REUSE =
+            new JourneyResponse(JOURNEY_OPERATIONAL_PROFILE_REUSE_PATH);
+    private static final JourneyResponse JOURNEY_IN_MIGRATION_REUSE =
+            new JourneyResponse(JOURNEY_IN_MIGRATION_REUSE_PATH);
     private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse(JOURNEY_NEXT_PATH);
     private static final JourneyResponse JOURNEY_RESET_IDENTITY =
             new JourneyResponse(JOURNEY_RESET_IDENTITY_PATH);
@@ -133,7 +144,10 @@ class CheckExistingIdentityHandlerTest {
             new JourneyResponse(JOURNEY_PENDING_PATH);
     private static final JourneyResponse JOURNEY_F2F_FAIL =
             new JourneyResponse(JOURNEY_F2F_FAIL_PATH);
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static ECDSASigner jwtSigner;
+    private static SignedJWT pcl200Vc;
+    private static SignedJWT pcl250Vc;
 
     @Mock private Context context;
     @Mock private UserIdentityService userIdentityService;
@@ -157,6 +171,9 @@ class CheckExistingIdentityHandlerTest {
         for (String cred : CREDENTIALS) {
             PARSED_CREDENTIALS.add(SignedJWT.parse(cred));
         }
+        jwtSigner = createJwtSigner();
+        pcl200Vc = createOperationalProfileVc(Vot.PCL200);
+        pcl250Vc = createOperationalProfileVc(Vot.PCL250);
     }
 
     @BeforeEach
@@ -231,144 +248,203 @@ class CheckExistingIdentityHandlerTest {
         verify(auditService, never()).sendAuditEvent(auditEventArgumentCaptor.capture());
     }
 
-    @Test
-    void shouldReturnJourneyReuseResponseIfScoresSatisfyM1AGpg45Profile() throws Exception {
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.areVCsCorrelated(any())).thenReturn(true);
-        when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(PARSED_CREDENTIALS);
-        when(gpg45ProfileEvaluator.getFirstMatchingProfile(
-                        any(), eq(Vot.P2.getSupportedGpg45Profiles())))
-                .thenReturn(Optional.of(Gpg45Profile.M1A));
-        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
+    @Nested
+    @DisplayName("reuse journeys")
+    class ReuseJourneys {
+        @BeforeEach
+        public void reuseSetup() throws Exception {
+            when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+            when(userIdentityService.areVCsCorrelated(any())).thenReturn(true);
+            when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                    .thenReturn(clientOAuthSessionItem);
+        }
 
-        JourneyResponse journeyResponse =
-                toResponseClass(
-                        checkExistingIdentityHandler.handleRequest(event, context),
-                        JourneyResponse.class);
+        @Test
+        void shouldReturnJourneyReuseResponseIfScoresSatisfyM1AGpg45Profile() throws Exception {
+            when(gpg45ProfileEvaluator.getFirstMatchingProfile(
+                            any(), eq(Vot.P2.getSupportedGpg45Profiles())))
+                    .thenReturn(Optional.of(Gpg45Profile.M1A));
 
-        assertEquals(JOURNEY_REUSE, journeyResponse);
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-        verify(mockVerifiableCredentialService).deleteVcStoreItem(TEST_USER_ID, TICF_CRI);
-        ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
-                ArgumentCaptor.forClass(AuditEvent.class);
-        verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());
-        assertEquals(
-                AuditEventTypes.IPV_GPG45_PROFILE_MATCHED,
-                auditEventArgumentCaptor.getAllValues().get(0).getEventName());
-        assertEquals(
-                AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
-                auditEventArgumentCaptor.getAllValues().get(1).getEventName());
-        verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockVerifiableCredentialService, times(1)).getVcStoreItems(TEST_USER_ID);
+            assertEquals(JOURNEY_REUSE, journeyResponse);
 
-        InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
-        inOrder.verify(ipvSessionItem).setVot(Vot.P2.name());
-        inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
-        inOrder.verify(ipvSessionItem, never()).setVot(any());
-        assertEquals(Vot.P2.name(), ipvSessionItem.getVot());
-    }
+            verify(mockVerifiableCredentialService).deleteVcStoreItem(TEST_USER_ID, TICF_CRI);
+            ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
+                    ArgumentCaptor.forClass(AuditEvent.class);
+            verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());
+            assertEquals(
+                    AuditEventTypes.IPV_GPG45_PROFILE_MATCHED,
+                    auditEventArgumentCaptor.getAllValues().get(0).getEventName());
+            assertEquals(
+                    AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
+                    auditEventArgumentCaptor.getAllValues().get(1).getEventName());
+            verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+            verify(mockVerifiableCredentialService, times(1)).getVcStoreItems(TEST_USER_ID);
 
-    @Test
-    void shouldReturnJourneyReuseResponseIfScoresSatisfyM1BGpg45Profile() throws Exception {
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getIdentityCredentials(any())).thenReturn(CREDENTIALS);
-        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(null);
-        when(userIdentityService.areVCsCorrelated(any())).thenReturn(true);
-        when(gpg45ProfileEvaluator.getFirstMatchingProfile(
-                        any(), eq(Vot.P2.getSupportedGpg45Profiles())))
-                .thenReturn(Optional.of(Gpg45Profile.M1B));
-        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
+            InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
+            inOrder.verify(ipvSessionItem).setVot(Vot.P2.name());
+            inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
+            inOrder.verify(ipvSessionItem, never()).setVot(any());
+            assertEquals(Vot.P2.name(), ipvSessionItem.getVot());
+        }
 
-        JourneyResponse journeyResponse =
-                toResponseClass(
-                        checkExistingIdentityHandler.handleRequest(event, context),
-                        JourneyResponse.class);
+        @Test
+        void shouldReturnJourneyReuseResponseIfScoresSatisfyM1BGpg45Profile() throws Exception {
+            when(gpg45ProfileEvaluator.getFirstMatchingProfile(
+                            any(), eq(Vot.P2.getSupportedGpg45Profiles())))
+                    .thenReturn(Optional.of(Gpg45Profile.M1B));
 
-        assertEquals(JOURNEY_REUSE, journeyResponse);
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-        ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
-                ArgumentCaptor.forClass(AuditEvent.class);
-        verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());
-        assertEquals(
-                AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
-                auditEventArgumentCaptor.getValue().getEventName());
-        verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+            assertEquals(JOURNEY_REUSE, journeyResponse);
 
-        verify(ipvSessionService, times(1)).updateIpvSession(ipvSessionItem);
+            ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
+                    ArgumentCaptor.forClass(AuditEvent.class);
+            verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());
+            assertEquals(
+                    AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
+                    auditEventArgumentCaptor.getValue().getEventName());
+            verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
 
-        InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
-        inOrder.verify(ipvSessionItem).setVot(Vot.P2.name());
-        inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
-        inOrder.verify(ipvSessionItem, never()).setVot(any());
-        assertEquals(Vot.P2.name(), ipvSessionItem.getVot());
-    }
+            verify(ipvSessionService, times(1)).updateIpvSession(ipvSessionItem);
 
-    @Test
-    void shouldReturnJourneyReuseResponseIfPCL200RequestedAndMet() throws Exception {
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(null);
-        when(userIdentityService.areVCsCorrelated(any())).thenReturn(true);
+            InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
+            inOrder.verify(ipvSessionItem).setVot(Vot.P2.name());
+            inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
+            inOrder.verify(ipvSessionItem, never()).setVot(any());
+            assertEquals(Vot.P2.name(), ipvSessionItem.getVot());
+        }
 
-        SignedJWT operationalProfileVc =
-                new SignedJWT(
-                        new JWSHeader(JWSAlgorithm.ES256),
-                        new JWTClaimsSet.Builder().claim("vot", Vot.PCL200.name()).build());
-        when(gpg45ProfileEvaluator.parseCredentials(any()))
-                .thenReturn(List.of(operationalProfileVc));
-        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
+        @Test // User returning after migration
+        void
+                shouldReturnJourneyOpProfileReuseResponseIfPCL200RequestedAndMetWhenNoVcInCurrentSession()
+                        throws Exception {
+            when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(List.of(pcl200Vc));
 
-        clientOAuthSessionItem.setVtr(List.of(Vot.P2.name(), Vot.PCL250.name(), Vot.PCL200.name()));
+            clientOAuthSessionItem.setVtr(
+                    List.of(Vot.P2.name(), Vot.PCL250.name(), Vot.PCL200.name()));
+            ipvSessionItem.setVcReceivedThisSession(List.of());
 
-        JourneyResponse journeyResponse =
-                toResponseClass(
-                        checkExistingIdentityHandler.handleRequest(event, context),
-                        JourneyResponse.class);
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-        assertEquals(JOURNEY_REUSE, journeyResponse);
+            assertEquals(JOURNEY_OP_PROFILE_REUSE, journeyResponse);
+            InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
+            inOrder.verify(ipvSessionItem).setVot(Vot.PCL200.name());
+            inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
+            inOrder.verify(ipvSessionItem, never()).setVot(any());
+            assertEquals(Vot.PCL200.name(), ipvSessionItem.getVot());
+        }
 
-        InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
-        inOrder.verify(ipvSessionItem).setVot(Vot.PCL200.name());
-        inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
-        inOrder.verify(ipvSessionItem, never()).setVot(any());
-        assertEquals(Vot.PCL200.name(), ipvSessionItem.getVot());
-    }
+        @Test // User returning after migration
+        void
+                shouldReturnJourneyOpProfileReuseResponseIfPCL250RequestedAndMetWhenNoVcInCurrentSession()
+                        throws Exception {
+            when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(List.of(pcl250Vc));
 
-    @Test
-    void shouldReturnJourneyReuseResponseIfPCL250RequestedAndMet() throws Exception {
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(null);
-        when(userIdentityService.areVCsCorrelated(any())).thenReturn(true);
+            clientOAuthSessionItem.setVtr(List.of(Vot.P2.name(), Vot.PCL250.name()));
+            ipvSessionItem.setVcReceivedThisSession(List.of());
 
-        SignedJWT operationalProfileVc =
-                new SignedJWT(
-                        new JWSHeader(JWSAlgorithm.ES256),
-                        new JWTClaimsSet.Builder().claim("vot", Vot.PCL250.name()).build());
-        when(gpg45ProfileEvaluator.parseCredentials(any()))
-                .thenReturn(List.of(operationalProfileVc));
-        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-        clientOAuthSessionItem.setVtr(List.of(Vot.P2.name(), Vot.PCL250.name()));
+            assertEquals(JOURNEY_OP_PROFILE_REUSE, journeyResponse);
 
-        JourneyResponse journeyResponse =
-                toResponseClass(
-                        checkExistingIdentityHandler.handleRequest(event, context),
-                        JourneyResponse.class);
+            InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
+            inOrder.verify(ipvSessionItem).setVot(Vot.PCL250.name());
+            inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
+            inOrder.verify(ipvSessionItem, never()).setVot(any());
+            assertEquals(Vot.PCL250.name(), ipvSessionItem.getVot());
+        }
 
-        assertEquals(JOURNEY_REUSE, journeyResponse);
+        @Test // User in process of migration
+        void
+                shouldReturnJourneyInMigrationReuseResponseIfPCL200RequestedAndMetWhenVcInCurrentSession()
+                        throws Exception {
+            when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(List.of(pcl200Vc));
 
-        InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
-        inOrder.verify(ipvSessionItem).setVot(Vot.PCL250.name());
-        inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
-        inOrder.verify(ipvSessionItem, never()).setVot(any());
-        assertEquals(Vot.PCL250.name(), ipvSessionItem.getVot());
+            clientOAuthSessionItem.setVtr(
+                    List.of(Vot.P2.name(), Vot.PCL250.name(), Vot.PCL200.name()));
+            ipvSessionItem.setVcReceivedThisSession(List.of(pcl200Vc.serialize()));
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_IN_MIGRATION_REUSE, journeyResponse);
+            InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
+            inOrder.verify(ipvSessionItem).setVot(Vot.PCL200.name());
+            inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
+            inOrder.verify(ipvSessionItem, never()).setVot(any());
+            assertEquals(Vot.PCL200.name(), ipvSessionItem.getVot());
+        }
+
+        @Test // User in process of migration
+        void
+                shouldReturnJourneyInMigrationReuseResponseIfPCL250RequestedAndMetWhenVcInCurrentSession()
+                        throws Exception {
+            when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(List.of(pcl250Vc));
+
+            clientOAuthSessionItem.setVtr(List.of(Vot.P2.name(), Vot.PCL250.name()));
+            ipvSessionItem.setVcReceivedThisSession(List.of(pcl250Vc.serialize()));
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_IN_MIGRATION_REUSE, journeyResponse);
+            InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
+            inOrder.verify(ipvSessionItem).setVot(Vot.PCL250.name());
+            inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
+            inOrder.verify(ipvSessionItem, never()).setVot(any());
+            assertEquals(Vot.PCL250.name(), ipvSessionItem.getVot());
+        }
+
+        @Test
+        void shouldMatchStrongestVotRegardlessOfVtrOrder() throws Exception {
+            when(gpg45ProfileEvaluator.getFirstMatchingProfile(
+                            any(), eq(Vot.P2.getSupportedGpg45Profiles())))
+                    .thenReturn(Optional.of(Gpg45Profile.M1B));
+
+            clientOAuthSessionItem.setVtr(
+                    List.of(Vot.PCL250.name(), Vot.PCL200.name(), Vot.P2.name()));
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_REUSE, journeyResponse);
+
+            ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
+                    ArgumentCaptor.forClass(AuditEvent.class);
+            verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());
+            assertEquals(
+                    AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
+                    auditEventArgumentCaptor.getValue().getEventName());
+            verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+
+            verify(ipvSessionService, times(1)).updateIpvSession(ipvSessionItem);
+
+            InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
+            inOrder.verify(ipvSessionItem).setVot(Vot.P2.name());
+            inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
+            inOrder.verify(ipvSessionItem, never()).setVot(any());
+            assertEquals(Vot.P2.name(), ipvSessionItem.getVot());
+        }
     }
 
     @ParameterizedTest
@@ -382,11 +458,7 @@ class CheckExistingIdentityHandlerTest {
         var vot = (Optional<Vot>) votAndVtr.get("operationalCredVot");
         List<SignedJWT> credentials = new ArrayList<>();
         if (vot.isPresent()) {
-            SignedJWT operationalProfileVc =
-                    new SignedJWT(
-                            new JWSHeader(JWSAlgorithm.ES256),
-                            new JWTClaimsSet.Builder().claim("vot", vot.get().name()).build());
-            credentials.add(operationalProfileVc);
+            credentials.add(createOperationalProfileVc(vot.get()));
         }
 
         when(gpg45ProfileEvaluator.parseCredentials(any())).thenReturn(credentials);
@@ -422,45 +494,6 @@ class CheckExistingIdentityHandlerTest {
                         List.of(Vot.P2, Vot.PCL250, Vot.PCL200),
                         "operationalCredVot",
                         Optional.empty()));
-    }
-
-    @Test
-    void shouldMatchStrongestVotRegardlessOfVtrOrder() throws Exception {
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(userIdentityService.getIdentityCredentials(any())).thenReturn(CREDENTIALS);
-        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(null);
-        when(userIdentityService.areVCsCorrelated(any())).thenReturn(true);
-        when(gpg45ProfileEvaluator.getFirstMatchingProfile(
-                        any(), eq(Vot.P2.getSupportedGpg45Profiles())))
-                .thenReturn(Optional.of(Gpg45Profile.M1B));
-        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(configService.enabled(RESET_IDENTITY.getName())).thenReturn(false);
-
-        clientOAuthSessionItem.setVtr(List.of(Vot.PCL250.name(), Vot.PCL200.name(), Vot.P2.name()));
-
-        JourneyResponse journeyResponse =
-                toResponseClass(
-                        checkExistingIdentityHandler.handleRequest(event, context),
-                        JourneyResponse.class);
-
-        assertEquals(JOURNEY_REUSE, journeyResponse);
-
-        ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
-                ArgumentCaptor.forClass(AuditEvent.class);
-        verify(auditService, times(2)).sendAuditEvent(auditEventArgumentCaptor.capture());
-        assertEquals(
-                AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
-                auditEventArgumentCaptor.getValue().getEventName());
-        verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-
-        verify(ipvSessionService, times(1)).updateIpvSession(ipvSessionItem);
-
-        InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
-        inOrder.verify(ipvSessionItem).setVot(Vot.P2.name());
-        inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
-        inOrder.verify(ipvSessionItem, never()).setVot(any());
-        assertEquals(Vot.P2.name(), ipvSessionItem.getVot());
     }
 
     @Test
@@ -910,7 +943,7 @@ class CheckExistingIdentityHandlerTest {
     }
 
     private <T> T toResponseClass(Map<String, Object> handlerOutput, Class<T> responseClass) {
-        return mapper.convertValue(handlerOutput, responseClass);
+        return MAPPER.convertValue(handlerOutput, responseClass);
     }
 
     @Test
@@ -1001,5 +1034,18 @@ class CheckExistingIdentityHandlerTest {
         criResponseItem.setDateCreated(dateCreated);
         criResponseItem.setStatus(CriResponseService.STATUS_ERROR);
         return criResponseItem;
+    }
+
+    private static SignedJWT createOperationalProfileVc(Vot vot) throws Exception {
+        var jwt =
+                new SignedJWT(
+                        new JWSHeader(JWSAlgorithm.ES256),
+                        new JWTClaimsSet.Builder().claim("vot", vot.name()).build());
+        jwt.sign(jwtSigner);
+        return jwt;
+    }
+
+    private static ECDSASigner createJwtSigner() throws Exception {
+        return new ECDSASigner(ECKey.parse(EC_PRIVATE_KEY_JWK).toECPrivateKey());
     }
 }

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -98,7 +98,7 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_P
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_F2F_FAIL_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_IN_MIGRATION_REUSE_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_IPV_GPG45_MEDIUM_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_OPERATIONAL_PROFILE_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PENDING_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_IDENTITY_PATH;
@@ -137,7 +137,8 @@ class CheckExistingIdentityHandlerTest {
             new JourneyResponse(JOURNEY_OPERATIONAL_PROFILE_REUSE_PATH);
     private static final JourneyResponse JOURNEY_IN_MIGRATION_REUSE =
             new JourneyResponse(JOURNEY_IN_MIGRATION_REUSE_PATH);
-    private static final JourneyResponse JOURNEY_NEXT = new JourneyResponse(JOURNEY_NEXT_PATH);
+    private static final JourneyResponse JOURNEY_IPV_GPG45_MEDIUM =
+            new JourneyResponse(JOURNEY_IPV_GPG45_MEDIUM_PATH);
     private static final JourneyResponse JOURNEY_RESET_IDENTITY =
             new JourneyResponse(JOURNEY_RESET_IDENTITY_PATH);
     private static final JourneyResponse JOURNEY_PENDING =
@@ -449,8 +450,8 @@ class CheckExistingIdentityHandlerTest {
 
     @ParameterizedTest
     @MethodSource("votAndVtrCombinationsThatShouldStartIpvJourney")
-    void shouldReturnJourneyNextResponseIfNoProfileAttainsVot(Map<String, Object> votAndVtr)
-            throws Exception {
+    void shouldReturnJourneyIpvGpg45MediumResponseIfNoProfileAttainsVot(
+            Map<String, Object> votAndVtr) throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(null);
         when(userIdentityService.areVCsCorrelated(any())).thenReturn(true);
@@ -473,7 +474,7 @@ class CheckExistingIdentityHandlerTest {
                         checkExistingIdentityHandler.handleRequest(event, context),
                         JourneyResponse.class);
 
-        assertEquals(JOURNEY_NEXT, journeyResponse);
+        assertEquals(JOURNEY_IPV_GPG45_MEDIUM, journeyResponse);
 
         verify(ipvSessionItem, never()).setVot(any());
     }
@@ -546,7 +547,7 @@ class CheckExistingIdentityHandlerTest {
                         checkExistingIdentityHandler.handleRequest(event, context),
                         JourneyResponse.class);
 
-        assertEquals("/journey/next", journeyResponse.getJourney());
+        assertEquals(JOURNEY_IPV_GPG45_MEDIUM_PATH, journeyResponse.getJourney());
 
         ArgumentCaptor<AuditEvent> auditEventArgumentCaptor =
                 ArgumentCaptor.forClass(AuditEvent.class);

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -105,6 +105,8 @@ CHECK_EXISTING_IDENTITY:
   events:
     next:
       targetState: IPV_IDENTITY_START_PAGE
+    ipv-gpg45-medium:
+      targetState: IPV_IDENTITY_START_PAGE
     reset-identity:
       targetState: RESET_IDENTITY
     reuse:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -47,6 +47,15 @@ CRI_STATE:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_NO_MATCH
 
+CRI_TICF_STATE:
+  events:
+    enhanced-verification:
+      targetState: PYI_NO_MATCH
+    fail-with-ci:
+      targetState: PYI_NO_MATCH
+    error:
+      targetState: ERROR
+
 # Shared states
 INITIAL_IPV_JOURNEY:
   events:
@@ -105,6 +114,16 @@ CHECK_EXISTING_IDENTITY:
           targetState: CRI_TICF_BEFORE_REUSE
         deleteDetailsEnabled:
           targetState: IPV_IDENTITY_REUSE_PAGE_TEST
+    operational-profile-reuse:
+      targetState: OPERATIONAL_PROFILE_REUSE_PAGE
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_OPERATIONAL_PROFILE_REUSE
+    in-migration-reuse:
+      targetState: END
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_END
     pending:
       targetState: IPV_IDENTITY_PENDING_PAGE
       checkFeatureFlag:
@@ -139,9 +158,14 @@ IPV_IDENTITY_REUSE_PAGE:
   response:
     type: page
     pageId: page-ipv-reuse
-  events:
-    next:
-      targetState: END
+  parent: END_JOURNEY
+
+OPERATIONAL_PROFILE_REUSE_PAGE:
+  response:
+    type: page
+    pageId: page-ipv-reuse
+    context: operational-profile
+  parent: END_JOURNEY
 
 # User initiated details delete for f2f journey. Hidden behind deleteDetailsEnabled feature flag.
 IPV_IDENTITY_PENDING_PAGE_TEST:
@@ -371,87 +395,81 @@ CRI_TICF_BEFORE_SUCCESS:
   response:
     type: process
     lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
   events:
     next:
       targetState: IPV_SUCCESS_PAGE
-    enhanced-verification:
-      targetState: PYI_NO_MATCH
-    fail-with-ci:
-      targetState: PYI_NO_MATCH
-    error:
-      targetState: ERROR
 
 CRI_TICF_BEFORE_REUSE:
   response:
     type: process
     lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
   events:
     next:
       targetState: IPV_IDENTITY_REUSE_PAGE
       checkFeatureFlag:
         deleteDetailsEnabled:
           targetState: IPV_IDENTITY_REUSE_PAGE_TEST
-    enhanced-verification:
-      targetState: PYI_NO_MATCH
-    fail-with-ci:
-      targetState: PYI_NO_MATCH
-    error:
-      targetState: ERROR
+
+CRI_TICF_BEFORE_OPERATIONAL_PROFILE_REUSE:
+  response:
+    type: process
+    lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
+  events:
+    next:
+      targetState: OPERATIONAL_PROFILE_REUSE_PAGE
+
+CRI_TICF_BEFORE_END:
+  response:
+    type: process
+    lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
+  events:
+    next:
+      targetState: END
 
 CRI_TICF_BEFORE_F2F:
   response:
     type: process
     lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
   events:
     next:
       targetState: CRI_F2F
     enhanced-verification:
       targetState: CRI_F2F
-    fail-with-ci:
-      targetState: PYI_NO_MATCH
-    error:
-      targetState: ERROR
 
 CRI_TICF_BEFORE_NO_MATCH:
   response:
     type: process
     lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
   events:
     next:
       targetState: PYI_NO_MATCH
-    enhanced-verification:
-      targetState: PYI_NO_MATCH
-    fail-with-ci:
-      targetState: PYI_NO_MATCH
-    error:
-      targetState: ERROR
 
 CRI_TICF_BEFORE_ANOTHER_WAY:
   response:
     type: process
     lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
   events:
     next:
       targetState: PYI_ANOTHER_WAY
     enhanced-verification:
       targetState: PYI_ANOTHER_WAY
-    fail-with-ci:
-      targetState: PYI_NO_MATCH
-    error:
-      targetState: ERROR
 
 CRI_TICF_BEFORE_ERROR:
   response:
     type: process
     lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
   events:
     next:
       targetState: ERROR
     enhanced-verification:
-      targetState: ERROR
-    fail-with-ci:
-      targetState: PYI_NO_MATCH
-    error:
       targetState: ERROR
 
 # Common pages

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -211,8 +211,13 @@ public class JourneyMapTest {
 
                 if (response instanceof PageStepResponse pageStepResponse) {
                     var pageId = (String) pageStepResponse.value().get("page");
-                    var pageEvents = basicState.getEvents().keySet();
-
+                    var pageEvents = new HashSet<>(basicState.getEvents().keySet());
+                    if (basicState.getParent() != null) {
+                        pageEvents.addAll(
+                                ((BasicState) stateMachine.get(basicState.getParent()))
+                                        .getEvents()
+                                        .keySet());
+                    }
                     pageMap.computeIfAbsent(pageId, k -> new ArrayList<>())
                             .add(new StateAndEvents(key, pageEvents));
                 }

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -11,6 +11,9 @@ public class JourneyUris {
     public static final String JOURNEY_F2F_FAIL_PATH = "/journey/f2f-fail";
     public static final String JOURNEY_FAIL_WITH_CI_PATH = "/journey/fail-with-ci";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
+    public static final String JOURNEY_IN_MIGRATION_REUSE_PATH = "/journey/in-migration-reuse";
+    public static final String JOURNEY_OPERATIONAL_PROFILE_REUSE_PATH =
+            "/journey/operational-profile-reuse";
     public static final String JOURNEY_MET_PATH = "/journey/met";
     public static final String JOURNEY_NEXT_PATH = "/journey/next";
     public static final String JOURNEY_VCS_NOT_CORRELATED = "/journey/vcs-not-correlated";

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -12,6 +12,7 @@ public class JourneyUris {
     public static final String JOURNEY_FAIL_WITH_CI_PATH = "/journey/fail-with-ci";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
     public static final String JOURNEY_IN_MIGRATION_REUSE_PATH = "/journey/in-migration-reuse";
+    public static final String JOURNEY_IPV_GPG45_MEDIUM_PATH = "/journey/ipv-gpg45-medium";
     public static final String JOURNEY_OPERATIONAL_PROFILE_REUSE_PATH =
             "/journey/operational-profile-reuse";
     public static final String JOURNEY_MET_PATH = "/journey/met";


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Send users on the right journey depending on what type of vot they've achieved, and if they're currently migrating or not.

### Why did it change

[PYIC-4601: Route users depending on reuse type](https://github.com/govuk-one-login/ipv-core-back/commit/0565453d1fe86b44d16b49d02fdb1a920eccfa32)

This updates the check-existing-identity lambda to send users on the
correct journey, depending on if they are reusing an identity and if
they are in the process of migration or not.

Users reusing an operational profile that have already migrated (in a
previous session) should see the reuse page but with some extra context.
Those that are migrating in the current session should just go straigh
back to the service.

This has required some extra CRI_TICF states to achieve, due to the new
follow on routes that we didn't support before. Namely ending
immediately and showing the reuse page with context.

This has added a new CRI_TICF parent state to the joureny map to dry up
some of the existing states.


[PYIC-4601: Rename next event to ipv-gpg45-medium](https://github.com/govuk-one-login/ipv-core-back/commit/cfb545f57822b3bd027730daf6c6dd98ec9e4d20)

The next event is a little lack lustre in its description of what's
going on.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4601](https://govukverify.atlassian.net/browse/PYIC-4601)


[PYIC-4601]: https://govukverify.atlassian.net/browse/PYIC-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ