### PR TITLE
BAU Remove default content type for CRI credential request

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java
@@ -250,6 +250,8 @@ public class CriApiService {
         var apiKey = getApiKey(criConfig, criOAuthSessionItem);
 
         var request = new HTTPRequest(HTTPRequest.Method.POST, criConfig.getCredentialUrl());
+        request.setHeader(
+                "Content-Type", ""); // remove the default, no request body so we don't need
 
         if (apiKey != null) {
             LOGGER.info(


### PR DESCRIPTION
## Proposed changes

### What changed

remove default content type header for CRI credential request

### Why did it change

nimbus (possibly since the upgrade to 11) sets a default Content-Type header for a request but the call to CRI issue credential doesn't have a request body so we shouldn't need to send a Content-Type header at all

NINO CRI is returning a 415 'unsupported media type' response because the Content-Type is not expected

