### PR TITLE
PYIC-5343: Don't override status code from process journey event

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -74,8 +74,6 @@ paths:
                 #set ($bodyObj = $util.parseJson($input.body))
 
                 #if ($bodyObj.status == "SUCCEEDED")
-                  #set($lambdaOutput = $util.parseJson($bodyObj.output))
-                  #set($context.responseOverride.status = $lambdaOutput.statusCode)
                   $bodyObj.output
 
                 #elseif ($bodyObj.status == "FAILED")
@@ -84,6 +82,7 @@ paths:
                     "cause": "$bodyObj.cause",
                     "error": "$bodyObj.error"
                   }
+
                 #else
                   #set($context.responseOverride.status = 500)
                   $bodyObj


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Don't override status code from process journey event

### Why did it change

The ErrorStepResponse class has a statusCode field. This class represents the json that is returned from the process-journey-event lambda when a users transitions to a state of type "error".

The vtl code in the openAPI spec was using the status code in the json to override the status code of the response to the frontend.

The `ERROR_PAGE` state sets the status code to 500 (this is actually the only state that uses the ErrorStepResponse class). When core-front received the response from core-back, with the status code overriden to 500, axios was intercepting it and throwing an error. This caused the wrong page to be displayed - the default error page rather than a recoverable one.

This change prevents the overriding from happening, so axios will stay out of the way. Instead the request will have a 200 status code. This is actually correct, as the backend has fulfilled its role quite happily.

With just this change the user will see an error page, but will get a
200. A follow up PR will get the frontend to honour the status code returned to it.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5343](https://govukverify.atlassian.net/browse/PYIC-5343)


[PYIC-5343]: https://govukverify.atlassian.net/browse/PYIC-5343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ