### PR TITLE
PYIC-5037: Enable snapstart in int and prod

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,42 +160,42 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 167
+        "line_number": 162
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 227
+        "line_number": 217
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
         "is_verified": false,
-        "line_number": 988
+        "line_number": 958
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 990
+        "line_number": 960
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1803
+        "line_number": 1743
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7456c32054693a3154d744c6729b2547b63e770c",
         "is_verified": false,
-        "line_number": 2190
+        "line_number": 2115
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -1747,5 +1747,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-20T15:58:41Z"
+  "generated_at": "2024-02-20T16:06:29Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,84 +118,84 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 23
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 29
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 35
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 41
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 47
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 70
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 173
+        "line_number": 167
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 233
+        "line_number": 227
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
         "is_verified": false,
-        "line_number": 994
+        "line_number": 988
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 996
+        "line_number": 990
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1809
+        "line_number": 1803
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7456c32054693a3154d744c6729b2547b63e770c",
         "is_verified": false,
-        "line_number": 2196
+        "line_number": 2190
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -1747,5 +1747,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-20T14:59:19Z"
+  "generated_at": "2024-02-20T15:58:41Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,42 +160,42 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 162
+        "line_number": 158
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 217
+        "line_number": 213
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
         "is_verified": false,
-        "line_number": 958
+        "line_number": 954
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 960
+        "line_number": 956
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1743
+        "line_number": 1739
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7456c32054693a3154d744c6729b2547b63e770c",
         "is_verified": false,
-        "line_number": 2115
+        "line_number": 2111
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -1747,5 +1747,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-20T16:06:29Z"
+  "generated_at": "2024-02-20T16:37:59Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -8,8 +8,6 @@ Globals:
     Timeout: 40
     SnapStart:
       ApplyOn: !If [ IsSnapStartEnvironment, PublishedVersions, None ]
-    Architectures:
-      - !If [ IsX86Arch, x86_64, arm64 ]
     MemorySize: !If [IsDevelopment, 1024, 3072]
     Runtime: java17
     Environment:
@@ -133,10 +131,6 @@ Conditions:
     - !Condition IsDevelopment
     - !Equals [ !Ref Environment, build ]
     - !Equals [ !Ref Environment, staging ]
-  IsX86Arch: !Or
-    - !Condition IsSnapStartEnvironment
-    - !Equals [ !Ref Environment, integration ]
-    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -112,10 +112,6 @@ Parameters:
     Default: ""
 
 Conditions:
-  AddProvisionedConcurrency: !Not
-    - !Equals
-      - !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-      -  0
   IsDevelopment: !Or
     - !Equals [ !Ref AWS::AccountId, "130355686670"]
     - !Equals [ !Ref AWS::AccountId, "175872367215"]
@@ -152,7 +148,6 @@ Conditions:
 Mappings:
   EnvironmentConfiguration:
     "130355686670": # core dev01
-      provisionedConcurrency: 0
       cimitAccountId: 388905755587 # di-ipv-stubs-prod
       cimitEnvironment: production # targeting the "production" CiMit stub
       environment: dev
@@ -166,7 +161,6 @@ Mappings:
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "175872367215": # Core dev02
-      provisionedConcurrency: 0
       cimitAccountId: 388905755587 # di-ipv-stubs-prod
       cimitEnvironment: production # targeting the "production" CiMit stub
       environment: dev
@@ -178,7 +172,6 @@ Mappings:
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "457601271792": # Build
-      provisionedConcurrency: 0
       cimitAccountId: 388905755587 # di-ipv-stubs-prod
       cimitEnvironment: production # targeting the "production" CiMit stub
       environment: build
@@ -190,7 +183,6 @@ Mappings:
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "335257547869": # Staging
-      provisionedConcurrency: 0
       cimitAccountId: 265689800486 # di-ipv-contra-indicators-staging
       cimitEnvironment: staging
       environment: staging
@@ -202,7 +194,6 @@ Mappings:
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "991138514218": # Integration
-      provisionedConcurrency: 1
       cimitAccountId: 697519714716 # di-ipv-contra-indicators-integration
       cimitEnvironment: integration
       environment: integration
@@ -214,7 +205,6 @@ Mappings:
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     "075701497069": # Production
-      provisionedConcurrency: 1
       cimitAccountId: 442136572379 # di-ipv-contra-indicators-prod
       cimitEnvironment: production
       environment: production
@@ -556,11 +546,6 @@ Resources:
             Path: /token
             Method: POST
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-          - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-          - !Ref AWS::NoValue
 
   IssueClientAccessTokenFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -647,11 +632,6 @@ Resources:
             Path: /journey/build-client-oauth-response
             Method: POST
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   BuildClientOauthResponseFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -750,11 +730,6 @@ Resources:
             Path: /session/initialise
             Method: POST
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   InitialiseIpvSessionFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -856,11 +831,6 @@ Resources:
             Path: /journey/cri/build-oauth-request/{criId}
             Method: POST
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   BuildCriOauthRequestFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1085,11 +1055,6 @@ Resources:
             Path: /cri/callback
             Method: POST
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   ProcessCriCallbackLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1221,11 +1186,6 @@ Resources:
             Path: /user-identity
             Method: GET
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-          - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-          - !Ref AWS::NoValue
 
   BuildUserIdentityFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1412,11 +1372,6 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-          - AddProvisionedConcurrency
-          - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-          - !Ref AWS::NoValue
 
   IPVProcessJourneyEventFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1499,11 +1454,6 @@ Resources:
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   EvaluateGpg45ScoresFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1587,11 +1537,6 @@ Resources:
             Path: /user/proven-identity-details
             Method: GET
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   BuildProvenUserIdentityDetailsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1713,11 +1658,6 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   CheckExistingIdentityFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1802,11 +1742,6 @@ Resources:
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/gov-uk-notify/*
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   ResetIdentityFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2000,11 +1935,6 @@ Resources:
             FunctionResponseTypes:
               - ReportBatchItemFailures
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   ProcessAsyncCriCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2073,11 +2003,6 @@ Resources:
                 "lambda:VpcIds":
                   - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   CheckGpg45ScoreFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2273,11 +2198,6 @@ Resources:
                   "lambda:VpcIds":
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   CallTicfCriFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2431,11 +2351,6 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   ReplayCimitVcsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2515,11 +2430,6 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   RevokeVcsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2599,11 +2509,6 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
       AutoPublishAlias: live
-      ProvisionedConcurrencyConfig:
-        !If
-        - AddProvisionedConcurrency
-        - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, provisionedConcurrency ]
-        - !Ref AWS::NoValue
 
   RestoreVcsFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -7,7 +7,7 @@ Globals:
   Function:
     Timeout: 40
     SnapStart:
-      ApplyOn: !If [ IsSnapStartEnvironment, PublishedVersions, None ]
+      ApplyOn: PublishedVersions
     MemorySize: !If [IsDevelopment, 1024, 3072]
     Runtime: java17
     Environment:
@@ -123,10 +123,6 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
-  IsSnapStartEnvironment: !Or
-    - !Condition IsDevelopment
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -89,7 +89,7 @@ public class BuildClientOauthResponseHandler
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest input, Context context) {
 
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
 
         try {
             String ipvSessionId = getIpvSessionIdAllowNull(input);

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -146,7 +146,7 @@ public class BuildCriOauthRequestHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest input, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         try {
             String ipvSessionId = getIpvSessionId(input);
             String ipAddress = getIpAddress(input);

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -90,7 +90,7 @@ public class BuildProvenUserIdentityDetailsHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest input, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         ProvenUserIdentityDetails.ProvenUserIdentityDetailsBuilder
                 provenUserIdentityDetailsBuilder = ProvenUserIdentityDetails.builder();
         try {

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -99,7 +99,7 @@ public class BuildUserIdentityHandler
     @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         try {
             AccessToken accessToken =
                     AccessToken.parse(

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -112,7 +112,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(ProcessRequest request, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         LogHelper.attachCriIdToLogs(TICF_CRI);
 
         IpvSessionItem ipvSessionItem = null;

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -159,7 +159,7 @@ public class CheckExistingIdentityHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest event, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
 
         try {
             String ipvSessionId = getIpvSessionId(event);

--- a/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
+++ b/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
@@ -82,6 +82,8 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(ProcessRequest event, Context context) {
+        LogHelper.attachComponentId(configService);
+
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(event);
             String featureSet = RequestHelper.getFeatureSet(event);

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -104,7 +104,7 @@ public class EvaluateGpg45ScoresHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(JourneyRequest event, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
 
         try {
             String ipvSessionId = RequestHelper.getIpvSessionId(event);

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -129,7 +129,7 @@ public class InitialiseIpvSessionHandler
     @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
 
         try {
             String ipAddress = RequestHelper.getIpAddress(input);

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -81,7 +81,7 @@ public class IssueClientAccessTokenHandler
     @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         try {
             tokenRequestValidator.authenticateClient(input.getBody());
 

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -98,7 +98,7 @@ public class ProcessAsyncCriCredentialHandler
     @Tracing
     @Logging(clearState = true)
     public SQSBatchResponse handleRequest(SQSEvent event, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         List<SQSBatchResponse.BatchItemFailure> failedRecords = new ArrayList<>();
 
         for (SQSMessage message : event.getRecords()) {

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -258,7 +258,7 @@ public class ProcessCriCallbackHandler
         LogHelper.attachIpvSessionIdToLogs(callbackRequest.getIpvSessionId());
         LogHelper.attachFeatureSetToLogs(callbackRequest.getFeatureSet());
         LogHelper.attachCriIdToLogs(callbackRequest.getCredentialIssuerId());
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
 
         // Validate callback request
         if (callbackRequest.getError() != null) {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -92,7 +92,7 @@ public class ProcessJourneyEventHandler
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(Map<String, String> input, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
 
         try {
             // Extract variables

--- a/lambdas/replay-cimit-vcs/src/main/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandler.java
+++ b/lambdas/replay-cimit-vcs/src/main/java/uk/gov/di/ipv/core/replaycimitvcs/ReplayCimitVcsHandler.java
@@ -56,7 +56,7 @@ public class ReplayCimitVcsHandler implements RequestStreamHandler {
     @Tracing
     @Logging(clearState = true)
     public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         ObjectMapper mapper = new ObjectMapper();
         String failureMessage = "Failed to replay VCs to CIMIT because: '%s'";
         List<ReplayItem> requestItems;

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -97,7 +97,7 @@ public class ResetIdentityHandler implements RequestHandler<ProcessRequest, Map<
     @Tracing
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(ProcessRequest event, Context context) {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
 
         try {
             String ipvSessionId = getIpvSessionId(event);

--- a/lambdas/restore-vcs/src/main/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandler.java
+++ b/lambdas/restore-vcs/src/main/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandler.java
@@ -80,7 +80,7 @@ public class RestoreVcsHandler implements RequestStreamHandler {
     @Tracing
     public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
             throws IOException {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         var userIdCriIdPairs =
                 new ObjectMapper()
                         .readValue(inputStream, VcsActionRequest.class)

--- a/lambdas/revoke-vcs/src/main/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandler.java
+++ b/lambdas/revoke-vcs/src/main/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandler.java
@@ -82,7 +82,7 @@ public class RevokeVcsHandler implements RequestStreamHandler {
     @Logging(clearState = true)
     public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
             throws IOException {
-        LogHelper.attachComponentIdToLogs(configService);
+        LogHelper.attachComponentId(configService);
         var userIdCriIdPairs =
                 new ObjectMapper()
                         .readValue(inputStream, VcsActionRequest.class)

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -83,7 +83,7 @@ public class LogHelper {
         throw new IllegalStateException("Utility class");
     }
 
-    public static void attachComponentIdToLogs(ConfigService configService) {
+    public static void attachComponentId(ConfigService configService) {
         attachFieldToLogs(
                 LogField.LOG_COMPONENT_ID,
                 configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID));


### PR DESCRIPTION
**To be merged shortly after https://github.com/govuk-one-login/ipv-core-back/pull/1671, and when traffic is minimal. Currently slated for 7.30am on Thursday morning**

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enable snapstart in int and prod

This PR inclues all the changes in https://github.com/govuk-one-login/ipv-core-back/pull/1671. This is to avoid a merge conflict when that PR is merged just before this one. As such only the last two commits should be reviewed. The first two should be reviewed as part of the other PR.

### Why did it change

This removes the logic around which envs to enable snapstart on and just
applies it globally. Int and prod are the last envs to start using it.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5037](https://govukverify.atlassian.net/browse/PYIC-5037)


[PYIC-5037]: https://govukverify.atlassian.net/browse/PYIC-5037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ