### PR TITLE
PYIC-5137: Return a custom OAuth error code for issues with inhertied identity JWT

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -289,21 +289,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 104
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 104
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 104
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1886,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-14T12:09:16Z"
+  "generated_at": "2024-03-18T11:21:05Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -289,21 +289,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 106
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 106
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 106
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1886,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-18T11:21:05Z"
+  "generated_at": "2024-03-18T11:58:25Z"
 }

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
@@ -80,6 +81,8 @@ public class InitialiseIpvSessionHandler
     private static final String REQUEST_EMAIL_ADDRESS_KEY = "email_address";
     private static final String REQUEST_VTR_KEY = "vtr";
     private static final List<Vot> HMRC_PROFILES_BY_STRENGTH = List.of(Vot.PCL250, Vot.PCL200);
+    private static final ErrorObject INVALID_INHERITED_IDENTITY_ERROR_OBJECT =
+            new ErrorObject("invalid_inherited_identity");
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionService;
@@ -319,7 +322,7 @@ public class InitialiseIpvSessionHandler
                 | UnrecognisedVotException
                 | AuditExtensionException e) {
             throw new RecoverableJarValidationException(
-                    OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
+                    INVALID_INHERITED_IDENTITY_ERROR_OBJECT.setDescription(
                             "Inherited identity JWT failed to validate"),
                     claimsSet,
                     e);
@@ -337,11 +340,12 @@ public class InitialiseIpvSessionHandler
                         .orElseThrow(
                                 () ->
                                         new JarValidationException(
-                                                OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
-                                                        "Inherited identity jwt claim received but value is null")));
+                                                INVALID_INHERITED_IDENTITY_ERROR_OBJECT
+                                                        .setDescription(
+                                                                "Inherited identity jwt claim received but value is null")));
         if (inheritedIdentityJwtList.size() != 1) {
             throw new JarValidationException(
-                    OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
+                    INVALID_INHERITED_IDENTITY_ERROR_OBJECT.setDescription(
                             String.format(
                                     "%d inherited identity jwts received - one expected",
                                     inheritedIdentityJwtList.size())));

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -21,6 +21,8 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -103,6 +105,7 @@ class InitialiseIpvSessionHandlerTest {
     public static final String TEST_SIGNING_KEY =
             "{\"kty\":\"EC\",\"d\":\"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}";
     public static final String TEST_USER_ID = "test-user-id";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final CriConfig TEST_CRI_CONFIG =
             CriConfig.builder().componentId(TEST_COMPONENT_ID).signingKey(TEST_SIGNING_KEY).build();
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
@@ -117,6 +120,39 @@ class InitialiseIpvSessionHandlerTest {
     private static final String USER_INFO = "userInfo";
     private static final String VALUES = "values";
     private static final String INVALID_INHERITED_IDENTITY = "invalid_inherited_identity";
+    private static final APIGatewayProxyRequestEvent validEvent = new APIGatewayProxyRequestEvent();
+    private static final JWTClaimsSet.Builder claimsBuilder =
+            new JWTClaimsSet.Builder()
+                    .expirationTime(new Date(Instant.now().plusSeconds(1000).getEpochSecond()))
+                    .issueTime(new Date())
+                    .notBeforeTime(new Date())
+                    .subject(TEST_USER_ID)
+                    .audience("test-audience")
+                    .issuer("test-issuer")
+                    .claim(RESPONSE_TYPE, "code")
+                    .claim(REDIRECT_URI, "https://example.com")
+                    .claim(STATE, "test-state")
+                    .claim(CLIENT_ID, "test-client")
+                    .claim(VTR, List.of("P2", "PCL200"))
+                    .claim(
+                            CLAIMS,
+                            Map.of(
+                                    USER_INFO,
+                                    Map.of(
+                                            ADDRESS_CLAIM_NAME,
+                                            "test-address-claim",
+                                            CORE_IDENTITY_JWT_CLAIM_NAME,
+                                            "test-core-identity-jwt-claim",
+                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                            Map.of(VALUES, List.of()),
+                                            PASSPORT_CLAIM_NAME,
+                                            "test-passport-claim")));
+    private static SignedJWT signedJWT;
+    private static JWEObject signedEncryptedJwt;
+    private static @Spy IpvSessionItem ipvSessionItem;
+    private static ClientOAuthSessionItem clientOAuthSessionItem;
+    private static VerifiableCredential PCL250_MIGRATION_VC;
+    private static VerifiableCredential PCL200_MIGRATION_VC;
 
     @Mock private Context mockContext;
     @Mock private IpvSessionService mockIpvSessionService;
@@ -135,50 +171,26 @@ class InitialiseIpvSessionHandlerTest {
     @Captor private ArgumentCaptor<IpvSessionItem> ipvSessionItemCaptor;
     @Captor private ArgumentCaptor<ErrorObject> errorObjectArgumentCaptor;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private static SignedJWT signedJWT;
-    private static JWEObject signedEncryptedJwt;
-    private static @Spy IpvSessionItem ipvSessionItem;
-    private static ClientOAuthSessionItem clientOAuthSessionItem;
-    private static JWTClaimsSet.Builder claimsBuilder =
-            new JWTClaimsSet.Builder()
-                    .expirationTime(new Date(Instant.now().plusSeconds(1000).getEpochSecond()))
-                    .issueTime(new Date())
-                    .notBeforeTime(new Date())
-                    .subject(TEST_USER_ID)
-                    .audience("test-audience")
-                    .issuer("test-issuer")
-                    .claim(RESPONSE_TYPE, "code")
-                    .claim(REDIRECT_URI, "https://example.com")
-                    .claim(STATE, "test-state")
-                    .claim(CLIENT_ID, "test-client")
-                    .claim(VTR, List.of("P2", "PCL200"))
-                    .claim(
-                            CLAIMS,
-                            Map.of(
-                                    USER_INFO,
-                                    Map.of(
-                                            ADDRESS_CLAIM_NAME, "test-address-claim",
-                                            CORE_IDENTITY_JWT_CLAIM_NAME,
-                                                    "test-core-identity-jwt-claim",
-                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                    Map.of(VALUES, List.of()),
-                                            PASSPORT_CLAIM_NAME, "test-passport-claim")));
-
-    private static VerifiableCredential PCL250_MIGRATION_VC;
-    private static VerifiableCredential PCL200_MIGRATION_VC;
-
     @BeforeAll
     static void setUpBeforeAll() throws Exception {
         PCL250_MIGRATION_VC = vcHmrcMigrationPCL250NoEvidence();
         PCL200_MIGRATION_VC = vcHmrcMigrationPCL200NoEvidence();
+
+        signedJWT = getSignedJWT(claimsBuilder);
+        signedEncryptedJwt = getJwe(signedJWT);
+
+        validEvent.setBody(
+                OBJECT_MAPPER.writeValueAsString(
+                        Map.of(
+                                "clientId",
+                                "test-client",
+                                "request",
+                                signedEncryptedJwt.serialize())));
+        validEvent.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
     }
 
     @BeforeEach
-    void setUp() throws Exception {
-        claimsBuilder.claim(VTR, List.of("P2", "PCL200"));
-        signClaims(claimsBuilder);
-
+    void setUp() {
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setClientOAuthSessionId(CLIENT_OAUTH_SESSION_ID);
@@ -207,19 +219,13 @@ class InitialiseIpvSessionHandlerTest {
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
         // Act
         APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+                initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
@@ -233,26 +239,21 @@ class InitialiseIpvSessionHandlerTest {
     @MethodSource("getVtrTestValues")
     void shouldReturn400IfMissingVtr(List<String> vtrList)
             throws JsonProcessingException, InvalidKeySpecException, NoSuchAlgorithmException,
-                    JOSEException, ParseException, HttpResponseExceptionWithErrorBody,
-                    JarValidationException {
+                    JOSEException, ParseException, JarValidationException {
         // Arrange
-        claimsBuilder.claim(VTR, vtrList);
-        signClaims(claimsBuilder);
+        var missingVtrClaimsBuilder = new JWTClaimsSet.Builder(claimsBuilder.build());
+        missingVtrClaimsBuilder.claim(VTR, vtrList);
+        var missingVtrSignedJwt = getSignedJWT(missingVtrClaimsBuilder);
         when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(signedJWT.getJWTClaimsSet());
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+                .thenReturn(missingVtrSignedJwt.getJWTClaimsSet());
 
         // Act
         APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+                initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(ErrorResponse.MISSING_VTR.getCode(), responseBody.get("code"));
@@ -269,16 +270,16 @@ class InitialiseIpvSessionHandlerTest {
     @Test
     void shouldReturn400IfMissingBody() throws JsonProcessingException {
         // Arrange
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+        APIGatewayProxyRequestEvent missingBodyEvent = new APIGatewayProxyRequestEvent();
+        missingBodyEvent.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         // Act
         APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+                initialiseIpvSessionHandler.handleRequest(missingBodyEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
@@ -289,17 +290,17 @@ class InitialiseIpvSessionHandlerTest {
     @Test
     void shouldReturn400IfInvalidBody() throws JsonProcessingException {
         // Arrange
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody("invalid-body");
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+        APIGatewayProxyRequestEvent invalidBodyEvent = new APIGatewayProxyRequestEvent();
+        invalidBodyEvent.setBody("invalid-body");
+        invalidBodyEvent.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         // Act
         APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+                initialiseIpvSessionHandler.handleRequest(invalidBodyEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
@@ -310,20 +311,18 @@ class InitialiseIpvSessionHandlerTest {
     @Test
     void shouldReturn400IfMissingClientIdParameter() throws JsonProcessingException {
         // Arrange
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
+        APIGatewayProxyRequestEvent missingClientIdEvent = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams = Map.of("request", signedEncryptedJwt.serialize());
-
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+        missingClientIdEvent.setBody(OBJECT_MAPPER.writeValueAsString(sessionParams));
+        missingClientIdEvent.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         // Act
         APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+                initialiseIpvSessionHandler.handleRequest(missingClientIdEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
@@ -334,20 +333,18 @@ class InitialiseIpvSessionHandlerTest {
     @Test
     void shouldReturn400IfMissingRequestParameter() throws JsonProcessingException {
         // Arrange
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
+        APIGatewayProxyRequestEvent missingRequestEvent = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams = Map.of("clientId", "test-client");
-
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+        missingRequestEvent.setBody(OBJECT_MAPPER.writeValueAsString(sessionParams));
+        missingRequestEvent.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         // Act
         APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+                initialiseIpvSessionHandler.handleRequest(missingRequestEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
@@ -358,20 +355,19 @@ class InitialiseIpvSessionHandlerTest {
     @Test
     void shouldReturn400IfRequestObjectNotEncrypted() throws JsonProcessingException {
         // Arrange
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-
+        APIGatewayProxyRequestEvent unencryptedRequestEvent = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams =
                 Map.of("clientId", "test-client", "request", signedJWT.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+        unencryptedRequestEvent.setBody(OBJECT_MAPPER.writeValueAsString(sessionParams));
+        unencryptedRequestEvent.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
         // Act
         APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+                initialiseIpvSessionHandler.handleRequest(unencryptedRequestEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
         assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
@@ -397,765 +393,647 @@ class InitialiseIpvSessionHandlerTest {
                                 "test-state",
                                 "test-journey-id"));
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
         // Act
         APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
+                initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
 
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
     }
 
-    @Test
-    void shouldValidateAndStoreAnyInheritedIdentityWhenStrongerVotThanExisting() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL250_MIGRATION_VC
-                                                                                .getVcString())))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY))
-                .thenReturn(true); // Mock enabled inherited identity feature flag
-        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        TEST_USER_ID,
-                        HMRC_MIGRATION_CRI,
-                        PCL250_MIGRATION_VC.getVcString(),
-                        IDENTITY_CHECK_CREDENTIAL_TYPE,
-                        ECKey.parse(TEST_SIGNING_KEY),
-                        TEST_COMPONENT_ID,
-                        true))
-                .thenReturn(PCL250_MIGRATION_VC);
-        when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
-                .thenReturn(PCL200_MIGRATION_VC);
-        when(mockUserIdentityService.getVot(any())).thenReturn(Vot.PCL200).thenReturn(Vot.PCL200);
+    @Nested
+    @DisplayName("inherited identity tests")
+    class InheritedIdentityTests {
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        verify(mockVerifiableCredentialValidator, times(1))
-                .parseAndValidate(
-                        eq(TEST_USER_ID),
-                        eq(HMRC_MIGRATION_CRI),
-                        stringArgumentCaptor.capture(),
-                        eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
-                        eq(ECKey.parse(TEST_SIGNING_KEY)),
-                        eq(TEST_COMPONENT_ID),
-                        eq(true));
-        assertEquals(PCL250_MIGRATION_VC.getVcString(), stringArgumentCaptor.getValue());
-
-        verify(mockVerifiableCredentialService, times(1))
-                .persistUserCredentials(verifiableCredentialArgumentCaptor.capture());
-        assertEquals(PCL250_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
-
-        verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
-        assertEquals(
-                ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
-                List.of(PCL250_MIGRATION_VC.getVcString()));
-    }
-
-    @Test
-    void shouldValidateAndStoreAnyInheritedIdentityWhenNoExistingIdentity() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString())))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        TEST_USER_ID,
-                        HMRC_MIGRATION_CRI,
-                        PCL200_MIGRATION_VC.getVcString(),
-                        IDENTITY_CHECK_CREDENTIAL_TYPE,
-                        ECKey.parse(TEST_SIGNING_KEY),
-                        TEST_COMPONENT_ID,
-                        true))
-                .thenReturn(PCL200_MIGRATION_VC);
-        when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
-                .thenReturn(null);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        verify(mockVerifiableCredentialValidator, times(1))
-                .parseAndValidate(
-                        eq(TEST_USER_ID),
-                        eq(HMRC_MIGRATION_CRI),
-                        stringArgumentCaptor.capture(),
-                        eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
-                        eq(ECKey.parse(TEST_SIGNING_KEY)),
-                        eq(TEST_COMPONENT_ID),
-                        eq(true));
-        assertEquals(PCL200_MIGRATION_VC.getVcString(), stringArgumentCaptor.getValue());
-
-        verify(mockVerifiableCredentialService, times(1))
-                .persistUserCredentials(verifiableCredentialArgumentCaptor.capture());
-        assertEquals(PCL200_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
-
-        verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
-        assertEquals(
-                ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
-                List.of(PCL200_MIGRATION_VC.getVcString()));
-    }
-
-    @Test
-    void shouldSendAuditEventForIpvInheritedIdentityVcReceived() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString())))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        TEST_USER_ID,
-                        HMRC_MIGRATION_CRI,
-                        PCL200_MIGRATION_VC.getVcString(),
-                        IDENTITY_CHECK_CREDENTIAL_TYPE,
-                        ECKey.parse(TEST_SIGNING_KEY),
-                        TEST_COMPONENT_ID,
-                        true))
-                .thenReturn(PCL200_MIGRATION_VC);
-        when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
-                .thenReturn(null);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
-        verify(mockAuditService, times(2)).sendAuditEvent(auditEventCaptor.capture());
-
-        var inheritedIdentityAuditEvent = auditEventCaptor.getAllValues().get(0);
-        assertEquals(
-                AuditEventTypes.IPV_INHERITED_IDENTITY_VC_RECEIVED,
-                inheritedIdentityAuditEvent.getEventName());
-        var extension = (AuditExtensionsVcEvidence) inheritedIdentityAuditEvent.getExtensions();
-        var expectedExtension =
-                new AuditExtensionsVcEvidence(
-                        "https://orch.stubs.account.gov.uk/migration/v1",
-                        "[]",
-                        null,
-                        Vot.PCL200,
-                        Boolean.TRUE,
-                        58);
-        assertEquals(expectedExtension, extension);
-        var restricted =
-                (AuditRestrictedInheritedIdentity) inheritedIdentityAuditEvent.getRestricted();
-        assertEquals(
-                "[{\"nameParts\":[{\"type\":\"GivenName\",\"value\":\"KENNETH\"},{\"type\":\"FamilyName\",\"value\":\"DECERQUEIRA\"}]}]",
-                restricted.name().toString());
-        assertEquals("[{\"value\":\"1965-07-08\"}]", restricted.birthDate().toString());
-        assertEquals(
-                "[{\"personalNumber\":\"AB123456C\"}]",
-                restricted.socialSecurityRecord().toString());
-
-        assertEquals(
-                AuditEventTypes.IPV_JOURNEY_START,
-                auditEventCaptor.getAllValues().get(1).getEventName());
-    }
-
-    @Test
-    void shouldNotStoreInheritedIdentityWhenVotWeakerThanExisting() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString())))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        TEST_USER_ID,
-                        HMRC_MIGRATION_CRI,
-                        PCL200_MIGRATION_VC.getVcString(),
-                        IDENTITY_CHECK_CREDENTIAL_TYPE,
-                        ECKey.parse(TEST_SIGNING_KEY),
-                        TEST_COMPONENT_ID,
-                        true))
-                .thenReturn(PCL200_MIGRATION_VC);
-        when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
-                .thenReturn(PCL250_MIGRATION_VC);
-        when(mockUserIdentityService.getVot(any())).thenReturn(Vot.PCL250).thenReturn(Vot.PCL200);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        verify(mockVerifiableCredentialValidator, times(1))
-                .parseAndValidate(
-                        eq(TEST_USER_ID),
-                        eq(HMRC_MIGRATION_CRI),
-                        stringArgumentCaptor.capture(),
-                        eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
-                        eq(ECKey.parse(TEST_SIGNING_KEY)),
-                        eq(TEST_COMPONENT_ID),
-                        eq(true));
-        assertEquals(PCL200_MIGRATION_VC.getVcString(), stringArgumentCaptor.getValue());
-
-        verify(mockUserIdentityService, times(2))
-                .getVot(verifiableCredentialArgumentCaptor.capture());
-
-        List<VerifiableCredential> capturedArguments =
-                verifiableCredentialArgumentCaptor.getAllValues();
-        assertEquals(2, capturedArguments.size());
-        assertEquals(PCL250_MIGRATION_VC, capturedArguments.get(0));
-        assertEquals(PCL200_MIGRATION_VC, capturedArguments.get(1));
-
-        verify(mockVerifiableCredentialService, times(0)).persistUserCredentials(any());
-    }
-
-    @Test
-    void shouldValidateAndStoreAnyInheritedIdentityWhenNoInheritedVcExist() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString())))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY))
-                .thenReturn(true); // Mock enabled inherited identity feature flag
-        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        TEST_USER_ID,
-                        HMRC_MIGRATION_CRI,
-                        PCL200_MIGRATION_VC.getVcString(),
-                        IDENTITY_CHECK_CREDENTIAL_TYPE,
-                        ECKey.parse(TEST_SIGNING_KEY),
-                        TEST_COMPONENT_ID,
-                        true))
-                .thenReturn(PCL200_MIGRATION_VC);
-        when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
-                .thenReturn(null);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        verify(mockVerifiableCredentialValidator, times(1))
-                .parseAndValidate(
-                        eq(TEST_USER_ID),
-                        eq(HMRC_MIGRATION_CRI),
-                        stringArgumentCaptor.capture(),
-                        eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
-                        eq(ECKey.parse(TEST_SIGNING_KEY)),
-                        eq(TEST_COMPONENT_ID),
-                        eq(true));
-        assertEquals(PCL200_MIGRATION_VC.getVcString(), stringArgumentCaptor.getValue());
-
-        verify(mockVerifiableCredentialService, times(1))
-                .persistUserCredentials(verifiableCredentialArgumentCaptor.capture());
-        assertEquals(PCL200_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
-
-        verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
-        assertEquals(
-                ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
-                List.of(PCL200_MIGRATION_VC.getVcString()));
-    }
-
-    @Test
-    void shouldHandleUnrecognisedVotExceptionFromSendingAuditEvent() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString())))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        TEST_USER_ID,
-                        HMRC_MIGRATION_CRI,
-                        PCL200_MIGRATION_VC.getVcString(),
-                        IDENTITY_CHECK_CREDENTIAL_TYPE,
-                        ECKey.parse(TEST_SIGNING_KEY),
-                        TEST_COMPONENT_ID,
-                        true))
-                .thenReturn(PCL200_MIGRATION_VC);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        APIGatewayProxyResponseEvent response;
-        try (MockedStatic<VcHelper> vcHelper = mockStatic(VcHelper.class)) {
-            vcHelper.when(() -> VcHelper.getVcVot(any()))
-                    .thenThrow(new UnrecognisedVotException(""));
-            response = initialiseIpvSessionHandler.handleRequest(event, mockContext);
+        @BeforeEach
+        void setUp() throws Exception {
+            when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY))
+                    .thenReturn(true); // Mock enabled inherited identity feature flag
+            when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
+                    .thenReturn(ipvSessionItem);
+            when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(
+                            any(), any(), any()))
+                    .thenReturn(clientOAuthSessionItem);
         }
 
-        // Assert
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
+        @Test
+        void shouldValidateAndStoreAnyInheritedIdentityWhenStrongerVotThanExisting()
+                throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(
+                                                                    VALUES,
+                                                                    List.of(
+                                                                            PCL250_MIGRATION_VC
+                                                                                    .getVcString())))))
+                                    .build());
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+            when(mockVerifiableCredentialValidator.parseAndValidate(
+                            TEST_USER_ID,
+                            HMRC_MIGRATION_CRI,
+                            PCL250_MIGRATION_VC.getVcString(),
+                            IDENTITY_CHECK_CREDENTIAL_TYPE,
+                            ECKey.parse(TEST_SIGNING_KEY),
+                            TEST_COMPONENT_ID,
+                            true))
+                    .thenReturn(PCL250_MIGRATION_VC);
+            when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
+                    .thenReturn(PCL200_MIGRATION_VC);
+            when(mockUserIdentityService.getVot(any()))
+                    .thenReturn(Vot.PCL200)
+                    .thenReturn(Vot.PCL200);
 
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+            // Act
+            initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
 
-        verify(mockIpvSessionService, times(2))
-                .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
-        var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
-        assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
-        assertEquals(
-                "Inherited identity JWT failed to validate", capturedErrorObject.getDescription());
+            // Assert
+            verify(mockVerifiableCredentialValidator, times(1))
+                    .parseAndValidate(
+                            eq(TEST_USER_ID),
+                            eq(HMRC_MIGRATION_CRI),
+                            stringArgumentCaptor.capture(),
+                            eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
+                            eq(ECKey.parse(TEST_SIGNING_KEY)),
+                            eq(TEST_COMPONENT_ID),
+                            eq(true));
+            assertEquals(PCL250_MIGRATION_VC.getVcString(), stringArgumentCaptor.getValue());
+
+            verify(mockVerifiableCredentialService, times(1))
+                    .persistUserCredentials(verifiableCredentialArgumentCaptor.capture());
+            assertEquals(PCL250_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
+
+            verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
+            assertEquals(
+                    ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
+                    List.of(PCL250_MIGRATION_VC.getVcString()));
+        }
+
+        @Test
+        void shouldValidateAndStoreAnyInheritedIdentityWhenNoExistingIdentity() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(
+                                                                    VALUES,
+                                                                    List.of(
+                                                                            PCL200_MIGRATION_VC
+                                                                                    .getVcString())))))
+                                    .build());
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+            when(mockVerifiableCredentialValidator.parseAndValidate(
+                            TEST_USER_ID,
+                            HMRC_MIGRATION_CRI,
+                            PCL200_MIGRATION_VC.getVcString(),
+                            IDENTITY_CHECK_CREDENTIAL_TYPE,
+                            ECKey.parse(TEST_SIGNING_KEY),
+                            TEST_COMPONENT_ID,
+                            true))
+                    .thenReturn(PCL200_MIGRATION_VC);
+            when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
+                    .thenReturn(null);
+
+            // Act
+            initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            verify(mockVerifiableCredentialValidator, times(1))
+                    .parseAndValidate(
+                            eq(TEST_USER_ID),
+                            eq(HMRC_MIGRATION_CRI),
+                            stringArgumentCaptor.capture(),
+                            eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
+                            eq(ECKey.parse(TEST_SIGNING_KEY)),
+                            eq(TEST_COMPONENT_ID),
+                            eq(true));
+            assertEquals(PCL200_MIGRATION_VC.getVcString(), stringArgumentCaptor.getValue());
+
+            verify(mockVerifiableCredentialService, times(1))
+                    .persistUserCredentials(verifiableCredentialArgumentCaptor.capture());
+            assertEquals(PCL200_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
+
+            verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
+            assertEquals(
+                    ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
+                    List.of(PCL200_MIGRATION_VC.getVcString()));
+        }
+
+        @Test
+        void shouldSendAuditEventForIpvInheritedIdentityVcReceived() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(
+                                                                    VALUES,
+                                                                    List.of(
+                                                                            PCL200_MIGRATION_VC
+                                                                                    .getVcString())))))
+                                    .build());
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+            when(mockVerifiableCredentialValidator.parseAndValidate(
+                            TEST_USER_ID,
+                            HMRC_MIGRATION_CRI,
+                            PCL200_MIGRATION_VC.getVcString(),
+                            IDENTITY_CHECK_CREDENTIAL_TYPE,
+                            ECKey.parse(TEST_SIGNING_KEY),
+                            TEST_COMPONENT_ID,
+                            true))
+                    .thenReturn(PCL200_MIGRATION_VC);
+            when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
+                    .thenReturn(null);
+
+            // Act
+            initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+            verify(mockAuditService, times(2)).sendAuditEvent(auditEventCaptor.capture());
+
+            var inheritedIdentityAuditEvent = auditEventCaptor.getAllValues().get(0);
+            assertEquals(
+                    AuditEventTypes.IPV_INHERITED_IDENTITY_VC_RECEIVED,
+                    inheritedIdentityAuditEvent.getEventName());
+            var extension = (AuditExtensionsVcEvidence) inheritedIdentityAuditEvent.getExtensions();
+            var expectedExtension =
+                    new AuditExtensionsVcEvidence(
+                            "https://orch.stubs.account.gov.uk/migration/v1",
+                            "[]",
+                            null,
+                            Vot.PCL200,
+                            Boolean.TRUE,
+                            58);
+            assertEquals(expectedExtension, extension);
+            var restricted =
+                    (AuditRestrictedInheritedIdentity) inheritedIdentityAuditEvent.getRestricted();
+            assertEquals(
+                    "[{\"nameParts\":[{\"type\":\"GivenName\",\"value\":\"KENNETH\"},{\"type\":\"FamilyName\",\"value\":\"DECERQUEIRA\"}]}]",
+                    restricted.name().toString());
+            assertEquals("[{\"value\":\"1965-07-08\"}]", restricted.birthDate().toString());
+            assertEquals(
+                    "[{\"personalNumber\":\"AB123456C\"}]",
+                    restricted.socialSecurityRecord().toString());
+
+            assertEquals(
+                    AuditEventTypes.IPV_JOURNEY_START,
+                    auditEventCaptor.getAllValues().get(1).getEventName());
+        }
+
+        @Test
+        void shouldNotStoreInheritedIdentityWhenVotWeakerThanExisting() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(
+                                                                    VALUES,
+                                                                    List.of(
+                                                                            PCL200_MIGRATION_VC
+                                                                                    .getVcString())))))
+                                    .build());
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+            when(mockVerifiableCredentialValidator.parseAndValidate(
+                            TEST_USER_ID,
+                            HMRC_MIGRATION_CRI,
+                            PCL200_MIGRATION_VC.getVcString(),
+                            IDENTITY_CHECK_CREDENTIAL_TYPE,
+                            ECKey.parse(TEST_SIGNING_KEY),
+                            TEST_COMPONENT_ID,
+                            true))
+                    .thenReturn(PCL200_MIGRATION_VC);
+            when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
+                    .thenReturn(PCL250_MIGRATION_VC);
+            when(mockUserIdentityService.getVot(any()))
+                    .thenReturn(Vot.PCL250)
+                    .thenReturn(Vot.PCL200);
+
+            // Act
+            initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            verify(mockVerifiableCredentialValidator, times(1))
+                    .parseAndValidate(
+                            eq(TEST_USER_ID),
+                            eq(HMRC_MIGRATION_CRI),
+                            stringArgumentCaptor.capture(),
+                            eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
+                            eq(ECKey.parse(TEST_SIGNING_KEY)),
+                            eq(TEST_COMPONENT_ID),
+                            eq(true));
+            assertEquals(PCL200_MIGRATION_VC.getVcString(), stringArgumentCaptor.getValue());
+
+            verify(mockUserIdentityService, times(2))
+                    .getVot(verifiableCredentialArgumentCaptor.capture());
+
+            List<VerifiableCredential> capturedArguments =
+                    verifiableCredentialArgumentCaptor.getAllValues();
+            assertEquals(2, capturedArguments.size());
+            assertEquals(PCL250_MIGRATION_VC, capturedArguments.get(0));
+            assertEquals(PCL200_MIGRATION_VC, capturedArguments.get(1));
+
+            verify(mockVerifiableCredentialService, times(0)).persistUserCredentials(any());
+        }
+
+        @Test
+        void shouldValidateAndStoreAnyInheritedIdentityWhenNoInheritedVcExist() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(
+                                                                    VALUES,
+                                                                    List.of(
+                                                                            PCL200_MIGRATION_VC
+                                                                                    .getVcString())))))
+                                    .build());
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+            when(mockVerifiableCredentialValidator.parseAndValidate(
+                            TEST_USER_ID,
+                            HMRC_MIGRATION_CRI,
+                            PCL200_MIGRATION_VC.getVcString(),
+                            IDENTITY_CHECK_CREDENTIAL_TYPE,
+                            ECKey.parse(TEST_SIGNING_KEY),
+                            TEST_COMPONENT_ID,
+                            true))
+                    .thenReturn(PCL200_MIGRATION_VC);
+            when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
+                    .thenReturn(null);
+
+            // Act
+            initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            verify(mockVerifiableCredentialValidator, times(1))
+                    .parseAndValidate(
+                            eq(TEST_USER_ID),
+                            eq(HMRC_MIGRATION_CRI),
+                            stringArgumentCaptor.capture(),
+                            eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
+                            eq(ECKey.parse(TEST_SIGNING_KEY)),
+                            eq(TEST_COMPONENT_ID),
+                            eq(true));
+            assertEquals(PCL200_MIGRATION_VC.getVcString(), stringArgumentCaptor.getValue());
+
+            verify(mockVerifiableCredentialService, times(1))
+                    .persistUserCredentials(verifiableCredentialArgumentCaptor.capture());
+            assertEquals(PCL200_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
+
+            verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
+            assertEquals(
+                    ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
+                    List.of(PCL200_MIGRATION_VC.getVcString()));
+        }
+
+        @Test
+        void shouldHandleUnrecognisedVotExceptionFromSendingAuditEvent() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(
+                                                                    VALUES,
+                                                                    List.of(
+                                                                            PCL200_MIGRATION_VC
+                                                                                    .getVcString())))))
+                                    .build());
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+            when(mockVerifiableCredentialValidator.parseAndValidate(
+                            TEST_USER_ID,
+                            HMRC_MIGRATION_CRI,
+                            PCL200_MIGRATION_VC.getVcString(),
+                            IDENTITY_CHECK_CREDENTIAL_TYPE,
+                            ECKey.parse(TEST_SIGNING_KEY),
+                            TEST_COMPONENT_ID,
+                            true))
+                    .thenReturn(PCL200_MIGRATION_VC);
+
+            // Act
+            APIGatewayProxyResponseEvent response;
+            try (MockedStatic<VcHelper> vcHelper = mockStatic(VcHelper.class)) {
+                vcHelper.when(() -> VcHelper.getVcVot(any()))
+                        .thenThrow(new UnrecognisedVotException(""));
+                response = initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+            }
+
+            // Assert
+            Map<String, Object> responseBody =
+                    OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+            assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+
+            verify(mockIpvSessionService, times(2))
+                    .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
+            var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
+            assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
+            assertEquals(
+                    "Inherited identity JWT failed to validate",
+                    capturedErrorObject.getDescription());
+        }
+
+        @Test
+        void shouldAllowRequestsThatDoNotIncludeAnInheritedIdentityJwtClaim() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(claimsBuilder.claim(CLAIMS, Map.of(USER_INFO, Map.of())).build());
+
+            // Act
+            APIGatewayProxyResponseEvent response =
+                    initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            Map<String, Object> responseBody =
+                    OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+            assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+        }
+
+        @Test
+        void shouldRecoverIfClaimsClaimCanNotBeConverted() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder.claim(CLAIMS, Map.of("This", "shouldn't work?")).build());
+
+            // Act
+            APIGatewayProxyResponseEvent response =
+                    initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            Map<String, Object> responseBody =
+                    OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+            assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+            verify(mockClientOAuthSessionDetailsService)
+                    .generateErrorClientSessionDetails(
+                            any(String.class),
+                            eq("https://example.com"),
+                            eq("test-client"),
+                            eq("test-state"),
+                            eq(null));
+        }
+
+        @Test
+        void shouldRecoverIfInheritedIdentityJwtHasMultipleValues() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(
+                                                                    VALUES,
+                                                                    List.of(
+                                                                            PCL200_MIGRATION_VC
+                                                                                    .getVcString(),
+                                                                            PCL200_MIGRATION_VC
+                                                                                    .getVcString())))))
+                                    .build());
+
+            // Act
+            APIGatewayProxyResponseEvent response =
+                    initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            Map<String, Object> responseBody =
+                    OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+            assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+            verify(mockClientOAuthSessionDetailsService)
+                    .generateErrorClientSessionDetails(
+                            any(String.class),
+                            eq("https://example.com"),
+                            eq("test-client"),
+                            eq("test-state"),
+                            eq(null));
+
+            verify(mockIpvSessionService, times(2))
+                    .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
+            var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
+            assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
+            assertEquals(
+                    "2 inherited identity jwts received - one expected",
+                    capturedErrorObject.getDescription());
+        }
+
+        @Test
+        void shouldRecoverIfInheritedIdentityJwtHasNullValue() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of())))
+                                    .build());
+
+            // Act
+            APIGatewayProxyResponseEvent response =
+                    initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            Map<String, Object> responseBody =
+                    OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+            assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+            verify(mockClientOAuthSessionDetailsService)
+                    .generateErrorClientSessionDetails(
+                            any(String.class),
+                            eq("https://example.com"),
+                            eq("test-client"),
+                            eq("test-state"),
+                            eq(null));
+
+            verify(mockIpvSessionService, times(2))
+                    .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
+            var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
+            assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
+            assertEquals(
+                    "Inherited identity jwt claim received but value is null",
+                    capturedErrorObject.getDescription());
+        }
+
+        @Test
+        void shouldRecoverIfInheritedIdentityJwtFailsToParseAndValidate() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(VALUES, List.of("🌭")))))
+                                    .build());
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+            when(mockVerifiableCredentialValidator.parseAndValidate(
+                            TEST_USER_ID,
+                            HMRC_MIGRATION_CRI,
+                            "🌭",
+                            IDENTITY_CHECK_CREDENTIAL_TYPE,
+                            TEST_CRI_CONFIG.getParsedSigningKey(),
+                            TEST_CRI_CONFIG.getComponentId(),
+                            true))
+                    .thenThrow(
+                            new VerifiableCredentialException(
+                                    HTTPResponse.SC_SERVER_ERROR,
+                                    ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS));
+
+            // Act
+            APIGatewayProxyResponseEvent response =
+                    initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            Map<String, Object> responseBody =
+                    OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+            assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+            verify(mockClientOAuthSessionDetailsService)
+                    .generateErrorClientSessionDetails(
+                            any(String.class),
+                            eq("https://example.com"),
+                            eq("test-client"),
+                            eq("test-state"),
+                            eq(null));
+
+            verify(mockIpvSessionService, times(2))
+                    .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
+            var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
+            assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
+            assertEquals(
+                    "Inherited identity JWT failed to validate",
+                    capturedErrorObject.getDescription());
+        }
+
+        @Test
+        void shouldRecoverIfInheritedIdentityJwtFailsToPersist() throws Exception {
+            // Arrange
+            when(mockJarValidator.validateRequestJwt(any(), any()))
+                    .thenReturn(
+                            claimsBuilder
+                                    .claim(
+                                            CLAIMS,
+                                            Map.of(
+                                                    USER_INFO,
+                                                    Map.of(
+                                                            INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                                            Map.of(
+                                                                    VALUES,
+                                                                    List.of(
+                                                                            PCL200_MIGRATION_VC
+                                                                                    .getVcString())))))
+                                    .build());
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
+            when(mockVerifiableCredentialValidator.parseAndValidate(
+                            TEST_USER_ID,
+                            HMRC_MIGRATION_CRI,
+                            PCL200_MIGRATION_VC.getVcString(),
+                            IDENTITY_CHECK_CREDENTIAL_TYPE,
+                            ECKey.parse(TEST_SIGNING_KEY),
+                            TEST_COMPONENT_ID,
+                            true))
+                    .thenReturn(PCL200_MIGRATION_VC);
+            when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
+                    .thenReturn(PCL200_MIGRATION_VC);
+            when(mockUserIdentityService.getVot(any()))
+                    .thenReturn(Vot.PCL200)
+                    .thenReturn(Vot.PCL200);
+            doThrow(
+                            new VerifiableCredentialException(
+                                    HTTPResponse.SC_SERVER_ERROR,
+                                    ErrorResponse.FAILED_TO_SAVE_CREDENTIAL))
+                    .when(mockVerifiableCredentialService)
+                    .persistUserCredentials(any());
+
+            // Act
+            APIGatewayProxyResponseEvent response =
+                    initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+            // Assert
+            Map<String, Object> responseBody =
+                    OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+            assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+            verify(mockClientOAuthSessionDetailsService)
+                    .generateErrorClientSessionDetails(
+                            any(String.class),
+                            eq("https://example.com"),
+                            eq("test-client"),
+                            eq("test-state"),
+                            eq(null));
+        }
     }
 
-    @Test
-    void shouldAllowRequestsThatDoNotIncludeAnInheritedIdentityJwtClaim() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(claimsBuilder.claim(CLAIMS, Map.of(USER_INFO, Map.of())).build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+    private static SignedJWT getSignedJWT(JWTClaimsSet.Builder claimsBuilder)
+            throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
+        var signedClaimsJwt =
+                new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsBuilder.build());
+        signedClaimsJwt.sign(new ECDSASigner(getPrivateKey()));
+        return signedClaimsJwt;
     }
 
-    @Test
-    void shouldRecoverIfClaimsClaimCanNotBeConverted() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(claimsBuilder.claim(CLAIMS, Map.of("This", "shouldn't work?")).build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
-        verify(mockClientOAuthSessionDetailsService)
-                .generateErrorClientSessionDetails(
-                        any(String.class),
-                        eq("https://example.com"),
-                        eq("test-client"),
-                        eq("test-state"),
-                        eq(null));
-    }
-
-    @Test
-    void shouldRecoverIfInheritedIdentityJwtHasMultipleValues() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString(),
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString())))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY))
-                .thenReturn(true); // Mock enabled inherited identity feature flag
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
-        verify(mockClientOAuthSessionDetailsService)
-                .generateErrorClientSessionDetails(
-                        any(String.class),
-                        eq("https://example.com"),
-                        eq("test-client"),
-                        eq("test-state"),
-                        eq(null));
-
-        verify(mockIpvSessionService, times(2))
-                .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
-        var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
-        assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
-        assertEquals(
-                "2 inherited identity jwts received - one expected",
-                capturedErrorObject.getDescription());
-    }
-
-    @Test
-    void shouldRecoverIfInheritedIdentityJwtHasNullValue() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of())))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY))
-                .thenReturn(true); // Mock enabled inherited identity feature flag
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
-        verify(mockClientOAuthSessionDetailsService)
-                .generateErrorClientSessionDetails(
-                        any(String.class),
-                        eq("https://example.com"),
-                        eq("test-client"),
-                        eq("test-state"),
-                        eq(null));
-
-        verify(mockIpvSessionService, times(2))
-                .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
-        var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
-        assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
-        assertEquals(
-                "Inherited identity jwt claim received but value is null",
-                capturedErrorObject.getDescription());
-    }
-
-    @Test
-    void shouldRecoverIfInheritedIdentityJwtFailsToParseAndValidate() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(VALUES, List.of("🌭")))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        TEST_USER_ID,
-                        HMRC_MIGRATION_CRI,
-                        "🌭",
-                        IDENTITY_CHECK_CREDENTIAL_TYPE,
-                        TEST_CRI_CONFIG.getParsedSigningKey(),
-                        TEST_CRI_CONFIG.getComponentId(),
-                        true))
-                .thenThrow(
-                        new VerifiableCredentialException(
-                                HTTPResponse.SC_SERVER_ERROR,
-                                ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS));
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
-        verify(mockClientOAuthSessionDetailsService)
-                .generateErrorClientSessionDetails(
-                        any(String.class),
-                        eq("https://example.com"),
-                        eq("test-client"),
-                        eq("test-state"),
-                        eq(null));
-
-        verify(mockIpvSessionService, times(2))
-                .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
-        var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
-        assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
-        assertEquals(
-                "Inherited identity JWT failed to validate", capturedErrorObject.getDescription());
-    }
-
-    @Test
-    void shouldRecoverIfInheritedIdentityJwtFailsToPersist() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString())))))
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-        CriConfig testCriConfig =
-                CriConfig.builder()
-                        .componentId(TEST_COMPONENT_ID)
-                        .signingKey(TEST_SIGNING_KEY)
-                        .build();
-        when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(testCriConfig);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        TEST_USER_ID,
-                        HMRC_MIGRATION_CRI,
-                        PCL200_MIGRATION_VC.getVcString(),
-                        IDENTITY_CHECK_CREDENTIAL_TYPE,
-                        ECKey.parse(TEST_SIGNING_KEY),
-                        TEST_COMPONENT_ID,
-                        true))
-                .thenReturn(PCL200_MIGRATION_VC);
-        when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION_CRI))
-                .thenReturn(PCL200_MIGRATION_VC);
-        when(mockUserIdentityService.getVot(any())).thenReturn(Vot.PCL200).thenReturn(Vot.PCL200);
-        doThrow(
-                        new VerifiableCredentialException(
-                                HTTPResponse.SC_SERVER_ERROR,
-                                ErrorResponse.FAILED_TO_SAVE_CREDENTIAL))
-                .when(mockVerifiableCredentialService)
-                .persistUserCredentials(any());
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
-        verify(mockClientOAuthSessionDetailsService)
-                .generateErrorClientSessionDetails(
-                        any(String.class),
-                        eq("https://example.com"),
-                        eq("test-client"),
-                        eq("test-state"),
-                        eq(null));
-    }
-
-    private static void signClaims(JWTClaimsSet.Builder claimsBuilder)
-            throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException,
-                    HttpResponseExceptionWithErrorBody, ParseException {
-        signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.ES256), claimsBuilder.build());
-        signedJWT.sign(new ECDSASigner(getPrivateKey()));
-        signedEncryptedJwt =
-                TestFixtures.createJweObject(
-                        new RSAEncrypter(RSAKey.parse(TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK)),
-                        signedJWT);
+    private static JWEObject getJwe(SignedJWT signedJwt)
+            throws JOSEException, HttpResponseExceptionWithErrorBody, ParseException {
+        return TestFixtures.createJweObject(
+                new RSAEncrypter(RSAKey.parse(TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK)), signedJwt);
     }
 
     private static ECPrivateKey getPrivateKey()

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -44,7 +44,6 @@ import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedInheritedId
 import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriConfig;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -80,14 +79,16 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.HMRC_MIGRATION_CRI;
+import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.ADDRESS_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.CORE_IDENTITY_JWT_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.INHERITED_IDENTITY_JWT_CLAIM_NAME;
@@ -115,6 +116,7 @@ class InitialiseIpvSessionHandlerTest {
     private static final String CLAIMS = "claims";
     private static final String USER_INFO = "userInfo";
     private static final String VALUES = "values";
+    private static final String INVALID_INHERITED_IDENTITY = "invalid_inherited_identity";
 
     @Mock private Context mockContext;
     @Mock private IpvSessionService mockIpvSessionService;
@@ -131,6 +133,7 @@ class InitialiseIpvSessionHandlerTest {
     @Captor private ArgumentCaptor<String> stringArgumentCaptor;
     @Captor private ArgumentCaptor<VerifiableCredential> verifiableCredentialArgumentCaptor;
     @Captor private ArgumentCaptor<IpvSessionItem> ipvSessionItemCaptor;
+    @Captor private ArgumentCaptor<ErrorObject> errorObjectArgumentCaptor;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private static SignedJWT signedJWT;
@@ -441,7 +444,7 @@ class InitialiseIpvSessionHandlerTest {
                         TEST_USER_ID,
                         HMRC_MIGRATION_CRI,
                         PCL250_MIGRATION_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
+                        IDENTITY_CHECK_CREDENTIAL_TYPE,
                         ECKey.parse(TEST_SIGNING_KEY),
                         TEST_COMPONENT_ID,
                         true))
@@ -465,7 +468,7 @@ class InitialiseIpvSessionHandlerTest {
                         eq(TEST_USER_ID),
                         eq(HMRC_MIGRATION_CRI),
                         stringArgumentCaptor.capture(),
-                        eq(VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE),
+                        eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
                         eq(ECKey.parse(TEST_SIGNING_KEY)),
                         eq(TEST_COMPONENT_ID),
                         eq(true));
@@ -509,7 +512,7 @@ class InitialiseIpvSessionHandlerTest {
                         TEST_USER_ID,
                         HMRC_MIGRATION_CRI,
                         PCL200_MIGRATION_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
+                        IDENTITY_CHECK_CREDENTIAL_TYPE,
                         ECKey.parse(TEST_SIGNING_KEY),
                         TEST_COMPONENT_ID,
                         true))
@@ -532,7 +535,7 @@ class InitialiseIpvSessionHandlerTest {
                         eq(TEST_USER_ID),
                         eq(HMRC_MIGRATION_CRI),
                         stringArgumentCaptor.capture(),
-                        eq(VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE),
+                        eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
                         eq(ECKey.parse(TEST_SIGNING_KEY)),
                         eq(TEST_COMPONENT_ID),
                         eq(true));
@@ -576,7 +579,7 @@ class InitialiseIpvSessionHandlerTest {
                         TEST_USER_ID,
                         HMRC_MIGRATION_CRI,
                         PCL200_MIGRATION_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
+                        IDENTITY_CHECK_CREDENTIAL_TYPE,
                         ECKey.parse(TEST_SIGNING_KEY),
                         TEST_COMPONENT_ID,
                         true))
@@ -654,7 +657,7 @@ class InitialiseIpvSessionHandlerTest {
                         TEST_USER_ID,
                         HMRC_MIGRATION_CRI,
                         PCL200_MIGRATION_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
+                        IDENTITY_CHECK_CREDENTIAL_TYPE,
                         ECKey.parse(TEST_SIGNING_KEY),
                         TEST_COMPONENT_ID,
                         true))
@@ -678,7 +681,7 @@ class InitialiseIpvSessionHandlerTest {
                         eq(TEST_USER_ID),
                         eq(HMRC_MIGRATION_CRI),
                         stringArgumentCaptor.capture(),
-                        eq(VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE),
+                        eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
                         eq(ECKey.parse(TEST_SIGNING_KEY)),
                         eq(TEST_COMPONENT_ID),
                         eq(true));
@@ -725,7 +728,7 @@ class InitialiseIpvSessionHandlerTest {
                         TEST_USER_ID,
                         HMRC_MIGRATION_CRI,
                         PCL200_MIGRATION_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
+                        IDENTITY_CHECK_CREDENTIAL_TYPE,
                         ECKey.parse(TEST_SIGNING_KEY),
                         TEST_COMPONENT_ID,
                         true))
@@ -748,7 +751,7 @@ class InitialiseIpvSessionHandlerTest {
                         eq(TEST_USER_ID),
                         eq(HMRC_MIGRATION_CRI),
                         stringArgumentCaptor.capture(),
-                        eq(VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE),
+                        eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
                         eq(ECKey.parse(TEST_SIGNING_KEY)),
                         eq(TEST_COMPONENT_ID),
                         eq(true));
@@ -792,7 +795,7 @@ class InitialiseIpvSessionHandlerTest {
                         TEST_USER_ID,
                         HMRC_MIGRATION_CRI,
                         PCL200_MIGRATION_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
+                        IDENTITY_CHECK_CREDENTIAL_TYPE,
                         ECKey.parse(TEST_SIGNING_KEY),
                         TEST_COMPONENT_ID,
                         true))
@@ -818,6 +821,13 @@ class InitialiseIpvSessionHandlerTest {
 
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
+
+        verify(mockIpvSessionService, times(2))
+                .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
+        var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
+        assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
+        assertEquals(
+                "Inherited identity JWT failed to validate", capturedErrorObject.getDescription());
     }
 
     @Test
@@ -904,8 +914,10 @@ class InitialiseIpvSessionHandlerTest {
                                                         Map.of(
                                                                 VALUES,
                                                                 List.of(
-                                                                        PCL200_MIGRATION_VC,
-                                                                        PCL200_MIGRATION_VC)))))
+                                                                        PCL200_MIGRATION_VC
+                                                                                .getVcString(),
+                                                                        PCL200_MIGRATION_VC
+                                                                                .getVcString())))))
                                 .build());
         when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY))
                 .thenReturn(true); // Mock enabled inherited identity feature flag
@@ -933,6 +945,14 @@ class InitialiseIpvSessionHandlerTest {
                         eq("test-client"),
                         eq("test-state"),
                         eq(null));
+
+        verify(mockIpvSessionService, times(2))
+                .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
+        var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
+        assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
+        assertEquals(
+                "2 inherited identity jwts received - one expected",
+                capturedErrorObject.getDescription());
     }
 
     @Test
@@ -979,10 +999,18 @@ class InitialiseIpvSessionHandlerTest {
                         eq("test-client"),
                         eq("test-state"),
                         eq(null));
+
+        verify(mockIpvSessionService, times(2))
+                .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
+        var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
+        assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
+        assertEquals(
+                "Inherited identity jwt claim received but value is null",
+                capturedErrorObject.getDescription());
     }
 
     @Test
-    void shouldRecoverIfInheritedIdentityJwtCanNotBeParsed() throws Exception {
+    void shouldRecoverIfInheritedIdentityJwtFailsToParseAndValidate() throws Exception {
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
                 .thenReturn(ipvSessionItem);
@@ -997,66 +1025,22 @@ class InitialiseIpvSessionHandlerTest {
                                                 USER_INFO,
                                                 Map.of(
                                                         INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        "🌭"))) // why did this have to change to
-                                // work?
-                                .build());
-        when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        Map<String, Object> sessionParams =
-                Map.of("clientId", "test-client", "request", signedEncryptedJwt.serialize());
-        event.setBody(objectMapper.writeValueAsString(sessionParams));
-        event.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(event, mockContext);
-
-        // Assert
-        Map<String, Object> responseBody =
-                objectMapper.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
-        verify(mockClientOAuthSessionDetailsService)
-                .generateErrorClientSessionDetails(
-                        any(String.class),
-                        eq("https://example.com"),
-                        eq("test-client"),
-                        eq("test-state"),
-                        eq(null));
-    }
-
-    @Test
-    void shouldRecoverIfInheritedIdentityJwtFailsValidation() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(
-                        claimsBuilder
-                                .claim(
-                                        CLAIMS,
-                                        Map.of(
-                                                USER_INFO,
-                                                Map.of(
-                                                        INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                        Map.of(
-                                                                VALUES,
-                                                                List.of(
-                                                                        PCL200_MIGRATION_VC
-                                                                                .getVcString())))))
+                                                        Map.of(VALUES, List.of("🌭")))))
                                 .build());
         when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)).thenReturn(true);
         when(mockConfigService.getCriConfig(HMRC_MIGRATION_CRI)).thenReturn(TEST_CRI_CONFIG);
-        doThrow(
+        when(mockVerifiableCredentialValidator.parseAndValidate(
+                        TEST_USER_ID,
+                        HMRC_MIGRATION_CRI,
+                        "🌭",
+                        IDENTITY_CHECK_CREDENTIAL_TYPE,
+                        TEST_CRI_CONFIG.getParsedSigningKey(),
+                        TEST_CRI_CONFIG.getComponentId(),
+                        true))
+                .thenThrow(
                         new VerifiableCredentialException(
                                 HTTPResponse.SC_SERVER_ERROR,
-                                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL))
-                .when(mockVerifiableCredentialValidator)
-                .parseAndValidate(any(), any(), any(), any(), any(), any(), anyBoolean());
+                                ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, Object> sessionParams =
@@ -1081,6 +1065,13 @@ class InitialiseIpvSessionHandlerTest {
                         eq("test-client"),
                         eq("test-state"),
                         eq(null));
+
+        verify(mockIpvSessionService, times(2))
+                .generateIpvSession(anyString(), errorObjectArgumentCaptor.capture(), isNull());
+        var capturedErrorObject = errorObjectArgumentCaptor.getAllValues().get(1);
+        assertEquals(INVALID_INHERITED_IDENTITY, capturedErrorObject.getCode());
+        assertEquals(
+                "Inherited identity JWT failed to validate", capturedErrorObject.getDescription());
     }
 
     @Test
@@ -1116,7 +1107,7 @@ class InitialiseIpvSessionHandlerTest {
                         TEST_USER_ID,
                         HMRC_MIGRATION_CRI,
                         PCL200_MIGRATION_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
+                        IDENTITY_CHECK_CREDENTIAL_TYPE,
                         ECKey.parse(TEST_SIGNING_KEY),
                         TEST_COMPONENT_ID,
                         true))


### PR DESCRIPTION
For reviewing the tests, suggest commit by commit. Commit two is just a big refactor.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return a custom OAuth error code for issues with inhertied identity JWT.

### Why did it change

[PYIC-5137: Return specific error code for inherited identities](https://github.com/govuk-one-login/ipv-core-back/commit/02d772e6fb8d86538a952d429d3831c9a6f9655b)

Orchestrator would like to receive a specific OAuth error code for if
the JAR validation fails due to an inherited identity. Currently they
will receive "invalid_request_object" for all issues with the JAR.

This creates a new `ErrorObject` that can be returned in the event of a
problem validating the inherited identity JWT contained within the JAR.


[PYIC-5137: Tidy up initalise ipv session tests](https://github.com/govuk-one-login/ipv-core-back/commit/ccfc364a83efaa4e0c149bb290467a68063dec21)

Moves the inherited identity tests to their own nested block, which
allows for some code to be moved to a setup block.

Also moves some stuff to constants so it can be reused by each test
rather than setting it up each time.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5137](https://govukverify.atlassian.net/browse/PYIC-5137)


[PYIC-5137]: https://govukverify.atlassian.net/browse/PYIC-5137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ