### PR TITLE
PYIC-4492: NINO exit page fail-with-ci

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -16,6 +16,14 @@ FAILED_BAV:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
 
+FAILED_NINO:
+  events:
+    next:
+      targetState: NO_MATCH_PAGE_NINO
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_NO_MATCH_NINO
+
 FAILED_NO_TICF:
   events:
     next:
@@ -53,6 +61,21 @@ CRI_TICF_BEFORE_NO_MATCH_BAV:
       targetJourney: TECHNICAL_ERROR
       targetState: ERROR_NO_TICF
 
+CRI_TICF_BEFORE_NO_MATCH_NINO:
+  response:
+    type: process
+    lambda: call-ticf-cri
+  events:
+    next:
+      targetState: NO_MATCH_PAGE_NINO
+    enhanced-verification:
+      targetState: NO_MATCH_PAGE_NINO
+    fail-with-ci:
+      targetState: NO_MATCH_PAGE_NINO
+    error:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR_NO_TICF
+
 NO_MATCH_PAGE:
   response:
     type: page
@@ -66,6 +89,15 @@ NO_MATCH_PAGE_BAV:
     type: page
     pageId: pyi-no-match
     context: bankAccount
+  events:
+    next:
+      targetState: RETURN_TO_RP
+
+NO_MATCH_PAGE_NINO:
+  response:
+    type: page
+    pageId: pyi-no-match
+    context: nino
   events:
     next:
       targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -513,6 +513,9 @@ CRI_NINO_WITH_SCOPE_M2B:
   events:
     next:
       targetState: ADDRESS_AND_FRAUD_M2B
+    fail-with-ci:
+      targetJourney: FAILED
+      targetState: FAILED_NINO
 
 ADDRESS_AND_FRAUD_M2B:
   nestedJourney: ADDRESS_AND_FRAUD


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

NINO exit page fail-with-ci

### Why did it change

When a user enters the NINO CRI stage of the M2B journey and fails for a 2nd time to enter a verifiable national insurance number, then they are routed to an exit page “Sorry we cannot confirm your identity”.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4492](https://govukverify.atlassian.net/browse/PYIC-4492)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-4492]: https://govukverify.atlassian.net/browse/PYIC-4492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ