### PR TITLE
PYIC-5364: Shorten branch name used on pact broker

### DIFF
--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -7,7 +7,7 @@ env:
   PACT_PASSWORD: ${{ secrets.PACT_PASSWORD }}
   PACT_URL: ${{ secrets.PACT_URL }}
   PACT_BROKER_SOURCE_SECRET_DEV: ${{ secrets.PACT_BROKER_SOURCE_SECRET_DEV }}
-  GIT_BRANCH: ${{ github.ref }}
+  GIT_BRANCH: ${{ github.ref_name }}
   CONSUMER_APP_VERSION: ${{ github.sha }}
 
 on:

--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -7,7 +7,9 @@ env:
   PACT_PASSWORD: ${{ secrets.PACT_PASSWORD }}
   PACT_URL: ${{ secrets.PACT_URL }}
   PACT_BROKER_SOURCE_SECRET_DEV: ${{ secrets.PACT_BROKER_SOURCE_SECRET_DEV }}
-  GIT_BRANCH: ${{ github.ref_name }}
+  # The branch name for a pull request is in a property that only exists on pull request runs. If it doesn't exist
+  # fall back to the branch name property for pushes.
+  GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   CONSUMER_APP_VERSION: ${{ github.sha }}
 
 on:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The property used to get the branch name for sending to the pact broker

### Why did it change

To shorten the names

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5364](https://govukverify.atlassian.net/browse/PYIC-5364)


[PYIC-5364]: https://govukverify.atlassian.net/browse/PYIC-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ