### PR TITLE
PYIC-4980: Disable snapstart in build temporarily

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -1747,5 +1743,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-19T14:28:41Z"
+  "generated_at": "2024-02-19T14:50:48Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -7,7 +7,7 @@ Globals:
   Function:
     Timeout: 40
     SnapStart:
-      ApplyOn: !If [ IsSnapStartEnvironment, PublishedVersions, None ]
+      ApplyOn: !If [ IsDevelopment, PublishedVersions, None ]
     Architectures:
       - !If [ IsX86Arch, x86_64, arm64 ]
     MemorySize: !If [IsDevelopment, 1024, 3072]


### PR DESCRIPTION


Once build is running, I'll be experimenting with my dev env to try and find a way to do this in prod without having to run without provisioned concurrency or snapstart.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Disable snapstart in build temporarily

### Why did it change

Snapstart needs provisioned concurrency to be disabled in order to activate. And provisioned concurrency needs snapstart to not be active to be disabled.

This temporarliy turns snapstart off in build, so we can stop the provisioned concurrency. Once that has happened we can turn snapstart back on.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4980](https://govukverify.atlassian.net/browse/PYIC-4980)


[PYIC-4980]: https://govukverify.atlassian.net/browse/PYIC-4980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ