### PR TITLE
PYIC-5290: Remove re-use page from operational profile journey map

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -6,11 +6,11 @@ START:
       targetState: RETURN_TO_RP
       checkFeatureFlag:
         ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_REUSE
+          targetState: CRI_TICF_BEFORE_RETURN_TO_RP
 
 # Journey states
 
-CRI_TICF_BEFORE_REUSE:
+CRI_TICF_BEFORE_RETURN_TO_RP:
   response:
     type: process
     lambda: call-ticf-cri

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -16,7 +16,7 @@ CRI_TICF_BEFORE_REUSE:
     lambda: call-ticf-cri
   events:
     next:
-      targetState: REUSE_PAGE
+      targetState: RETURN_TO_RP
     enhanced-verification:
       targetJourney: FAILED
       targetState: FAILED_NO_TICF
@@ -29,15 +29,6 @@ CRI_TICF_BEFORE_REUSE:
     error:
       targetJourney: TECHNICAL_ERROR
       targetState: ERROR_NO_TICF
-
-REUSE_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-reuse
-    context: operational-profile
-  events:
-    next:
-      targetState: RETURN_TO_RP
 
 RETURN_TO_RP:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -3,7 +3,7 @@
 START:
   events:
     next:
-      targetState: REUSE_PAGE
+      targetState: RETURN_TO_RP
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_REUSE


### PR DESCRIPTION
# Not to be merged until QA completed

## Proposed changes

### What changed

Removes re-use page operational profile journey map

### Why did it change

Page no longer required as part of journey

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5290](https://govukverify.atlassian.net/browse/PYIC-5290)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-5290]: https://govukverify.atlassian.net/browse/PYIC-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ