### PR TITLE
PYIC-5001: Reprove Identity Flag + Breaching CIs Should Fail/Use Mitigation Route

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -68,6 +68,7 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_F2F_FAIL_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_AND_FORCED_RESET_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_IN_MIGRATION_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_IPV_GPG45_MEDIUM_PATH;
@@ -99,6 +100,8 @@ public class CheckExistingIdentityHandler
             new JourneyResponse(JOURNEY_RESET_GPG45_IDENTITY_PATH);
     private static final JourneyResponse JOURNEY_FAIL_WITH_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
+    private static final JourneyResponse JOURNEY_FAIL_WITH_CI_AND_FORCED_RESET =
+            new JourneyResponse(JOURNEY_FAIL_WITH_CI_AND_FORCED_RESET_PATH);
     public static final List<Vot> SUPPORTED_VOTS_BY_STRENGTH =
             List.of(Vot.P2, Vot.PCL250, Vot.PCL200);
 
@@ -199,15 +202,6 @@ public class CheckExistingIdentityHandler
             // Clear TICF VCs
             verifiableCredentialService.deleteVcStoreItem(userId, TICF_CRI);
 
-            // Reset identity if reprove is true.
-            // or
-            // Force reset
-            Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
-            if ((reproveIdentity != null && reproveIdentity)
-                    || configService.enabled(RESET_IDENTITY.getName())) {
-                return buildForceResetResponse();
-            }
-
             AuditEventUser auditEventUser =
                     new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
 
@@ -221,10 +215,15 @@ public class CheckExistingIdentityHandler
             final boolean isF2FIncomplete = !Objects.isNull(f2fRequest) && !hasF2fVc;
             final boolean isF2FComplete = !Objects.isNull(f2fRequest) && hasF2fVc;
 
-            var ciScoringCheckResponse =
+            Optional<JourneyResponse> ciScoringCheckResponse =
                     checkForCIScoringFailure(
                             ipAddress, clientOAuthSessionItem, govukSigninJourneyId);
 
+            Boolean reproveIdentity = clientOAuthSessionItem.getReproveIdentity();
+            if ((reproveIdentity != null && reproveIdentity)
+                    || configService.enabled(RESET_IDENTITY.getName())) {
+                return buildForceResetResponse(ciScoringCheckResponse.orElse(null));
+            }
             if (ciScoringCheckResponse.isPresent()) {
                 return isF2FIncomplete
                         ? buildF2FIncompleteResponse(
@@ -276,9 +275,20 @@ public class CheckExistingIdentityHandler
     }
 
     @Tracing
-    private JourneyResponse buildForceResetResponse() {
-        LOGGER.info(
-                LogHelper.buildLogMessage("resetIdentity flag is enabled, reset users identity."));
+    private JourneyResponse buildForceResetResponse(JourneyResponse ciScoringCheckResponse) {
+        if (ciScoringCheckResponse != null) {
+            LOGGER.info(
+                    LogHelper.buildLogMessage(
+                            "resetIdentity flag is enabled, reset users identity."));
+            if (JOURNEY_FAIL_WITH_CI.equals(ciScoringCheckResponse)) {
+                //                forces a reset of the user's identity if the CI score is breached
+                // and no mitigation is possible
+                return JOURNEY_FAIL_WITH_CI_AND_FORCED_RESET;
+            }
+            //            sends the user on mitigation journey if the CI score is breached and
+            // mitigation is possible
+            return ciScoringCheckResponse;
+        }
         return JOURNEY_RESET_IDENTITY;
     }
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -36,6 +36,9 @@ RESET_VCS:
   response:
     type: process
     lambda: reset-identity
+    lambdaInput:
+      isUserInitiated: false
+      deleteOnlyGPG45VCs: false
   events:
     next:
       targetState: NO_MATCH_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -16,32 +16,12 @@ FAILED_BAV:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
 
-FAILED_FORCED_RESET:
-  events:
-    next:
-      targetState: RESET_VCS
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_RESET_VCS
-
-
 FAILED_NO_TICF:
   events:
     next:
       targetState: NO_MATCH_PAGE
 
 # Journey states
-
-RESET_VCS:
-  response:
-    type: process
-    lambda: reset-identity
-    lambdaInput:
-      isUserInitiated: false
-      deleteOnlyGPG45VCs: false
-  events:
-    next:
-      targetState: NO_MATCH_PAGE
 
 CRI_TICF_BEFORE_RESET_VCS:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -23,22 +23,6 @@ FAILED_NO_TICF:
 
 # Journey states
 
-CRI_TICF_BEFORE_RESET_VCS:
-  response:
-      type: process
-      lambda: call-ticf-cri
-  events:
-      next:
-        targetState: RESET_VCS
-      enhanced-verification:
-          targetState: NO_MATCH_PAGE
-      fail-with-ci:
-          targetState: NO_MATCH_PAGE
-      error:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR_NO_TICF
-
-
 CRI_TICF_BEFORE_NO_MATCH:
   response:
     type: process

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -16,12 +16,45 @@ FAILED_BAV:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
 
+FAILED_FORCED_RESET:
+  events:
+    next:
+      targetState: RESET_VCS
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_RESET_VCS
+
+
 FAILED_NO_TICF:
   events:
     next:
       targetState: NO_MATCH_PAGE
 
 # Journey states
+
+RESET_VCS:
+  response:
+    type: process
+    lambda: reset-identity
+  events:
+    next:
+      targetState: NO_MATCH_PAGE
+
+CRI_TICF_BEFORE_RESET_VCS:
+  response:
+      type: process
+      lambda: call-ticf-cri
+  events:
+      next:
+        targetState: RESET_VCS
+      enhanced-verification:
+          targetState: NO_MATCH_PAGE
+      fail-with-ci:
+          targetState: NO_MATCH_PAGE
+      error:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR_NO_TICF
+
 
 CRI_TICF_BEFORE_NO_MATCH:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -35,7 +35,6 @@ CHECK_EXISTING_IDENTITY:
       targetJourney: FAILED
       targetState: FAILED
     fail-with-ci-and-forced-reset:
-      targetJourney: FAILED
       targetState: RESET_VCS
     f2f-fail:
       targetJourney: F2F_FAILED
@@ -71,7 +70,7 @@ RESET_GPG45_IDENTITY:
       targetJourney: NEW_P2_IDENTITY
       targetState: START
 
-RESET_VCS:
+RESET_FAILED_IDENTITY:
   response:
     type: process
     lambda: reset-identity
@@ -80,4 +79,5 @@ RESET_VCS:
       deleteOnlyGPG45VCs: false
   events:
     next:
-      targetState: NO_MATCH_PAGE
+      targetJourney: FAILED
+      targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -36,7 +36,7 @@ CHECK_EXISTING_IDENTITY:
       targetState: FAILED
     fail-with-ci-and-forced-reset:
       targetJourney: FAILED
-      targetState: FAILED_FORCED_RESET
+      targetState: RESET_VCS
     f2f-fail:
       targetJourney: F2F_FAILED
       targetState: FAILED
@@ -70,3 +70,14 @@ RESET_GPG45_IDENTITY:
     next:
       targetJourney: NEW_P2_IDENTITY
       targetState: START
+
+RESET_VCS:
+  response:
+    type: process
+    lambda: reset-identity
+    lambdaInput:
+      isUserInitiated: false
+      deleteOnlyGPG45VCs: false
+  events:
+    next:
+      targetState: NO_MATCH_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -34,6 +34,9 @@ CHECK_EXISTING_IDENTITY:
     fail-with-ci:
       targetJourney: FAILED
       targetState: FAILED
+    fail-with-ci-and-forced-reset:
+      targetJourney: FAILED
+      targetState: FAILED_FORCED_RESET
     f2f-fail:
       targetJourney: F2F_FAILED
       targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -35,7 +35,7 @@ CHECK_EXISTING_IDENTITY:
       targetJourney: FAILED
       targetState: FAILED
     fail-with-ci-and-forced-reset:
-      targetState: RESET_VCS
+      targetState: RESET_FAILED_IDENTITY
     f2f-fail:
       targetJourney: F2F_FAILED
       targetState: FAILED

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -10,6 +10,8 @@ public class JourneyUris {
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
     public static final String JOURNEY_F2F_FAIL_PATH = "/journey/f2f-fail";
     public static final String JOURNEY_FAIL_WITH_CI_PATH = "/journey/fail-with-ci";
+    public static final String JOURNEY_FAIL_WITH_CI_AND_FORCED_RESET_PATH =
+            "/journey/fail-with-ci-and-forced-reset";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
     public static final String JOURNEY_IN_MIGRATION_REUSE_PATH = "/journey/in-migration-reuse";
     public static final String JOURNEY_IPV_GPG45_MEDIUM_PATH = "/journey/ipv-gpg45-medium";


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

[PYIC 5001](https://govukverify.atlassian.net/browse/PYIC-5001) Reprove identity flag + breaching CIs should fail/use mitigation route

- Adds new journey for reset identity for user with CI and no mitigation
- Fixes reset identity + CI mitigation bug 

<!-- Describe the changes in detail - the "what"-->

### Why did it change
If a user has breaching CIs and the reprove identity flag, the reprove flag triggers a reset, but then begins a normal identity proving journey, which will fail after the first CRI.  Instead, we still need to respect CIs after the reset.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC 5001](https://govukverify.atlassian.net/browse/PYIC-5001)

