### PR TITLE
PYIC-4980: Activate snapstart in build and prep staging

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -156,42 +160,42 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 171
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 231
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
         "is_verified": false,
-        "line_number": 989
+        "line_number": 992
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 991
+        "line_number": 994
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1804
+        "line_number": 1807
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7456c32054693a3154d744c6729b2547b63e770c",
         "is_verified": false,
-        "line_number": 2191
+        "line_number": 2194
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -1725,5 +1729,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-19T10:58:50Z"
+  "generated_at": "2024-02-19T12:09:22Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -7,9 +7,9 @@ Globals:
   Function:
     Timeout: 40
     SnapStart:
-      ApplyOn: !If [IsDevelopment, PublishedVersions, None]
+      ApplyOn: !If [ IsSnapStartEnvironment, PublishedVersions, None ]
     Architectures:
-      - !If [ IsSnapStartEnvironment, x86_64, arm64 ]
+      - !If [ IsX86Arch, x86_64, arm64 ]
     MemorySize: !If [IsDevelopment, 1024, 3072]
     Runtime: java17
     Environment:
@@ -132,6 +132,9 @@ Conditions:
   IsSnapStartEnvironment: !Or
     - !Condition IsDevelopment
     - !Equals [ !Ref Environment, build ]
+  IsX86Arch: !Or
+    - !Condition IsSnapStartEnvironment
+    - !Equals [ !Ref Environment, staging ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Activate snapstart in build and prep staging

### Why did it change

This turns on snapstart in the build env, and preps staging for it. We can probably just turn snapstart on in staging immediately. We'll potentially want to to int/prod together once we're comfortable with it in the lower envs.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4980](https://govukverify.atlassian.net/browse/PYIC-4980)


[PYIC-4980]: https://govukverify.atlassian.net/browse/PYIC-4980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ