### PR TITLE
BAU: Remove impossible events from state

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -745,9 +745,6 @@ MITIGATION_02_OPTIONS_WITH_F2F:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
 
 MITIGATION_02_OPTIONS_WITH_F2F_M2B:
   response:
@@ -763,9 +760,6 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
 
 PYI_POST_OFFICE:
   response:


### PR DESCRIPTION
The `pyi-suggest-other-options` page (https://identity.build.account.gov.uk/dev/template/pyi-suggest-other-options/en) does not have an `end` event. This means we can remove it from the journey map.

(`pyi-suggest-other-options-no-f2f` does, because it replaces the F2F option)