### PR TITLE
PYIC-5362: Added FRAUD_CHECK_EXPIRY_PERIOD_HOURS config variable

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -10,6 +10,7 @@ public enum ConfigurationVariable {
     JAR_KMS_ENCRYPTION_KEY_ID("self/jarKmsEncryptionKeyId"),
     JWT_TTL_SECONDS("self/jwtTtlSeconds"),
     MAX_ALLOWED_AUTH_CLIENT_TTL("self/maxAllowedAuthClientTtl"),
+    FRAUD_CHECK_EXPIRY_PERIOD_HOURS("self/fraudCheckExpiryPeriodHours"),
     AUTH_CODE_EXPIRY_SECONDS("self/authCodeExpirySeconds"),
     PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("clients/%s/publicKeyMaterialForCoreToVerify"),
     CLIENT_VALID_REDIRECT_URLS("clients/%s/validRedirectUrls"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added FRAUD_CHECK_EXPIRY_PERIOD_HOURS config variable

### Why did it change

So that we can access the new SSM parameter in core-back when we implement the logic to push users down the re-fraud check route

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5362](https://govukverify.atlassian.net/browse/PYIC-5362)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-5362]: https://govukverify.atlassian.net/browse/PYIC-5362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ