### PR TITLE
Revert "Revert "PYIC-4563: Added journey-map routing for M2B KBV fail…

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -841,7 +841,7 @@ CRI_EXPERIAN_KBV_M2B:
   parent: CRI_STATE
   events:
     fail-with-no-ci:
-      targetState: PYI_CRI_ESCAPE
+      targetState: PYI_KBV_DROPOUT_M2B
       checkIfDisabled:
         f2f:
           targetState: PYI_CRI_ESCAPE_NO_F2F
@@ -851,7 +851,7 @@ CRI_EXPERIAN_KBV_M2B:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_NO_MATCH
     enhanced-verification:
-      targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+      targetState: MITIGATION_KBV_FAIL_M2B
       checkIfDisabled:
         f2f:
           targetState: MITIGATION_02_OPTIONS
@@ -862,6 +862,44 @@ PYI_NO_MATCH_BAV_M2B:
     context: bankAccount
     pageId: pyi-no-match
   parent: END_JOURNEY
+
+MITIGATION_KBV_FAIL_M2B:
+  response:
+    mitigationStart: true
+    type: page
+    pageId: pyi-kbv-escape-m2b
+  events:
+    f2f:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+    dcmaw:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+    end:
+      targetState: PYI_ANOTHER_WAY
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_ANOTHER_WAY
+
+PYI_KBV_DROPOUT_M2B:
+  response:
+    type: page
+    pageId: pyi-kbv-escape-m2b
+    context: dropout
+  events:
+    f2f:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+    dcmaw:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+    end:
+      targetState: PYI_ANOTHER_WAY
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_ANOTHER_WAY
 
 # Mitigation journey (01)
 MITIGATION_01:


### PR DESCRIPTION
… and dropout pages""

This reverts commit f107e031

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Readded journey-map routing for M2B KBV fail and dropout

### Why did it change

This caused pipeline failure when merged in so got reverted. This is to reimplement the feature once the test are changed

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4563](https://govukverify.atlassian.net/browse/PYIC-4563)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-4563]: https://govukverify.atlassian.net/browse/PYIC-4563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ