### PR TITLE
PYIC-4942: CIMIT D02 - Always re-mitigate in separate session

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -379,7 +379,8 @@ public class CheckExistingIdentityHandler
                     .getMitigatedCiJourneyStep(mitigatedCI.get())
                     .orElse(JOURNEY_RESET_GPG45_IDENTITY);
         }
-        if (!VcHelper.filterVCBasedOnProfileType(verifiableCredentials, ProfileType.GPG45).isEmpty()) {
+        if (!VcHelper.filterVCBasedOnProfileType(verifiableCredentials, ProfileType.GPG45)
+                .isEmpty()) {
             LOGGER.info(
                     LogHelper.buildLogMessage("Failed to match profile so resetting identity."));
             sendAuditEvent(AuditEventTypes.IPV_IDENTITY_REUSE_RESET, auditEventUser);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -376,10 +376,11 @@ public class CheckExistingIdentityHandler
             LOGGER.info(
                     LogHelper.buildLogMessage("Failed to match profile so resetting identity."));
             sendAuditEvent(AuditEventTypes.IPV_IDENTITY_REUSE_RESET, auditEventUser);
-            if (ciMitUtilityService.hasMitigatedContraIndicator(contraIndicators).isPresent()) {
+            var mitigatedCI = ciMitUtilityService.hasMitigatedContraIndicator(contraIndicators);
+            if (mitigatedCI.isPresent()) {
                 return ciMitUtilityService
-                        .getCiMitigationJourneyStep(contraIndicators)
-                        .orElse(JOURNEY_FAIL_WITH_CI);
+                        .getMitigatedCiJourneyStep(mitigatedCI.get())
+                        .orElse(JOURNEY_RESET_GPG45_IDENTITY);
             }
             return JOURNEY_RESET_GPG45_IDENTITY;
         }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -402,13 +402,14 @@ public class CheckExistingIdentityHandler
 
         var mitigatedCI = ciMitUtilityService.hasMitigatedContraIndicator(contraIndicators);
         if (mitigatedCI.isPresent()) {
-            var mitigationRoute = ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI.get());
-            if (mitigationRoute.isEmpty()) {
-                throw new UnsupportedMitigationRouteException(
-                        String.format(
-                                "Empty mitigation route for mitigated CI: %s", mitigatedCI.get()));
-            }
-            return mitigationRoute.get();
+            return ciMitUtilityService
+                    .getMitigatedCiJourneyStep(mitigatedCI.get())
+                    .orElseThrow(
+                            () ->
+                                    new UnsupportedMitigationRouteException(
+                                            String.format(
+                                                    "Empty mitigation route for mitigated CI: %s",
+                                                    mitigatedCI.get())));
         }
         if (!VcHelper.filterVCBasedOnProfileType(verifiableCredentials, ProfileType.GPG45)
                 .isEmpty()) {

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -212,7 +212,7 @@ public class CheckExistingIdentityHandler
             final boolean isF2FComplete = !Objects.isNull(f2fRequest) && hasF2fVc;
 
             var contraIndicators =
-                    ciMitService.getContraIndicatorsVC(
+                    ciMitService.getContraIndicators(
                             clientOAuthSessionItem.getUserId(), govukSigninJourneyId, ipAddress);
 
             var ciScoringCheckResponse = checkForCIScoringFailure(contraIndicators);
@@ -379,7 +379,7 @@ public class CheckExistingIdentityHandler
                     .getMitigatedCiJourneyStep(mitigatedCI.get())
                     .orElse(JOURNEY_RESET_GPG45_IDENTITY);
         }
-        if (!VcHelper.filterVCBasedOnProfileType(vcStoreItems, ProfileType.GPG45).isEmpty()) {
+        if (!VcHelper.filterVCBasedOnProfileType(verifiableCredentials, ProfileType.GPG45).isEmpty()) {
             LOGGER.info(
                     LogHelper.buildLogMessage("Failed to match profile so resetting identity."));
             sendAuditEvent(AuditEventTypes.IPV_IDENTITY_REUSE_RESET, auditEventUser);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -381,7 +381,7 @@ public class CheckExistingIdentityHandler
             var mitigationRoute = ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI.get());
             if (mitigationRoute.isPresent()) {
                 JourneyResponse journeyResponse = mitigationRoute.get();
-                if (!journeyResponse.getJourney().equals(JOURNEY_ENHANCED_VERIFICATION_PATH)) {
+                if (!JOURNEY_ENHANCED_VERIFICATION_PATH.equals(journeyResponse.getJourney())) {
                     throw new UnsupportedMitigationRouteException(
                             String.format(
                                     "Unsupported mitigation route: %s",

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -397,7 +397,8 @@ public class CheckExistingIdentityHandler
             List<VerifiableCredential> verifiableCredentials,
             AuditEventUser auditEventUser,
             ContraIndicators contraIndicators)
-            throws SqsException, MitigationRouteConfigNotFoundException, ConfigException, UnsupportedMitigationRouteException {
+            throws SqsException, MitigationRouteConfigNotFoundException, ConfigException,
+                    UnsupportedMitigationRouteException {
 
         var mitigatedCI = ciMitUtilityService.hasMitigatedContraIndicator(contraIndicators);
         if (mitigatedCI.isPresent()) {

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/exceptions/UnsupportedMitigationRouteException.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/exceptions/UnsupportedMitigationRouteException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.checkexistingidentity.exceptions;
+
+public class UnsupportedMitigationRouteException extends Exception {
+    public UnsupportedMitigationRouteException(String message) {
+        super(message);
+    }
+}

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1160,6 +1160,27 @@ class CheckExistingIdentityHandlerTest {
         assertEquals(testJourneyResponse, journeyResponse.getJourney());
     }
 
+    @Test
+    void shouldReturnJourneyFailedWhenHasBreachedCIAndIsBreachingCi() throws Exception {
+        var testContraIndicators = ContraIndicators.builder().build();
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(ciMitService.getContraIndicatorsVC(
+                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
+                .thenReturn(testContraIndicators);
+        when(ciMitUtilityService.isBreachingCiThreshold(testContraIndicators)).thenReturn(true);
+
+        //
+        // when(ciMitUtilityService.hasMitigatedContraIndicator(testContraIndicators)).thenReturn(Optional.of(any()));
+        JourneyResponse journeyResponse =
+                toResponseClass(
+                        checkExistingIdentityHandler.handleRequest(event, context),
+                        JourneyResponse.class);
+
+        assertEquals(JOURNEY_FAIL_WITH_CI_PATH, journeyResponse.getJourney());
+    }
+
     private static Stream<Map<String, Object>> votAndVtrCombinationsThatShouldStartIpvJourney() {
         return Stream.of(
                 Map.of("vtr", List.of(Vot.P2), "operationalCredVot", Optional.empty()),

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1173,7 +1173,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(ciMitService.getContraIndicatorsVC(
+        when(ciMitService.getContraIndicators(
                         TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(testContraIndicators);
         when(ciMitUtilityService.isBreachingCiThreshold(testContraIndicators)).thenReturn(false);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -31,9 +31,9 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.domain.cimitvc.ContraIndicator;
 import uk.gov.di.ipv.core.library.domain.cimitvc.Mitigation;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.ContraIndicatorMitigationDetailsDto;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
@@ -1173,8 +1173,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(ciMitService.getContraIndicators(
-                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
+        when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(testContraIndicators);
         when(ciMitUtilityService.isBreachingCiThreshold(testContraIndicators)).thenReturn(false);
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -23,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.checkexistingidentity.exceptions.UnsupportedMitigationRouteException;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
@@ -66,6 +67,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -88,6 +90,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcF2fM1a;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL250NoEvidence;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcVerificationM1a;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ENHANCED_VERIFICATION_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_F2F_FAIL_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_AND_FORCED_RESET_PATH;
@@ -99,6 +102,7 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PENDING
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_GPG45_IDENTITY_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_IDENTITY_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ENHANCED_VERIFICATION_F2F_FAIL_PATH;
 
 @ExtendWith(MockitoExtension.class)
 class CheckExistingIdentityHandlerTest {
@@ -452,6 +456,7 @@ class CheckExistingIdentityHandlerTest {
             inOrder.verify(ipvSessionItem, never()).setVot(any());
             assertEquals(Vot.P2, ipvSessionItem.getVot());
         }
+
     }
 
     @Test
@@ -1188,6 +1193,71 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(journey, journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnSameJourneyMitigationWhenCiAlreadyMitigatedF2F() throws Exception {
+        var code = "ci_code";
+        var mitigatedCI =
+                ContraIndicator.builder().mitigation(List.of(Mitigation.builder().build())).build();
+        var testContraIndicators =
+                ContraIndicators.builder().contraIndicatorsMap(Map.of(code, mitigatedCI)).build();
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
+        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
+        when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
+                .thenReturn(testContraIndicators);
+        when(ciMitUtilityService.isBreachingCiThreshold(testContraIndicators)).thenReturn(false);
+
+        when(ciMitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
+                .thenReturn(Optional.of(mitigatedCI));
+        when(ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI))
+                .thenReturn(Optional.of(new JourneyResponse(JOURNEY_ENHANCED_VERIFICATION_PATH)));
+
+        JourneyResponse journeyResponse =
+                toResponseClass(
+                        checkExistingIdentityHandler.handleRequest(event, context),
+                        JourneyResponse.class);
+
+        assertEquals(JOURNEY_ENHANCED_VERIFICATION_F2F_FAIL_PATH, journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldThrowUnsupportedMitigationRouteExceptionWhenCiMitigationJourneyStepPresentButNotSupported()
+            throws Exception {
+        var code = "ci_code";
+        var journey = "unsupported_mitigation";
+        var mitigatedCI =
+                ContraIndicator.builder().mitigation(List.of(Mitigation.builder().build())).build();
+        var testContraIndicators =
+                ContraIndicators.builder().contraIndicatorsMap(Map.of(code, mitigatedCI)).build();
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
+        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
+        when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
+                .thenReturn(testContraIndicators);
+        when(ciMitUtilityService.isBreachingCiThreshold(testContraIndicators)).thenReturn(false);
+
+        when(ciMitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
+                .thenReturn(Optional.of(mitigatedCI));
+        when(ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI))
+                .thenReturn(Optional.of(new JourneyResponse(journey)));
+
+        JourneyErrorResponse response =
+                toResponseClass(
+                        checkExistingIdentityHandler.handleRequest(event, context),
+                        JourneyErrorResponse.class);
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(ErrorResponse.UNSUPPORTED_MITIGATION_ROUTE.getCode(), response.getCode());
+        assertEquals(ErrorResponse.UNSUPPORTED_MITIGATION_ROUTE.getMessage(), response.getMessage());
+
     }
 
     private static Stream<Map<String, Object>> votAndVtrCombinationsThatShouldStartIpvJourney() {

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -23,7 +23,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.checkexistingidentity.exceptions.UnsupportedMitigationRouteException;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
@@ -67,7 +66,6 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -90,6 +88,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcF2fM1a;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL250NoEvidence;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcVerificationM1a;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ENHANCED_VERIFICATION_F2F_FAIL_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ENHANCED_VERIFICATION_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_F2F_FAIL_PATH;
@@ -102,7 +101,6 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_PENDING
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_GPG45_IDENTITY_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_RESET_IDENTITY_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_PATH;
-import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ENHANCED_VERIFICATION_F2F_FAIL_PATH;
 
 @ExtendWith(MockitoExtension.class)
 class CheckExistingIdentityHandlerTest {
@@ -456,7 +454,6 @@ class CheckExistingIdentityHandlerTest {
             inOrder.verify(ipvSessionItem, never()).setVot(any());
             assertEquals(Vot.P2, ipvSessionItem.getVot());
         }
-
     }
 
     @Test
@@ -1226,8 +1223,9 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldThrowUnsupportedMitigationRouteExceptionWhenCiMitigationJourneyStepPresentButNotSupported()
-            throws Exception {
+    void
+            shouldThrowUnsupportedMitigationRouteExceptionWhenCiMitigationJourneyStepPresentButNotSupported()
+                    throws Exception {
         var code = "ci_code";
         var journey = "unsupported_mitigation";
         var mitigatedCI =
@@ -1256,8 +1254,8 @@ class CheckExistingIdentityHandlerTest {
 
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertEquals(ErrorResponse.UNSUPPORTED_MITIGATION_ROUTE.getCode(), response.getCode());
-        assertEquals(ErrorResponse.UNSUPPORTED_MITIGATION_ROUTE.getMessage(), response.getMessage());
-
+        assertEquals(
+                ErrorResponse.UNSUPPORTED_MITIGATION_ROUTE.getMessage(), response.getMessage());
     }
 
     private static Stream<Map<String, Object>> votAndVtrCombinationsThatShouldStartIpvJourney() {

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -48,6 +48,10 @@ CHECK_EXISTING_IDENTITY:
     alternate-doc-invalid-dl:
       targetJourney: NEW_P2_IDENTITY
       targetState: ALTERNATE_DOC_PASSPORT
+    enhanced-verification-f2f-fail:
+      targetJourney: NEW_P2_IDENTITY
+      targetState: ENHANCED_VERIFICATION_F2F_FAIL
+
 RESET_IDENTITY:
   response:
     type: process

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -15,6 +15,11 @@ ALTERNATE_DOC_PASSPORT:
     next:
       targetState: MITIGATION_04
 
+ENHANCED_VERIFICATION_F2F_FAIL:
+  events:
+    next:
+      targetState: F2F_FAILED_MITIGATION_PAGE
+
 # Parent states
 
 CRI_STATE:
@@ -942,3 +947,13 @@ MITIGATION_CRI_HMRC_KBV:
     enhanced-verification:
       targetJourney: FAILED
       targetState: FAILED
+
+F2F_FAILED_MITIGATION_PAGE:
+  response:
+    type: page
+    pageId: pyi-f2f-technical
+  events:
+    next:
+      targetState: MITIGATION_01
+    end:
+      targetState: RETURN_TO_RP

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -79,7 +79,8 @@ public enum ErrorResponse {
     ERROR_PROCESSING_TICF_CRI_RESPONSE(1067, "Error processing response from the TICF CRI"),
     MISSING_IS_RESET_DELETE_GPG45_ONLY_PARAMETER(1068, "Missing deleteOnlyGPG45VCs in request"),
     MITIGATION_ROUTE_CONFIG_NOT_FOUND(
-            1069, "No mitigation journey route event found in cimit config");
+            1069, "No mitigation journey route event found in cimit config"),
+    UNSUPPORTED_MITIGATION_ROUTE(1070, "Unsupported mitigation route");
 
     @JsonProperty("code")
     private final int code;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
@@ -71,6 +71,18 @@ public class CiMitUtilityService {
                                         "No mitigation journey route event found."));
     }
 
+    public Optional<JourneyResponse> getMitigatedCiJourneyStep(ContraIndicator ci)
+            throws ConfigException, MitigationRouteConfigNotFoundException {
+        var cimitConfig = configService.getCimitConfig();
+        if (isCiMitigatable(ci)) {
+            return Optional.of(
+                    new JourneyResponse(
+                            getMitigationRoute(cimitConfig.get(ci.getCode()), ci.getDocument())
+                                    .event()));
+        }
+        return Optional.empty();
+    }
+
     private boolean isCiMitigatable(ContraIndicator ci) throws ConfigException {
         var cimitConfig = configService.getCimitConfig();
         return cimitConfig.containsKey(ci.getCode()) && !ci.isMitigated();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
@@ -43,6 +43,9 @@ public class CiMitUtilityService {
         var cimitConfig = configService.getCimitConfig();
         for (var ci : contraIndicators.getContraIndicatorsMap().values()) {
             if (isCiMitigatable(ci) && !isBreachingCiThresholdIfMitigated(ci, contraIndicators)) {
+                if (hasMitigatedContraIndicator(contraIndicators).isPresent()) {
+                    return Optional.empty();
+                }
                 String journeyEvent =
                         getMitigationRoute(cimitConfig.get(ci.getCode()), ci.getDocument()).event();
                 if (journeyEvent.startsWith(JOURNEY_ALTERNATE_DOC_PATH)
@@ -71,5 +74,15 @@ public class CiMitUtilityService {
     private boolean isCiMitigatable(ContraIndicator ci) throws ConfigException {
         var cimitConfig = configService.getCimitConfig();
         return cimitConfig.containsKey(ci.getCode()) && !ci.isMitigated();
+    }
+
+    public Optional<ContraIndicator> hasMitigatedContraIndicator(
+            ContraIndicators contraIndicators) {
+        for (var ci : contraIndicators.getContraIndicatorsMap().values()) {
+            if (ci.isMitigated()) {
+                return Optional.of(ci);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
@@ -75,7 +75,7 @@ public class CiMitUtilityService {
     public Optional<JourneyResponse> getMitigatedCiJourneyStep(ContraIndicator ci)
             throws ConfigException, MitigationRouteConfigNotFoundException {
         var cimitConfig = configService.getCimitConfig();
-        if (isCiMitigatable(ci)) {
+        if (cimitConfig.containsKey(ci.getCode()) && ci.isMitigated()) {
             return Optional.of(
                     new JourneyResponse(
                             getMitigationRoute(cimitConfig.get(ci.getCode()), ci.getDocument())

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
@@ -43,6 +43,7 @@ public class CiMitUtilityService {
         var cimitConfig = configService.getCimitConfig();
         for (var ci : contraIndicators.getContraIndicatorsMap().values()) {
             if (isCiMitigatable(ci) && !isBreachingCiThresholdIfMitigated(ci, contraIndicators)) {
+                // Prevent new mitigation journey if there is already a mitigated CI
                 if (hasMitigatedContraIndicator(contraIndicators).isPresent()) {
                     return Optional.empty();
                 }
@@ -90,11 +91,8 @@ public class CiMitUtilityService {
 
     public Optional<ContraIndicator> hasMitigatedContraIndicator(
             ContraIndicators contraIndicators) {
-        for (var ci : contraIndicators.getContraIndicatorsMap().values()) {
-            if (ci.isMitigated()) {
-                return Optional.of(ci);
-            }
-        }
-        return Optional.empty();
+        return contraIndicators.getContraIndicatorsMap().values().stream()
+                .filter(ContraIndicator::isMitigated)
+                .findFirst();
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
@@ -425,6 +425,7 @@ class CiMitUtilityServiceTest {
                         .code(code)
                         .document(document)
                         .issuanceDate("some_date")
+                        .mitigation(List.of(Mitigation.builder().build()))
                         .build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
@@ -412,4 +412,41 @@ class CiMitUtilityServiceTest {
         // assert
         assertEquals(Optional.empty(), result);
     }
+
+    @Test
+    void getMitigatedCiJourneyStepShouldReturnMitigationWhenCiCanBeMitigated() throws Exception {
+        // arrange
+        var code = "ci_code";
+        var journey = "some_mitigation";
+        String document = "doc_type/213123";
+        String documentType = "doc_type";
+        var ci =
+                ContraIndicator.builder()
+                        .code(code)
+                        .document(document)
+                        .issuanceDate("some_date")
+                        .build();
+        when(mockConfigService.getCimitConfig())
+                .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
+
+        // act
+        var result = ciMitUtilityService.getMitigatedCiJourneyStep(ci);
+
+        // assert
+        assertEquals(Optional.of(new JourneyResponse(journey)), result);
+    }
+
+    @Test
+    void getMitigatedCiJourneyStepShouldReturnEmptyWhenCiIsNotMitigatable() throws Exception {
+        // arrange
+        var code = "ci_code";
+        var ci = ContraIndicator.builder().code(code).issuanceDate("some_date").build();
+        when(mockConfigService.getCimitConfig()).thenReturn(Collections.emptyMap());
+
+        // act
+        var result = ciMitUtilityService.getMitigatedCiJourneyStep(ci);
+
+        // assert
+        assertEquals(Optional.empty(), result);
+    }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
@@ -368,4 +368,48 @@ class CiMitUtilityServiceTest {
         // assert
         assertEquals(Optional.of(new JourneyResponse(journey)), result);
     }
+
+    @Test
+    void
+            getCiMitigationJourneyStepShouldReturnEmptyWhenCiCanBeMitigatedButHasAlreadyMitigatedContraIndicator()
+                    throws Exception {
+        // arrange
+        var code = "ci_code";
+        var journey = "some_mitigation";
+        String document = "doc_type/213123";
+        String documentType = "doc_type";
+        var ci =
+                ContraIndicator.builder()
+                        .code(code)
+                        .document(document)
+                        .issuanceDate("some_date")
+                        .build();
+        var mitCi =
+                ContraIndicator.builder()
+                        .code("mit_ci_code")
+                        .document(document)
+                        .issuanceDate("some_date")
+                        .mitigation(List.of(Mitigation.builder().build()))
+                        .build();
+        var cis =
+                ContraIndicators.builder()
+                        .contraIndicatorsMap(Map.of(code, ci, "mit_ci_code", mitCi))
+                        .build();
+        when(mockConfigService.getCimitConfig())
+                .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
+        Map<String, ContraIndicatorConfig> ciConfigMap =
+                Map.of(
+                        code,
+                        new ContraIndicatorConfig(code, 7, -5, "X"),
+                        "mit_ci_code",
+                        new ContraIndicatorConfig("mit_ci_code", 7, -5, "X"));
+        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
+        when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
+
+        // act
+        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
+
+        // assert
+        assertEquals(Optional.empty(), result);
+    }
 }

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -9,6 +9,10 @@ public class JourneyUris {
     public static final String JOURNEY_ACCESS_DENIED_PATH = "/journey/access-denied";
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
     public static final String JOURNEY_F2F_FAIL_PATH = "/journey/f2f-fail";
+    public static final String JOURNEY_ENHANCED_VERIFICATION_F2F_FAIL_PATH =
+            "/journey/enhanced-verification-f2f-fail";
+    public static final String JOURNEY_ENHANCED_VERIFICATION_PATH =
+            "/journey/enhanced-verification";
     public static final String JOURNEY_FAIL_WITH_CI_PATH = "/journey/fail-with-ci";
     public static final String JOURNEY_FAIL_WITH_CI_AND_FORCED_RESET_PATH =
             "/journey/fail-with-ci-and-forced-reset";


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

[PYIC-4942](https://govukverify.atlassian.net/browse/PYIC-4942) CIMIT D02 - Always re-mitigate in separate session.

Adds new rules for CI Mitigations.

- At the start of a journey users still have to follow same mitigation journey for any CIs mitigated in a previous incomplete journey
- You can't follow two mitigation routes at the same time
- Users cannot proceed on a new journey if they have a mitigated CI and new unmitigated CIs

<!-- Describe the changes in detail - the "what"-->

### Why did it change

When returning, the user will be forced to take a mitigation route after returning to IPV Core, even if that CI is mitigated: 

- Mitigated D02/V03 + Complete identity => Reuse

- Mitigated D02 + Incomplete identity => Mitigation route

- Mitigated V03 + Incomplete identity => Mitigation route

- Mitigated D02 + V03 => No Match

- Mitigated D02 + D02 => No Match

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4942](https://govukverify.atlassian.net/browse/PYIC-4942)


[PYIC-4942]: https://govukverify.atlassian.net/browse/PYIC-4942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-4942]: https://govukverify.atlassian.net/browse/PYIC-4942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ