### PR TITLE
PYIC-5070: Fix missing calls to TICF

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -13,6 +13,14 @@ INELIGIBLE_NO_TICF:
     next:
       targetState: ANOTHER_WAY_PAGE
 
+INELIGIBLE_SKIP_MESSAGE:
+  events:
+    next:
+      targetState: RETURN_TO_RP
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+
 # Journey states
 
 CRI_TICF_BEFORE_ANOTHER_WAY:
@@ -24,6 +32,23 @@ CRI_TICF_BEFORE_ANOTHER_WAY:
       targetState: ANOTHER_WAY_PAGE
     enhanced-verification:
       targetState: ANOTHER_WAY_PAGE
+    fail-with-ci:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    error:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR_NO_TICF
+
+CRI_TICF_BEFORE_RETURN_TO_RP:
+  response:
+    type: process
+    lambda: call-ticf-cri
+  events:
+    next:
+      targetState: RETURN_TO_RP
+    enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
     fail-with-ci:
       targetJourney: FAILED
       targetState: FAILED_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -196,7 +196,8 @@ MULTIPLE_DOC_CHECK_PAGE:
     drivingLicence:
       targetState: CRI_DRIVING_LICENCE_J3
     end:
-      targetState: RETURN_TO_RP
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
 
 MULTIPLE_DOC_F2F_CHECK_PAGE:
   response:
@@ -219,7 +220,8 @@ PYI_ESCAPE:
     next:
       targetState: RESET_IDENTITY
     end:
-      targetState: RETURN_TO_RP
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
 
 PYI_CRI_ESCAPE:
   response:
@@ -242,7 +244,8 @@ PYI_CRI_ESCAPE_NO_F2F:
     next:
       targetState: CRI_DCMAW_PYI_ESCAPE
     end:
-      targetState: RETURN_TO_RP
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
 
 EVALUATE_GPG45_SCORES:
   response:
@@ -585,7 +588,8 @@ PYI_ESCAPE_M2B:
     bankAccount:
       targetState: BANK_ACCOUNT_START_PAGE
     end:
-      targetState: RETURN_TO_RP
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
 
 PYI_KBV_DROPOUT_M2B:
   response:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix missing calls to TICF

### Why did it change

A few of the escape routes weren't calling TICF. This addresses that and moves those journeys to the INELIGIBLE sub journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5070](https://govukverify.atlassian.net/browse/PYIC-5070)


[PYIC-5070]: https://govukverify.atlassian.net/browse/PYIC-5070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ