### PR TITLE
Bau refactor local running

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -53,7 +53,6 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.Arrays;
@@ -146,9 +145,7 @@ public class BuildCriOauthRequestHandler
             String ipAddress = getIpAddress(input);
             configService.setFeatureSet(getFeatureSet(input));
 
-            URI journeyUri = URI.create(input.getJourney());
-
-            var criId = getCriIdFromJourney(journeyUri.getPath());
+            var criId = getCriIdFromJourney(input.getJourneyUri().getPath());
             if (criId == null) {
                 return new JourneyErrorResponse(
                                 JOURNEY_ERROR_PATH,
@@ -158,8 +155,8 @@ public class BuildCriOauthRequestHandler
             }
             LogHelper.attachCriIdToLogs(criId);
 
-            String criContext = getJourneyParameter(journeyUri, CONTEXT);
-            String criScope = getJourneyParameter(journeyUri, SCOPE);
+            String criContext = getJourneyParameter(input, CONTEXT);
+            String criScope = getJourneyParameter(input, SCOPE);
             String connection = configService.getActiveConnection(criId);
             OauthCriConfig criConfig =
                     configService.getOauthCriConfigForConnection(connection, criId);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -85,7 +85,8 @@ public enum ErrorResponse {
     MITIGATION_ROUTE_CONFIG_NOT_FOUND(
             1069, "No mitigation journey route event found in cimit config"),
     UNSUPPORTED_MITIGATION_ROUTE(1070, "Unsupported mitigation route"),
-    FAILED_TO_DELETE_CREDENTIAL(1071, "Failed to delete credential");
+    FAILED_TO_DELETE_CREDENTIAL(1071, "Failed to delete credential"),
+    INVALID_JOURNEY_EVENT(1072, "Invalid journey event in input");
 
     private final int code;
     private final String message;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -4,6 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.http.HttpStatus;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -15,4 +20,17 @@ public class JourneyRequest {
     private String clientOAuthSessionId;
     private String journey;
     private String featureSet;
+
+    public URI getJourneyUri() throws HttpResponseExceptionWithErrorBody {
+        if (journey == null) {
+            throw new HttpResponseExceptionWithErrorBody(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_JOURNEY_EVENT);
+        }
+        try {
+            return new URI(journey);
+        } catch (URISyntaxException e) {
+            throw new HttpResponseExceptionWithErrorBody(
+                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_JOURNEY_EVENT);
+        }
+    }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -13,13 +13,11 @@ import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 
@@ -124,14 +122,21 @@ public class RequestHelper {
         return featureSet;
     }
 
-    public static String getJourneyParameter(URI journeyUri, String key) {
-        List<NameValuePair> queryParams = new URIBuilder(journeyUri).getQueryParams();
-        Optional<NameValuePair> parameter =
-                queryParams.stream()
-                        .filter(query -> Objects.equals(query.getName(), key))
-                        .findFirst();
+    public static String getJourneyEvent(JourneyRequest request)
+            throws HttpResponseExceptionWithErrorBody {
+        var parts = request.getJourneyUri().getPath().split("/");
+        return parts[parts.length - 1];
+    }
 
-        return parameter.map(NameValuePair::getValue).orElse(null);
+    public static String getJourneyParameter(JourneyRequest request, String key)
+            throws HttpResponseExceptionWithErrorBody {
+        List<NameValuePair> queryParams = new URIBuilder(request.getJourneyUri()).getQueryParams();
+        return queryParams.stream()
+                .filter(query -> Objects.equals(query.getName(), key))
+                .findFirst()
+                .map(NameValuePair::getValue)
+                .filter(StringUtils::isNotBlank)
+                .orElse(null);
     }
 
     public static String getScoreType(ProcessRequest request)

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpers.java
@@ -1,91 +1,19 @@
 package uk.gov.di.ipv.core.library.helpers;
 
-import org.apache.http.HttpStatus;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class StepFunctionHelpers {
     private static final String CODE = "code";
-    private static final String IPV_SESSION_ID = "ipvSessionId";
-    private static final String JOURNEY = "journey";
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
-    private static final String IP_ADDRESS = "ipAddress";
     private static final String TYPE = "type";
     private static final String PAGE = "page";
-    private static final String FEATURE_SET = "featureSet";
-    public static final String CURRENT_PAGE = "currentPage";
 
     private StepFunctionHelpers() {
         throw new IllegalStateException("Utility class");
-    }
-
-    public static String getIpvSessionId(Map<String, String> input)
-            throws HttpResponseExceptionWithErrorBody {
-        String ipvSessionId = input.get(IPV_SESSION_ID);
-
-        if (ipvSessionId == null) {
-            throw new HttpResponseExceptionWithErrorBody(
-                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_IPV_SESSION_ID);
-        }
-
-        LogHelper.attachIpvSessionIdToLogs(ipvSessionId);
-
-        return ipvSessionId;
-    }
-
-    public static String getIpAddress(Map<String, String> input) {
-        return input.get(IP_ADDRESS);
-    }
-
-    public static List<String> getFeatureSet(Map<String, String> input) {
-        String featureSet = input.get(FEATURE_SET);
-        LogHelper.attachFeatureSetToLogs(Collections.singletonList(featureSet));
-        return (featureSet != null)
-                ? Arrays.asList(featureSet.split(","))
-                : Collections.emptyList();
-    }
-
-    public static String getJourneyEvent(Map<String, String> input)
-            throws HttpResponseExceptionWithErrorBody, URISyntaxException {
-        String journeyEvent =
-                Optional.ofNullable(input.get(JOURNEY))
-                        .orElseThrow(
-                                () ->
-                                        new HttpResponseExceptionWithErrorBody(
-                                                HttpStatus.SC_BAD_REQUEST,
-                                                ErrorResponse.MISSING_JOURNEY_EVENT));
-
-        URI uri = new URI(journeyEvent);
-
-        String[] parts = uri.getPath().split("/");
-
-        return parts[parts.length - 1];
-    }
-
-    public static String getCurrentPage(Map<String, String> input)
-            throws HttpResponseExceptionWithErrorBody, URISyntaxException {
-
-        String journeyEvent =
-                Optional.ofNullable(input.get(JOURNEY))
-                        .orElseThrow(
-                                () ->
-                                        new HttpResponseExceptionWithErrorBody(
-                                                HttpStatus.SC_BAD_REQUEST,
-                                                ErrorResponse.MISSING_JOURNEY_EVENT));
-
-        String currentPage = RequestHelper.getJourneyParameter(new URI(journeyEvent), CURRENT_PAGE);
-
-        return currentPage != null && !currentPage.isEmpty() ? currentPage : null;
     }
 
     public static Map<String, Object> generateErrorOutputMap(

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/StepFunctionHelpersTest.java
@@ -1,16 +1,11 @@
 package uk.gov.di.ipv.core.library.helpers;
 
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class StepFunctionHelpersTest {
 
@@ -19,72 +14,6 @@ class StepFunctionHelpersTest {
     private static final String STATUS_CODE = "statusCode";
     private static final String TYPE = "type";
     private static final String PAGE = "page";
-
-    @Test
-    void getIpvSessionIdShouldReturnIpvSessionId() throws Exception {
-        Map<String, String> input = Map.of("ipvSessionId", "something");
-
-        assertEquals("something", StepFunctionHelpers.getIpvSessionId(input));
-    }
-
-    @Test
-    void getIpvSessionIdShouldThrowIfIpvSessionIdMissing() {
-        Map<String, String> input = Map.of();
-
-        var exception =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () -> StepFunctionHelpers.getIpvSessionId(input));
-        assertEquals(ErrorResponse.MISSING_IPV_SESSION_ID, exception.getErrorResponse());
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
-    }
-
-    @Test
-    void getJourneyEventShouldReturnJourneyEvent() throws Exception {
-        Map<String, String> input = Map.of("journey", "/journey/next?currentPage=testCurrentPage");
-
-        assertEquals("next", StepFunctionHelpers.getJourneyEvent(input));
-    }
-
-    @Test
-    void getCurrentPageShouldReturnCurrentPage() throws Exception {
-        Map<String, String> input = Map.of("journey", "/journey/next?currentPage=testCurrentPage");
-
-        assertEquals("testCurrentPage", StepFunctionHelpers.getCurrentPage(input));
-    }
-
-    @Test
-    void getCurrentPageShouldReturnNullIfMissing() throws Exception {
-        Map<String, String> input = Map.of("journey", "/journey/next?currentPage=");
-
-        assertNull(StepFunctionHelpers.getCurrentPage(input));
-    }
-
-    @Test
-    void getCurrentPageShouldReturnNullIfNoParameter() throws Exception {
-        Map<String, String> input = Map.of("journey", "/journey/next");
-
-        assertNull(StepFunctionHelpers.getCurrentPage(input));
-    }
-
-    @Test
-    void getJourneyEventShouldThrowIfJourneyMissing() {
-        Map<String, String> input = Map.of();
-
-        var exception =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () -> StepFunctionHelpers.getJourneyEvent(input));
-        assertEquals(ErrorResponse.MISSING_JOURNEY_EVENT, exception.getErrorResponse());
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
-    }
-
-    @Test
-    void getIpAddressShouldReturnIpAddress() {
-        Map<String, String> input = Map.of("ipAddress", "something");
-
-        assertEquals("something", StepFunctionHelpers.getIpAddress(input));
-    }
 
     @Test
     void generateErrorOutputMapShouldGenerateAnErrorOutputMap() {
@@ -110,12 +39,5 @@ class StepFunctionHelpersTest {
 
         assertEquals(
                 expected, StepFunctionHelpers.generatePageOutputMap("error", 400, "some-page"));
-    }
-
-    @Test
-    void getFeatureSetShouldReturnFeatureSet() {
-        Map<String, String> input = Map.of("featureSet", "test-feature-set");
-
-        assertEquals(List.of("test-feature-set"), StepFunctionHelpers.getFeatureSet(input));
     }
 }

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/CoreBack.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/CoreBack.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.coreback;
 import spark.Spark;
 import uk.gov.di.ipv.core.processasynccricredential.ProcessAsyncCriCredentialHandler;
 import uk.gov.di.ipv.coreback.handlers.HomeHandler;
+import uk.gov.di.ipv.coreback.handlers.JourneyEngineHandler;
 import uk.gov.di.ipv.coreback.handlers.LambdaHandler;
 import uk.gov.di.ipv.coreback.sqs.SqsPoller;
 
@@ -10,7 +11,8 @@ import java.io.IOException;
 
 public class CoreBack {
     public CoreBack() throws IOException {
-        LambdaHandler lambdaHandler = new LambdaHandler();
+        var lambdaHandler = new LambdaHandler();
+        var journeyEngineHandler = new JourneyEngineHandler();
 
         new SqsPoller().start(new ProcessAsyncCriCredentialHandler());
 
@@ -18,7 +20,7 @@ public class CoreBack {
         Spark.get("/", HomeHandler.serveHomePage);
 
         Spark.post("/session/initialise", lambdaHandler.getInitialiseSession());
-        Spark.post("/journey/:event", lambdaHandler.getJourneyEngine());
+        Spark.post("/journey/:event", journeyEngineHandler.getJourneyEngine());
         Spark.post("/cri/callback", lambdaHandler.getCriCallBack());
         Spark.get(
                 "/user/proven-identity-details", lambdaHandler.getBuildProvenUserIdentityDetails());

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -68,10 +68,10 @@ public class JourneyEngineHandler {
                             processJourneyStep(request, processJourneyEventOutput);
 
                     if (!processJourneyStepOutput.containsKey(JOURNEY)) {
-                        return OBJECT_MAPPER.writeValueAsString(processJourneyEventOutput);
+                        return OBJECT_MAPPER.writeValueAsString(processJourneyStepOutput);
                     }
 
-                    journeyEvent = (String) processJourneyEventOutput.get(JOURNEY);
+                    journeyEvent = (String) processJourneyStepOutput.get(JOURNEY);
                 }
             };
 

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -1,0 +1,139 @@
+package uk.gov.di.ipv.coreback.handlers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+import uk.gov.di.ipv.core.buildclientoauthresponse.BuildClientOauthResponseHandler;
+import uk.gov.di.ipv.core.buildcrioauthrequest.BuildCriOauthRequestHandler;
+import uk.gov.di.ipv.core.callticfcri.CallTicfCriHandler;
+import uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler;
+import uk.gov.di.ipv.core.checkgpg45score.CheckGpg45ScoreHandler;
+import uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler;
+import uk.gov.di.ipv.core.library.domain.JourneyRequest;
+import uk.gov.di.ipv.core.library.domain.ProcessRequest;
+import uk.gov.di.ipv.core.processjourneyevent.ProcessJourneyEventHandler;
+import uk.gov.di.ipv.core.resetidentity.ResetIdentityHandler;
+import uk.gov.di.ipv.coreback.domain.CoreContext;
+import uk.gov.di.ipv.coreback.exceptions.UnrecognisedJourneyException;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class JourneyEngineHandler {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static final CoreContext EMPTY_CONTEXT = new CoreContext();
+    public static final String APPLICATION_JSON = "application/json";
+
+    public static final String JOURNEY = "journey";
+    public static final String IPV_SESSION_ID = "ipv-session-id";
+    public static final String IP_ADDRESS = "ip-address";
+    public static final String CLIENT_SESSION_ID = "client-session-id";
+    public static final String FEATURE_SET = "feature-set";
+
+    private final ProcessJourneyEventHandler processJourneyEventHandler;
+    private final CheckExistingIdentityHandler checkExistingIdentityHandler;
+    private final ResetIdentityHandler resetIdentityHandler;
+    private final BuildCriOauthRequestHandler buildCriOauthRequestHandler;
+    private final BuildClientOauthResponseHandler buildClientOauthResponseHandler;
+    private final CheckGpg45ScoreHandler checkGpg45ScoreHandler;
+    private final EvaluateGpg45ScoresHandler evaluateGpg45ScoresHandler;
+    private final CallTicfCriHandler callTicfCriHandler;
+
+    public JourneyEngineHandler() throws IOException {
+        this.processJourneyEventHandler = new ProcessJourneyEventHandler();
+        this.checkExistingIdentityHandler = new CheckExistingIdentityHandler();
+        this.resetIdentityHandler = new ResetIdentityHandler();
+        this.buildCriOauthRequestHandler = new BuildCriOauthRequestHandler();
+        this.buildClientOauthResponseHandler = new BuildClientOauthResponseHandler();
+        this.checkGpg45ScoreHandler = new CheckGpg45ScoreHandler();
+        this.evaluateGpg45ScoresHandler = new EvaluateGpg45ScoresHandler();
+        this.callTicfCriHandler = new CallTicfCriHandler();
+    }
+
+    private final Route journeyEngine =
+            (Request request, Response response) -> {
+                response.type(APPLICATION_JSON);
+                String journeyEvent = request.pathInfo();
+
+                while (true) {
+                    var processJourneyEventOutput = processJourneyEvent(request, journeyEvent);
+
+                    if (!processJourneyEventOutput.containsKey(JOURNEY)) {
+                        return OBJECT_MAPPER.writeValueAsString(processJourneyEventOutput);
+                    }
+
+                    var processJourneyStepOutput =
+                            processJourneyStep(request, processJourneyEventOutput);
+
+                    if (!processJourneyStepOutput.containsKey(JOURNEY)) {
+                        return OBJECT_MAPPER.writeValueAsString(processJourneyEventOutput);
+                    }
+
+                    journeyEvent = (String) processJourneyEventOutput.get(JOURNEY);
+                }
+            };
+
+    public Route getJourneyEngine() {
+        return journeyEngine;
+    }
+
+    // Corresponds to the ProcessJourneyStep state in the step function
+    private Map<String, Object> processJourneyEvent(Request request, String journeyEvent) {
+        return processJourneyEventHandler.handleRequest(
+                buildJourneyRequest(request, journeyEvent), EMPTY_CONTEXT);
+    }
+
+    // Corresponds to the ProcessJourneyStepResult state in the step function
+    private Map<String, Object> processJourneyStep(
+            Request request, Map<String, Object> processJourneyEventOutput) {
+        var journeyStep = (String) processJourneyEventOutput.get(JOURNEY);
+
+        return switch (journeyStep) {
+            case "/journey/check-existing-identity" -> checkExistingIdentityHandler.handleRequest(
+                    buildJourneyRequest(request, journeyStep), EMPTY_CONTEXT);
+            case "/journey/reset-identity" -> resetIdentityHandler.handleRequest(
+                    buildProcessRequest(request, processJourneyEventOutput), EMPTY_CONTEXT);
+            case "/journey/build-client-oauth-response" -> buildClientOauthResponseHandler
+                    .handleRequest(buildJourneyRequest(request, journeyStep), EMPTY_CONTEXT);
+            case "/journey/evaluate-gpg45-scores" -> evaluateGpg45ScoresHandler.handleRequest(
+                    buildProcessRequest(request, processJourneyEventOutput), EMPTY_CONTEXT);
+            case "/journey/check-gpg45-scores" -> checkGpg45ScoreHandler.handleRequest(
+                    buildProcessRequest(request, processJourneyEventOutput), EMPTY_CONTEXT);
+            case "/journey/call-ticf-cri" -> callTicfCriHandler.handleRequest(
+                    buildProcessRequest(request, processJourneyEventOutput), EMPTY_CONTEXT);
+            default -> {
+                if (journeyStep.matches("/journey/cri/build-oauth-request/.*")) {
+                    yield buildCriOauthRequestHandler.handleRequest(
+                            buildJourneyRequest(request, journeyStep), EMPTY_CONTEXT);
+                } else {
+                    throw new UnrecognisedJourneyException(
+                            String.format("Journey not configured: %s", journeyStep));
+                }
+            }
+        };
+    }
+
+    private JourneyRequest buildJourneyRequest(Request request, String journey) {
+        return JourneyRequest.builder()
+                .ipvSessionId(request.headers(IPV_SESSION_ID))
+                .ipAddress(request.headers(IP_ADDRESS))
+                .clientOAuthSessionId(request.headers(CLIENT_SESSION_ID))
+                .featureSet(request.headers(FEATURE_SET))
+                .journey(journey)
+                .build();
+    }
+
+    private ProcessRequest buildProcessRequest(
+            Request request, Map<String, Object> processJourneyEventOutput) {
+        return ProcessRequest.processRequestBuilder()
+                .ipvSessionId(request.headers(IPV_SESSION_ID))
+                .ipAddress(request.headers(IP_ADDRESS))
+                .clientOAuthSessionId(request.headers(CLIENT_SESSION_ID))
+                .featureSet(request.headers(FEATURE_SET))
+                .journey((String) processJourneyEventOutput.get(JOURNEY))
+                .lambdaInput((Map<String, Object>) processJourneyEventOutput.get("lambdaInput"))
+                .build();
+    }
+}

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
@@ -3,133 +3,24 @@ package uk.gov.di.ipv.coreback.handlers;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import spark.Request;
 import spark.Response;
 import spark.Route;
-import uk.gov.di.ipv.core.buildclientoauthresponse.BuildClientOauthResponseHandler;
-import uk.gov.di.ipv.core.buildcrioauthrequest.BuildCriOauthRequestHandler;
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.BuildProvenUserIdentityDetailsHandler;
 import uk.gov.di.ipv.core.builduseridentity.BuildUserIdentityHandler;
-import uk.gov.di.ipv.core.callticfcri.CallTicfCriHandler;
-import uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler;
-import uk.gov.di.ipv.core.checkgpg45score.CheckGpg45ScoreHandler;
-import uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler;
 import uk.gov.di.ipv.core.initialiseipvsession.InitialiseIpvSessionHandler;
 import uk.gov.di.ipv.core.issueclientaccesstoken.IssueClientAccessTokenHandler;
-import uk.gov.di.ipv.core.library.domain.JourneyRequest;
-import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.processcricallback.ProcessCriCallbackHandler;
-import uk.gov.di.ipv.core.processjourneyevent.ProcessJourneyEventHandler;
-import uk.gov.di.ipv.core.resetidentity.ResetIdentityHandler;
 import uk.gov.di.ipv.coreback.domain.CoreContext;
-import uk.gov.di.ipv.coreback.exceptions.UnrecognisedJourneyException;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
 public class LambdaHandler {
-
-    private static final Gson gson = new Gson();
     public static final CoreContext EMPTY_CONTEXT = new CoreContext();
-    public static final Type MAP_STRING_STRING_TYPE =
-            new TypeToken<Map<String, String>>() {}.getType();
     public static final String APPLICATION_JSON = "application/json";
-    public static final String JOURNEY = "journey";
-    public static final String IPV_SESSION_ID = "ipv-session-id";
-    public static final String IP_ADDRESS = "ip-address";
-    public static final String CLIENT_SESSION_ID = "client-session-id";
-    public static final String FEATURE_SET = "feature-set";
-
-    private ProcessJourneyEventHandler processJourneyEventHandler;
-    private CheckExistingIdentityHandler checkExistingIdentityHandler;
-    private ResetIdentityHandler resetIdentityHandler;
-    private BuildCriOauthRequestHandler buildCriOauthRequestHandler;
-    private BuildClientOauthResponseHandler buildClientOauthResponseHandler;
-    private CheckGpg45ScoreHandler checkGpg45ScoreHandler;
-    private EvaluateGpg45ScoresHandler evaluateGpg45ScoresHandler;
-    private CallTicfCriHandler callTicfCriHandler;
-
-    public LambdaHandler() throws IOException {
-        this.processJourneyEventHandler = new ProcessJourneyEventHandler();
-        this.checkExistingIdentityHandler = new CheckExistingIdentityHandler();
-        this.resetIdentityHandler = new ResetIdentityHandler();
-        this.buildCriOauthRequestHandler = new BuildCriOauthRequestHandler();
-        this.buildClientOauthResponseHandler = new BuildClientOauthResponseHandler();
-        this.checkGpg45ScoreHandler = new CheckGpg45ScoreHandler();
-        this.evaluateGpg45ScoresHandler = new EvaluateGpg45ScoresHandler();
-        this.callTicfCriHandler = new CallTicfCriHandler();
-    }
 
     private final Route initialiseSession = apiGatewayProxyRoute(new InitialiseIpvSessionHandler());
-
-    private final Route journeyEngine =
-            (Request request, Response response) -> {
-                String journey = request.pathInfo();
-
-                while (true) {
-                    var processJourneyEventOutput =
-                            processJourneyEventHandler.handleRequest(
-                                    buildProcessJourneyEventLambdaInput(request, journey),
-                                    EMPTY_CONTEXT);
-
-                    journey = (String) processJourneyEventOutput.get(JOURNEY);
-
-                    if (journey == null) {
-                        return gson.toJson(processJourneyEventOutput);
-                    }
-
-                    var lambdaOutput =
-                            switch (journey) {
-                                case "/journey/check-existing-identity" -> checkExistingIdentityHandler
-                                        .handleRequest(
-                                                buildJourneyRequest(request, journey),
-                                                EMPTY_CONTEXT);
-                                case "/journey/reset-identity" -> resetIdentityHandler
-                                        .handleRequest(
-                                                buildProcessRequest(
-                                                        request, processJourneyEventOutput),
-                                                EMPTY_CONTEXT);
-                                case "/journey/build-client-oauth-response" -> buildClientOauthResponseHandler
-                                        .handleRequest(
-                                                buildJourneyRequest(request, journey),
-                                                EMPTY_CONTEXT);
-                                case "/journey/evaluate-gpg45-scores" -> evaluateGpg45ScoresHandler
-                                        .handleRequest(
-                                                buildProcessRequest(
-                                                        request, processJourneyEventOutput),
-                                                EMPTY_CONTEXT);
-                                case "/journey/check-gpg45-scores" -> checkGpg45ScoreHandler
-                                        .handleRequest(
-                                                buildProcessRequest(
-                                                        request, processJourneyEventOutput),
-                                                EMPTY_CONTEXT);
-                                case "/journey/call-ticf-cri" -> callTicfCriHandler.handleRequest(
-                                        buildProcessRequest(request, processJourneyEventOutput),
-                                        EMPTY_CONTEXT);
-                                default -> {
-                                    if (journey.matches("/journey/cri/build-oauth-request/.*")) {
-                                        yield buildCriOauthRequestHandler.handleRequest(
-                                                buildJourneyRequest(request, journey),
-                                                EMPTY_CONTEXT);
-                                    } else {
-                                        throw new UnrecognisedJourneyException(
-                                                String.format(
-                                                        "Journey not configured: %s", journey));
-                                    }
-                                }
-                            };
-
-                    if (!lambdaOutput.containsKey(JOURNEY)) {
-                        return gson.toJson(lambdaOutput);
-                    }
-
-                    journey = (String) lambdaOutput.get(JOURNEY);
-                }
-            };
 
     private final Route buildProvenUserIdentityDetails =
             apiGatewayProxyRoute(new BuildProvenUserIdentityDetailsHandler());
@@ -156,16 +47,6 @@ public class LambdaHandler {
         };
     }
 
-    private JourneyRequest buildJourneyRequest(Request request, String journey) {
-        return JourneyRequest.builder()
-                .ipvSessionId(request.headers(IPV_SESSION_ID))
-                .ipAddress(request.headers(IP_ADDRESS))
-                .clientOAuthSessionId(request.headers(CLIENT_SESSION_ID))
-                .featureSet(request.headers(FEATURE_SET))
-                .journey(journey)
-                .build();
-    }
-
     private Map<String, String> getHeadersMap(Request request) {
         Map<String, String> headers = new HashMap<>();
         request.headers().forEach(header -> headers.put(header, request.headers(header)));
@@ -173,30 +54,8 @@ public class LambdaHandler {
         return headers;
     }
 
-    private Map<String, String> buildProcessJourneyEventLambdaInput(
-            Request request, String journey) {
-        return gson.fromJson(
-                gson.toJson(buildJourneyRequest(request, journey)), MAP_STRING_STRING_TYPE);
-    }
-
-    private ProcessRequest buildProcessRequest(
-            Request request, Map<String, Object> processJourneyEventOutput) {
-        return ProcessRequest.processRequestBuilder()
-                .ipvSessionId(request.headers(IPV_SESSION_ID))
-                .ipAddress(request.headers(IP_ADDRESS))
-                .clientOAuthSessionId(request.headers(CLIENT_SESSION_ID))
-                .featureSet(request.headers(FEATURE_SET))
-                .journey((String) processJourneyEventOutput.get(JOURNEY))
-                .lambdaInput((Map<String, Object>) processJourneyEventOutput.get("lambdaInput"))
-                .build();
-    }
-
     public Route getInitialiseSession() {
         return this.initialiseSession;
-    }
-
-    public Route getJourneyEngine() {
-        return this.journeyEngine;
     }
 
     public Route getBuildProvenUserIdentityDetails() {


### PR DESCRIPTION
## Proposed changes

### What changed

- `ProcessJourneyEventHandler` now uses `JourneyRequest`, rather than a raw map class.
- Local running has separate handlers for lambda requests and the journey engine step function.

### Why did it change

- Using typed request classes is more type-safe and easier to consume
- Separating the lambda and journey engine step function makes it easier to work with the local running set up