### PR TITLE
BAU Add OKActions for DLQ alarms to auto-resolve

### DIFF
--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -337,7 +337,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-         - !Ref DLQAlarmsSNSTopic
+        - !Ref DLQAlarmsSNSTopic
+      OKActions:
+        - !Ref DLQAlarmsSNSTopic
       AlarmDescription: "Delete Account SNS Topic Dead Letter Queue Alarm"
       AlarmName: !Join
         - "-"
@@ -370,7 +372,9 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-       - !Ref DLQAlarmsSNSTopic
+        - !Ref DLQAlarmsSNSTopic
+      OKActions:
+        - !Ref DLQAlarmsSNSTopic
       AlarmDescription: "Delete Account SNS Topic Dead Letter Queue Alarm"
       AlarmName: !Join
         - "-"


### PR DESCRIPTION
## Proposed changes

### What changed

Add `OKActions` for delete account DLQ alarms
> The actions to execute when this alarm transitions to the OK state from any other state. Each action is specified as an Amazon Resource Name (ARN).

### Why did it change

The PagerDuty alerts are not auto-resolving when the alarm state moves back to `OK` - this means the alert has to be resolved manually otherwise no further alerts for the alarm will be triggered. I believe adding the `OKActions` subscription should fix this

