### PR TITLE
PYIC-5403: Add JSON version of journey API

### DIFF
--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -60,6 +60,21 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:states:action/StartSyncExecution
         passthroughBehavior: "when_no_match"
         requestTemplates:
+          application/json:
+            # This VTL template maps the request into the format required by the step function API
+            # Note that the lack of indentation is deliberate:
+            # the 'input' field must be condensed into a single line to be a valid JSON string
+            Fn::Sub: >
+              {
+              "input": "{
+              \"journey\":\"/journey/$util.escapeJavaScript($input.params('journeyStep'))\",
+              \"ipAddress\":\"$util.escapeJavaScript($input.params('ip-address'))\",
+              \"featureSet\":\"$util.escapeJavaScript($input.params('feature-set'))\",
+              \"ipvSessionId\":\"$util.escapeJavaScript($input.params('ipv-session-id'))\",
+              \"clientOAuthSessionId\":\"$util.escapeJavaScript($input.params('client-session-id'))\"
+              }",
+              "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${JourneyEngineStepFunction.Name}"
+              }
           application/x-www-form-urlencoded:
             Fn::Sub: |
               {


### PR DESCRIPTION
The existing journey API uses `application/x-www-form-urlencoded`. This is largely irrelevant, since there is no request body, but it would be nice to stick with JSON for consistency.

Also refactors the VTL to (try) and make it a bit more readable...