### PR TITLE
PYIC-5331: Clean up config service cimit parsing

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -283,20 +283,7 @@ public class ConfigService {
             return objectMapper.readValue(
                     cimitConfig, new TypeReference<HashMap<String, List<MitigationRoute>>>() {});
         } catch (JsonProcessingException e) {
-            try {
-                // fall back to try out with old cimit config
-                Map<String, String> oldCimitConfig =
-                        objectMapper.readValue(
-                                cimitConfig, new TypeReference<HashMap<String, String>>() {});
-                Map<String, List<MitigationRoute>> cimitMitigationRoutes = new HashMap<>();
-                oldCimitConfig.forEach(
-                        (key, value) ->
-                                cimitMitigationRoutes.put(
-                                        key, List.of(new MitigationRoute(value, null))));
-                return cimitMitigationRoutes;
-            } catch (JsonProcessingException ex) {
-                throw new ConfigException("Failed to parse CIMit configuration");
-            }
+            throw new ConfigException("Failed to parse CIMit configuration");
         }
     }
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -752,9 +752,7 @@ class ConfigServiceTest {
                 Arguments.of("{\"X01\": [{\"event\": \"/journey/do-a-thing\"}]}", null),
                 Arguments.of(
                         "{\"X01\": [{\"event\": \"/journey/do-a-thing\", \"document\": \"drivingPermit\"}]}",
-                        "drivingPermit"),
-                Arguments.of("{\"X01\":\"/journey/do-a-thing\"}", null) // old cimit-config
-                );
+                        "drivingPermit"));
     }
 
     @Test


### PR DESCRIPTION
**Not to be merged before https://github.com/govuk-one-login/ipv-core-common-infra/pull/875**

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Clean up config service cimit parsing

### Why did it change

The cimit config is now in the new format in all envs. This means we can clean up the code for handling the old format.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5331](https://govukverify.atlassian.net/browse/PYIC-5331)


[PYIC-5331]: https://govukverify.atlassian.net/browse/PYIC-5331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ