### PR TITLE
PYIC-5718: Added routing for new reprove identity start page

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -68,7 +68,7 @@ RESET_IDENTITY:
   events:
     next:
       targetJourney: NEW_P2_IDENTITY
-      targetState: START
+      targetState: REPROVE_IDENTITY
 
 RESET_GPG45_IDENTITY:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -25,6 +25,11 @@ ENHANCED_VERIFICATION_F2F_FAIL:
     next:
       targetState: F2F_FAILED_MITIGATION_PAGE
 
+REPROVE_IDENTITY:
+  events:
+    next:
+      targetState: REPROVE_IDENTITY_START
+
 # Parent states
 
 CRI_STATE:
@@ -73,6 +78,15 @@ CRI_TICF_STATE:
       targetState: ERROR_NO_TICF
 
 # Journey states
+
+
+REPROVE_IDENTITY_START:
+  response:
+    type: page
+    pageId: reprove-identity-start
+  events:
+    next:
+      targetState: IDENTITY_START_PAGE
 
 RESET_IDENTITY:
   response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added routing for new reprove identity start page

### Why did it change

So we have a new information screen telling a user they must reprove their identity if it has been deleted, instead of simply being redirected to the start new IPV journey page

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5718](https://govukverify.atlassian.net/browse/PYIC-5718)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed



[PYIC-5718]: https://govukverify.atlassian.net/browse/PYIC-5718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ