### PR TITLE
PYIC-5403: Remove dedicated build-client-oauth-response endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -174,28 +174,28 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "49edc8e5cce3d7f30610b919b21c6722f4553131",
         "is_verified": false,
-        "line_number": 946
+        "line_number": 938
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 948
+        "line_number": 940
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1731
+        "line_number": 1723
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
-        "line_number": 2103
+        "line_number": 2095
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -1886,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-02T13:30:27Z"
+  "generated_at": "2024-04-03T09:03:05Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -619,14 +619,6 @@ Resources:
                 - 'kms:GenerateDataKey'
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
-      Events:
-        IPVCorePrivateAPI:
-          Type: Api
-          Properties:
-            RestApiId:
-              Ref: IPVCorePrivateAPI
-            Path: /journey/build-client-oauth-response
-            Method: POST
       AutoPublishAlias: live
 
   BuildClientOauthResponseFunctionLogGroup:

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -88,42 +88,6 @@ paths:
                   $bodyObj
                 #end
 
-  /journey/build-client-oauth-response:
-    post:
-      description: "Called when the user has completed their user journey in IPV Core"
-      responses:
-        200:
-          description: "Authorization Code and details"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/journeyType"
-      x-amazon-apigateway-integration:
-        httpMethod: "POST"
-        uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BuildClientOauthResponseFunction.Arn}:live/invocations
-        passthroughBehavior: "when_no_match"
-        type: "aws"
-        requestTemplates:
-          application/x-www-form-urlencoded:
-            Fn::Sub: |
-              {
-                "ipvSessionId": "$input.params('ipv-session-id')",
-                "ipAddress": "$input.params('ip-address')",
-                "clientOAuthSessionId": "$input.params('client-session-id')",
-                "featureSet": "$input.params('feature-set')"
-              }
-        responses:
-          default:
-            statusCode: 200
-            responseTemplates:
-              application/json: |
-                #set ($bodyObj = $util.parseJson($input.body))
-                #if ($bodyObj.statusCode)
-                #set($context.responseOverride.status = $bodyObj.statusCode)
-                #end
-                $input.body
-
   /user/proven-identity-details:
     get:
       description: "Called when core front needs to display information about a users proven identity"


### PR DESCRIPTION
## Proposed changes

### What changed

Removed the dedicated `build-client-oauth-response` endpoint so it is handled as a special case in the journey engine.

### Why did it change

This is already effectively just bypassing the journey engine to hit one of the internal lambdas. This keeps the internals private to the journey engine and removes the confusing parallel `/journey/` endpoint.

### Issue tracking

- [PYIC-5403](https://govukverify.atlassian.net/browse/PYIC-5403)


[PYIC-5403]: https://govukverify.atlassian.net/browse/PYIC-5403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ