### PR TITLE
PYIC-5152 Correct the metric used for DLQ alarms

### DIFF
--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -352,27 +352,17 @@ Resources:
                       - Fn::Split:
                           - "/"
                           - Ref: AWS::StackId
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 1
-      DatapointsToAlarm: 1
+      Namespace: AWS/SQS
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt DeleteAccountSNSDLQ.QueueName
+      MetricName: ApproximateNumberOfMessagesVisible
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      Period: 60
       EvaluationPeriods: 1
+      Statistic: Sum
       TreatMissingData: notBreaching
-      Metrics:
-        - Id: e1
-          Label: Sum-of-SQS-DQL-Messages
-          ReturnData: true
-          Expression: SUM(METRICS())
-        - Id: m1
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/SQS
-              MetricName: NumberOfMessagesReceived
-              Dimensions:
-                - Name: QueueName
-                  Value: !GetAtt DeleteAccountSNSDLQ.QueueName
-            Period: 300
-            Stat: Sum
 
 #Alarm for other DLQ
   DeleteAccountLambdaDLQAlarm:
@@ -395,27 +385,17 @@ Resources:
                       - Fn::Split:
                           - "/"
                           - Ref: AWS::StackId
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 1
-      DatapointsToAlarm: 1
+      Namespace: AWS/SQS
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt DeleteAccountLambdaDLQ.QueueName
+      MetricName: ApproximateNumberOfMessagesVisible
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      Period: 60
       EvaluationPeriods: 1
+      Statistic: Sum
       TreatMissingData: notBreaching
-      Metrics:
-        - Id: e1
-          Label: Sum-of-SQS-DQL-Messages
-          ReturnData: true
-          Expression: SUM(METRICS())
-        - Id: m1
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/SQS
-              MetricName: NumberOfMessagesReceived
-              Dimensions:
-                - Name: QueueName
-                  Value: !GetAtt DeleteAccountLambdaDLQ.QueueName
-            Period: 300
-            Stat: Sum
 
 # SNS Topic for DLQ Alarms
   DLQAlarmsSNSTopic:
@@ -435,9 +415,9 @@ Resources:
                           - "/"
                           - Ref: AWS::StackId
       Subscription:
-        - Endpoint: tobias.saunders@digital.cabinet-office.gov.uk
+        - Endpoint: patrick.blakey@digital.cabinet-office.gov.uk
           Protocol: email
-        - Endpoint: kerr.rainey@digital.cabinet-office.gov.uk
+        - Endpoint: joe.edwards@digital.cabinet-office.gov.uk
           Protocol: email
         - Endpoint: vam.hedayati@digital.cabinet-office.gov.uk
           Protocol: email


### PR DESCRIPTION
## Proposed changes

### What changed

Update the delete account DLQ alarms to use the metric `ApproximateNumberOfMessagesVisible` triggered when greater than 0 for a single data point. Also updated the email notification to myself and @Joe-Edwards-GDS's email

### Why did it change

The existing metric the alarms use `NumberOfMessagesReceived` is the number of messages that get read _off_ the queue - we found the alarms fired when we processed a redrive of the DLQ onto the source queue. `NumberOfMessagesSent` is the number of messages enqueued, however the [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html#sqs-dead-letter-queues-troubleshooting) state:

> If you send a message to a dead-letter queue manually, it is captured by the NumberOfMessagesSent metric. However, if a message is sent to a dead-letter queue as a result of a failed processing attempt, it isn't captured by this metric

Therefore we can only really use `ApproximateNumberOfMessagesVisible` which captures the number of messages available for consumption off the queue in any circumstance

### Issue tracking

- [PYIC-5152](https://govukverify.atlassian.net/browse/PYIC-5152)



[PYIC-5152]: https://govukverify.atlassian.net/browse/PYIC-5152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ