### PR TITLE
PYIC-5058: Remove provisioned concurrency in staging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -194,7 +194,7 @@ Mappings:
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "335257547869": # Staging
-      provisionedConcurrency: 1
+      provisionedConcurrency: 0
       cimitAccountId: 265689800486 # di-ipv-contra-indicators-staging
       cimitEnvironment: staging
       environment: staging


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove provisioned concurrency in staging

### Why did it change

Due to our use of the AutoPublishAlias feature in our SAM template we need to remove provisioned concurrency before enabling snapstart.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5058](https://govukverify.atlassian.net/browse/PYIC-5058)


[PYIC-5058]: https://govukverify.atlassian.net/browse/PYIC-5058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ