### PR TITLE
PYIC-4980: Remove provisioned concurrency in build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -182,7 +182,7 @@ Mappings:
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "457601271792": # Build
-      provisionedConcurrency: 1
+      provisionedConcurrency: 0
       cimitAccountId: 388905755587 # di-ipv-stubs-prod
       cimitEnvironment: production # targeting the "production" CiMit stub
       environment: build


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove provisioned concurrency in build

### Why did it change

Snapstart and provisioned concurrency are not compatible. Trying to use both will not deploy.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4980](https://govukverify.atlassian.net/browse/PYIC-4980)


[PYIC-4980]: https://govukverify.atlassian.net/browse/PYIC-4980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ