### PR TITLE
BAU: Send IPV_SUBJOURNEY_START event for timeout

### DIFF
--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -186,6 +186,17 @@ class ProcessJourneyEventHandlerTest {
                 capturedIpvSessionItem.getErrorDescription());
 
         assertEquals(PYI_UNRECOVERABLE_TIMEOUT_ERROR_PAGE, output.get("page"));
+
+        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        var capturedAuditEvent = auditEventCaptor.getValue();
+
+        assertEquals(AuditEventTypes.IPV_SUBJOURNEY_START, capturedAuditEvent.getEventName());
+        assertEquals(
+                SESSION_TIMEOUT,
+                ((AuditExtensionSubjourneyType) capturedAuditEvent.getExtensions()).journeyType());
+        assertEquals("core", capturedAuditEvent.getComponentId());
+        assertEquals("testuserid", capturedAuditEvent.getUser().getUserId());
+        assertEquals("testjourneyid", capturedAuditEvent.getUser().getGovukSigninJourneyId());
     }
 
     @Test


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Send IPV_SUBJOURNEY_START event for timeout

### Why did it change

The mechanism for transitioning a user to a timeout state is separate from the usual state changes. This means it the IPV_SUBJOURNEY_START audit event needs to be sent separately.
