### PR TITLE
BAU: Split driving licence contract tests into two contracts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -676,90 +676,69 @@
         "line_number": 1351
       }
     ],
-    "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java": [
+    "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java": [
       {
         "type": "Secret Keyword",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
         "is_verified": false,
         "line_number": 73
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 78
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
-        "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 78
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
-        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 78
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 82
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
-        "hashed_secret": "28dca06207b1c570f7d1b25ae549d37bdeb93353",
-        "is_verified": false,
-        "line_number": 89
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
-        "hashed_secret": "5a2eb5c8850b9e4c2cd896826d871114652ac2f1",
-        "is_verified": false,
-        "line_number": 92
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "4f9fce5708c37ee363ec1627d3fec390a8610b5f",
         "is_verified": false,
-        "line_number": 179
+        "line_number": 163
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "9f9d4c7ca0656e4d1ea4bb9b4932e09435973b82",
         "is_verified": false,
-        "line_number": 256
+        "line_number": 240
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "35bd684504646c60b54288575e917284d043c618",
         "is_verified": false,
-        "line_number": 333
+        "line_number": 317
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "3dd37bc4b5083b9bb330b228bd4a40c5fba200af",
         "is_verified": false,
-        "line_number": 409
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/ContractTest.java",
-        "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 469
+        "line_number": 393
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java": [
@@ -1747,5 +1726,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-20T16:37:59Z"
+  "generated_at": "2024-02-22T11:10:36Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -741,6 +741,64 @@
         "line_number": 393
       }
     ],
+    "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "28dca06207b1c570f7d1b25ae549d37bdeb93353",
+        "is_verified": false,
+        "line_number": 72
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "5a2eb5c8850b9e4c2cd896826d871114652ac2f1",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
+        "is_verified": false,
+        "line_number": 135
+      }
+    ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java": [
       {
         "type": "Secret Keyword",
@@ -1726,5 +1784,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-22T11:10:36Z"
+  "generated_at": "2024-02-22T11:32:34Z"
 }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java
@@ -10,12 +10,8 @@ import au.com.dius.pact.core.model.annotations.Pact;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
-import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Disabled;
@@ -24,7 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
@@ -49,13 +44,9 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
-import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,9 +55,9 @@ import static org.mockito.Mockito.when;
 @Disabled("PACT tests should not be run in build pipelines at this time")
 @ExtendWith(PactConsumerTestExt.class)
 @ExtendWith(MockitoExtension.class)
-@PactTestFor(providerName = "DrivingLicenceCriProvider")
+@PactTestFor(providerName = "DrivingLicenceVcProvider")
 @MockServerConfig(hostInterface = "localhost", port = "1234")
-class ContractTest {
+class CredentialTests {
     private static final String TEST_USER = "test-subject";
     private static final String TEST_ISSUER = "dummyDrivingLicenceComponentId";
     private static final String IPV_CORE_CLIENT_ID = "ipv-core";
@@ -83,13 +74,6 @@ class ContractTest {
             """;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    private static final String CLIENT_ASSERTION_HEADER = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9";
-    private static final String CLIENT_ASSERTION_BODY =
-            "eyJpc3MiOiJpcHYtY29yZSIsInN1YiI6Imlwdi1jb3JlIiwiYXVkIjoiZHVtbXlEcml2aW5nTGljZW5jZUNvbXBvbmVudElkIiwiZXhwIjo0MDcwOTA5NzAwLCJqdGkiOiJTY25GNGRHWHRoWllYU181azg1T2JFb1NVMDRXLUgzcWFfcDZucHYyWlVZIn0";
-    // Signature generated using JWT.io
-    private static final String CLIENT_ASSERTION_SIGNATURE =
-            "2Shugh1NCcII0yemPId2GYEXRLNMYI0xhLunVA5dHhNealHDgDobfuCptZ-tAGDl9pcWCux9Wlc2Y4aTWp8Vbw";
 
     // We hardcode the VC headers and bodies like this so that it is easy to update them from JSON
     // sent by the CRI team
@@ -412,152 +396,6 @@ class ContractTest {
     @Mock private KmsEs256SignerFactory mockKmsEs256SignerFactory;
     @Mock private JWSSigner mockSigner;
     @Mock private SecureTokenHelper mockSecureTokenHelper;
-
-    @Pact(provider = "DrivingLicenceCriProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact validRequestReturnsValidAccessToken(PactDslWithProvider builder) {
-        return builder.given("dummyAuthCode is a valid authorization code")
-                .given("dummyApiKey is a valid api key")
-                .given("dummyDrivingLicenceComponentId is the driving licence CRI component ID")
-                .given(
-                        "Driving licence CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
-                .uponReceiving("Valid auth code")
-                .path("/token")
-                .method("POST")
-                .body(
-                        "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3DdrivingLicence&client_assertion="
-                                + CLIENT_ASSERTION_HEADER
-                                + "."
-                                + CLIENT_ASSERTION_BODY
-                                + "."
-                                + CLIENT_ASSERTION_SIGNATURE)
-                .headers(
-                        "x-api-key",
-                        PRIVATE_API_KEY,
-                        "Content-Type",
-                        "application/x-www-form-urlencoded; charset=UTF-8")
-                .willRespondWith()
-                .status(200)
-                .body(
-                        newJsonBody(
-                                        (body) -> {
-                                            body.stringType("access_token");
-                                            body.stringValue("token_type", "Bearer");
-                                            body.integerType("expires_in");
-                                        })
-                                .build())
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "validRequestReturnsValidAccessToken")
-    void fetchAccessToken_whenCalledAgainstDrivingLicenceCri_retrievesAValidAccessToken(
-            MockServer mockServer) throws URISyntaxException, JOSEException, CriApiException {
-        // Arrange
-        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
-
-        when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
-                .thenReturn("900");
-        when(mockConfigService.getOauthCriConfig(any())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
-
-        // Fix the signature here as mocking out the AWSKMS class inside the real signer would be
-        // painful.
-        when(mockKmsEs256SignerFactory.getSigner(any())).thenReturn(mockSigner);
-        when(mockSigner.sign(any(), any())).thenReturn(new Base64URL(CLIENT_ASSERTION_SIGNATURE));
-        when(mockSigner.supportedJWSAlgorithms()).thenReturn(Set.of(JWSAlgorithm.ES256));
-        when(mockSecureTokenHelper.generate())
-                .thenReturn("ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY");
-
-        // We need to generate a fixed request, so we set the secure token and expiry to constant
-        // values.
-        var underTest =
-                new CriApiService(
-                        mockConfigService,
-                        mockKmsEs256SignerFactory,
-                        mockSecureTokenHelper,
-                        CURRENT_TIME);
-
-        // Act
-        BearerAccessToken accessToken =
-                underTest.fetchAccessToken(
-                        getCallbackRequest("dummyAuthCode", credentialIssuerConfig),
-                        getCriOAuthSessionItem());
-        // Assert
-        assertThat(accessToken.getType(), is(AccessTokenType.BEARER));
-        assertThat(accessToken.getValue(), notNullValue());
-        assertThat(accessToken.getLifetime(), greaterThan(0L));
-    }
-
-    @Pact(provider = "DrivingLicenceCriProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact invalidAuthCodeRequestReturns400(PactDslWithProvider builder) {
-        return builder.given("dummyInvalidAuthCode is an invalid authorization code")
-                .given("dummyApiKey is a valid api key")
-                .given("dummyDrivingLicenceComponentId is the driving licence CRI component ID")
-                .given(
-                        "Driving licence CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
-                .uponReceiving("Invalid auth code")
-                .path("/token")
-                .method("POST")
-                .body(
-                        "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyInvalidAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3DdrivingLicence&client_assertion="
-                                + CLIENT_ASSERTION_HEADER
-                                + "."
-                                + CLIENT_ASSERTION_BODY
-                                + "."
-                                + CLIENT_ASSERTION_SIGNATURE)
-                .headers(
-                        "x-api-key",
-                        PRIVATE_API_KEY,
-                        "Content-Type",
-                        "application/x-www-form-urlencoded; charset=UTF-8")
-                .willRespondWith()
-                .status(400)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "invalidAuthCodeRequestReturns400")
-    void fetchAccessToken_whenCalledAgainstDrivingLicenceCriWithInvalidAuthCode_throwsAnException(
-            MockServer mockServer) throws URISyntaxException, JOSEException, CriApiException {
-        // Arrange
-        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
-
-        when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
-                .thenReturn("900");
-        when(mockConfigService.getOauthCriConfig(any())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
-
-        // Fix the signature here as mocking out the AWSKMS class inside the real signer would be
-        // painful.
-        when(mockKmsEs256SignerFactory.getSigner(any())).thenReturn(mockSigner);
-        when(mockSigner.sign(any(), any())).thenReturn(new Base64URL(CLIENT_ASSERTION_SIGNATURE));
-        when(mockSigner.supportedJWSAlgorithms()).thenReturn(Set.of(JWSAlgorithm.ES256));
-        when(mockSecureTokenHelper.generate())
-                .thenReturn("ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY");
-
-        // We need to generate a fixed request, so we set the secure token and expiry to constant
-        // values.
-        var underTest =
-                new CriApiService(
-                        mockConfigService,
-                        mockKmsEs256SignerFactory,
-                        mockSecureTokenHelper,
-                        CURRENT_TIME);
-
-        // Act
-        CriApiException exception =
-                assertThrows(
-                        CriApiException.class,
-                        () ->
-                                underTest.fetchAccessToken(
-                                        getCallbackRequest(
-                                                "dummyInvalidAuthCode", credentialIssuerConfig),
-                                        getCriOAuthSessionItem()));
-
-        // Assert
-        assertThat(exception.getErrorResponse(), is(ErrorResponse.INVALID_TOKEN_REQUEST));
-        assertThat(exception.getHttpStatusCode(), is(HTTPResponse.SC_BAD_REQUEST));
-    }
 
     @Pact(provider = "DrivingLicenceCriProvider", consumer = "IpvCoreBack")
     public RequestResponsePact validRequestReturnsDvlaIssuedCredential(

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java
@@ -1,0 +1,268 @@
+package uk.gov.di.ipv.core.processcricallback.pact.drivingLicenceCri;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
+import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
+import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
+import uk.gov.di.ipv.core.library.kmses256signer.KmsEs256SignerFactory;
+import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.processcricallback.exception.CriApiException;
+import uk.gov.di.ipv.core.processcricallback.service.CriApiService;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Set;
+
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@Disabled("PACT tests should not be run in build pipelines at this time")
+@ExtendWith(PactConsumerTestExt.class)
+@ExtendWith(MockitoExtension.class)
+@PactTestFor(providerName = "DrivingLicenceTokenProvider")
+@MockServerConfig(hostInterface = "localhost", port = "1234")
+class TokenTests {
+    private static final String TEST_ISSUER = "dummyDrivingLicenceComponentId";
+    private static final String IPV_CORE_CLIENT_ID = "ipv-core";
+    private static final String PRIVATE_API_KEY = "dummyApiKey";
+    private static final Clock CURRENT_TIME =
+            Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
+    private static final String CRI_SIGNING_PRIVATE_KEY_JWK =
+            """
+            {"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}
+            """;
+    private static final String CRI_RSA_ENCRYPTION_PUBLIC_JWK =
+            """
+            {"kty":"RSA","e":"AQAB","n":"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q"}
+            """;
+
+    private static final String CLIENT_ASSERTION_HEADER = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9";
+    private static final String CLIENT_ASSERTION_BODY =
+            "eyJpc3MiOiJpcHYtY29yZSIsInN1YiI6Imlwdi1jb3JlIiwiYXVkIjoiZHVtbXlEcml2aW5nTGljZW5jZUNvbXBvbmVudElkIiwiZXhwIjo0MDcwOTA5NzAwLCJqdGkiOiJTY25GNGRHWHRoWllYU181azg1T2JFb1NVMDRXLUgzcWFfcDZucHYyWlVZIn0";
+    // Signature generated using JWT.io
+    private static final String CLIENT_ASSERTION_SIGNATURE =
+            "2Shugh1NCcII0yemPId2GYEXRLNMYI0xhLunVA5dHhNealHDgDobfuCptZ-tAGDl9pcWCux9Wlc2Y4aTWp8Vbw";
+
+    @Mock private ConfigService mockConfigService;
+    @Mock private KmsEs256SignerFactory mockKmsEs256SignerFactory;
+    @Mock private JWSSigner mockSigner;
+    @Mock private SecureTokenHelper mockSecureTokenHelper;
+
+    @Pact(provider = "DrivingLicenceTokenProvider", consumer = "IpvCoreBack")
+    public RequestResponsePact validRequestReturnsValidAccessToken(PactDslWithProvider builder) {
+        return builder.given("dummyAuthCode is a valid authorization code")
+                .given("dummyApiKey is a valid api key")
+                .given("dummyDrivingLicenceComponentId is the driving licence CRI component ID")
+                .given(
+                        "Driving licence CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
+                .uponReceiving("Valid auth code")
+                .path("/token")
+                .method("POST")
+                .body(
+                        "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3DdrivingLicence&client_assertion="
+                                + CLIENT_ASSERTION_HEADER
+                                + "."
+                                + CLIENT_ASSERTION_BODY
+                                + "."
+                                + CLIENT_ASSERTION_SIGNATURE)
+                .headers(
+                        "x-api-key",
+                        PRIVATE_API_KEY,
+                        "Content-Type",
+                        "application/x-www-form-urlencoded; charset=UTF-8")
+                .willRespondWith()
+                .status(200)
+                .body(
+                        newJsonBody(
+                                        (body) -> {
+                                            body.stringType("access_token");
+                                            body.stringValue("token_type", "Bearer");
+                                            body.integerType("expires_in");
+                                        })
+                                .build())
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "validRequestReturnsValidAccessToken")
+    void fetchAccessToken_whenCalledAgainstDrivingLicenceCri_retrievesAValidAccessToken(
+            MockServer mockServer) throws URISyntaxException, JOSEException, CriApiException {
+        // Arrange
+        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
+
+        when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
+                .thenReturn("900");
+        when(mockConfigService.getOauthCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
+
+        // Fix the signature here as mocking out the AWSKMS class inside the real signer would be
+        // painful.
+        when(mockKmsEs256SignerFactory.getSigner(any())).thenReturn(mockSigner);
+        when(mockSigner.sign(any(), any())).thenReturn(new Base64URL(CLIENT_ASSERTION_SIGNATURE));
+        when(mockSigner.supportedJWSAlgorithms()).thenReturn(Set.of(JWSAlgorithm.ES256));
+        when(mockSecureTokenHelper.generate())
+                .thenReturn("ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY");
+
+        // We need to generate a fixed request, so we set the secure token and expiry to constant
+        // values.
+        var underTest =
+                new CriApiService(
+                        mockConfigService,
+                        mockKmsEs256SignerFactory,
+                        mockSecureTokenHelper,
+                        CURRENT_TIME);
+
+        // Act
+        BearerAccessToken accessToken =
+                underTest.fetchAccessToken(
+                        getCallbackRequest("dummyAuthCode", credentialIssuerConfig),
+                        getCriOAuthSessionItem());
+        // Assert
+        assertThat(accessToken.getType(), is(AccessTokenType.BEARER));
+        assertThat(accessToken.getValue(), notNullValue());
+        assertThat(accessToken.getLifetime(), greaterThan(0L));
+    }
+
+    @Pact(provider = "DrivingLicenceTokenProvider", consumer = "IpvCoreBack")
+    public RequestResponsePact invalidAuthCodeRequestReturns400(PactDslWithProvider builder) {
+        return builder.given("dummyInvalidAuthCode is an invalid authorization code")
+                .given("dummyApiKey is a valid api key")
+                .given("dummyDrivingLicenceComponentId is the driving licence CRI component ID")
+                .given(
+                        "Driving licence CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
+                .uponReceiving("Invalid auth code")
+                .path("/token")
+                .method("POST")
+                .body(
+                        "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyInvalidAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3DdrivingLicence&client_assertion="
+                                + CLIENT_ASSERTION_HEADER
+                                + "."
+                                + CLIENT_ASSERTION_BODY
+                                + "."
+                                + CLIENT_ASSERTION_SIGNATURE)
+                .headers(
+                        "x-api-key",
+                        PRIVATE_API_KEY,
+                        "Content-Type",
+                        "application/x-www-form-urlencoded; charset=UTF-8")
+                .willRespondWith()
+                .status(400)
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "invalidAuthCodeRequestReturns400")
+    void fetchAccessToken_whenCalledAgainstDrivingLicenceCriWithInvalidAuthCode_throwsAnException(
+            MockServer mockServer) throws URISyntaxException, JOSEException, CriApiException {
+        // Arrange
+        var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
+
+        when(mockConfigService.getSsmParameter(ConfigurationVariable.JWT_TTL_SECONDS))
+                .thenReturn("900");
+        when(mockConfigService.getOauthCriConfig(any())).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKey(any())).thenReturn(PRIVATE_API_KEY);
+
+        // Fix the signature here as mocking out the AWSKMS class inside the real signer would be
+        // painful.
+        when(mockKmsEs256SignerFactory.getSigner(any())).thenReturn(mockSigner);
+        when(mockSigner.sign(any(), any())).thenReturn(new Base64URL(CLIENT_ASSERTION_SIGNATURE));
+        when(mockSigner.supportedJWSAlgorithms()).thenReturn(Set.of(JWSAlgorithm.ES256));
+        when(mockSecureTokenHelper.generate())
+                .thenReturn("ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY");
+
+        // We need to generate a fixed request, so we set the secure token and expiry to constant
+        // values.
+        var underTest =
+                new CriApiService(
+                        mockConfigService,
+                        mockKmsEs256SignerFactory,
+                        mockSecureTokenHelper,
+                        CURRENT_TIME);
+
+        // Act
+        CriApiException exception =
+                assertThrows(
+                        CriApiException.class,
+                        () ->
+                                underTest.fetchAccessToken(
+                                        getCallbackRequest(
+                                                "dummyInvalidAuthCode", credentialIssuerConfig),
+                                        getCriOAuthSessionItem()));
+
+        // Assert
+        assertThat(exception.getErrorResponse(), is(ErrorResponse.INVALID_TOKEN_REQUEST));
+        assertThat(exception.getHttpStatusCode(), is(HTTPResponse.SC_BAD_REQUEST));
+    }
+
+    @NotNull
+    private static CriOAuthSessionItem getCriOAuthSessionItem() {
+        return new CriOAuthSessionItem(
+                "dummySessionId", "dummyOAuthSessionId", "dummyCriId", "dummyConnection", 900);
+    }
+
+    @NotNull
+    private static CriCallbackRequest getCallbackRequest(
+            String authCode, OauthCriConfig credentialIssuerConfig) {
+        return new CriCallbackRequest(
+                authCode,
+                credentialIssuerConfig.getClientId(),
+                "dummySessionId",
+                "https://identity.staging.account.gov.uk/credential-issuer/callback?id=drivingLicence",
+                "dummyState",
+                null,
+                null,
+                "dummyIpAddress",
+                "dummyFeatureSet");
+    }
+
+    @NotNull
+    private static OauthCriConfig getMockCredentialIssuerConfig(MockServer mockServer)
+            throws URISyntaxException {
+        return OauthCriConfig.builder()
+                .tokenUrl(new URI("http://localhost:" + mockServer.getPort() + "/token"))
+                .credentialUrl(
+                        new URI("http://localhost:" + mockServer.getPort() + "/credential/issue"))
+                .authorizeUrl(new URI("http://localhost:" + mockServer.getPort() + "/authorize"))
+                .clientId(IPV_CORE_CLIENT_ID)
+                .signingKey(CRI_SIGNING_PRIVATE_KEY_JWK)
+                .encryptionKey(CRI_RSA_ENCRYPTION_PUBLIC_JWK)
+                .componentId(TEST_ISSUER)
+                .clientCallbackUrl(
+                        URI.create(
+                                "https://identity.staging.account.gov.uk/credential-issuer/callback?id=drivingLicence"))
+                .requiresApiKey(true)
+                .requiresAdditionalEvidence(false)
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Split the driving licence contract tests into two files.

### Why did it change

Lime need two separate contracts to test.

