### PR TITLE
PYIC-5178: Add mitigationType in IPV_MITIGATION_START extension

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
+import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionMitigationType;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
@@ -118,8 +119,12 @@ public class ProcessJourneyEventHandler
 
             StepResponse stepResponse = executeJourneyEvent(journeyEvent, ipvSessionItem);
 
-            if (Boolean.TRUE.equals(stepResponse.getMitigationStart())) {
-                sendMitigationStartAuditEvent(ipvSessionId, ipAddress, clientOAuthSessionItem);
+            if (stepResponse.getMitigationStart() != null) {
+                sendMitigationStartAuditEvent(
+                        ipvSessionId,
+                        ipAddress,
+                        clientOAuthSessionItem,
+                        stepResponse.getMitigationStart());
             }
 
             return stepResponse.value();
@@ -279,7 +284,10 @@ public class ProcessJourneyEventHandler
     }
 
     private void sendMitigationStartAuditEvent(
-            String ipvSessionId, String ipAddress, ClientOAuthSessionItem clientOAuthSessionItem)
+            String ipvSessionId,
+            String ipAddress,
+            ClientOAuthSessionItem clientOAuthSessionItem,
+            String mitigationType)
             throws SqsException {
         var auditEventUser =
                 new AuditEventUser(
@@ -292,6 +300,7 @@ public class ProcessJourneyEventHandler
                 new AuditEvent(
                         AuditEventTypes.IPV_MITIGATION_START,
                         configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
-                        auditEventUser));
+                        auditEventUser,
+                        new AuditExtensionMitigationType(mitigationType)));
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -31,7 +30,7 @@ public class CriStepResponse implements StepResponse {
     private String criId;
     private String context;
     private String scope;
-    @Getter private Boolean mitigationStart;
+    private String mitigationStart;
 
     public Map<String, Object> value() {
         try {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponse.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Map;
@@ -14,7 +13,7 @@ public class ErrorStepResponse implements StepResponse {
     private static final String ERROR = "error";
     private String pageId;
     private String statusCode;
-    @Getter private Boolean mitigationStart;
+    private String mitigationStart;
 
     public Map<String, Object> value() {
         return Map.of("type", ERROR, "page", pageId, "statusCode", Integer.parseInt(statusCode));

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.HashMap;
@@ -15,7 +14,7 @@ public class PageStepResponse implements StepResponse {
 
     private String pageId;
     private String context;
-    @Getter private Boolean mitigationStart;
+    private String mitigationStart;
 
     public Map<String, Object> value() {
         Map<String, Object> response = new HashMap<>();

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponse.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.HashMap;
@@ -17,7 +16,7 @@ public class ProcessStepResponse implements StepResponse {
     private static final String JOURNEY_TEMPLATE = "/journey/%s";
     private String lambda;
     private Map<String, Object> lambdaInput;
-    @Getter private Boolean mitigationStart;
+    private String mitigationStart;
 
     @Override
     public Map<String, Object> value() {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
@@ -15,5 +15,5 @@ import java.util.Map;
 public interface StepResponse {
     Map<String, Object> value();
 
-    Boolean getMitigationStart();
+    String getMitigationStart();
 }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -557,7 +557,7 @@ CRI_EXPERIAN_KBV_M2B:
 
 MITIGATION_KBV_FAIL_M2B:
   response:
-    mitigationStart: true
+    mitigationStart: enhanced-verification
     type: page
     pageId: pyi-kbv-escape-m2b
   events:
@@ -609,7 +609,7 @@ MITIGATION_01:
     lambdaInput:
       isUserInitiated: false
       deleteOnlyGPG45VCs: true
-    mitigationStart: true
+    mitigationStart: enhanced-verification
   events:
     next:
       targetState: MITIGATION_01_IDENTITY_START_PAGE
@@ -697,7 +697,7 @@ MITIGATION_02_OPTIONS:
   response:
     type: page
     pageId: pyi-suggest-other-options-no-f2f
-    mitigationStart: true
+    mitigationStart: enhanced-verification
   events:
     next:
       targetState: CRI_DCMAW_PYI_ESCAPE
@@ -748,7 +748,7 @@ MITIGATION_02_OPTIONS_WITH_F2F:
   response:
     type: page
     pageId: pyi-suggest-other-options
-    mitigationStart: true
+    mitigationStart: enhanced-verification
   events:
     f2f:
       targetState: CRI_F2F
@@ -763,7 +763,7 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
     type: page
     pageId: pyi-suggest-other-options
     context: no-photo-id
-    mitigationStart: true
+    mitigationStart: enhanced-verification
   events:
     f2f:
       targetState: CRI_F2F

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -70,7 +70,7 @@ PAGE_STATE_AT_START_OF_MITIGATION:
   response:
     type: page
     pageId: page-id-for-some-page
-    mitigationStart: true
+    mitigationStart: a-mitigation-type
   events:
     enterNestedJourneyAtStateOne:
       targetState: NESTED_JOURNEY_INVOKE_STATE

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionMitigationType;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
@@ -293,6 +294,10 @@ class ProcessJourneyEventHandlerTest {
         assertEquals("component_id", capturedAuditEvent.getComponentId());
         assertEquals("testuserid", capturedAuditEvent.getUser().getUserId());
         assertEquals("testjourneyid", capturedAuditEvent.getUser().getGovukSigninJourneyId());
+        assertEquals(
+                "a-mitigation-type",
+                ((AuditExtensionMitigationType) capturedAuditEvent.getExtensions())
+                        .mitigationType());
     }
 
     private void mockIpvSessionItemAndTimeout(String userState) {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PageStepResponseTest {
 
     public static final PageStepResponse PAGE_RESPONSE =
-            new PageStepResponse("aPageId", "testContext", true);
+            new PageStepResponse("aPageId", "testContext", "mitigationType");
 
     @Test
     void valueReturnsCorrectPageResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponseTest.java
@@ -12,7 +12,9 @@ class ProcessStepResponseTest {
     void valueReturnsCorrectJourneyResponse() {
         ProcessStepResponse processStepResponse =
                 new ProcessStepResponse(
-                        "a-process-lambda", Map.of("input1", "Windom Earle", "input2", 315), true);
+                        "a-process-lambda",
+                        Map.of("input1", "Windom Earle", "input2", 315),
+                        "mitigationType");
 
         Map<String, Object> expectedValue =
                 Map.of(

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionMitigationType.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionMitigationType.java
@@ -1,0 +1,8 @@
+package uk.gov.di.ipv.core.library.auditing.extension;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public record AuditExtensionMitigationType(@JsonProperty("mitigation_type") String mitigationType)
+        implements AuditExtensions {}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add mitigationType in IPV_MITIGATION_START extension

### Why did it change

This will allow us to determine from the audit events which mitigation journey a user has started.

### Example audit event after change
```
{
    "event_name": "IPV_MITIGATION_START",
    "component_id": "https://dev-chrisw.01.dev.identity.account.gov.uk",
    "user": {
        "user_id": "urn:uuid:376aadc3-1850-4ccf-8489-c921af51eb4e",
        "session_id": "BO80mMfmP04G2PAxLXCNtdtps4wBjuJedz8zj9y990I",
        "govuk_signin_journey_id": "4974db9d-fe54-4334-91fb-aea89bc99b54",
        "ip_address": "217.196.229.79"
    },
    "extensions": {
        "mitigation_type": "enhanced-verification"
    },
    "timestamp": 1709218934,
    "event_timestamp_ms": 1709218934244
}
```

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5178](https://govukverify.atlassian.net/browse/PYIC-5178)


[PYIC-5178]: https://govukverify.atlassian.net/browse/PYIC-5178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ