### PR TITLE
BAU: Add Smithy to AWS dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,7 @@ updates:
       aws:
         patterns:
           - "@aws-*"
+          - "@smithy/*"
       babel:
         patterns:
           - "@babel/*"


### PR DESCRIPTION
Smithy was developed by, and is primarily used by AWS, so we can bump its versions together with the AWS SDKs.