### PR TITLE
PYIC-4590: Add leading slash to api key secret lookup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -172,7 +172,7 @@
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "b23bfcf171726bb7759b91aae38bf146e6eaac70",
+        "hashed_secret": "49edc8e5cce3d7f30610b919b21c6722f4553131",
         "is_verified": false,
         "line_number": 954
       },
@@ -193,7 +193,7 @@
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "7456c32054693a3154d744c6729b2547b63e770c",
+        "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
         "line_number": 2111
       }
@@ -1886,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-19T16:42:03Z"
+  "generated_at": "2024-03-26T10:53:29Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -951,7 +951,7 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - AWSSecretsManagerGetSecretValuePolicy:
-            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/*/connections/*/api-key-*
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/credential-issuers/*/connections/*/api-key-*
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
         - Statement:
@@ -2108,7 +2108,7 @@ Resources:
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
         - AWSSecretsManagerGetSecretValuePolicy:
-            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:${Environment}/credential-issuers/ticf/connections/*/api-key-*
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/credential-issuers/ticf/connections/*/api-key-*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - Statement:

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -46,11 +46,6 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_P
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
 
-/* For developers, this lambda requires manual configuration of the following secret in SecretsManager
-A secret will be created automatically with a "/" character
-This secret needs to be manually recreated without the leading "/"
-Example: dev-<account>/credential-issuers/ticf/connections/stub/api-key
- */
 public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final JourneyResponse JOURNEY_FAIL_WITH_CI =

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -338,7 +338,7 @@ public class ConfigService {
     private String getApiKeyFromSecretManager(String criId, String connection) {
         String secretId =
                 String.format(
-                        "%s/credential-issuers/%s/connections/%s/api-key",
+                        "/%s/credential-issuers/%s/connections/%s/api-key",
                         getEnvironmentVariable(ENVIRONMENT), criId, connection);
         try {
             String secretValue = getSecretValue(secretId);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -415,7 +415,7 @@ class ConfigServiceTest {
     void getCriPrivateApiKeyForActiveConnectionShouldReturnApiKeySecret() {
         environmentVariables.set("ENVIRONMENT", "test");
         Map<String, String> apiKeySecret = Map.of("apiKey", "api-key-value");
-        when(secretsProvider.get("test/credential-issuers/ukPassport/connections/stub/api-key"))
+        when(secretsProvider.get("/test/credential-issuers/ukPassport/connections/stub/api-key"))
                 .thenReturn(gson.toJson(apiKeySecret));
         when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                 .thenReturn("stub");


### PR DESCRIPTION
Updates core back to lookup api key secrets with a leading forward slash

## Proposed changes

### What changed

Core back config service now retrieves api key secrets with a leading forward slash e.g.
`/integration/credential-issuers/drivingLicence/connections/main/api-key`	

### Why did it change

Secret names have been updated to match usual paramter/secret naming conventions

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4590](https://govukverify.atlassian.net/browse/PYIC-4590)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-4590]: https://govukverify.atlassian.net/browse/PYIC-4590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ