### PR TITLE
BAU: Set correct criId on logs from build-cri-oauth-request

### DIFF
--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -110,7 +110,7 @@ class BuildCriOauthRequestHandlerTest {
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
     private static final String TEST_SHARED_CLAIMS = "shared_claims";
     private static final String TEST_EVIDENCE_REQUESTED = "evidence_requested";
-    private static final String JOURNEY_BASE_URL = "/journey/cri/build-oauth-request/";
+    private static final String JOURNEY_BASE_URL = "/journey/cri/build-oauth-request/%s";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String TEST_NI_NUMBER = "AA000003D";
     private static final String CONTEXT = "context";
@@ -259,7 +259,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId("aSessionId")
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey("nope")
                         .build();
 
         // Act
@@ -267,7 +267,7 @@ class BuildCriOauthRequestHandlerTest {
 
         // Assert
         assertErrorResponse(
-                HttpStatus.SC_BAD_REQUEST, response, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
+                HttpStatus.SC_BAD_REQUEST, response, ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
     }
 
     @Test
@@ -278,7 +278,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId("aSessionId")
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey("MissingCriId")
+                        .journey(String.format(JOURNEY_BASE_URL, "bad"))
                         .build();
 
         // Act
@@ -325,7 +325,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -407,7 +407,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -490,7 +490,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(JOURNEY_BASE_URL + CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -576,7 +576,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -661,7 +661,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(DCMAW_CRI)
+                        .journey(String.format(JOURNEY_BASE_URL, DCMAW_CRI))
                         .build();
 
         // Act
@@ -836,7 +836,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -903,7 +903,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -968,7 +968,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -1057,7 +1057,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -1124,7 +1124,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -1202,7 +1202,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(CRI_ID)
+                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
                         .build();
 
         // Act
@@ -1279,7 +1279,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(F2F_CRI)
+                        .journey(String.format(JOURNEY_BASE_URL, F2F_CRI))
                         .build();
 
         // Act
@@ -1354,7 +1354,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(HMRC_KBV_CRI)
+                        .journey(String.format(JOURNEY_BASE_URL, HMRC_KBV_CRI))
                         .build();
 
         // Act
@@ -1403,7 +1403,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(F2F_CRI)
+                        .journey(String.format(JOURNEY_BASE_URL, F2F_CRI))
                         .build();
 
         // Act
@@ -1436,7 +1436,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(JOURNEY_BASE_URL + journeyUri)
+                        .journey(String.format(JOURNEY_BASE_URL, journeyUri))
                         .build();
 
         // Act


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set correct criId on logs from build-cri-oauth-request

### Why did it change

I noticed that the logs from the build-cri-oauth-request lambda had the criId set to the journey received by the lambda, rather than just the criId. So like this `criId: /journey/cri/build-oauth-request/fraud` rather than just `criId: fraud`.

This straightens that out and also fixes up so validation, which I don't think was actually working.
