### PR TITLE
PYIC-4980: Re-enable snapstart in build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -7,7 +7,7 @@ Globals:
   Function:
     Timeout: 40
     SnapStart:
-      ApplyOn: !If [ IsDevelopment, PublishedVersions, None ]
+      ApplyOn: !If [ IsSnapStartEnvironment, PublishedVersions, None ]
     Architectures:
       - !If [ IsX86Arch, x86_64, arm64 ]
     MemorySize: !If [IsDevelopment, 1024, 3072]


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Re-enable snapstart in build

### Why did it change

Hopefully now we don't have provisioned concurrency running in build, and so we can enable snapstart.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4980](https://govukverify.atlassian.net/browse/PYIC-4980)


[PYIC-4980]: https://govukverify.atlassian.net/browse/PYIC-4980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ