### PR TITLE
BAU: Allow multiple same CI codes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -204,21 +200,21 @@
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "85d1e7563098941624848ca8a7c731a6c013235b",
         "is_verified": false,
-        "line_number": 217
+        "line_number": 215
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "69facda46567909882c049ea59985c33000974b3",
         "is_verified": false,
-        "line_number": 300
+        "line_number": 298
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "1bb4f6b3cf1f8b05e40be98e555120bbac8bb8a8",
         "is_verified": false,
-        "line_number": 353
+        "line_number": 351
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -1886,5 +1882,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-18T11:58:25Z"
+  "generated_at": "2024-03-19T09:26:42Z"
 }

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -236,7 +236,7 @@ public class BuildUserIdentityHandler
             ContraIndicators contraIndicators,
             Map<String, ContraIndicatorConfig> ciConfig) {
         var issuers =
-                contraIndicators.getContraIndicatorsMap().values().stream()
+                contraIndicators.getUsersContraIndicators().stream()
                         .filter(
                                 ci ->
                                         ciConfig.get(ci.getCode())

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -101,9 +101,8 @@ class BuildUserIdentityHandlerTest {
 
     private static final ContraIndicators contraIndicators =
             ContraIndicators.builder()
-                    .contraIndicatorsMap(
-                            Map.of(
-                                    "X01",
+                    .usersContraIndicators(
+                            List.of(
                                     ContraIndicator.builder()
                                             .code("X01")
                                             .issuers(
@@ -111,7 +110,6 @@ class BuildUserIdentityHandlerTest {
                                                             "https://review-d.account.gov.uk",
                                                             "https://review-f.account.gov.uk"))
                                             .build(),
-                                    "X02",
                                     ContraIndicator.builder()
                                             .code("X02")
                                             .issuers(
@@ -119,7 +117,6 @@ class BuildUserIdentityHandlerTest {
                                                             "https://review-q.account.gov.uk",
                                                             "https://review-f.account.gov.uk"))
                                             .build(),
-                                    "Z03",
                                     ContraIndicator.builder()
                                             .code("Z03")
                                             .issuers(
@@ -340,9 +337,8 @@ class BuildUserIdentityHandlerTest {
                     throws Exception {
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
-                        .contraIndicatorsMap(
-                                Map.of(
-                                        "X01",
+                        .usersContraIndicators(
+                                List.of(
                                         ContraIndicator.builder()
                                                 .code("X01")
                                                 .issuers(
@@ -350,7 +346,6 @@ class BuildUserIdentityHandlerTest {
                                                                 "https://review-d.account.gov.uk",
                                                                 "https://review-f.account.gov.uk"))
                                                 .build(),
-                                        "X02",
                                         ContraIndicator.builder()
                                                 .code("X02")
                                                 .issuers(
@@ -358,7 +353,6 @@ class BuildUserIdentityHandlerTest {
                                                                 "https://review-d.account.gov.uk",
                                                                 "https://review-f.account.gov.uk"))
                                                 .build(),
-                                        "Z03",
                                         ContraIndicator.builder()
                                                 .code("Z03")
                                                 .issuers(

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -93,8 +92,7 @@ class BuildUserIdentityHandlerTest {
                         "dummyOAuthUserId", "dummySigninJourneyId", null))
                 .thenReturn(cimitVc);
 
-        var contraIndicators =
-                ContraIndicators.builder().contraIndicatorsMap(new HashMap<>()).build();
+        var contraIndicators = ContraIndicators.builder().usersContraIndicators(List.of()).build();
         when(mockCiMitService.getContraIndicators(cimitVc)).thenReturn(contraIndicators);
 
         // Configure the config service

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1166,12 +1166,11 @@ class CheckExistingIdentityHandlerTest {
 
     @Test
     void shouldReturnSameMitigationJourneyWhenCiAlreadyMitigated() throws Exception {
-        var code = "ci_code";
         var journey = "some_mitigation";
         var mitigatedCI =
                 ContraIndicator.builder().mitigation(List.of(Mitigation.builder().build())).build();
         var testContraIndicators =
-                ContraIndicators.builder().contraIndicatorsMap(Map.of(code, mitigatedCI)).build();
+                ContraIndicators.builder().usersContraIndicators(List.of(mitigatedCI)).build();
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -1194,11 +1193,10 @@ class CheckExistingIdentityHandlerTest {
 
     @Test
     void shouldReturnSameJourneyMitigationWhenCiAlreadyMitigatedF2F() throws Exception {
-        var code = "ci_code";
         var mitigatedCI =
                 ContraIndicator.builder().mitigation(List.of(Mitigation.builder().build())).build();
         var testContraIndicators =
-                ContraIndicators.builder().contraIndicatorsMap(Map.of(code, mitigatedCI)).build();
+                ContraIndicators.builder().usersContraIndicators(List.of(mitigatedCI)).build();
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -1226,12 +1224,11 @@ class CheckExistingIdentityHandlerTest {
     void
             shouldThrowUnsupportedMitigationRouteExceptionWhenCiMitigationJourneyStepPresentButNotSupported()
                     throws Exception {
-        var code = "ci_code";
         var journey = "unsupported_mitigation";
         var mitigatedCI =
                 ContraIndicator.builder().mitigation(List.of(Mitigation.builder().build())).build();
         var testContraIndicators =
-                ContraIndicators.builder().contraIndicatorsMap(Map.of(code, mitigatedCI)).build();
+                ContraIndicators.builder().usersContraIndicators(List.of(mitigatedCI)).build();
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -40,7 +40,6 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredent
 import uk.gov.di.ipv.core.processcricallback.exception.InvalidCriCallbackRequestException;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -73,9 +72,8 @@ class CriCheckingServiceTest {
     private static final String TEST_CI_CODE = "test_ci_code";
     private static final ContraIndicators TEST_CONTRA_INDICATORS =
             ContraIndicators.builder()
-                    .contraIndicatorsMap(
-                            Map.of(
-                                    TEST_CI_CODE,
+                    .usersContraIndicators(
+                            List.of(
                                     ContraIndicator.builder()
                                             .code(TEST_CI_CODE)
                                             .mitigation(List.of(Mitigation.builder().build()))

--- a/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CiMitServiceTest.java
+++ b/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CiMitServiceTest.java
@@ -218,7 +218,7 @@ class CiMitServiceTest {
                 new String(request.getPayload().array(), StandardCharsets.UTF_8));
 
         assertEquals(
-                "ContraIndicators(contraIndicatorsMap={D01=ContraIndicator(code=D01, issuers=[https://issuing-cri.example], issuanceDate=2022-09-20T15:54:50.000Z, document=passport/GBR/824159121, txn=[abcdef], mitigation=[Mitigation(code=M01, mitigatingCredential=[MitigatingCredential(issuer=https://credential-issuer.example/, validFrom=2022-09-21T15:54:50.000Z, txn=ghij, id=urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6)])], incompleteMitigation=[Mitigation(code=M02, mitigatingCredential=[MitigatingCredential(issuer=https://another-credential-issuer.example/, validFrom=2022-09-22T15:54:50.000Z, txn=cdeef, id=urn:uuid:f5c9ff40-1dcd-4a8b-bf92-9456047c132f)])])})",
+                "ContraIndicators(usersContraIndicators=[ContraIndicator(code=D01, issuers=[https://issuing-cri.example], issuanceDate=2022-09-20T15:54:50.000Z, document=passport/GBR/824159121, txn=[abcdef], mitigation=[Mitigation(code=M01, mitigatingCredential=[MitigatingCredential(issuer=https://credential-issuer.example/, validFrom=2022-09-21T15:54:50.000Z, txn=ghij, id=urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6)])], incompleteMitigation=[Mitigation(code=M02, mitigatingCredential=[MitigatingCredential(issuer=https://another-credential-issuer.example/, validFrom=2022-09-22T15:54:50.000Z, txn=cdeef, id=urn:uuid:f5c9ff40-1dcd-4a8b-bf92-9456047c132f)])])])",
                 contraIndications.toString());
     }
 
@@ -348,7 +348,7 @@ class CiMitServiceTest {
                         GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP, TEST_USER_ID),
                 new String(request.getPayload().array(), StandardCharsets.UTF_8));
 
-        assertEquals("ContraIndicators(contraIndicatorsMap={})", contraIndicators.toString());
+        assertEquals("ContraIndicators(usersContraIndicators=[])", contraIndicators.toString());
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CiMitUtilityService.java
@@ -41,7 +41,7 @@ public class CiMitUtilityService {
             throws ConfigException, MitigationRouteConfigNotFoundException {
         // Try to mitigate an unmitigated ci to resolve the threshold breach
         var cimitConfig = configService.getCimitConfig();
-        for (var ci : contraIndicators.getContraIndicatorsMap().values()) {
+        for (var ci : contraIndicators.getUsersContraIndicators()) {
             if (isCiMitigatable(ci) && !isBreachingCiThresholdIfMitigated(ci, contraIndicators)) {
                 // Prevent new mitigation journey if there is already a mitigated CI
                 if (hasMitigatedContraIndicator(contraIndicators).isPresent()) {
@@ -91,7 +91,7 @@ public class CiMitUtilityService {
 
     public Optional<ContraIndicator> hasMitigatedContraIndicator(
             ContraIndicators contraIndicators) {
-        return contraIndicators.getContraIndicatorsMap().values().stream()
+        return contraIndicators.getUsersContraIndicators().stream()
                 .filter(ContraIndicator::isMitigated)
                 .findFirst();
     }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
@@ -54,11 +54,11 @@ class CiMitUtilityServiceTest {
 
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
 
-        Map<String, ContraIndicator> cisMap = new HashMap<>();
-        cisMap.put("ci_1", ContraIndicator.builder().build());
-        cisMap.put("ci_2", ContraIndicator.builder().build());
-
-        ContraIndicators cis = ContraIndicators.builder().contraIndicatorsMap(cisMap).build();
+        var usersCis =
+                List.of(
+                        ContraIndicator.builder().code("ci_1").build(),
+                        ContraIndicator.builder().code("ci_2").build());
+        ContraIndicators cis = ContraIndicators.builder().usersContraIndicators(usersCis).build();
 
         assertTrue(
                 ciMitUtilityService.isBreachingCiThreshold(cis),
@@ -91,11 +91,11 @@ class CiMitUtilityServiceTest {
 
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
 
-        Map<String, ContraIndicator> cisMap = new HashMap<>();
-        cisMap.put("ci_1", ContraIndicator.builder().build());
-        cisMap.put("ci_2", ContraIndicator.builder().build());
-
-        ContraIndicators cis = ContraIndicators.builder().contraIndicatorsMap(cisMap).build();
+        var usersCis =
+                List.of(
+                        ContraIndicator.builder().code("ci_1").build(),
+                        ContraIndicator.builder().code("ci_2").build());
+        ContraIndicators cis = ContraIndicators.builder().usersContraIndicators(usersCis).build();
 
         assertFalse(
                 ciMitUtilityService.isBreachingCiThreshold(cis),
@@ -119,9 +119,7 @@ class CiMitUtilityServiceTest {
         ContraIndicator ci2 =
                 ContraIndicator.builder().code("ciCode2").issuanceDate("some_date").build();
         ContraIndicators cis =
-                ContraIndicators.builder()
-                        .contraIndicatorsMap(Map.of("ciCode1", ci1, "ciCode2", ci2))
-                        .build();
+                ContraIndicators.builder().usersContraIndicators(List.of(ci1, ci2)).build();
         Map<String, ContraIndicatorConfig> ciConfigMap =
                 Map.of(
                         "ciCode1", new ContraIndicatorConfig("ciCode", 4, -3, "X"),
@@ -140,9 +138,7 @@ class CiMitUtilityServiceTest {
         ContraIndicator ci2 =
                 ContraIndicator.builder().code("ciCode2").issuanceDate("some_date").build();
         ContraIndicators cis =
-                ContraIndicators.builder()
-                        .contraIndicatorsMap(Map.of("ciCode1", ci1, "ciCode2", ci2))
-                        .build();
+                ContraIndicators.builder().usersContraIndicators(List.of(ci1, ci2)).build();
         Map<String, ContraIndicatorConfig> ciConfigMap =
                 Map.of(
                         "ciCode1", new ContraIndicatorConfig("ciCode", 5, -5, "X"),
@@ -166,7 +162,7 @@ class CiMitUtilityServiceTest {
                         .document(document)
                         .issuanceDate("some_date")
                         .build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
         Map<String, ContraIndicatorConfig> ciConfigMap =
@@ -188,7 +184,7 @@ class CiMitUtilityServiceTest {
         var code = "ci_code";
         var journey = "some_mitigation";
         var ci = ContraIndicator.builder().code(code).issuanceDate("some_date").build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, null))));
         Map<String, ContraIndicatorConfig> ciConfigMap =
@@ -218,7 +214,7 @@ class CiMitUtilityServiceTest {
                         .document(document)
                         .issuanceDate("some_date")
                         .build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
         Map<String, ContraIndicatorConfig> ciConfigMap =
@@ -237,7 +233,7 @@ class CiMitUtilityServiceTest {
         // arrange
         var code = "ci_code";
         var ci = ContraIndicator.builder().code(code).issuanceDate("some_date").build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig()).thenReturn(Collections.emptyMap());
 
         // act
@@ -257,7 +253,7 @@ class CiMitUtilityServiceTest {
                         .issuanceDate("some_date")
                         .mitigation(List.of(Mitigation.builder().build()))
                         .build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute("journey", null))));
 
@@ -274,7 +270,7 @@ class CiMitUtilityServiceTest {
         // arrange
         var code = "ci_code";
         var ci = ContraIndicator.builder().code(code).issuanceDate("some_date").build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute("journey", null))));
         Map<String, ContraIndicatorConfig> ciConfigMap =
@@ -296,7 +292,7 @@ class CiMitUtilityServiceTest {
         var code = "ci_code";
         var journey = "some_mitigation";
         var ci = ContraIndicator.builder().code(code).issuanceDate("some_date").build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, "documentType"))));
         Map<String, ContraIndicatorConfig> ciConfigMap =
@@ -324,7 +320,7 @@ class CiMitUtilityServiceTest {
                         .document(document)
                         .issuanceDate("some_date")
                         .build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
         Map<String, ContraIndicatorConfig> ciConfigMap =
@@ -354,7 +350,7 @@ class CiMitUtilityServiceTest {
                         .document(document)
                         .issuanceDate("some_date")
                         .build();
-        var cis = ContraIndicators.builder().contraIndicatorsMap(Map.of(code, ci)).build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
         Map<String, ContraIndicatorConfig> ciConfigMap =
@@ -391,10 +387,7 @@ class CiMitUtilityServiceTest {
                         .issuanceDate("some_date")
                         .mitigation(List.of(Mitigation.builder().build()))
                         .build();
-        var cis =
-                ContraIndicators.builder()
-                        .contraIndicatorsMap(Map.of(code, ci, "mit_ci_code", mitCi))
-                        .build();
+        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci, mitCi)).build();
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
         Map<String, ContraIndicatorConfig> ciConfigMap =

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -388,7 +388,7 @@ public class UserIdentityService {
 
     private List<ReturnCode> mapCisToReturnCodes(ContraIndicators contraIndicators)
             throws UnrecognisedCiException {
-        return contraIndicators.getContraIndicatorsMap().values().stream()
+        return contraIndicators.getUsersContraIndicators().stream()
                 .map(ContraIndicator::getCode)
                 .map(
                         ciCode ->

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -90,7 +90,7 @@ class UserIdentityServiceTest {
     @Mock private ConfigService mockConfigService;
     @Mock private DataStore<VcStoreItem> mockDataStore;
     private final ContraIndicators emptyContraIndicators =
-            ContraIndicators.builder().contraIndicatorsMap(new HashMap<>()).build();
+            ContraIndicators.builder().usersContraIndicators(List.of()).build();
     private UserIdentityService userIdentityService;
     private final Map<ConfigurationVariable, String> paramsToMockForP2 =
             Map.of(CORE_VTM_CLAIM, "mock-vtm-claim");
@@ -1175,11 +1175,11 @@ class UserIdentityServiceTest {
 
         var contraIndicators =
                 ContraIndicators.builder()
-                        .contraIndicatorsMap(
-                                Map.of(
-                                        "X01", ContraIndicator.builder().code("X01").build(),
-                                        "X02", ContraIndicator.builder().code("X02").build(),
-                                        "Z03", ContraIndicator.builder().code("Z03").build()))
+                        .usersContraIndicators(
+                                List.of(
+                                        ContraIndicator.builder().code("X01").build(),
+                                        ContraIndicator.builder().code("X02").build(),
+                                        ContraIndicator.builder().code("Z03").build()))
                         .build();
 
         // Act
@@ -1215,8 +1215,8 @@ class UserIdentityServiceTest {
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
-                        .contraIndicatorsMap(
-                                Map.of("wat", ContraIndicator.builder().code("wat").build()))
+                        .usersContraIndicators(
+                                List.of(ContraIndicator.builder().code("wat").build()))
                         .build();
 
         // Act & Assert
@@ -1240,19 +1240,18 @@ class UserIdentityServiceTest {
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
-                        .contraIndicatorsMap(
-                                Map.of(
-                                        "X01", ContraIndicator.builder().code("X01").build(),
-                                        "X02",
-                                                ContraIndicator.builder()
-                                                        .code("X02")
-                                                        .mitigation(
-                                                                List.of(
-                                                                        Mitigation.builder()
-                                                                                .code("M01")
-                                                                                .build()))
-                                                        .build(),
-                                        "Z03", ContraIndicator.builder().code("Z03").build()))
+                        .usersContraIndicators(
+                                List.of(
+                                        ContraIndicator.builder().code("X01").build(),
+                                        ContraIndicator.builder()
+                                                .code("X02")
+                                                .mitigation(
+                                                        List.of(
+                                                                Mitigation.builder()
+                                                                        .code("M01")
+                                                                        .build()))
+                                                .build(),
+                                        ContraIndicator.builder().code("Z03").build()))
                         .build();
 
         // Act
@@ -1276,8 +1275,8 @@ class UserIdentityServiceTest {
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
-                        .contraIndicatorsMap(
-                                Map.of("wat", ContraIndicator.builder().code("wat").build()))
+                        .usersContraIndicators(
+                                List.of(ContraIndicator.builder().code("wat").build()))
                         .build();
 
         assertThrows(
@@ -1301,12 +1300,12 @@ class UserIdentityServiceTest {
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
-                        .contraIndicatorsMap(
-                                Map.of(
-                                        "X01", ContraIndicator.builder().code("X01").build(),
-                                        "X02", ContraIndicator.builder().code("X02").build(),
-                                        "Z03", ContraIndicator.builder().code("Z03").build(),
-                                        "Z04", ContraIndicator.builder().code("Z04").build()))
+                        .usersContraIndicators(
+                                List.of(
+                                        ContraIndicator.builder().code("X01").build(),
+                                        ContraIndicator.builder().code("X02").build(),
+                                        ContraIndicator.builder().code("Z03").build(),
+                                        ContraIndicator.builder().code("Z04").build()))
                         .build();
 
         // Act
@@ -1333,8 +1332,8 @@ class UserIdentityServiceTest {
 
         ContraIndicators contraIndicators =
                 ContraIndicators.builder()
-                        .contraIndicatorsMap(
-                                Map.of("X01", ContraIndicator.builder().code("X01").build()))
+                        .usersContraIndicators(
+                                List.of(ContraIndicator.builder().code("X01").build()))
                         .build();
 
         // Act


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow multiple same CI codes

### Why did it change

Core was blowing up when a user had more than one CI with the same code. This is likely to happen with the new mitigation work.

Internally we were converting the list of CI received from CiMit into a map, with the CI code as the key. This doesn't work for multiple same CI codes.

This change updates the internal structure to a list, and fixes up all the methods that previosuly operated on the map to operate on the list instead.
