### PR TITLE
PYIC-5132: Define dependencies in `libs.versions.toml`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id "java"
-	id "org.sonarqube" version "4.4.1.3373"
-	id "com.diffplug.spotless" version "6.25.0"
+	alias libs.plugins.sonar
+	alias libs.plugins.spotless
 }
 
 repositories {
@@ -29,28 +29,6 @@ spotless {
 		trimTrailingWhitespace()
 		endWithNewline()
 	}
-}
-
-ext {
-	dependencyVersions = [
-		awsJavaSdkDynamodb:'1.12.665',
-		awsJavaSdkLambda:'1.12.665',
-		awsJavaSdkSqs:'1.12.665',
-		awsJavaSdkKms:'1.12.665',
-		awsLambdaJavaCore:'1.2.3',
-		awsLambdaJavaEvents:'3.11.4',
-		dynamodbEnhanced:'2.24.9',
-		gson:'2.10.1',
-		jacksonDataformatYaml:'2.15.3',
-		kms:'2.24.9',
-		log4j:'2.23.0',
-		lombok:'1.18.30',
-		nimbusdsOauth2OidcSdk:'9.27',
-		notificationsJavaClient: '4.1.1-RELEASE',
-		powertoolsParameters:'1.18.0',
-		powertoolsLogging:'1.18.0',
-		powertoolsTracing:'1.18.0'
-	]
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,48 @@
+[versions]
+awsSdk = "1.12.665"
+log4j = "2.23.0"
+mockito = "5.11.0"
+pact = "4.6.5"
+powertools = "1.18.0"
+
+[libraries]
+aspectj = { module = "org.aspectj:aspectjrt", version = { strictly = "1.9.8" } }
+awsJavaSdkDynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version.ref = "awsSdk" }
+awsJavaSdkKms = { module = "com.amazonaws:aws-java-sdk-kms", version.ref = "awsSdk" }
+awsJavaSdkLambda = { module = "com.amazonaws:aws-java-sdk-lambda", version.ref = "awsSdk" }
+awsJavaSdkSqs = { module = "com.amazonaws:aws-java-sdk-sqs", version.ref = "awsSdk" }
+awsLambdaJavaCore = "com.amazonaws:aws-lambda-java-core:1.2.3"
+awsLambdaJavaEvents = "com.amazonaws:aws-lambda-java-events:3.11.4"
+dynamodbEnhanced = "software.amazon.awssdk:dynamodb-enhanced:2.24.9"
+gson = "com.google.code.gson:gson:2.10.1"
+hamcrest = "org.hamcrest:hamcrest:2.2"
+jacksonDatabind = "com.fasterxml.jackson.core:jackson-databind:2.15.3"
+jacksonDataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3"
+jacksonDatatypeJsr = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3"
+junitJupiter = "org.junit.jupiter:junit-jupiter:5.10.0"
+junitPlatform = "org.junit.platform:junit-platform-launcher:1.10.2"
+kms = "software.amazon.awssdk:kms:2.24.9"
+log4j12Api = { module = "org.apache.logging.log4j:log4j-1.2-api", version.ref = "log4j" }
+log4jApi = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
+log4jCore = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+lombok = "org.projectlombok:lombok:1.18.30"
+mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockitoJunit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+nimbusdsOauth2OidcSdk = "com.nimbusds:oauth2-oidc-sdk:9.27"
+notificationsJavaClient = "uk.gov.service.notify:notifications-java-client:4.1.1-RELEASE"
+pactConsumerJunit = { module = "au.com.dius.pact.consumer:junit5", version.ref = "pact" }
+pactProviderJunit = { module = "au.com.dius.pact.provider:junit5", version.ref = "pact" }
+powertoolsLogging = { module = "software.amazon.lambda:powertools-logging", version.ref = "powertools" }
+powertoolsParameters = { module = "software.amazon.lambda:powertools-parameters", version.ref = "powertools" }
+powertoolsTracing = { module = "software.amazon.lambda:powertools-tracing", version.ref = "powertools" }
+spark = "com.sparkjava:spark-core:2.9.4"
+systemStubs = "uk.org.webcompere:system-stubs-jupiter:2.1.3"
+wiremock = "com.github.tomakehurst:wiremock-jre8:3.0.1"
+
+[bundles]
+log4j = ["log4jApi", "log4jCore"]
+
+[plugins]
+postCompileWeaving = "io.freefair.aspectj.post-compile-weaving:8.6"
+sonar = "org.sonarqube:4.4.1.3373"
+spotless = "com.diffplug.spotless:6.25.0"

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -14,24 +14,23 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"org.apache.logging.log4j:log4j-api:$rootProject.ext.dependencyVersions.log4j",
-			"org.apache.logging.log4j:log4j-core:$rootProject.ext.dependencyVersions.log4j",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.awsJavaSdkDynamodb,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.gson,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.bundles.log4j,
+			libs.dynamodbEnhanced,
+			libs.powertoolsParameters,
 			project(":libs:common-services")
 
-	testImplementation "com.github.tomakehurst:wiremock-jre8:3.0.1",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-core:5.11.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"uk.org.webcompere:system-stubs-jupiter:2.1.3",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0"
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation libs.wiremock,
+			libs.junitJupiter,
+			libs.mockitoCore,
+			libs.mockitoJunit,
+			libs.systemStubs,
+			libs.jacksonDatatypeJsr
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/build-client-oauth-response/build.gradle
+++ b/lambdas/build-client-oauth-response/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -11,25 +11,22 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:audit-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0"
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/build-cri-oauth-request/build.gradle
+++ b/lambdas/build-cri-oauth-request/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,10 +10,10 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:kms-es256-signer"),
 			project(":libs:journey-uris"),
@@ -22,21 +22,17 @@ dependencies {
 			project(":libs:verifiable-credentials"),
 			project(":libs:user-identity-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,30 +10,26 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:verifiable-credentials"),
 			project(":libs:user-identity-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testRuntimeOnly(libs.junitPlatform)
 }
 
 java {

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -11,30 +11,27 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),
 			project(":libs:audit-service"),
 			project(":libs:user-identity-service"),
 			project(":libs:verifiable-credentials")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"au.com.dius.pact.provider:junit5:4.6.5",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
+			libs.pactProviderJunit,
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:pact-test-helpers')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/call-ticf-cri/build.gradle
+++ b/lambdas/call-ticf-cri/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,10 +10,10 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:audit-service"),
 			project(":libs:cimit-service"),
 			project(":libs:common-services"),
@@ -22,21 +22,17 @@ dependencies {
 			project(":libs:user-identity-service"),
 			project(":libs:verifiable-credentials")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"au.com.dius.pact.consumer:junit5:4.6.5",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
+			libs.pactConsumerJunit,
 			project(path: ':libs:common-services', configuration: 'tests'),
-			project(":libs:pact-test-helpers")
+			project(path: ':libs:pact-test-helpers')
 
-	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,10 +10,10 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),
 			project(":libs:journey-uris"),
@@ -23,19 +23,16 @@ dependencies {
 			project(":libs:verifiable-credentials"),
 			project(":libs:user-identity-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.gson,
+			libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly(libs.junitPlatform)
 }
 
 java {

--- a/lambdas/check-gpg45-score/build.gradle
+++ b/lambdas/check-gpg45-score/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,10 +10,10 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:audit-service"),
 			project(":libs:journey-uris"),
@@ -21,19 +21,16 @@ dependencies {
 			project(":libs:user-identity-service"),
 			project(":libs:verifiable-credentials")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.gson,
+			libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly(libs.junitPlatform)
 }
 
 java {

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -11,10 +11,10 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:audit-service"),
@@ -22,19 +22,16 @@ dependencies {
 			project(":libs:verifiable-credentials"),
 			project(":libs:user-identity-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.gson,
+			libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly(libs.junitPlatform)
 }
 
 java {

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -11,32 +11,29 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-java-sdk-kms:$rootProject.ext.dependencyVersions.awsJavaSdkKms",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsJavaSdkKms,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.powertoolsParameters,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials"),
 			project(":libs:audit-service"),
 			project(":libs:user-identity-service")
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	compileOnly	libs.lombok
+	annotationProcessor libs.lombok
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.gson,
+			libs.junitJupiter,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly(libs.junitPlatform)
 }
 
 java {

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -11,30 +11,26 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+	implementation libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.dynamodbEnhanced,
 			project(":libs:common-services")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"au.com.dius.pact.provider:junit5:4.6.5",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
+			libs.pactProviderJunit,
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:pact-test-helpers')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,35 +10,32 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.dynamodbEnhanced,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),
 			project(":libs:cri-response-service"),
 			project(":libs:audit-service"),
 			project(":libs:verifiable-credentials")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	compileOnly	libs.lombok
+	annotationProcessor libs.lombok
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "com.github.tomakehurst:wiremock-jre8:3.0.1",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"au.com.dius.pact.consumer:junit5:4.6.5",
+	testImplementation libs.wiremock,
+			libs.junitJupiter,
+			libs.mockitoJunit,
+			libs.pactConsumerJunit,
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:pact-test-helpers')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -11,10 +11,10 @@ repositories {
 
 dependencies {
 
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:audit-service"),
 			project(":libs:cimit-service"),
 			project(":libs:common-services"),
@@ -26,24 +26,20 @@ dependencies {
 			project(":libs:user-identity-service"),
 			project(":libs:verifiable-credentials")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"au.com.dius.pact.consumer:junit5:4.6.5",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
+			libs.pactConsumerJunit,
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(":libs:pact-test-helpers")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/process-journey-event/build.gradle
+++ b/lambdas/process-journey-event/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,29 +10,26 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$rootProject.ext.dependencyVersions.jacksonDataformatYaml",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.jacksonDataformatYaml,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:audit-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"uk.org.webcompere:system-stubs-jupiter:2.1.3"
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
+			libs.systemStubs
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/replay-cimit-vcs/build.gradle
+++ b/lambdas/replay-cimit-vcs/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,28 +10,25 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:cri-response-service"),
 			project(":libs:verifiable-credentials"),
 			project(":libs:cimit-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/reset-identity/build.gradle
+++ b/lambdas/reset-identity/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,10 +10,10 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:cri-response-service"),
@@ -22,19 +22,16 @@ dependencies {
 			project(":libs:email-service"),
 			project(":libs:user-identity-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.gson,
+			libs.junitJupiter,
+			libs.mockitoJunit,
 			project(":libs:common-services").sourceSets.test.output
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/restore-vcs/build.gradle
+++ b/lambdas/restore-vcs/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,32 +10,29 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.dynamodbEnhanced,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:cri-response-service"),
 			project(":libs:verifiable-credentials"),
 			project(":libs:audit-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
+
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/lambdas/revoke-vcs/build.gradle
+++ b/lambdas/revoke-vcs/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.6'
+	alias libs.plugins.postCompileWeaving
 }
 
 repositories {
@@ -10,32 +10,29 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.dynamodbEnhanced,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:cri-response-service"),
 			project(":libs:verifiable-credentials"),
 			project(":libs:audit-service")
 
-	aspect "software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-tracing:$rootProject.ext.dependencyVersions.powertoolsTracing"
-	aspect('org.aspectj:aspectjrt') {
-		version {
-			strictly '1.9.8'
-		}
-	}
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
+
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -10,21 +10,22 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
+	implementation libs.awsJavaSdkSqs,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
+			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:gpg45-evaluator"),
 			project(":libs:verifiable-credentials")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testRuntimeOnly libs.junitPlatform
+
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 }
 
 java {

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -10,21 +10,22 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-lambda:$rootProject.ext.dependencyVersions.awsJavaSdkLambda",
-			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.awsJavaSdkLambda,
+			libs.gson,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
+			project(path: ':libs:common-services', configuration: 'tests')
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -10,27 +10,29 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
-			"com.amazonaws:aws-java-sdk-lambda:$rootProject.ext.dependencyVersions.awsJavaSdkLambda",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.awsJavaSdkDynamodb,
+			libs.awsJavaSdkLambda,
+			libs.awsLambdaJavaEvents,
+			libs.gson,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.dynamodbEnhanced,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
 			project(":libs:journey-uris")
 
-	testImplementation "com.github.tomakehurst:wiremock-jre8:3.0.1",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"uk.org.webcompere:system-stubs-jupiter:2.1.3",
-			"org.hamcrest:hamcrest:2.2"
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-	testCompileOnly("org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok")
-	testAnnotationProcessor("org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok")
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testImplementation libs.wiremock,
+			libs.junitJupiter,
+			libs.mockitoJunit,
+			libs.systemStubs,
+			libs.hamcrest
+
+	testRuntimeOnly libs.junitPlatform
+
+	testCompileOnly libs.lombok
+	testAnnotationProcessor libs.lombok
 }
 
 java {

--- a/libs/cri-response-service/build.gradle
+++ b/libs/cri-response-service/build.gradle
@@ -10,15 +10,16 @@ repositories {
 }
 
 def var = dependencies {
-	implementation "software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.dynamodbEnhanced,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
 			project(":libs:common-services")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(":libs:common-services").sourceSets.test.output
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 var
 

--- a/libs/cri-storing-service/build.gradle
+++ b/libs/cri-storing-service/build.gradle
@@ -9,8 +9,8 @@ repositories {
 }
 
 dependencies {
-	implementation "com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
+	implementation libs.nimbusdsOauth2OidcSdk,
+			libs.powertoolsLogging,
 			project(":libs:audit-service"),
 			project(":libs:cimit-service"),
 			project(":libs:common-services"),
@@ -18,10 +18,11 @@ dependencies {
 
 	api project(":libs:cri-response-service")
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0',
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/libs/email-service/build.gradle
+++ b/libs/email-service/build.gradle
@@ -10,21 +10,22 @@ repositories {
 }
 
 dependencies {
-	implementation "com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
-			"uk.gov.service.notify:notifications-java-client:$rootProject.ext.dependencyVersions.notificationsJavaClient",
+	implementation libs.gson,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
+			libs.notificationsJavaClient,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
+			project(path: ':libs:common-services', configuration: 'tests')
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/libs/gpg45-evaluator/build.gradle
+++ b/libs/gpg45-evaluator/build.gradle
@@ -10,20 +10,21 @@ repositories {
 }
 
 dependencies {
-	implementation "com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.gson,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.dynamodbEnhanced,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
 			project(":libs:common-services")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
+			project(path: ':libs:common-services', configuration: 'tests')
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -10,25 +10,26 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-dynamodb:$rootProject.ext.dependencyVersions.awsJavaSdkDynamodb",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.awssdk:kms:$rootProject.ext.dependencyVersions.kms",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.awsJavaSdkDynamodb,
+			libs.awsLambdaJavaEvents,
+			libs.gson,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.dynamodbEnhanced,
+			libs.kms,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
 			project(":libs:common-services")
 
-	testImplementation "com.github.tomakehurst:wiremock-jre8:3.0.1",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"uk.org.webcompere:system-stubs-jupiter:2.1.3",
-			project(":libs:common-services").sourceSets.test.output
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testImplementation libs.wiremock,
+			libs.junitJupiter,
+			libs.mockitoJunit,
+			libs.systemStubs,
+			project(":libs:common-services").sourceSets.test.output
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/libs/pact-test-helpers/build.gradle
+++ b/libs/pact-test-helpers/build.gradle
@@ -10,17 +10,18 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"au.com.dius.pact.consumer:junit5:4.6.5",
-			'com.fasterxml.jackson.core:jackson-databind:2.15.3',
+	implementation libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.mockitoJunit,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.pactConsumerJunit,
+			libs.jacksonDatabind,
 			project(path: ':libs:common-services')
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/libs/user-identity-service/build.gradle
+++ b/libs/user-identity-service/build.gradle
@@ -10,18 +10,19 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-lambda:$rootProject.ext.dependencyVersions.awsJavaSdkLambda",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.awsJavaSdkLambda,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.dynamodbEnhanced,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials")
 
-	testImplementation "org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
+	testImplementation libs.junitJupiter,
+			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -10,23 +10,24 @@ repositories {
 }
 
 dependencies {
-	implementation "com.amazonaws:aws-java-sdk-lambda:$rootProject.ext.dependencyVersions.awsJavaSdkLambda",
-			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
-			"software.amazon.awssdk:dynamodb-enhanced:$rootProject.ext.dependencyVersions.dynamodbEnhanced",
-			"software.amazon.lambda:powertools-logging:$rootProject.ext.dependencyVersions.powertoolsLogging",
-			"software.amazon.lambda:powertools-parameters:$rootProject.ext.dependencyVersions.powertoolsParameters",
+	implementation libs.awsJavaSdkLambda,
+			libs.gson,
+			libs.nimbusdsOauth2OidcSdk,
+			libs.dynamodbEnhanced,
+			libs.powertoolsLogging,
+			libs.powertoolsParameters,
 			project(":libs:common-services"),
 			project(":libs:gpg45-evaluator")
 
-	testImplementation "com.github.tomakehurst:wiremock-jre8:3.0.1",
-			"org.junit.jupiter:junit-jupiter:5.10.0",
-			"org.mockito:mockito-junit-jupiter:5.11.0",
-			project(":libs:common-services").sourceSets.test.output
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
 
-	compileOnly "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
-	annotationProcessor "org.projectlombok:lombok:$rootProject.ext.dependencyVersions.lombok"
+	testImplementation libs.wiremock,
+			libs.junitJupiter,
+			libs.mockitoJunit,
+			project(":libs:common-services").sourceSets.test.output
+
+	testRuntimeOnly libs.junitPlatform
 }
 
 java {

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -9,14 +9,13 @@ repositories {
 }
 
 dependencies {
-	implementation "com.sparkjava:spark-core:2.9.4",
-			"com.amazonaws:aws-java-sdk-sqs:$rootProject.ext.dependencyVersions.awsJavaSdkSqs",
-			"com.amazonaws:aws-lambda-java-core:$rootProject.ext.dependencyVersions.awsLambdaJavaCore",
-			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
-			"com.google.code.gson:gson:$rootProject.ext.dependencyVersions.gson",
-			"org.apache.logging.log4j:log4j-1.2-api:2.23.0",
-			"org.apache.logging.log4j:log4j-api:2.23.0",
-			"org.apache.logging.log4j:log4j-core:2.23.0",
+	implementation libs.spark,
+			libs.awsJavaSdkSqs,
+			libs.awsLambdaJavaCore,
+			libs.awsLambdaJavaEvents,
+			libs.gson,
+			libs.log4j12Api,
+			libs.bundles.log4j,
 			project(":lambdas:build-client-oauth-response"),
 			project(":lambdas:build-client-oauth-response"),
 			project(":lambdas:build-cri-oauth-request"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Define dependencies in `libs.versions.toml`

### Why did it change

This creates a "version catalogue" in gradle - a central place to declare dependencies and their versions which can be shared by sub-projects. For the gradle docs see the link below: https://docs.gradle.org/current/userguide/platforms.html

We were previously declaring versions in an extension in the root of the project to do a similar job. Whilst this worked, it meant that dependabot was unable to raise PRs to bump versions. The dependabot docs suggest that it can work with a `libs.versions.toml`: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#gradle

Makes sense to use the proper tool for the job.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5132](https://govukverify.atlassian.net/browse/PYIC-5132)


[PYIC-5132]: https://govukverify.atlassian.net/browse/PYIC-5132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ