### PR TITLE
PYIC-5599 Update ticfHandler to not persist vc to vcstore. Also update BuildUserIdentity to include ticfVc to bundle when enabled.

### DIFF
--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -50,6 +50,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.TICF_CRI_BETA;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_VOT;
 
@@ -163,6 +164,10 @@ public class BuildUserIdentityHandler
                     userIdentityService.generateUserIdentity(
                             vcs, userId, ipvSessionItem.getVot(), contraIndicators);
             userIdentity.getVcs().add(contraIndicatorsVc.getVcString());
+            if (configService.enabled(TICF_CRI_BETA)
+                    && (ipvSessionItem.getRiskAssessmentCredential() != null)) {
+                userIdentity.getVcs().add(ipvSessionItem.getRiskAssessmentCredential());
+            }
 
             sendIdentityIssuedAuditEvent(
                     ipvSessionItem, auditEventUser, contraIndicators, userIdentity);

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -156,11 +156,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
         LogHelper.attachGovukSigninJourneyIdToLogs(
                 clientOAuthSessionItem.getGovukSigninJourneyId());
 
-        var ticfVcs =
-                ticfCriService.getTicfVc(
-                        clientOAuthSessionItem,
-                        ipvSessionItem,
-                        ipvSessionItem.getVcReceivedThisSession());
+        var ticfVcs = ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem);
 
         if (ticfVcs.isEmpty()) {
             LOGGER.warn(LogHelper.buildLogMessage("No TICF VC to process - returning next"));

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -61,9 +61,7 @@ public class TicfCriService {
     }
 
     public List<VerifiableCredential> getTicfVc(
-            ClientOAuthSessionItem clientOAuthSessionItem,
-            IpvSessionItem ipvSessionItem,
-            List<String> vcs)
+            ClientOAuthSessionItem clientOAuthSessionItem, IpvSessionItem ipvSessionItem)
             throws TicfCriServiceException {
         try {
             RestCriConfig ticfCriConfig = configService.getRestCriConfig(TICF_CRI);
@@ -75,7 +73,7 @@ public class TicfCriService {
                             TRUSTMARK,
                             clientOAuthSessionItem.getUserId(),
                             clientOAuthSessionItem.getGovukSigninJourneyId(),
-                            vcs);
+                            ipvSessionItem.getVcReceivedThisSession());
 
             HttpRequest.Builder httpRequestBuilder =
                     HttpRequest.newBuilder()

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
@@ -103,8 +103,7 @@ class CallTicfCriHandlerTest {
         when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockTicfCriService.getTicfVc(
-                        clientOAuthSessionItem, spyIpvSessionItem, VCS_RECEIVED_THIS_SESSION))
+        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem))
                 .thenReturn(List.of(mockVerifiableCredential));
 
         Map<String, Object> lambdaResult = callTicfCriHandler.handleRequest(input, mockContext);
@@ -132,7 +131,7 @@ class CallTicfCriHandlerTest {
         when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem, null))
+        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem))
                 .thenReturn(List.of());
 
         Map<String, Object> lambdaResult = callTicfCriHandler.handleRequest(input, mockContext);
@@ -152,7 +151,7 @@ class CallTicfCriHandlerTest {
         when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem, null))
+        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem))
                 .thenReturn(List.of(mockVerifiableCredential));
         when(mockCiMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
 
@@ -171,7 +170,7 @@ class CallTicfCriHandlerTest {
         when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem, null))
+        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem))
                 .thenReturn(List.of(mockVerifiableCredential));
         when(mockCiMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
         when(mockCiMitUtilityService.getCiMitigationJourneyStep(any()))
@@ -193,7 +192,7 @@ class CallTicfCriHandlerTest {
         when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem, null))
+        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem))
                 .thenReturn(List.of(mockVerifiableCredential));
         when(mockCiMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
         when(mockCiMitUtilityService.getCiMitigationJourneyStep(any()))
@@ -235,7 +234,7 @@ class CallTicfCriHandlerTest {
         when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(new ClientOAuthSessionItem());
-        when(mockTicfCriService.getTicfVc(any(), any(), any()))
+        when(mockTicfCriService.getTicfVc(any(), any()))
                 .thenThrow(new TicfCriServiceException("Oh dear"));
 
         Map<String, Object> lambdaResult = callTicfCriHandler.handleRequest(input, mockContext);
@@ -264,7 +263,7 @@ class CallTicfCriHandlerTest {
             when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
             when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                     .thenReturn(new ClientOAuthSessionItem());
-            when(mockTicfCriService.getTicfVc(any(), any(), any()))
+            when(mockTicfCriService.getTicfVc(any(), any()))
                     .thenReturn(List.of(mockVerifiableCredential));
             doThrow(e).when(mockCriStoringService).storeVcs(any(), any(), any(), any(), any());
 
@@ -307,7 +306,7 @@ class CallTicfCriHandlerTest {
         when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(new ClientOAuthSessionItem());
-        when(mockTicfCriService.getTicfVc(any(), any(), any()))
+        when(mockTicfCriService.getTicfVc(any(), any()))
                 .thenReturn(List.of(mockVerifiableCredential));
         when(mockCiMitService.getContraIndicators(any(), any(), any()))
                 .thenThrow(new CiRetrievalException("Oh dear"));

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java
@@ -121,11 +121,7 @@ class ContractTest {
         var underTest = getTicfCriService();
 
         // Act
-        var ticfVcs =
-                underTest.getTicfVc(
-                        getClientOAuthSessionItem(),
-                        getIpvSessionItem(),
-                        List.of(passportVcJwtHelper.buildJwt()));
+        var ticfVcs = underTest.getTicfVc(getClientOAuthSessionItem(), getIpvSessionItem());
 
         // Assert
         var claimsSet = ticfVcs.get(0).getClaimsSet();
@@ -189,11 +185,7 @@ class ContractTest {
         var underTest = getTicfCriService();
 
         // Act
-        var ticfVcs =
-                underTest.getTicfVc(
-                        getClientOAuthSessionItem(),
-                        getIpvSessionItem(),
-                        List.of(passportVcJwtHelper.buildJwt()));
+        var ticfVcs = underTest.getTicfVc(getClientOAuthSessionItem(), getIpvSessionItem());
 
         // Assert
         var claimsSet = ticfVcs.get(0).getClaimsSet();
@@ -255,11 +247,7 @@ class ContractTest {
         var underTest = getTicfCriService();
 
         // Act
-        var ticfVcs =
-                underTest.getTicfVc(
-                        getClientOAuthSessionItem(),
-                        getIpvSessionItem(),
-                        List.of(passportVcJwtHelper.buildJwt()));
+        var ticfVcs = underTest.getTicfVc(getClientOAuthSessionItem(), getIpvSessionItem());
 
         // Assert
         var claimsSet = ticfVcs.get(0).getClaimsSet();
@@ -324,11 +312,7 @@ class ContractTest {
         var underTest = getTicfCriService();
 
         // Act
-        var ticfVcs =
-                underTest.getTicfVc(
-                        getClientOAuthSessionItem(),
-                        getIpvSessionItem(),
-                        List.of(passportVcJwtHelper.buildJwt()));
+        var ticfVcs = underTest.getTicfVc(getClientOAuthSessionItem(), getIpvSessionItem());
 
         // Assert
         var claimsSet = ticfVcs.get(0).getClaimsSet();
@@ -383,11 +367,7 @@ class ContractTest {
         var underTest = getTicfCriService();
 
         // Act
-        var ticfVcs =
-                underTest.getTicfVc(
-                        getClientOAuthSessionItem(),
-                        getIpvSessionItem(),
-                        List.of(dvlaVcJwtHelper.buildJwt(), passportVcJwtHelper.buildJwt()));
+        var ticfVcs = underTest.getTicfVc(getClientOAuthSessionItem(), getIpvSessionItem());
 
         // Assert
         var claimsSet = ticfVcs.get(0).getClaimsSet();
@@ -444,8 +424,9 @@ class ContractTest {
         var underTest = getTicfCriService();
 
         // Act
-        var ticfVcs =
-                underTest.getTicfVc(getClientOAuthSessionItem(), getIpvSessionItem(), List.of());
+        IpvSessionItem ipvSessionItem = getIpvSessionItem();
+        ipvSessionItem.setVcReceivedThisSession(List.of());
+        var ticfVcs = underTest.getTicfVc(getClientOAuthSessionItem(), ipvSessionItem);
 
         // Assert
         var claimsSet = ticfVcs.get(0).getClaimsSet();
@@ -510,11 +491,7 @@ class ContractTest {
         var underTest = getTicfCriService();
 
         // Act
-        var ticfVcs =
-                underTest.getTicfVc(
-                        getClientOAuthSessionItem(),
-                        getIpvSessionItem(),
-                        List.of(dvlaWithCiVcJwtHelper.buildJwt()));
+        var ticfVcs = underTest.getTicfVc(getClientOAuthSessionItem(), getIpvSessionItem());
 
         // Assert
         var claimsSet = ticfVcs.get(0).getClaimsSet();
@@ -606,6 +583,7 @@ class ContractTest {
     private IpvSessionItem getIpvSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setVot(Vot.P2);
+        ipvSessionItem.setVcReceivedThisSession(List.of(passportVcJwtHelper.buildJwt()));
 
         return ipvSessionItem;
     }

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriServiceTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriServiceTest.java
@@ -117,10 +117,7 @@ class TicfCriServiceTest {
 
         assertEquals(
                 VC_ADDRESS.getVcString(),
-                ticfCriService
-                        .getTicfVc(clientSessionItem, ipvSessionItem, vcsReceivedThisSession)
-                        .get(0)
-                        .getVcString());
+                ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem).get(0).getVcString());
 
         verify(mockHttpClient).send(requestCaptor.capture(), any());
         assertEquals(
@@ -135,7 +132,7 @@ class TicfCriServiceTest {
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatus.SC_OK);
         when(mockHttpResponse.body()).thenReturn(objectMapper.writeValueAsString(ticfCriResponse));
 
-        ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem, vcsReceivedThisSession);
+        ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem);
 
         verify(mockHttpClient).send(requestCaptor.capture(), any());
 
@@ -150,22 +147,17 @@ class TicfCriServiceTest {
                 .thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(statusCode);
 
-        assertEquals(
-                List.of(),
-                ticfCriService.getTicfVc(
-                        clientSessionItem, ipvSessionItem, vcsReceivedThisSession));
+        assertEquals(List.of(), ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem));
     }
 
     @Test
     void getTicfVcShouldThrowIfCanNotSerializeRequest() {
+        ipvSessionItem.setVcReceivedThisSession(mock(List.class));
         when(mockConfigService.getRestCriConfig(TICF_CRI)).thenReturn(ticfCriConfig);
-
         // Jackson can't serialize mocks
         assertThrows(
                 TicfCriServiceException.class,
-                () ->
-                        ticfCriService.getTicfVc(
-                                clientSessionItem, ipvSessionItem, mock(List.class)));
+                () -> ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem));
     }
 
     @ParameterizedTest
@@ -182,10 +174,7 @@ class TicfCriServiceTest {
         when(mockHttpClient.send(any(), any()))
                 .thenThrow((Throwable) exceptionToThrow.getConstructor().newInstance());
 
-        assertEquals(
-                List.of(),
-                ticfCriService.getTicfVc(
-                        clientSessionItem, ipvSessionItem, vcsReceivedThisSession));
+        assertEquals(List.of(), ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem));
     }
 
     @Test
@@ -198,9 +187,7 @@ class TicfCriServiceTest {
 
         assertThrows(
                 TicfCriServiceException.class,
-                () ->
-                        ticfCriService.getTicfVc(
-                                clientSessionItem, ipvSessionItem, vcsReceivedThisSession));
+                () -> ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem));
     }
 
     @Test
@@ -224,9 +211,7 @@ class TicfCriServiceTest {
         TicfCriServiceException thrown =
                 assertThrows(
                         TicfCriServiceException.class,
-                        () ->
-                                ticfCriService.getTicfVc(
-                                        clientSessionItem, ipvSessionItem, vcsReceivedThisSession));
+                        () -> ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem));
 
         assertTrue(thrown.getMessage().contains("No credentials in TICF CRI response"));
     }
@@ -249,8 +234,6 @@ class TicfCriServiceTest {
 
         assertThrows(
                 TicfCriServiceException.class,
-                () ->
-                        ticfCriService.getTicfVc(
-                                clientSessionItem, ipvSessionItem, vcsReceivedThisSession));
+                () -> ticfCriService.getTicfVc(clientSessionItem, ipvSessionItem));
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -5,7 +5,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     RESET_IDENTITY("resetIdentity"),
     INHERITED_IDENTITY("inheritedIdentity"),
     REPROVE_IDENTITY_ENABLED("reproveIdentityEnabled"),
-    ALTERNATE_DOC_MITIGATION_ENABLED("alternateDocMitigationEnabled");
+    ALTERNATE_DOC_MITIGATION_ENABLED("alternateDocMitigationEnabled"),
+    TICF_CRI_BETA("ticfCriBeta");
 
     private final String name;
 

--- a/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
+++ b/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
@@ -120,10 +120,11 @@ public class CriStoringService {
             ciMitService.submitVC(vc, govukSigninJourneyId, ipAddress);
             ciMitService.submitMitigatingVcList(List.of(vc), govukSigninJourneyId, ipAddress);
 
-            verifiableCredentialService.persistUserCredentials(vc);
-            ipvSessionItem.addVcReceivedThisSession(vc);
             if (criId.equals(TICF_CRI)) {
                 ipvSessionItem.setRiskAssessmentCredential(vc.getVcString());
+            } else {
+                verifiableCredentialService.persistUserCredentials(vc);
+                ipvSessionItem.addVcReceivedThisSession(vc);
             }
         }
 

--- a/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
+++ b/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
@@ -170,6 +170,7 @@ class CriStoringServiceTest {
         assertEquals(
                 AuditEventTypes.IPV_CORE_CRI_RESOURCE_RETRIEVED, secondAuditEvent.getEventName());
 
+        verify(mockVerifiableCredentialService).persistUserCredentials(vc);
         verify(mockIpvSessionItem).addVcReceivedThisSession(vc);
         verify(mockIpvSessionItem, times(0)).setRiskAssessmentCredential(vc.getVcString());
     }
@@ -216,7 +217,8 @@ class CriStoringServiceTest {
         assertEquals(
                 AuditEventTypes.IPV_CORE_CRI_RESOURCE_RETRIEVED, secondAuditEvent.getEventName());
 
-        verify(mockIpvSessionItem).addVcReceivedThisSession(vc);
+        verify(mockVerifiableCredentialService, times(0)).persistUserCredentials(vc);
+        verify(mockIpvSessionItem, times(0)).addVcReceivedThisSession(vc);
         verify(mockIpvSessionItem).setRiskAssessmentCredential(vc.getVcString());
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Update ticfHandler to not persist vc to vcstore and also not add to the vcReceivedThisSession in session.
Also update BuildUserIdentity to include the riskAssessmentCredential in the bundle when ticf is enabled.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5599](https://govukverify.atlassian.net/browse/PYIC-5599)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-5599]: https://govukverify.atlassian.net/browse/PYIC-5599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ