### PR TITLE
PYIC-5403: Convert BuildProvenUserIdentityDetails to an API GW proxy

### DIFF
--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -15,7 +15,6 @@ dependencies {
 			"com.amazonaws:aws-lambda-java-events:$rootProject.ext.dependencyVersions.awsLambdaJavaEvents",
 			"com.nimbusds:oauth2-oidc-sdk:$rootProject.ext.dependencyVersions.nimbusdsOauth2OidcSdk",
 			project(":libs:common-services"),
-			project(":libs:journey-uris"),
 			project(":libs:verifiable-credentials"),
 			project(":libs:user-identity-service")
 

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/ProvenUserIdentityDetails.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/ProvenUserIdentityDetails.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.Address;
-import uk.gov.di.ipv.core.library.domain.BaseResponse;
 
 import java.util.List;
 
@@ -15,7 +14,7 @@ import java.util.List;
 @ExcludeFromGeneratedCoverageReport
 @Data
 @Builder
-public class ProvenUserIdentityDetails extends BaseResponse {
+public class ProvenUserIdentityDetails {
     @JsonProperty private final String name;
     @JsonProperty private final String dateOfBirth;
     @JsonProperty private final List<Address> addresses;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -3,10 +3,14 @@ package uk.gov.di.ipv.core.library.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 @ExcludeFromGeneratedCoverageReport
+@AllArgsConstructor
+@Getter
 public enum ErrorResponse {
     MISSING_QUERY_PARAMETERS(1000, "Missing query parameters for auth request"),
     MISSING_AUTHORIZATION_CODE(1003, "Missing authorization code"),
@@ -82,33 +86,11 @@ public enum ErrorResponse {
             1069, "No mitigation journey route event found in cimit config"),
     UNSUPPORTED_MITIGATION_ROUTE(1070, "Unsupported mitigation route");
 
-    @JsonProperty("code")
     private final int code;
-
-    @JsonProperty("message")
     private final String message;
 
-    ErrorResponse(
-            @JsonProperty(required = true, value = "code") int code,
-            @JsonProperty(required = true, value = "message") String message) {
-        this.code = code;
-        this.message = message;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    public String toJsonString() {
-        return String.format("{\"code\":%d,\"message\":\"%s\"}", code, message);
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
     @JsonCreator
-    public static ErrorResponse forCode(int code) {
+    public static ErrorResponse forCode(@JsonProperty("code") int code) {
         for (ErrorResponse element : values()) {
             if (element.getCode() == code) {
                 return element;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyErrorResponse.java
@@ -14,17 +14,19 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
         value = {"message"},
         allowGetters = true)
 public class JourneyErrorResponse extends JourneyResponse {
-    @JsonProperty private int statusCode;
-
-    @JsonProperty private ErrorResponse code;
-
-    private String message;
+    private final int statusCode;
+    private final ErrorResponse code;
+    private final String message;
 
     @JsonCreator
     public JourneyErrorResponse(
             @JsonProperty(value = "journey", required = true) String journey,
             @JsonProperty(value = "statusCode") int statusCode,
-            @JsonProperty(value = "code") ErrorResponse code) {
+            @JsonProperty(value = "code") int code) {
+        this(journey, statusCode, ErrorResponse.forCode(code));
+    }
+
+    public JourneyErrorResponse(String journey, int statusCode, ErrorResponse code) {
         this(journey, statusCode, code, null);
     }
 
@@ -47,10 +49,12 @@ public class JourneyErrorResponse extends JourneyResponse {
         return null;
     }
 
+    @JsonProperty("statusCode")
     public int getStatusCode() {
         return this.statusCode;
     }
 
+    @JsonProperty("code")
     public int getCode() {
         return this.code != null ? this.code.getCode() : 0;
     }

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -135,30 +135,11 @@ paths:
               schema:
                 type: "object"
       x-amazon-apigateway-integration:
+        type: "aws_proxy"
         httpMethod: "POST"
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildProvenUserIdentityDetailsFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
-        type: "aws"
-        requestTemplates:
-          application/x-www-form-urlencoded:
-            Fn::Sub: |
-              {
-                "ipvSessionId": "$input.params('ipv-session-id')",
-                "ipAddress": "$input.params('ip-address')",
-                "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
-              }
-        responses:
-          default:
-            statusCode: 200
-            responseTemplates:
-              application/json: |
-                #set ($bodyObj = $util.parseJson($input.body))
-                #if ($bodyObj.statusCode)
-                #set($context.responseOverride.status = $bodyObj.statusCode)
-                #end
-                $input.body
 
 components:
   schemas:


### PR DESCRIPTION
Previously this endpoint used VTL to transform the request/response, but a proxy passthrough removes the need to use VTL, and keeps all processing logic in the lambda code.