### PR TITLE
BAU: Fix up TICF states

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -70,6 +70,12 @@ CRI_TICF_STATE:
     enhanced-verification:
       targetJourney: FAILED
       targetState: FAILED_NO_TICF
+    alternate-doc-invalid-dl:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    alternate-doc-invalid-passport:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
     fail-with-ci:
       targetJourney: FAILED
       targetState: FAILED_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -109,11 +109,16 @@ CRI_TICF_BEFORE_SUCCESS_RFC:
   response:
     type: process
     lambda: call-ticf-cri
-  parent: CRI_TICF_STATE_RFC
   events:
     next:
       targetState: IPV_SUCCESS_PAGE_RFC
     enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    alternate-doc-invalid-dl:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    alternate-doc-invalid-passport:
       targetJourney: FAILED
       targetState: FAILED_NO_TICF
     fail-with-ci:


### PR DESCRIPTION
The TICF state in `repeat-fraud-check.yaml` references a nonexistent parent. Additionally, we should handle the alternate doc events.