### PR TITLE
PYIC-4816: Add strategic app triage

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -28,7 +28,7 @@ ADDRESS_AND_FRAUD:
 
 DCMAW_TRIAGE:
   entryEvents:
-    next:
+    dcmaw:
       targetState: SELECT_DEVICE_PAGE
     smartphone:
       targetState: MAM_SELECT_SMARTPHONE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -26,7 +26,7 @@ ADDRESS_AND_FRAUD:
         enhanced-verification:
           exitEventToEmit: enhanced-verification
 
-DCMAW_TRIAGE:
+STRATEGIC_APP_TRIAGE:
   entryEvents:
     appTriage:
       targetState: SELECT_DEVICE_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -30,6 +30,8 @@ DCMAW_TRIAGE:
   entryEvents:
     next:
       targetState: SELECT_DEVICE_PAGE
+    smartphone:
+      targetState: MAM_SELECT_SMARTPHONE
 
   nestedJourneyStates:
     SELECT_DEVICE_PAGE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -73,7 +73,7 @@ DCMAW_TRIAGE:
         context: iphone
       events:
         next:
-          targetState: next
+          exitEventToEmit: next
 
     DESKTOP_ANDROID_DOWNLOAD_PAGE:
       response:
@@ -82,7 +82,7 @@ DCMAW_TRIAGE:
         context: android
       events:
         next:
-          targetState: next
+          exitEventToEmit: next
 
     MOBILE_IPHONE_DOWNLOAD_PAGE:
       response:
@@ -91,7 +91,7 @@ DCMAW_TRIAGE:
         context: iphone
       events:
         next:
-          targetState: next
+          exitEventToEmit: next
 
     MOBILE_ANDROID_DOWNLOAD_PAGE:
       response:
@@ -100,4 +100,4 @@ DCMAW_TRIAGE:
         context: android
       events:
         next:
-          targetState: next
+          exitEventToEmit: next

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -28,9 +28,9 @@ ADDRESS_AND_FRAUD:
 
 DCMAW_TRIAGE:
   entryEvents:
-    dcmaw:
+    appTriage:
       targetState: SELECT_DEVICE_PAGE
-    smartphone:
+    appTriage/smartphone:
       targetState: MAM_SELECT_SMARTPHONE
 
   nestedJourneyStates:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -30,7 +30,7 @@ DCMAW_TRIAGE:
   entryEvents:
     appTriage:
       targetState: SELECT_DEVICE_PAGE
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: MAM_SELECT_SMARTPHONE
 
   nestedJourneyStates:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -71,18 +71,12 @@ DCMAW_TRIAGE:
         type: page
         pageId: pyi-triage-desktop-download-app
         context: iphone
-      events:
-        next:
-          exitEventToEmit: next
 
     DESKTOP_ANDROID_DOWNLOAD_PAGE:
       response:
         type: page
         pageId: pyi-triage-desktop-download-app
         context: android
-      events:
-        next:
-          exitEventToEmit: next
 
     MOBILE_IPHONE_DOWNLOAD_PAGE:
       response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -25,3 +25,79 @@ ADDRESS_AND_FRAUD:
           exitEventToEmit: next
         enhanced-verification:
           exitEventToEmit: enhanced-verification
+
+DCMAW_TRIAGE:
+  entryEvents:
+    next:
+      targetState: SELECT_DEVICE_PAGE
+
+  nestedJourneyStates:
+    SELECT_DEVICE_PAGE:
+      response:
+        type: page
+        pageId: pyi-triage-select-device
+      events:
+        computer-or-tablet:
+          targetState: DAD_SELECT_SMARTPHONE
+        smartphone:
+          targetState: MAM_SELECT_SMARTPHONE
+
+    DAD_SELECT_SMARTPHONE:
+      response:
+        type: page
+        pageId: pyi-triage-select-smartphone
+      events:
+        iphone:
+          targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
+        android:
+          targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
+        end:
+          exitEventToEmit: end
+
+    MAM_SELECT_SMARTPHONE:
+      response:
+        type: page
+        pageId: pyi-triage-select-smartphone
+      events:
+        iphone:
+          targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
+        android:
+          targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+        end:
+          exitEventToEmit: end
+
+    DESKTOP_IPHONE_DOWNLOAD_PAGE:
+      response:
+        type: page
+        pageId: pyi-triage-desktop-download-app
+        context: iphone
+      events:
+        next:
+          targetState: next
+
+    DESKTOP_ANDROID_DOWNLOAD_PAGE:
+      response:
+        type: page
+        pageId: pyi-triage-desktop-download-app
+        context: android
+      events:
+        next:
+          targetState: next
+
+    MOBILE_IPHONE_DOWNLOAD_PAGE:
+      response:
+        type: page
+        pageId: pyi-triage-mobile-download-app
+        context: iphone
+      events:
+        next:
+          targetState: next
+
+    MOBILE_ANDROID_DOWNLOAD_PAGE:
+      response:
+        type: page
+        pageId: pyi-triage-mobile-download-app
+        context: android
+      events:
+        next:
+          targetState: next

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -113,7 +113,7 @@ IDENTITY_START_PAGE:
     next:
       targetState: CRI_DCMAW
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: DCMAW_TRIAGE
       checkIfDisabled:
         dcmaw:
@@ -289,7 +289,7 @@ PYI_CRI_ESCAPE:
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
@@ -309,7 +309,7 @@ PYI_CRI_ESCAPE_NO_F2F:
     next:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
@@ -683,7 +683,7 @@ MITIGATION_KBV_FAIL_M2B:
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
@@ -732,7 +732,7 @@ PYI_KBV_DROPOUT_M2B:
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
@@ -763,7 +763,7 @@ MITIGATION_01_IDENTITY_START_PAGE:
     next:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: MITIGATION_01_DCMAW_TRIAGE
       checkIfDisabled:
         dcmaw:
@@ -858,7 +858,7 @@ MITIGATION_02_OPTIONS:
     next:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
@@ -929,7 +929,7 @@ MITIGATION_02_OPTIONS_WITH_F2F:
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
@@ -951,7 +951,7 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
-        dcmawTriage:
+        strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -121,6 +121,12 @@ IDENTITY_START_PAGE:
           checkIfDisabled:
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
+    smartphone:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE
     end:
       targetState: F2F_START_PAGE
       checkIfDisabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -114,7 +114,7 @@ IDENTITY_START_PAGE:
       targetState: CRI_DCMAW
       checkFeatureFlag:
         dcmawTriage:
-          targetState: SELECT_DEVICE_PAGE
+          targetState: DCMAW_TRIAGE
       checkIfDisabled:
         dcmaw:
           targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
@@ -128,75 +128,13 @@ IDENTITY_START_PAGE:
           targetJourney: INELIGIBLE
           targetState: INELIGIBLE
 
-SELECT_DEVICE_PAGE:
-  response:
-    type: page
-    pageId: pyi-triage-select-device
-  events:
-    computer-or-tablet:
-      targetState: DAD_SELECT_SMARTPHONE
-    smartphone:
-      targetState: MAM_SELECT_SMARTPHONE
-
-DAD_SELECT_SMARTPHONE:
-  response:
-    type: page
-    pageId: pyi-triage-select-smartphone
-  events:
-    iphone:
-      targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
-    android:
-      targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
+DCMAW_TRIAGE:
+  nestedJourney: DCMAW_TRIAGE
+  exitEvents:
+    next:
+      targetState: CRI_DCMAW
     end:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-
-MAM_SELECT_SMARTPHONE:
-  response:
-    type: page
-    pageId: pyi-triage-select-smartphone
-  events:
-    iphone:
-      targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
-    android:
-      targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
-    end:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-
-DESKTOP_IPHONE_DOWNLOAD_PAGE:
-  response:
-    type: page
-    pageId: pyi-triage-desktop-download-app
-    context: iphone
-  events:
-    next:
-      targetState: POST_DCMAW_SUCCESS_PAGE
-
-DESKTOP_ANDROID_DOWNLOAD_PAGE:
-  response:
-    type: page
-    pageId: pyi-triage-desktop-download-app
-    context: android
-  events:
-    next:
-      targetState: POST_DCMAW_SUCCESS_PAGE
-
-MOBILE_IPHONE_DOWNLOAD_PAGE:
-  response:
-    type: page
-    pageId: pyi-triage-mobile-download-app
-    context: iphone
-  events:
-    next:
-      targetState: POST_DCMAW_SUCCESS_PAGE
-
-MOBILE_ANDROID_DOWNLOAD_PAGE:
-  response:
-    type: page
-    pageId: pyi-triage-mobile-download-app
-    context: android
-  events:
-    next:
-      targetState: POST_DCMAW_SUCCESS_PAGE
 
 F2F_START_PAGE:
   response:
@@ -350,6 +288,9 @@ PYI_CRI_ESCAPE:
   events:
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -367,6 +308,9 @@ PYI_CRI_ESCAPE_NO_F2F:
   events:
     next:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -738,6 +682,9 @@ MITIGATION_KBV_FAIL_M2B:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -784,6 +731,9 @@ PYI_KBV_DROPOUT_M2B:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -812,6 +762,9 @@ MITIGATION_01_IDENTITY_START_PAGE:
   events:
     next:
       targetState: MITIGATION_01_CRI_DCMAW
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: MITIGATION_01_DCMAW_TRIAGE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -822,6 +775,14 @@ MITIGATION_01_IDENTITY_START_PAGE:
         f2f:
           targetJourney: INELIGIBLE
           targetState: INELIGIBLE
+
+MITIGATION_01_DCMAW_TRIAGE:
+  nestedJourney: DCMAW_TRIAGE
+  exitEvents:
+    next:
+      targetState: CRI_DCMAW
+    end:
+      targetState: MITIGATION_01_PYI_POST_OFFICE
 
 MITIGATION_01_CRI_DCMAW:
   response:
@@ -896,6 +857,9 @@ MITIGATION_02_OPTIONS:
   events:
     next:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -903,6 +867,14 @@ MITIGATION_02_OPTIONS:
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
+
+DCMAW_TRIAGE_PYI_ESCAPE:
+  nestedJourney: DCMAW_TRIAGE
+  exitEvents:
+    next:
+      targetState: CRI_DCMAW
+    end:
+      targetState: PYI_POST_OFFICE
 
 CRI_DCMAW_PYI_ESCAPE:
   response:
@@ -956,6 +928,9 @@ MITIGATION_02_OPTIONS_WITH_F2F:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -975,6 +950,9 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
           targetState: CRI_TICF_BEFORE_F2F
     dcmaw:
       targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -110,21 +110,27 @@ IDENTITY_START_PAGE:
   events:
     next:
       targetState: CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
       checkIfDisabled:
         dcmaw:
           targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
           checkIfDisabled:
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     dcmaw:
       targetState: CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+          checkIfDisabled:
+            f2f:
+              targetState: MULTIPLE_DOC_CHECK_PAGE
     smartphone:
       targetState: CRI_DCMAW
       checkFeatureFlag:
@@ -313,6 +319,10 @@ PYI_CRI_ESCAPE:
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     f2f:
       targetState: CRI_F2F
       checkFeatureFlag:
@@ -339,11 +349,19 @@ PYI_CRI_ESCAPE_NO_F2F:
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE_SKIP_MESSAGE
@@ -723,6 +741,10 @@ MITIGATION_KBV_FAIL_M2B:
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -777,6 +799,10 @@ PYI_KBV_DROPOUT_M2B:
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -814,11 +840,19 @@ MITIGATION_01_IDENTITY_START_PAGE:
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: MITIGATION_01_DCMAW_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     smartphone:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: MITIGATION_01_DCMAW_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     end:
       targetState: MITIGATION_01_F2F_START_PAGE
       checkIfDisabled:
@@ -925,11 +959,19 @@ MITIGATION_02_OPTIONS:
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -1011,6 +1053,10 @@ MITIGATION_02_OPTIONS_WITH_F2F:
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
 
 MITIGATION_02_OPTIONS_WITH_F2F_M2B:
   response:
@@ -1038,6 +1084,10 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
 
 PYI_POST_OFFICE:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -84,8 +84,6 @@ CRI_TICF_STATE:
       targetState: ERROR_NO_TICF
 
 # Journey states
-
-
 REPROVE_IDENTITY_START:
   response:
     type: page
@@ -112,18 +110,23 @@ IDENTITY_START_PAGE:
   events:
     next:
       targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: DCMAW_TRIAGE
       checkIfDisabled:
         dcmaw:
           targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
           checkIfDisabled:
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    dcmaw:
+      targetState: CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE
     smartphone:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
+      targetState: CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE
@@ -138,7 +141,8 @@ DCMAW_TRIAGE:
   nestedJourney: DCMAW_TRIAGE
   exitEvents:
     next:
-      targetState: CRI_DCMAW
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
     end:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
 
@@ -301,6 +305,11 @@ PYI_CRI_ESCAPE:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
+    smartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
     f2f:
       targetState: CRI_F2F
       checkFeatureFlag:
@@ -316,11 +325,22 @@ PYI_CRI_ESCAPE_NO_F2F:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
+    dcmaw:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+    smartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE_SKIP_MESSAGE
@@ -695,6 +715,11 @@ MITIGATION_KBV_FAIL_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
+    smartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -744,6 +769,11 @@ PYI_KBV_DROPOUT_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
+    smartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -770,11 +800,22 @@ MITIGATION_01_IDENTITY_START_PAGE:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: MITIGATION_01_DCMAW_TRIAGE
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
+    dcmaw:
+      targetState: MITIGATION_01_CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: MITIGATION_01_DCMAW_TRIAGE
+    smartphone:
+      targetState: MITIGATION_01_CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: MITIGATION_01_DCMAW_TRIAGE
     end:
       targetState: MITIGATION_01_F2F_START_PAGE
       checkIfDisabled:
@@ -786,7 +827,8 @@ MITIGATION_01_DCMAW_TRIAGE:
   nestedJourney: DCMAW_TRIAGE
   exitEvents:
     next:
-      targetState: CRI_DCMAW
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
     end:
       targetState: MITIGATION_01_PYI_POST_OFFICE
 
@@ -865,11 +907,22 @@ MITIGATION_02_OPTIONS:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
+    dcmaw:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+    smartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
     end:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
@@ -878,7 +931,8 @@ DCMAW_TRIAGE_PYI_ESCAPE:
   nestedJourney: DCMAW_TRIAGE
   exitEvents:
     next:
-      targetState: CRI_DCMAW
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
     end:
       targetState: PYI_POST_OFFICE
 
@@ -941,6 +995,11 @@ MITIGATION_02_OPTIONS_WITH_F2F:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
+    smartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
 
 MITIGATION_02_OPTIONS_WITH_F2F_M2B:
   response:
@@ -963,6 +1022,11 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
+    smartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: DCMAW_TRIAGE_PYI_ESCAPE
 
 PYI_POST_OFFICE:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -112,6 +112,9 @@ IDENTITY_START_PAGE:
   events:
     next:
       targetState: CRI_DCMAW
+      checkFeatureFlag:
+        dcmawTriage:
+          targetState: SELECT_DEVICE_PAGE
       checkIfDisabled:
         dcmaw:
           targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
@@ -124,6 +127,76 @@ IDENTITY_START_PAGE:
         f2f:
           targetJourney: INELIGIBLE
           targetState: INELIGIBLE
+
+SELECT_DEVICE_PAGE:
+  response:
+    type: page
+    pageId: pyi-triage-select-device
+  events:
+    computer-or-tablet:
+      targetState: DAD_SELECT_SMARTPHONE
+    smartphone:
+      targetState: MAM_SELECT_SMARTPHONE
+
+DAD_SELECT_SMARTPHONE:
+  response:
+    type: page
+    pageId: pyi-triage-select-smartphone
+  events:
+    iphone:
+      targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
+    android:
+      targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
+    end:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+
+MAM_SELECT_SMARTPHONE:
+  response:
+    type: page
+    pageId: pyi-triage-select-smartphone
+  events:
+    iphone:
+      targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
+    android:
+      targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+    end:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+
+DESKTOP_IPHONE_DOWNLOAD_PAGE:
+  response:
+    type: page
+    pageId: pyi-triage-desktop-download-app
+    context: iphone
+  events:
+    next:
+      targetState: POST_DCMAW_SUCCESS_PAGE
+
+DESKTOP_ANDROID_DOWNLOAD_PAGE:
+  response:
+    type: page
+    pageId: pyi-triage-desktop-download-app
+    context: android
+  events:
+    next:
+      targetState: POST_DCMAW_SUCCESS_PAGE
+
+MOBILE_IPHONE_DOWNLOAD_PAGE:
+  response:
+    type: page
+    pageId: pyi-triage-mobile-download-app
+    context: iphone
+  events:
+    next:
+      targetState: POST_DCMAW_SUCCESS_PAGE
+
+MOBILE_ANDROID_DOWNLOAD_PAGE:
+  response:
+    type: page
+    pageId: pyi-triage-mobile-download-app
+    context: android
+  events:
+    next:
+      targetState: POST_DCMAW_SUCCESS_PAGE
 
 F2F_START_PAGE:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -145,6 +145,9 @@ DCMAW_TRIAGE:
       targetState: ERROR
     end:
       targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
 
 F2F_START_PAGE:
   response:
@@ -831,6 +834,10 @@ MITIGATION_01_DCMAW_TRIAGE:
       targetState: ERROR
     end:
       targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
 
 MITIGATION_01_CRI_DCMAW:
   response:
@@ -935,6 +942,10 @@ DCMAW_TRIAGE_PYI_ESCAPE:
       targetState: ERROR
     end:
       targetState: PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
 
 CRI_DCMAW_PYI_ESCAPE:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -127,7 +127,7 @@ IDENTITY_START_PAGE:
           checkIfDisabled:
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
@@ -322,7 +322,7 @@ PYI_CRI_ESCAPE:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -357,7 +357,7 @@ PYI_CRI_ESCAPE_NO_F2F:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -746,7 +746,7 @@ MITIGATION_KBV_FAIL_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -810,7 +810,7 @@ PYI_KBV_DROPOUT_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -860,7 +860,7 @@ MITIGATION_01_IDENTITY_START_PAGE:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
@@ -979,7 +979,7 @@ MITIGATION_02_OPTIONS:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -1070,7 +1070,7 @@ MITIGATION_02_OPTIONS_WITH_F2F:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -1107,7 +1107,7 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    appTriage/smartphone:
+    appTriageSmartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -120,7 +120,7 @@ IDENTITY_START_PAGE:
       targetState: CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE
+          targetState: STRATEGIC_APP_TRIAGE
       checkIfDisabled:
         dcmaw:
           targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
@@ -131,7 +131,7 @@ IDENTITY_START_PAGE:
       targetState: CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE
+          targetState: STRATEGIC_APP_TRIAGE
       checkIfDisabled:
         dcmaw:
           targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
@@ -145,8 +145,8 @@ IDENTITY_START_PAGE:
           targetJourney: INELIGIBLE
           targetState: INELIGIBLE
 
-DCMAW_TRIAGE:
-  nestedJourney: DCMAW_TRIAGE
+STRATEGIC_APP_TRIAGE:
+  nestedJourney: STRATEGIC_APP_TRIAGE
   exitEvents:
     next:
       targetJourney: TECHNICAL_ERROR
@@ -317,7 +317,7 @@ PYI_CRI_ESCAPE:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -326,7 +326,7 @@ PYI_CRI_ESCAPE:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -352,7 +352,7 @@ PYI_CRI_ESCAPE_NO_F2F:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -361,7 +361,7 @@ PYI_CRI_ESCAPE_NO_F2F:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -741,7 +741,7 @@ MITIGATION_KBV_FAIL_M2B:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -750,7 +750,7 @@ MITIGATION_KBV_FAIL_M2B:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -805,7 +805,7 @@ PYI_KBV_DROPOUT_M2B:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -814,7 +814,7 @@ PYI_KBV_DROPOUT_M2B:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -855,7 +855,7 @@ MITIGATION_01_IDENTITY_START_PAGE:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: MITIGATION_01_DCMAW_TRIAGE
+          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -864,7 +864,7 @@ MITIGATION_01_IDENTITY_START_PAGE:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: MITIGATION_01_DCMAW_TRIAGE
+          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -876,8 +876,8 @@ MITIGATION_01_IDENTITY_START_PAGE:
           targetJourney: INELIGIBLE
           targetState: INELIGIBLE
 
-MITIGATION_01_DCMAW_TRIAGE:
-  nestedJourney: DCMAW_TRIAGE
+MITIGATION_01_STRATEGIC_APP_TRIAGE:
+  nestedJourney: STRATEGIC_APP_TRIAGE
   exitEvents:
     next:
       targetJourney: TECHNICAL_ERROR
@@ -974,7 +974,7 @@ MITIGATION_02_OPTIONS:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -983,7 +983,7 @@ MITIGATION_02_OPTIONS:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -992,8 +992,8 @@ MITIGATION_02_OPTIONS:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE
 
-DCMAW_TRIAGE_PYI_ESCAPE:
-  nestedJourney: DCMAW_TRIAGE
+STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
+  nestedJourney: STRATEGIC_APP_TRIAGE
   exitEvents:
     next:
       targetJourney: TECHNICAL_ERROR
@@ -1065,7 +1065,7 @@ MITIGATION_02_OPTIONS_WITH_F2F:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -1074,7 +1074,7 @@ MITIGATION_02_OPTIONS_WITH_F2F:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -1102,7 +1102,7 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
@@ -1111,7 +1111,7 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
-          targetState: DCMAW_TRIAGE_PYI_ESCAPE
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -108,19 +108,15 @@ IDENTITY_START_PAGE:
     type: page
     pageId: page-ipv-identity-document-start
   events:
-    next:
+    next: # TODO: Remove after PYIC-5264
       targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
       checkIfDisabled:
         dcmaw:
           targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
           checkIfDisabled:
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
-    dcmaw:
+    appTriage:
       targetState: CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
@@ -131,11 +127,17 @@ IDENTITY_START_PAGE:
           checkIfDisabled:
             f2f:
               targetState: MULTIPLE_DOC_CHECK_PAGE
-    smartphone:
+    appTriage/smartphone:
       targetState: CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
           targetState: DCMAW_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+          checkIfDisabled:
+            f2f:
+              targetState: MULTIPLE_DOC_CHECK_PAGE
     end:
       targetState: F2F_START_PAGE
       checkIfDisabled:
@@ -305,7 +307,13 @@ PYI_CRI_ESCAPE:
     type: page
     pageId: pyi-cri-escape
   events:
-    dcmaw:
+    dcmaw: # TODO: Remove after PYIC-5264
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -314,7 +322,7 @@ PYI_CRI_ESCAPE:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    smartphone:
+    appTriage/smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -334,17 +342,13 @@ PYI_CRI_ESCAPE_NO_F2F:
     type: page
     pageId: pyi-cri-escape-no-f2f
   events:
-    next:
+    next: # TODO: Remove after PYIC-5264
       targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
       checkIfDisabled:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    dcmaw:
+    appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -353,7 +357,7 @@ PYI_CRI_ESCAPE_NO_F2F:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    smartphone:
+    appTriage/smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -727,7 +731,13 @@ MITIGATION_KBV_FAIL_M2B:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_F2F
-    dcmaw:
+    dcmaw: # TODO: Remove after 5624
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -736,7 +746,7 @@ MITIGATION_KBV_FAIL_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    smartphone:
+    appTriage/smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -785,7 +795,13 @@ PYI_KBV_DROPOUT_M2B:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_F2F
-    dcmaw:
+    dcmaw: # TODO: Remove after PYIC-5264
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -794,7 +810,7 @@ PYI_KBV_DROPOUT_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    smartphone:
+    appTriage/smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -825,7 +841,7 @@ MITIGATION_01_IDENTITY_START_PAGE:
     type: page
     pageId: page-ipv-identity-document-start
   events:
-    next:
+    next: # TODO: Remove after PYIC-5624
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
@@ -835,7 +851,7 @@ MITIGATION_01_IDENTITY_START_PAGE:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    dcmaw:
+    appTriage:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
@@ -844,7 +860,7 @@ MITIGATION_01_IDENTITY_START_PAGE:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    smartphone:
+    appTriage/smartphone:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
         strategicAppEnabled:
@@ -944,7 +960,7 @@ MITIGATION_02_OPTIONS:
     pageId: pyi-suggest-other-options-no-f2f
     mitigationStart: enhanced-verification
   events:
-    next:
+    next: # TODO: Remove after PYIC-5624
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -954,7 +970,7 @@ MITIGATION_02_OPTIONS:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    dcmaw:
+    appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -963,7 +979,7 @@ MITIGATION_02_OPTIONS:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    smartphone:
+    appTriage/smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -1039,7 +1055,13 @@ MITIGATION_02_OPTIONS_WITH_F2F:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_F2F
-    dcmaw:
+    dcmaw: # TODO: Remove after PYIC-5264
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -1048,7 +1070,7 @@ MITIGATION_02_OPTIONS_WITH_F2F:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    smartphone:
+    appTriage/smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -1070,7 +1092,13 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_F2F
-    dcmaw:
+    dcmaw: # TODO: Remove after PYIC-5264
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:
@@ -1079,7 +1107,7 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
         dcmaw:
           targetJourney: TECHNICAL_ERROR
           targetState: ERROR
-    smartphone:
+    appTriage/smartphone:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
         strategicAppEnabled:


### PR DESCRIPTION
## Proposed changes

### What changed

- Added appTriage and appTriageSmartphone events (leading to DCMAW_TRIAGE nested journeys) for all states which can lead to CRI_DCMAW.
- Added DCMAW_TRIAGE nested journey to triage the device used for the strategic app
- Used the difference of appTriage/Smartphone entry events to dictate the context passed to the page for appropriate steps in the journey map

### Why did it change

- To enable strategic app triaging, inc sniffing

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4816](https://govukverify.atlassian.net/browse/PYIC-4816)

test this deployed w main core-front

[PYIC-4816]: https://govukverify.atlassian.net/browse/PYIC-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ