### PR TITLE
PYIC-3984: Show error page if dcmaw disabled in mitigation journeys

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -677,6 +677,10 @@ MITIGATION_01_IDENTITY_START_PAGE:
   events:
     next:
       targetState: MITIGATION_01_CRI_DCMAW
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR_NO_TICF
     end:
       targetState: MITIGATION_01_F2F_START_PAGE
       checkIfDisabled:
@@ -756,6 +760,10 @@ MITIGATION_02_OPTIONS:
     mitigationStart: enhanced-verification
   events:
     next:
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR_NO_TICF
       targetState: CRI_DCMAW_PYI_ESCAPE
     end:
       targetJourney: INELIGIBLE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -251,6 +251,10 @@ PYI_CRI_ESCAPE:
   events:
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     f2f:
       targetState: CRI_F2F
       checkFeatureFlag:
@@ -264,6 +268,10 @@ PYI_CRI_ESCAPE_NO_F2F:
   events:
     next:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE_SKIP_MESSAGE
@@ -611,6 +619,10 @@ MITIGATION_KBV_FAIL_M2B:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -653,6 +665,10 @@ PYI_KBV_DROPOUT_M2B:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -680,7 +696,7 @@ MITIGATION_01_IDENTITY_START_PAGE:
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
-          targetState: ERROR_NO_TICF
+          targetState: ERROR
     end:
       targetState: MITIGATION_01_F2F_START_PAGE
       checkIfDisabled:
@@ -760,11 +776,11 @@ MITIGATION_02_OPTIONS:
     mitigationStart: enhanced-verification
   events:
     next:
+      targetState: CRI_DCMAW_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
-          targetState: ERROR_NO_TICF
-      targetState: CRI_DCMAW_PYI_ESCAPE
+          targetState: ERROR
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -821,6 +837,10 @@ MITIGATION_02_OPTIONS_WITH_F2F:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
 
 MITIGATION_02_OPTIONS_WITH_F2F_M2B:
   response:
@@ -836,6 +856,10 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
 
 PYI_POST_OFFICE:
   response:


### PR DESCRIPTION
## Proposed changes

### What changed

On mitigation journeys where dcmaw is a journey step, add checks to see if dcmaw is enabled and if not, show an error page.

### Why did it change

Disabling DCMAW still allowed users to reach the DCMAW CRI

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-3984](https://govukverify.atlassian.net/browse/PYIC-3984)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-3984]: https://govukverify.atlassian.net/browse/PYIC-3984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ