### PR TITLE
PYIC-4489: add m2b escape page

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ipv-core-main-journey.yaml
@@ -96,7 +96,7 @@ BANK_ACCOUNT_START_PAGE:
     next:
       targetState: CRI_CLAIMED_IDENTITY_M2B
     end:
-      targetState: PYI_ESCAPE
+      targetState: PYI_ESCAPE_M2B
 
 CHECK_EXISTING_IDENTITY:
   response:
@@ -881,6 +881,18 @@ MITIGATION_KBV_FAIL_M2B:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_ANOTHER_WAY
+
+PYI_ESCAPE_M2B:
+  response:
+    type: page
+    pageId: pyi-escape-m2b
+  events:
+    next:
+      targetState: IDENTITY_START_PAGE
+    bankAccount:
+      targetState: BANK_ACCOUNT_START_PAGE
+    end:
+      targetState: RETURN_TO_RP
 
 PYI_KBV_DROPOUT_M2B:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -118,7 +118,7 @@ BANK_ACCOUNT_START_PAGE:
     next:
       targetState: CRI_CLAIMED_IDENTITY_M2B
     end:
-      targetState: PYI_ESCAPE
+      targetState: PYI_ESCAPE_M2B
 
 CRI_F2F:
   response:
@@ -571,6 +571,18 @@ MITIGATION_KBV_FAIL_M2B:
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
+
+PYI_ESCAPE_M2B:
+  response:
+    type: page
+    pageId: pyi-escape-m2b
+  events:
+    next:
+      targetState: IDENTITY_START_PAGE
+    bankAccount:
+      targetState: BANK_ACCOUNT_START_PAGE
+    end:
+      targetState: RETURN_TO_RP
 
 PYI_KBV_DROPOUT_M2B:
   response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

add m2b escape page

### Why did it change

create a new page for “find another way to prove your identity” and an additional radio button, So that the M2B journey meets finalised requirements.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4489](https://govukverify.atlassian.net/browse/PYIC-4489)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-4489]: https://govukverify.atlassian.net/browse/PYIC-4489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ