### PR TITLE
PYIC-5675: Add SessionUserIssuedCredentialsTable

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2543,6 +2543,34 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
 
+  SessionCredentialsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table
+      TableName: !Sub "session-credentials-${Environment}"
+      BillingMode: "PAY_PER_REQUEST"
+      DeletionProtectionEnabled: !If
+        - IsProduction
+        - true
+        - false
+      AttributeDefinitions:
+        - AttributeName: "ipvSessionId"
+          AttributeType: "S"
+        - AttributeName: "sortKey"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "ipvSessionId"
+          KeyType: "HASH"
+        - AttributeName: "sortKey"
+          KeyType: "RANGE"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: true
+      SSESpecification:
+        SSEEnabled: true
+        SSEType: KMS
+        KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
+
   RevokedUserCredentialsTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItem.java
@@ -1,0 +1,45 @@
+package uk.gov.di.ipv.core.library.persistence.item;
+
+import com.nimbusds.jwt.SignedJWT;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@DynamoDbBean
+public class SessionCredentialItem implements DynamodbItem {
+
+    private static final String SORT_KEY_TEMPLATE = "%s#%s";
+    private final String ipvSessionId;
+    private final String sortKey;
+    private final String credential;
+    private final boolean receivedThisSession;
+    private long ttl;
+
+    public SessionCredentialItem(
+            String ipvSessionId,
+            String criId,
+            SignedJWT signedCredJwt,
+            boolean receivedThisSession) {
+        this.ipvSessionId = ipvSessionId;
+        this.sortKey = String.format(SORT_KEY_TEMPLATE, criId, signedCredJwt.getSignature());
+        this.credential = signedCredJwt.serialize();
+        this.receivedThisSession = receivedThisSession;
+    }
+
+    @DynamoDbPartitionKey
+    public String getIpvSessionId() {
+        return ipvSessionId;
+    }
+
+    @DynamoDbSortKey
+    public String getSortKey() {
+        return sortKey;
+    }
+
+    @Override
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistance/item/SessionCredentialItemTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistance/item/SessionCredentialItemTest.java
@@ -1,0 +1,22 @@
+package uk.gov.di.ipv.core.library.persistance.item;
+
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SessionCredentialItemTest {
+    @Test
+    void shouldCorrectlyFormSortKey() {
+        var mockJwt = mock(SignedJWT.class);
+        when(mockJwt.getSignature()).thenReturn(Base64URL.encode("signature"));
+
+        var item = new SessionCredentialItem("session-id", "cri-id", mockJwt, true);
+
+        assertEquals("cri-id#c2lnbmF0dXJl", item.getSortKey());
+    }
+}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add SessionUserIssuedCredentialsTable

### Why did it change

This adds a new DynamoDB table for storing users credentials gathered during their session, before writing them to a long term store. This change is just to create the table, and not start writing to it.

It also adds a class to represent the data that will be stored in it - I'm adding this with the table to ensure the correct format of the data, specifically the sort key. The class may change slightly when we acutally implement the writes.

The Sonar quality check is failing due to code smells. These are from the new `SessionCredentialItem` not being used yet, so should be safe to ignore.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5675](https://govukverify.atlassian.net/browse/PYIC-5675)


[PYIC-5675]: https://govukverify.atlassian.net/browse/PYIC-5675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ