### PR TITLE
PYIC-4975: Allow operational profiles with pending F2F

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -216,16 +216,15 @@ public class CheckExistingIdentityHandler
             final boolean isF2FIncomplete = !Objects.isNull(f2fRequest) && !hasF2fVc;
             final boolean isF2FComplete = !Objects.isNull(f2fRequest) && hasF2fVc;
 
-            // Incomplete F2F journey
-            if (isF2FIncomplete) {
-                return buildF2FIncompleteResponse(f2fRequest);
-            }
-
             var ciScoringCheckResponse =
                     checkForCIScoringFailure(
                             ipAddress, clientOAuthSessionItem, govukSigninJourneyId);
+
             if (ciScoringCheckResponse.isPresent()) {
-                return ciScoringCheckResponse.get();
+                return isF2FIncomplete
+                        ? buildF2FIncompleteResponse(
+                                f2fRequest) // F2F mitigation journey in progress
+                        : ciScoringCheckResponse.get(); // CI fail or mitigation journey
             }
 
             // Check for credentials correlation failure
@@ -240,6 +239,11 @@ public class CheckExistingIdentityHandler
                             areGpg45VcsCorrelated);
             if (profileMatchResponse.isPresent()) {
                 return profileMatchResponse.get();
+            }
+
+            // No profile matched but has a pending F2F request
+            if (isF2FIncomplete) {
+                return buildF2FIncompleteResponse(f2fRequest);
             }
 
             // No profile match


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow operational profiles with pending F2F

### Why did it change

If a user has an operational profile they should be able to use it, even when they have a pending F2F request.

This slightly reorders the logic in the check-existing-identity lambda to allow this. We only return a pending f2f response once we've checked that they're breaching CIs, or if they haven't matched any profiles (gpg45 or operational).


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4975](https://govukverify.atlassian.net/browse/PYIC-4975)


[PYIC-4975]: https://govukverify.atlassian.net/browse/PYIC-4975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ