### PR TITLE
PYIC-4534: Relative URLs in journey map links

### DIFF
--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -64,7 +64,7 @@ const loadJourney = async () => {
 };
 
 const getPageUrl = (id) => `https://identity.build.account.gov.uk/dev/template/${encodeURIComponent(id)}/en`;
-const getJourneyUrl = (id) => `/?journeyType=${encodeURIComponent(upperToKebab(id))}`;
+const getJourneyUrl = (id) => `?journeyType=${encodeURIComponent(upperToKebab(id))}`;
 
 const switchJourney = async (id) => {
     window.history.pushState(undefined, undefined, getJourneyUrl(id));


### PR DESCRIPTION
The deployed journey map is on a subpath, so the URL needs to be path-relative