### PR TITLE
PYIC-5035/36: Enable snapstart in staging and switch int/prod to X86_64

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up Python 3.8

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -156,42 +160,42 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 171
+        "line_number": 172
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 231
+        "line_number": 232
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
         "is_verified": false,
-        "line_number": 992
+        "line_number": 993
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 994
+        "line_number": 995
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1807
+        "line_number": 1808
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7456c32054693a3154d744c6729b2547b63e770c",
         "is_verified": false,
-        "line_number": 2194
+        "line_number": 2195
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -1743,5 +1747,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-19T14:50:48Z"
+  "generated_at": "2024-02-20T14:57:39Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,42 +160,42 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 172
+        "line_number": 173
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 232
+        "line_number": 233
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
         "is_verified": false,
-        "line_number": 993
+        "line_number": 994
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 995
+        "line_number": 996
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1808
+        "line_number": 1809
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7456c32054693a3154d744c6729b2547b63e770c",
         "is_verified": false,
-        "line_number": 2195
+        "line_number": 2196
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -1747,5 +1747,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-20T14:57:39Z"
+  "generated_at": "2024-02-20T14:59:19Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -132,6 +132,7 @@ Conditions:
   IsSnapStartEnvironment: !Or
     - !Condition IsDevelopment
     - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
   IsX86Arch: !Or
     - !Condition IsSnapStartEnvironment
     - !Equals [ !Ref Environment, staging ]

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -135,7 +135,8 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
   IsX86Arch: !Or
     - !Condition IsSnapStartEnvironment
-    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enable snapstart in staging and switch int/prod to X86_64

Also fixes an issue with a actions/checkout version

### Why did it change

So staging is snappy and int/prod can be switched in the future.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5035](https://govukverify.atlassian.net/browse/PYIC-5035)



[PYIC-5035]: https://govukverify.atlassian.net/browse/PYIC-5035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ