### PR TITLE
BAU: Prevent duplicate keys in journey maps

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
@@ -18,8 +18,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
+import static com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION;
+
 public class StateMachineInitializer {
-    private static final ObjectMapper yamlOm = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper yamlOm =
+            new ObjectMapper(new YAMLFactory()).configure(STRICT_DUPLICATE_DETECTION, true);
     private static final ObjectMapper om = new ObjectMapper();
     private Map<String, State> journeyStates;
     private Map<String, NestedJourneyDefinition> nestedJourneyDefinitions;

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/journey-map-with-duplicate-keys.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/journey-map-with-duplicate-keys.yaml
@@ -1,0 +1,9 @@
+DUPLICATE_PAGE:
+  response:
+    type: page
+    pageId: duplicate-page
+
+DUPLICATE_PAGE:
+  response:
+    type: page
+    pageId: this-seems-familiar

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.processjourneyevent.statemachine;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +24,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,6 +54,20 @@ class StateMachineInitializerTest {
                     new StateMachineInitializer(IpvJourneyTypes.INITIAL_JOURNEY_SELECTION, modeMock)
                             .initialize();
                 });
+    }
+
+    @Test
+    void initializeShouldThrowIfJourneyMapHasDuplicateKeys() {
+        var journeyTypeMock = mock(IpvJourneyTypes.class);
+        when(journeyTypeMock.getPath()).thenReturn("journey-map-with-duplicate-keys");
+
+        var stateMachineInitializer =
+                new StateMachineInitializer(journeyTypeMock, StateMachineInitializerMode.TEST);
+
+        var jsonParseException =
+                assertThrows(JsonParseException.class, stateMachineInitializer::initialize);
+
+        assertTrue(jsonParseException.getMessage().contains("Duplicate field 'DUPLICATE_PAGE'"));
     }
 
     @java.lang.SuppressWarnings("java:S5961") // Too many assertions


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Prevent duplicate keys in journey maps

### Why did it change

We recently had an issue where a duplicate state was added to one of them journey maps. This configures the object mapper used to parse the yaml files to not allow duplicates.
