### PR TITLE
PYIC-4896: Modify tests to generate their own VCs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1682,7 +1682,7 @@
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java",
         "hashed_secret": "8ee890f6d27197fff7e84647ce06290699d09812",
         "is_verified": false,
-        "line_number": 830
+        "line_number": 839
       }
     ],
     "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java": [
@@ -1863,5 +1863,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-06T12:26:36Z"
+  "generated_at": "2024-03-07T11:46:56Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -1678,7 +1682,7 @@
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java",
         "hashed_secret": "8ee890f6d27197fff7e84647ce06290699d09812",
         "is_verified": false,
-        "line_number": 839
+        "line_number": 845
       }
     ],
     "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java": [
@@ -1859,5 +1863,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-07T11:46:56Z"
+  "generated_at": "2024-03-08T09:32:16Z"
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -289,27 +289,52 @@ public interface VcFixtures {
                     TestVc.builder().evidence(SUCCESSFUL_EVIDENCE).build(),
                     Instant.ofEpochSecond(1705986521));
 
+    List<Object> PASSPORT_DETAILS =
+            List.of(
+                    Map.of(
+                            "documentNumber", "321654987",
+                            "icaoIssuerCode", "GBR",
+                            "expiryDate", "2030-01-01"));
+
     static String vcPassportM1aFailed() {
+        TestVc.TestCredentialSubject credentialSubject =
+                TestVc.TestCredentialSubject.builder().passport(PASSPORT_DETAILS).build();
         return generateVerifiableCredential(
-                TestVc.builder().evidence(UNSUCCESSFUL_EVIDENCE).build(),
+                TestVc.builder()
+                        .credentialSubject(credentialSubject)
+                        .evidence(UNSUCCESSFUL_EVIDENCE)
+                        .build(),
                 Instant.ofEpochSecond(1705986521));
     }
 
     static String vcPassportM1aWithCI() {
+        TestVc.TestCredentialSubject credentialSubject =
+                TestVc.TestCredentialSubject.builder().passport(PASSPORT_DETAILS).build();
         return generateVerifiableCredential(
-                TestVc.builder().evidence(TEST_CI_EVIDENCE).build(),
+                TestVc.builder()
+                        .credentialSubject(credentialSubject)
+                        .evidence(TEST_CI_EVIDENCE)
+                        .build(),
                 Instant.ofEpochSecond(1705986521));
     }
 
     static String vcPassportM1aMissingEvidence() {
+        TestVc.TestCredentialSubject credentialSubject =
+                TestVc.TestCredentialSubject.builder().passport(PASSPORT_DETAILS).build();
         return generateVerifiableCredential(
-                TestVc.builder().evidence(Collections.emptyList()).build(),
+                TestVc.builder()
+                        .credentialSubject(credentialSubject)
+                        .evidence(Collections.emptyList())
+                        .build(),
                 Instant.ofEpochSecond(1705986521));
     }
 
     static String vcPassportMissingName() {
         TestVc.TestCredentialSubject credentialSubject =
-                TestVc.TestCredentialSubject.builder().name(Collections.emptyList()).build();
+                TestVc.TestCredentialSubject.builder()
+                        .passport(PASSPORT_DETAILS)
+                        .name(Collections.emptyList())
+                        .build();
         return generateVerifiableCredential(
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
@@ -319,7 +344,10 @@ public interface VcFixtures {
 
     static String vcPassportMissingBirthDate() {
         TestVc.TestCredentialSubject credentialSubject =
-                TestVc.TestCredentialSubject.builder().birthDate(Collections.emptyList()).build();
+                TestVc.TestCredentialSubject.builder()
+                        .passport(PASSPORT_DETAILS)
+                        .birthDate(Collections.emptyList())
+                        .build();
         return generateVerifiableCredential(
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
@@ -330,6 +358,7 @@ public interface VcFixtures {
     static String vcPassportInvalidBirthDate() {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder()
+                        .passport(PASSPORT_DETAILS)
                         .birthDate(List.of(new BirthDate("invalid")))
                         .build();
         return generateVerifiableCredential(
@@ -363,7 +392,6 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder()
                         .name(List.of(ALICE_PARKER_NAME))
                         .address(List.of(ADDRESS_2))
-                        .passport(Collections.emptyList())
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder().credentialSubject(credentialSubject).build());
@@ -376,7 +404,6 @@ public interface VcFixtures {
                                     TestVc.TestCredentialSubject.builder()
                                             .name(null)
                                             .address(List.of(ADDRESS_3))
-                                            .passport(null)
                                             .build())
                             .evidence(null)
                             .build(),
@@ -389,7 +416,6 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder()
                         .name(null)
                         .address(MULTIPLE_ADDRESSES_VALID)
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder().credentialSubject(credentialSubject).evidence(null).build(),
@@ -403,7 +429,6 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder()
                         .name(null)
                         .address(MULTIPLE_ADDRESSES_NO_VALID_FROM)
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder().credentialSubject(credentialSubject).evidence(null).build(),
@@ -420,7 +445,6 @@ public interface VcFixtures {
                                     TestVc.TestCredentialSubject.builder()
                                             .address(List.of(ADDRESS_3))
                                             .birthDate(List.of(new BirthDate("1959-08-23")))
-                                            .passport(null)
                                             .build())
                             .build(),
                     TEST_SUBJECT,
@@ -432,7 +456,6 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder()
                         .address(List.of(ADDRESS_3))
                         .birthDate(List.of(new BirthDate("1959-08-23")))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -446,10 +469,7 @@ public interface VcFixtures {
 
     static String vcExperianFraudScoreOne() {
         TestVc.TestCredentialSubject credentialSubject =
-                TestVc.TestCredentialSubject.builder()
-                        .address(List.of(ADDRESS_3))
-                        .passport(null)
-                        .build();
+                TestVc.TestCredentialSubject.builder().address(List.of(ADDRESS_3)).build();
         return generateVerifiableCredential(
                 TestVc.builder()
                         .evidence(FRAUD_EVIDENCE_WITH_CHECK_DETAILS)
@@ -470,7 +490,6 @@ public interface VcFixtures {
                                                 List.of(new NameParts("Chris", VC_GIVEN_NAME)))))
                         .address(List.of(Map.of("type", "PostalAddress", "postalCode", "LE12 9BN")))
                         .birthDate(List.of(new BirthDate("1984-09-28")))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -487,7 +506,6 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder()
                         .name(Collections.emptyList())
                         .address(List.of(ADDRESS_3))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -504,7 +522,6 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder()
                         .address(List.of(ADDRESS_4))
                         .drivingPermit(List.of(DRIVING_PERMIT_DVA))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -516,10 +533,7 @@ public interface VcFixtures {
 
     static String vcDrivingPermitMissingDrivingPermit() {
         TestVc.TestCredentialSubject credentialSubject =
-                TestVc.TestCredentialSubject.builder()
-                        .address(List.of(ADDRESS_4))
-                        .passport(null)
-                        .build();
+                TestVc.TestCredentialSubject.builder().address(List.of(ADDRESS_4)).build();
         return generateVerifiableCredential(
                 TestVc.builder()
                         .evidence(DCMAW_EVIDENCE_VRI_CHECK)
@@ -533,7 +547,6 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder()
                         .address(List.of(ADDRESS_4))
                         .drivingPermit(List.of(INVALID_DRIVING_PERMIT))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -550,7 +563,6 @@ public interface VcFixtures {
                         .name(List.of((ALICE_PARKER_NAME)))
                         .birthDate(List.of(new BirthDate("1970-01-01")))
                         .drivingPermit(List.of(DRIVING_PERMIT_DVLA))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -569,7 +581,6 @@ public interface VcFixtures {
                         .name(List.of((ALICE_PARKER_NAME)))
                         .birthDate(List.of(new BirthDate("1970-01-01")))
                         .socialSecurityRecord(List.of(Map.of("personalNumber", "AA000003D")))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -594,7 +605,6 @@ public interface VcFixtures {
                         .name(List.of((ALICE_PARKER_NAME)))
                         .birthDate(List.of(new BirthDate("1970-01-01")))
                         .socialSecurityRecord(List.of(Map.of("personalNumber", "AA000003D")))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -618,7 +628,6 @@ public interface VcFixtures {
                         .address(null)
                         .name(List.of((ALICE_PARKER_NAME)))
                         .birthDate(List.of(new BirthDate("1970-01-01")))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -657,7 +666,6 @@ public interface VcFixtures {
                         .address(List.of(ADDRESS_4))
                         .name(List.of((ALICE_PARKER_NAME)))
                         .birthDate(List.of(new BirthDate("1970-01-01")))
-                        .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
@@ -704,7 +712,6 @@ public interface VcFixtures {
                                             .name(List.of(MORGAN_SARAH_MEREDYTH_NAME))
                                             .address(List.of(ADDRESS_4))
                                             .drivingPermit(List.of(DRIVING_PERMIT_DVA))
-                                            .passport(null)
                                             .build())
                             .build(),
                     Instant.ofEpochSecond(1705986521));
@@ -761,7 +768,6 @@ public interface VcFixtures {
                                                 VC_NAME_PARTS,
                                                 List.of(new NameParts("Chris", VC_GIVEN_NAME)))))
                         .birthDate(List.of(new BirthDate("1984-09-28")))
-                        .passport(null)
                         .residencePermit(
                                 List.of(
                                         Map.of(
@@ -797,7 +803,6 @@ public interface VcFixtures {
                                                 VC_NAME_PARTS,
                                                 List.of(new NameParts("Chris", VC_GIVEN_NAME)))))
                         .birthDate(List.of(new BirthDate("1984-09-28")))
-                        .passport(null)
                         .idCard(
                                 List.of(
                                         Map.of(

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -861,6 +861,7 @@ public interface VcFixtures {
     static String vcHmrcMigrationPCL250NoEvidence() throws Exception {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder()
+                        .passport(PASSPORT_DETAILS)
                         .socialSecurityRecord(List.of(Map.of("personalNumber", "AB123456C")))
                         .build();
         return generateVerifiableCredential(
@@ -878,6 +879,7 @@ public interface VcFixtures {
     static String vcHmrcMigrationPCL200NoEvidence() throws Exception {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder()
+                        .passport(PASSPORT_DETAILS)
                         .socialSecurityRecord(List.of(Map.of("personalNumber", "AB123456C")))
                         .build();
         return generateVerifiableCredential(

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -284,17 +284,23 @@ public interface VcFixtures {
                     "personalNumber", "MORGA753116SM9IJ",
                     "expiryDate", "2042-10-01");
 
-    String PASSPORT_NON_DCMAW_SUCCESSFUL_VC =
-            generateVerifiableCredential(
-                    TestVc.builder().evidence(SUCCESSFUL_EVIDENCE).build(),
-                    Instant.ofEpochSecond(1705986521));
-
     List<Object> PASSPORT_DETAILS =
             List.of(
                     Map.of(
                             "documentNumber", "321654987",
                             "icaoIssuerCode", "GBR",
                             "expiryDate", "2030-01-01"));
+
+    String PASSPORT_NON_DCMAW_SUCCESSFUL_VC =
+            generateVerifiableCredential(
+                    TestVc.builder()
+                            .credentialSubject(
+                                    TestVc.TestCredentialSubject.builder()
+                                            .passport(PASSPORT_DETAILS)
+                                            .build())
+                            .evidence(SUCCESSFUL_EVIDENCE)
+                            .build(),
+                    Instant.ofEpochSecond(1705986521));
 
     static String vcPassportM1aFailed() {
         TestVc.TestCredentialSubject credentialSubject =

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -20,6 +20,10 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VE
 import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.generateVerifiableCredential;
 
 public interface VcFixtures {
+    String TEST_SUBJECT = "urn:uuid:e6e2e324-5b66-4ad6-8338-83f9f837e345";
+    String TEST_ISSUER_INTEGRATION = "https://review-a.integration.account.gov.uk";
+    String TEST_ISSUER_STAGING = "https://review-f.staging.account.gov.uk";
+
     List<TestVc.TestEvidence> SUCCESSFUL_EVIDENCE =
             List.of(TestVc.TestEvidence.builder().strengthScore(4).validityScore(2).build());
     List<TestVc.TestEvidence> UNSUCCESSFUL_EVIDENCE =
@@ -33,7 +37,7 @@ public interface VcFixtures {
                             .ciReasons(List.of(Map.of("ci", "testValue", "reason", "testReason")))
                             .build());
 
-    List<TestVc.TestEvidence> FRAUD_EVIDENCE =
+    List<TestVc.TestEvidence> FRAUD_EVIDENCE_NO_CHECK_DETAILS =
             List.of(
                     TestVc.TestEvidence.builder()
                             .checkDetails(null)
@@ -49,7 +53,7 @@ public interface VcFixtures {
                             .identityFraudScore(0)
                             .build());
 
-    List<TestVc.TestEvidence> FRAUD_EVIDENCE_SCORE_ONE =
+    List<TestVc.TestEvidence> FRAUD_EVIDENCE_WITH_CHECK_DETAILS =
             List.of(
                     TestVc.TestEvidence.builder()
                             .txn("RB000180729610")
@@ -84,7 +88,7 @@ public interface VcFixtures {
                             .identityFraudScore(1)
                             .build());
 
-    List<TestVc.TestEvidence> DCMAW_EVIDENCE =
+    List<TestVc.TestEvidence> DCMAW_EVIDENCE_VRI_CHECK =
             List.of(
                     TestVc.TestEvidence.builder()
                             .txn("bcd2346")
@@ -104,7 +108,7 @@ public interface VcFixtures {
                                                     3)))
                             .build());
 
-    List<TestVc.TestEvidence> DCMAW_EVIDENCE_2 =
+    List<TestVc.TestEvidence> DCMAW_EVIDENCE_DATA_CHECK =
             List.of(
                     TestVc.TestEvidence.builder()
                             .txn("cbf56c46-f33a-49de-8be0-c6318d8eecfc")
@@ -260,7 +264,7 @@ public interface VcFixtures {
                             new NameParts("Mary", VC_GIVEN_NAME),
                             new NameParts("Watson", VC_FAMILY_NAME)));
 
-    Map<String, Object> DRIVING_PERMIT =
+    Map<String, Object> DRIVING_PERMIT_DVA =
             Map.of(
                     "personalNumber", "MORGA753116SM9IJ",
                     "expiryDate", "2042-10-01",
@@ -268,7 +272,7 @@ public interface VcFixtures {
                     "issueNumber", 123456,
                     "issueDate", "2018-04-19");
 
-    Map<String, Object> DRIVING_PERMIT_2 =
+    Map<String, Object> DRIVING_PERMIT_DVLA =
             Map.of(
                     "personalNumber", "PARKE710112PBFGA",
                     "expiryDate", "2032-02-02",
@@ -376,8 +380,8 @@ public interface VcFixtures {
                                             .build())
                             .evidence(null)
                             .build(),
-                    "urn:uuid:e6e2e324-5b66-4ad6-8338-83f9f837e345",
-                    "https://review-a.integration.account.gov.uk",
+                    TEST_SUBJECT,
+                    TEST_ISSUER_INTEGRATION,
                     Instant.ofEpochSecond(1658829720));
 
     static String vcAddressMultipleAddresses() {
@@ -389,8 +393,8 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder().credentialSubject(credentialSubject).evidence(null).build(),
-                "urn:uuid:e6e2e324-5b66-4ad6-8338-83f9f837e345",
-                "https://review-a.integration.account.gov.uk",
+                TEST_SUBJECT,
+                TEST_ISSUER_INTEGRATION,
                 Instant.ofEpochSecond(1658829720));
     }
 
@@ -403,15 +407,15 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder().credentialSubject(credentialSubject).evidence(null).build(),
-                "urn:uuid:e6e2e324-5b66-4ad6-8338-83f9f837e345",
-                "https://review-a.integration.account.gov.uk",
+                TEST_SUBJECT,
+                TEST_ISSUER_INTEGRATION,
                 Instant.ofEpochSecond(1658829720));
     }
 
     String M1A_EXPERIAN_FRAUD_VC =
             generateVerifiableCredential(
                     TestVc.builder()
-                            .evidence(FRAUD_EVIDENCE)
+                            .evidence(FRAUD_EVIDENCE_NO_CHECK_DETAILS)
                             .credentialSubject(
                                     TestVc.TestCredentialSubject.builder()
                                             .address(List.of(ADDRESS_3))
@@ -419,7 +423,7 @@ public interface VcFixtures {
                                             .passport(null)
                                             .build())
                             .build(),
-                    "urn:uuid:e6e2e324-5b66-4ad6-8338-83f9f837e345",
+                    TEST_SUBJECT,
                     "https://review-f.integration.account.gov.uk",
                     Instant.ofEpochSecond(1658829758));
 
@@ -435,7 +439,7 @@ public interface VcFixtures {
                         .evidence(FRAUD_FAILED_EVIDENCE)
                         .credentialSubject(credentialSubject)
                         .build(),
-                "urn:uuid:e6e2e324-5b66-4ad6-8338-83f9f837e345",
+                TEST_SUBJECT,
                 "https://review-f.integration.account.gov.uk",
                 Instant.ofEpochSecond(1658829758));
     }
@@ -448,11 +452,11 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
-                        .evidence(FRAUD_EVIDENCE_SCORE_ONE)
+                        .evidence(FRAUD_EVIDENCE_WITH_CHECK_DETAILS)
                         .credentialSubject(credentialSubject)
                         .build(),
                 "urn:uuid:7fadacac-0d61-4786-aca3-8ef7934cb092",
-                "https://review-f.staging.account.gov.uk",
+                TEST_ISSUER_STAGING,
                 Instant.ofEpochSecond(1704290386));
     }
 
@@ -474,7 +478,7 @@ public interface VcFixtures {
                         .credentialSubject(credentialSubject)
                         .build(),
                 "user-id",
-                "https://review-f.staging.account.gov.uk",
+                TEST_ISSUER_STAGING,
                 Instant.ofEpochSecond(1652953380));
     }
 
@@ -491,7 +495,7 @@ public interface VcFixtures {
                         .credentialSubject(credentialSubject)
                         .build(),
                 "urn:uuid:7fadacac-0d61-4786-aca3-8ef7934cb092",
-                "https://review-f.staging.account.gov.uk",
+                TEST_ISSUER_STAGING,
                 Instant.ofEpochSecond(1704290386));
     }
 
@@ -499,12 +503,12 @@ public interface VcFixtures {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder()
                         .address(List.of(ADDRESS_4))
-                        .drivingPermit(List.of(DRIVING_PERMIT))
+                        .drivingPermit(List.of(DRIVING_PERMIT_DVA))
                         .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
-                        .evidence(DCMAW_EVIDENCE)
+                        .evidence(DCMAW_EVIDENCE_VRI_CHECK)
                         .credentialSubject(credentialSubject)
                         .build(),
                 Instant.ofEpochSecond(1705986521));
@@ -518,7 +522,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
-                        .evidence(DCMAW_EVIDENCE)
+                        .evidence(DCMAW_EVIDENCE_VRI_CHECK)
                         .credentialSubject(credentialSubject)
                         .build(),
                 Instant.ofEpochSecond(1705986521));
@@ -545,12 +549,12 @@ public interface VcFixtures {
                         .address(null)
                         .name(List.of((ALICE_PARKER_NAME)))
                         .birthDate(List.of(new BirthDate("1970-01-01")))
-                        .drivingPermit(List.of(DRIVING_PERMIT_2))
+                        .drivingPermit(List.of(DRIVING_PERMIT_DVLA))
                         .passport(null)
                         .build();
         return generateVerifiableCredential(
                 TestVc.builder()
-                        .evidence(DCMAW_EVIDENCE_2)
+                        .evidence(DCMAW_EVIDENCE_DATA_CHECK)
                         .credentialSubject(credentialSubject)
                         .build(),
                 "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
@@ -699,7 +703,7 @@ public interface VcFixtures {
                                     TestVc.TestCredentialSubject.builder()
                                             .name(List.of(MORGAN_SARAH_MEREDYTH_NAME))
                                             .address(List.of(ADDRESS_4))
-                                            .drivingPermit(List.of(DRIVING_PERMIT))
+                                            .drivingPermit(List.of(DRIVING_PERMIT_DVA))
                                             .passport(null)
                                             .build())
                             .build(),

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/TestVc.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/TestVc.java
@@ -51,15 +51,7 @@ public class TestVc {
                                         new NameParts("DECERQUEIRA", VC_FAMILY_NAME))));
 
         @Builder.Default private List<BirthDate> birthDate = List.of(new BirthDate("1965-07-08"));
-
-        @Builder.Default
-        private List<Object> passport =
-                List.of(
-                        Map.of(
-                                "documentNumber", "321654987",
-                                "icaoIssuerCode", "GBR",
-                                "expiryDate", "2030-01-01"));
-
+        private List<Object> passport;
         private List<Object> address;
         private List<Object> socialSecurityRecord;
         private List<Object> drivingPermit;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
@@ -17,7 +17,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static com.nimbusds.jwt.JWTClaimNames.JWT_ID;
 import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
@@ -49,7 +48,6 @@ public class VerifiableCredentialGenerator {
                         .claim(SUBJECT, subject)
                         .claim(ISSUER, issuer)
                         .claim(NOT_BEFORE, now.getEpochSecond())
-                        .claim(EXPIRATION_TIME, now.plusSeconds(600).getEpochSecond())
                         .claim(VC_CLAIM, vcClaim)
                         .build();
         return signTestJWT(claimsSet);
@@ -72,16 +70,14 @@ public class VerifiableCredentialGenerator {
     }
 
     public static String generateVerifiableCredential(TestVc vcClaim) {
-        Instant now = Instant.now();
-        JWTClaimsSet claimsSet =
-                new JWTClaimsSet.Builder()
-                        .claim(SUBJECT, "urn:uuid:811cefe0-7db6-48ad-ad89-0b93d2259980")
-                        .claim(ISSUER, "https://review-p.staging.account.gov.uk")
-                        .claim(NOT_BEFORE, now.getEpochSecond())
-                        .claim(VC_CLAIM, vcClaim)
-                        .build();
         try {
-            return signTestJWT(claimsSet);
+            return generateVerifiableCredential(
+                    vcClaim,
+                    "urn:uuid:811cefe0-7db6-48ad-ad89-0b93d2259980",
+                    "https://review-p.staging.account.gov.uk",
+                    null,
+                    null,
+                    null);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Follow-up PR to some comments not addressed as part of https://github.com/govuk-one-login/ipv-core-back/pull/1655

## Proposed changes

### What changed

- Define a few repeated test variables as constants
- Remove the default passport details from the credential subject builder
- Where possible, re-use generateVc constructors
- Renames a few VCs with ambiguous names 

### Why did it change

- Less repeated code 
- Clearer definition of VCs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4896](https://govukverify.atlassian.net/browse/PYIC-4896)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-4896]: https://govukverify.atlassian.net/browse/PYIC-4896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ