### PR TITLE
BAU: Add Snapstart scanning tool to core-back

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ ext {
 		awsLambdaJavaCore:'1.2.1',
 		awsLambdaJavaEvents:'3.11.0',
 		awsLambdaJavaLog4j2:'1.5.1',
+		awsLambdaSnapstartJavaRules:'0.2.0',
 		dynamodbEnhanced:'2.17.89',
 		gson:'2.8.9',
 		jacksonDataformatYaml:'2.13.2',
@@ -51,7 +52,8 @@ ext {
 		notificationsJavaClient: '4.1.1-RELEASE',
 		powertoolsParameters:'1.16.1',
 		powertoolsLogging:'1.16.1',
-		powertoolsTracing:'1.16.1'
+		powertoolsTracing:'1.16.1',
+		spotbugs:'4.8.3'
 	]
 }
 

--- a/lambdas/build-client-oauth-response/build.gradle
+++ b/lambdas/build-client-oauth-response/build.gradle
@@ -53,3 +53,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/build-client-oauth-response/build.gradle
+++ b/lambdas/build-client-oauth-response/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -10,7 +11,6 @@ repositories {
 }
 
 dependencies {
-
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
@@ -30,6 +30,9 @@ dependencies {
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
 			"org.mockito:mockito-junit-jupiter:5.10.0"
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/build-cri-oauth-request/build.gradle
+++ b/lambdas/build-cri-oauth-request/build.gradle
@@ -3,11 +3,13 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
 	mavenCentral()
 }
+
 
 dependencies {
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
@@ -37,6 +39,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/build-cri-oauth-request/build.gradle
+++ b/lambdas/build-cri-oauth-request/build.gradle
@@ -62,3 +62,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -34,6 +35,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -58,3 +58,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -55,3 +55,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -10,7 +11,6 @@ repositories {
 }
 
 dependencies {
-
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
@@ -32,6 +32,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/call-ticf-cri/build.gradle
+++ b/lambdas/call-ticf-cri/build.gradle
@@ -59,3 +59,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/call-ticf-cri/build.gradle
+++ b/lambdas/call-ticf-cri/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -35,6 +36,9 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests')
 
 	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -60,3 +60,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -36,6 +37,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/check-gpg45-score/build.gradle
+++ b/lambdas/check-gpg45-score/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -34,6 +35,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/check-gpg45-score/build.gradle
+++ b/lambdas/check-gpg45-score/build.gradle
@@ -58,3 +58,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -10,7 +11,6 @@ repositories {
 }
 
 dependencies {
-
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
@@ -35,6 +35,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -58,3 +58,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -10,7 +11,6 @@ repositories {
 }
 
 dependencies {
-
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
 			"com.amazonaws:aws-java-sdk-kms:$rootProject.ext.dependencyVersions.awsJavcSdkKms",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
@@ -37,6 +37,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -60,3 +60,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -56,3 +56,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -10,7 +11,6 @@ repositories {
 }
 
 dependencies {
-
 	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
@@ -33,6 +33,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -62,3 +62,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -38,6 +39,9 @@ dependencies {
 			"au.com.dius.pact.consumer:junit5:4.6.5",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -10,7 +11,6 @@ repositories {
 }
 
 dependencies {
-
 	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
 			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
@@ -43,6 +43,9 @@ dependencies {
 			"au.com.dius.pact.consumer:junit5:4.6.3",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -66,3 +66,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/process-journey-event/build.gradle
+++ b/lambdas/process-journey-event/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -33,6 +34,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			"uk.org.webcompere:system-stubs-jupiter:2.1.3"
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/process-journey-event/build.gradle
+++ b/lambdas/process-journey-event/build.gradle
@@ -57,3 +57,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/replay-cimit-vcs/build.gradle
+++ b/lambdas/replay-cimit-vcs/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -32,6 +33,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/replay-cimit-vcs/build.gradle
+++ b/lambdas/replay-cimit-vcs/build.gradle
@@ -56,3 +56,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/reset-identity/build.gradle
+++ b/lambdas/reset-identity/build.gradle
@@ -59,3 +59,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/reset-identity/build.gradle
+++ b/lambdas/reset-identity/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -35,6 +36,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(":libs:common-services").sourceSets.test.output
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/restore-vcs/build.gradle
+++ b/lambdas/restore-vcs/build.gradle
@@ -60,3 +60,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/restore-vcs/build.gradle
+++ b/lambdas/restore-vcs/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -36,6 +37,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/lambdas/revoke-vcs/build.gradle
+++ b/lambdas/revoke-vcs/build.gradle
@@ -60,3 +60,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/lambdas/revoke-vcs/build.gradle
+++ b/lambdas/revoke-vcs/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "jacoco"
 	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -36,6 +37,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -57,3 +57,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -22,6 +23,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -60,3 +60,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -25,6 +26,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -75,3 +75,12 @@ tasks.register('jarTest', Jar) {
 artifacts {
 	tests jarTest
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -28,6 +29,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs("com.github.spotbugs:spotbugs:4.7.3")
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:0.2.0")
 }
 
 java {

--- a/libs/cri-response-service/build.gradle
+++ b/libs/cri-response-service/build.gradle
@@ -54,3 +54,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/cri-response-service/build.gradle
+++ b/libs/cri-response-service/build.gradle
@@ -3,13 +3,14 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
 	mavenCentral()
 }
 
-def var = dependencies {
+dependencies {
 	implementation "software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
 			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
 			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
@@ -19,8 +20,10 @@ def var = dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(":libs:common-services").sourceSets.test.output
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
-var
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_17

--- a/libs/cri-storing-service/build.gradle
+++ b/libs/cri-storing-service/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -22,6 +23,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/cri-storing-service/build.gradle
+++ b/libs/cri-storing-service/build.gradle
@@ -57,3 +57,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/email-service/build.gradle
+++ b/libs/email-service/build.gradle
@@ -60,3 +60,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/email-service/build.gradle
+++ b/libs/email-service/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -25,6 +26,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/gpg45-evaluator/build.gradle
+++ b/libs/gpg45-evaluator/build.gradle
@@ -59,3 +59,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/gpg45-evaluator/build.gradle
+++ b/libs/gpg45-evaluator/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -24,6 +25,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/journey-uris/build.gradle
+++ b/libs/journey-uris/build.gradle
@@ -44,3 +44,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/journey-uris/build.gradle
+++ b/libs/journey-uris/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -10,6 +11,8 @@ repositories {
 }
 
 dependencies {
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -64,3 +64,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -29,6 +30,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/user-identity-service/build.gradle
+++ b/libs/user-identity-service/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -22,6 +23,9 @@ dependencies {
 			"org.mockito:mockito-junit-jupiter:5.10.0",
 			project(path: ':libs:common-services', configuration: 'tests')
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {

--- a/libs/user-identity-service/build.gradle
+++ b/libs/user-identity-service/build.gradle
@@ -57,3 +57,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -62,3 +62,12 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+spotbugs {
+	visitors = [
+		"LambdaHandlerInitedWithRandomValue",
+		"CacheLambdaHandlerFields",
+		"CacheLambdaHandlerParentClasses",
+		"BuildRandomReturningMethodsDatabase"
+	]
+}

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	id "com.github.spotbugs" version "6.0.7"
 }
 
 repositories {
@@ -27,6 +28,9 @@ dependencies {
 
 	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
 	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+
+	spotbugs "com.github.spotbugs:spotbugs:$rootProject.ext.dependencyVersions.spotbugs"
+	spotbugsPlugins("software.amazon.lambda.snapstart:aws-lambda-snapstart-java-rules:$rootProject.ext.dependencyVersions.awsLambdaSnapstartJavaRules")
 }
 
 java {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add snapstart scanning tool to core-back

### Why did it change

AWS offer a scanning tool to help ensure that lambdas don't fall foul of assuming uniqueness that could be baked into your snapstart images: https://docs.aws.amazon.com/lambda/latest/dg/snapstart-uniqueness.html#snapstart-scanning

It's a spotbugs plugin. This adds spotbugs as a tool, along with the AWS plugin. It also restricts the detectors used to just those from the AWS plugin to avoid all the noise generated by the default spotbugs detectors.

Using the defaults is an option but we already have a staic analysis tool and we don't want to overload ourselves.

The results of running the scanning tool show no current issues. It might be useful as a check for future work though.

This also doesn't cover off all things needed to check for snapstart, such as network connections, config getting baked in etc.
