### PR TITLE
PYIC-5635: Upgrade AWS SDK to v2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -1777,7 +1781,7 @@
         "filename": "libs/kms-es256-signer/src/test/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerTest.java",
         "hashed_secret": "1b6c8b4ac46cd7d0168c8b99fe2aa923a8f8c628",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 29
       }
     ],
     "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtBuilderTest.java": [
@@ -1882,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-15T12:25:43Z"
+  "generated_at": "2024-04-16T15:58:25Z"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ spotless {
 
 subprojects {
 	task allDeps(type: DependencyReportTask) {}
+	configurations.all {
+		exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
+		exclude group: 'software.amazon.awssdk', module: 'apache-client'
+	}
 }
 
 pact {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,14 +9,15 @@ powertools = "1.18.0"
 [libraries]
 aspectj = { module = "org.aspectj:aspectjrt", version = { strictly = "1.9.8" } }
 awsJavaSdkDynamodb = { module = "software.amazon.awssdk:dynamodb" }
+awsJavaSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
 awsJavaSdkKms = { module = "software.amazon.awssdk:kms" }
 awsJavaSdkLambda = { module = "software.amazon.awssdk:lambda" }
 awsJavaSdkSqs = { module = "software.amazon.awssdk:sqs" }
+awsJavaSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
 awsLambdaJavaCore = "com.amazonaws:aws-lambda-java-core:1.2.3"
 awsLambdaJavaEvents = "com.amazonaws:aws-lambda-java-events:3.11.4"
 awsSdkBom = { module = "software.amazon.awssdk:bom", version.ref = "awsSdk" }
 commonsCodec = "commons-codec:commons-codec:1.16.0"
-awsJavaSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
 gson = "com.google.code.gson:gson:2.10.1"
 hamcrest = "org.hamcrest:hamcrest:2.2"
 jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
-awsSdk = "2.25.18"
-awsJavaSdk = "1.12.665"
+awsSdk = "2.25.31"
 jackson = "2.15.3"
 log4j = "2.23.0"
 mockito = "5.11.0"
@@ -9,13 +8,15 @@ powertools = "1.18.0"
 
 [libraries]
 aspectj = { module = "org.aspectj:aspectjrt", version = { strictly = "1.9.8" } }
-awsJavaSdkDynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version.ref = "awsJavaSdk" }
-awsJavaSdkKms = { module = "com.amazonaws:aws-java-sdk-kms", version.ref = "awsJavaSdk" }
-awsJavaSdkLambda = { module = "com.amazonaws:aws-java-sdk-lambda", version.ref = "awsJavaSdk" }
-awsJavaSdkSqs = { module = "com.amazonaws:aws-java-sdk-sqs", version.ref = "awsJavaSdk" }
+awsJavaSdkDynamodb = { module = "software.amazon.awssdk:dynamodb" }
+awsJavaSdkKms = { module = "software.amazon.awssdk:kms" }
+awsJavaSdkLambda = { module = "software.amazon.awssdk:lambda" }
+awsJavaSdkSqs = { module = "software.amazon.awssdk:sqs" }
 awsLambdaJavaCore = "com.amazonaws:aws-lambda-java-core:1.2.3"
 awsLambdaJavaEvents = "com.amazonaws:aws-lambda-java-events:3.11.4"
-dynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version.ref = "awsSdk" }
+awsSdkBom = { module = "software.amazon.awssdk:bom", version.ref = "awsSdk" }
+commonsCodec = "commons-codec:commons-codec:1.16.0"
+awsJavaSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
 gson = "com.google.code.gson:gson:2.10.1"
 hamcrest = "org.hamcrest:hamcrest:2.2"
 jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,15 +8,15 @@ powertools = "1.18.0"
 
 [libraries]
 aspectj = { module = "org.aspectj:aspectjrt", version = { strictly = "1.9.8" } }
-awsJavaSdkDynamodb = { module = "software.amazon.awssdk:dynamodb" }
-awsJavaSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
-awsJavaSdkKms = { module = "software.amazon.awssdk:kms" }
-awsJavaSdkLambda = { module = "software.amazon.awssdk:lambda" }
-awsJavaSdkSqs = { module = "software.amazon.awssdk:sqs" }
-awsJavaSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
 awsLambdaJavaCore = "com.amazonaws:aws-lambda-java-core:1.2.3"
 awsLambdaJavaEvents = "com.amazonaws:aws-lambda-java-events:3.11.4"
 awsSdkBom = { module = "software.amazon.awssdk:bom", version.ref = "awsSdk" }
+awsSdkDynamodb = { module = "software.amazon.awssdk:dynamodb" }
+awsSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
+awsSdkKms = { module = "software.amazon.awssdk:kms" }
+awsSdkLambda = { module = "software.amazon.awssdk:lambda" }
+awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
+awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
 commonsCodec = "commons-codec:commons-codec:1.16.0"
 gson = "com.google.code.gson:gson:2.10.1"
 hamcrest = "org.hamcrest:hamcrest:2.2"
@@ -25,7 +25,6 @@ jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dat
 jacksonDatatypeJsr = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 junitJupiter = "org.junit.jupiter:junit-jupiter:5.10.0"
 junitPlatform = "org.junit.platform:junit-platform-launcher:1.10.2"
-kms = { module = "software.amazon.awssdk:kms", version.ref = "awsSdk" }
 log4j12Api = { module = "org.apache.logging.log4j:log4j-1.2-api", version.ref = "log4j" }
 log4jApi = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4jCore = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
@@ -45,6 +44,7 @@ wiremock = "com.github.tomakehurst:wiremock-jre8:3.0.1"
 
 [bundles]
 log4j = ["log4jApi", "log4jCore"]
+awsLambda = ["awsLambdaJavaCore", "awsLambdaJavaEvents"]
 
 [plugins]
 postCompileWeaving = "io.freefair.aspectj.post-compile-weaving:8.6"

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -14,13 +14,14 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkDynamodb,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkDynamodb,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.bundles.log4j,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsParameters,
 			project(":libs:common-services")
 

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -15,23 +15,13 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkDynamodb,
-			libs.awsJavaSdkDynamodbEnhanced,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
-			libs.awsJavaSdkUrlConnectionClient,
+			libs.awsSdkDynamodb,
+			libs.awsSdkDynamodbEnhanced,
+			libs.awsSdkUrlConnectionClient,
 			libs.bundles.log4j,
-			libs.gson,
-			libs.nimbusdsOauth2OidcSdk,
-			libs.powertoolsParameters,
 			project(":libs:common-services")
 
-	testImplementation libs.wiremock,
-			libs.junitJupiter,
-			libs.mockitoCore,
-			libs.mockitoJunit,
-			libs.systemStubs,
-			libs.jacksonDatatypeJsr
+	testImplementation libs.junitJupiter
 	testRuntimeOnly libs.junitPlatform
 }
 

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -16,12 +16,13 @@ repositories {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsJavaSdkDynamodb,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
+			libs.awsJavaSdkUrlConnectionClient,
+			libs.bundles.log4j,
 			libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.bundles.log4j,
-			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsParameters,
 			project(":libs:common-services")
 

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.message.StringMapMessage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
@@ -56,12 +55,7 @@ public class DataStoreIpvSessionIT {
 
         var enhancedClient =
                 DynamoDbEnhancedClient.builder()
-                        .dynamoDbClient(
-                                DynamoDbClient.builder()
-                                        .region(US_WEST_2)
-                                        .credentialsProvider(
-                                                EnvironmentVariableCredentialsProvider.create())
-                                        .build())
+                        .dynamoDbClient(DynamoDbClient.builder().region(US_WEST_2).build())
                         .build();
         tableTestHarness =
                 enhancedClient.table(

--- a/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
+++ b/integration-test/src/integration-test/java/uk/gov/di/ipv/core/integrationtest/DataStoreIpvSessionIT.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
@@ -55,7 +56,11 @@ public class DataStoreIpvSessionIT {
 
         var enhancedClient =
                 DynamoDbEnhancedClient.builder()
-                        .dynamoDbClient(DynamoDbClient.builder().region(US_WEST_2).build())
+                        .dynamoDbClient(
+                                DynamoDbClient.builder()
+                                        .region(US_WEST_2)
+                                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                                        .build())
                         .build();
         tableTestHarness =
                 enhancedClient.table(

--- a/lambdas/build-client-oauth-response/build.gradle
+++ b/lambdas/build-client-oauth-response/build.gradle
@@ -11,10 +11,7 @@ repositories {
 
 dependencies {
 
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),

--- a/lambdas/build-client-oauth-response/build.gradle
+++ b/lambdas/build-client-oauth-response/build.gradle
@@ -11,7 +11,8 @@ repositories {
 
 dependencies {
 
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -68,7 +68,7 @@ public class BuildClientOauthResponseHandler
         this.sessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.authRequestValidator = new AuthRequestValidator(configService);
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
     }
 
     public BuildClientOauthResponseHandler(

--- a/lambdas/build-cri-oauth-request/build.gradle
+++ b/lambdas/build-cri-oauth-request/build.gradle
@@ -10,10 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:kms-es256-signer"),

--- a/lambdas/build-cri-oauth-request/build.gradle
+++ b/lambdas/build-cri-oauth-request/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -136,7 +136,7 @@ public class BuildCriOauthRequestHandler
     public BuildCriOauthRequestHandler() {
         this.configService = new ConfigService();
         this.signerFactory = new KmsEs256SignerFactory();
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);

--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -10,10 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials"),

--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -11,10 +11,7 @@ repositories {
 
 dependencies {
 
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -11,7 +11,8 @@ repositories {
 
 dependencies {
 
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -100,7 +100,7 @@ public class BuildUserIdentityHandler
         this.configService = new ConfigService();
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.ciMitService = new CiMitService(configService);
         this.ciMitUtilityService = new CiMitUtilityService(configService);

--- a/lambdas/call-ticf-cri/build.gradle
+++ b/lambdas/call-ticf-cri/build.gradle
@@ -10,10 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:audit-service"),
 			project(":libs:cimit-service"),

--- a/lambdas/call-ticf-cri/build.gradle
+++ b/lambdas/call-ticf-cri/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -73,7 +73,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
         this.criStoringService =
                 new CriStoringService(
                         configService,
-                        new AuditService(AuditService.getDefaultSqsClient(), configService),
+                        new AuditService(AuditService.getSqsClient(), configService),
                         null,
                         new VerifiableCredentialService(configService),
                         new SessionCredentialsService(configService),

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -10,10 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -167,7 +167,7 @@ public class CheckExistingIdentityHandler
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator();
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.criResponseService = new CriResponseService(configService);
         this.ciMitService = new CiMitService(configService);

--- a/lambdas/check-gpg45-score/build.gradle
+++ b/lambdas/check-gpg45-score/build.gradle
@@ -10,10 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:audit-service"),

--- a/lambdas/check-gpg45-score/build.gradle
+++ b/lambdas/check-gpg45-score/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -11,10 +11,7 @@ repositories {
 
 dependencies {
 
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -11,7 +11,8 @@ repositories {
 
 dependencies {
 
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -102,7 +102,7 @@ public class EvaluateGpg45ScoresHandler
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator();
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.sessionCredentialsService = new SessionCredentialsService(configService);

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 			libs.awsJavaSdkKms,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
+			libs.awsJavaSdkUrlConnectionClient,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -11,12 +11,8 @@ repositories {
 
 dependencies {
 
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsJavaSdkKms,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
-			libs.awsJavaSdkUrlConnectionClient,
+	implementation libs.bundles.awsLambda,
+			libs.awsSdkKms,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -11,7 +11,8 @@ repositories {
 
 dependencies {
 
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsJavaSdkKms,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -103,7 +103,7 @@ public class InitialiseIpvSessionHandler
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.kmsRsaDecrypter = new KmsRsaDecrypter();
         this.jarValidator = new JarValidator(kmsRsaDecrypter, configService);
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
     }
 
     @SuppressWarnings("java:S107") // Methods should not have too many parameters

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -9,7 +9,6 @@ import com.nimbusds.jose.crypto.impl.AlgorithmSupportMessage;
 import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
 import com.nimbusds.jose.jca.JWEJCAContext;
 import com.nimbusds.jose.util.Base64URL;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
@@ -35,11 +34,7 @@ public class KmsRsaDecrypter implements JWEDecrypter {
     private final JWEJCAContext jwejcaContext = new JWEJCAContext();
 
     public KmsRsaDecrypter() {
-        this.kmsClient =
-                KmsClient.builder()
-                        .region(EU_WEST_2)
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                        .build();
+        this.kmsClient = KmsClient.builder().region(EU_WEST_2).build();
     }
 
     public void setKeyId(String keyId) {

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -1,10 +1,5 @@
 package uk.gov.di.ipv.core.initialiseipvsession.service;
 
-import com.amazonaws.services.kms.AWSKMS;
-import com.amazonaws.services.kms.AWSKMSClientBuilder;
-import com.amazonaws.services.kms.model.DecryptRequest;
-import com.amazonaws.services.kms.model.DecryptResult;
-import com.amazonaws.services.kms.model.EncryptionAlgorithmSpec;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEAlgorithm;
@@ -14,15 +9,20 @@ import com.nimbusds.jose.crypto.impl.AlgorithmSupportMessage;
 import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
 import com.nimbusds.jose.jca.JWEJCAContext;
 import com.nimbusds.jose.util.Base64URL;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import javax.crypto.spec.SecretKeySpec;
 
-import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.Set;
 
 import static com.nimbusds.jose.JWEAlgorithm.RSA_OAEP_256;
+import static software.amazon.awssdk.regions.Region.EU_WEST_2;
+import static software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256;
 
 @ExcludeFromGeneratedCoverageReport
 public class KmsRsaDecrypter implements JWEDecrypter {
@@ -30,12 +30,16 @@ public class KmsRsaDecrypter implements JWEDecrypter {
     private static final Set<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS =
             Set.of(EncryptionMethod.A256GCM);
 
-    private final AWSKMS kmsClient;
+    private final KmsClient kmsClient;
     private String keyId;
     private final JWEJCAContext jwejcaContext = new JWEJCAContext();
 
     public KmsRsaDecrypter() {
-        this.kmsClient = AWSKMSClientBuilder.defaultClient();
+        this.kmsClient =
+                KmsClient.builder()
+                        .region(EU_WEST_2)
+                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                        .build();
     }
 
     public void setKeyId(String keyId) {
@@ -70,16 +74,17 @@ public class KmsRsaDecrypter implements JWEDecrypter {
                     AlgorithmSupportMessage.unsupportedJWEAlgorithm(alg, supportedJWEAlgorithms()));
         }
 
-        DecryptRequest encryptedKeyDecryptRequest =
-                new DecryptRequest()
-                        .withCiphertextBlob(ByteBuffer.wrap(encryptedKey.decode()))
-                        .withEncryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
-                        .withKeyId(keyId);
+        var encryptedKeyDecryptRequest =
+                DecryptRequest.builder()
+                        .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
+                        .encryptionAlgorithm(RSAES_OAEP_SHA_256)
+                        .keyId(keyId)
+                        .build();
 
-        DecryptResult decryptResult = kmsClient.decrypt(encryptedKeyDecryptRequest);
+        var decryptResponse = kmsClient.decrypt(encryptedKeyDecryptRequest);
 
         SecretKeySpec contentEncryptionKey =
-                new SecretKeySpec(decryptResult.getPlaintext().array(), "AES");
+                new SecretKeySpec(decryptResponse.plaintext().asByteArray(), "AES");
 
         return ContentCryptoProvider.decrypt(
                 header, encryptedKey, iv, cipherText, authTag, contentEncryptionKey, jwejcaContext);

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -10,6 +10,7 @@ import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
 import com.nimbusds.jose.jca.JWEJCAContext;
 import com.nimbusds.jose.util.Base64URL;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -34,7 +35,11 @@ public class KmsRsaDecrypter implements JWEDecrypter {
     private final JWEJCAContext jwejcaContext = new JWEJCAContext();
 
     public KmsRsaDecrypter() {
-        this.kmsClient = KmsClient.builder().region(EU_WEST_2).build();
+        this.kmsClient =
+                KmsClient.builder()
+                        .region(EU_WEST_2)
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .build();
     }
 
     public void setKeyId(String keyId) {

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
@@ -58,7 +58,7 @@ public class JarValidator {
 
             return jweObject.getPayload().toSignedJWT();
         } catch (JOSEException e) {
-            LOGGER.error(LogHelper.buildLogMessage("Failed to decrypt the JWE"));
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to decrypt the JWE", e));
             throw new JarValidationException(
                     OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
                             "Failed to decrypt the contents of the JAR"));

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -12,10 +12,9 @@ repositories {
 dependencies {
 
 	implementation platform(libs.awsSdkBom),
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+			libs.awsSdkDynamodbEnhanced,
+			libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.awsJavaSdkDynamodbEnhanced,
 			project(":libs:common-services")
 
 	aspect libs.powertoolsLogging,

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -11,10 +11,11 @@ repositories {
 
 dependencies {
 
-	implementation libs.awsLambdaJavaCore,
+	implementation platform(libs.awsSdkBom),
+			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			project(":libs:common-services")
 
 	aspect libs.powertoolsLogging,

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -10,12 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.awsJavaSdkDynamodbEnhanced,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),
 			project(":libs:cri-response-service"),

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -10,11 +10,12 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),
 			project(":libs:cri-response-service"),

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -84,7 +84,7 @@ public class ProcessAsyncCriCredentialHandler
         this.configService = new ConfigService();
         this.verifiableCredentialValidator = new VerifiableCredentialValidator(configService);
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
         this.ciMitService = new CiMitService(configService);
         this.criResponseService = new CriResponseService(configService);
         VcHelper.setConfigService(this.configService);

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -11,10 +11,7 @@ repositories {
 
 dependencies {
 
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:audit-service"),
 			project(":libs:cimit-service"),

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -11,7 +11,8 @@ repositories {
 
 dependencies {
 
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -115,7 +115,7 @@ public class ProcessCriCallbackHandler
         verifiableCredentialValidator = new VerifiableCredentialValidator(configService);
         clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
 
-        var auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        var auditService = new AuditService(AuditService.getSqsClient(), configService);
         var verifiableCredentialService = new VerifiableCredentialService(configService);
         var sessionCredentialsService = new SessionCredentialsService(configService);
         var ciMitService = new CiMitService(configService);

--- a/lambdas/process-journey-event/build.gradle
+++ b/lambdas/process-journey-event/build.gradle
@@ -10,10 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.jacksonDataformatYaml,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),

--- a/lambdas/process-journey-event/build.gradle
+++ b/lambdas/process-journey-event/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.jacksonDataformatYaml,

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -90,7 +90,7 @@ public class ProcessJourneyEventHandler
     @ExcludeFromGeneratedCoverageReport
     public ProcessJourneyEventHandler() throws IOException {
         this.configService = new ConfigService();
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.stateMachines =

--- a/lambdas/replay-cimit-vcs/build.gradle
+++ b/lambdas/replay-cimit-vcs/build.gradle
@@ -10,11 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
-			libs.nimbusdsOauth2OidcSdk,
+	implementation libs.bundles.awsLambda,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:cri-response-service"),

--- a/lambdas/replay-cimit-vcs/build.gradle
+++ b/lambdas/replay-cimit-vcs/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/reset-identity/build.gradle
+++ b/lambdas/reset-identity/build.gradle
@@ -10,10 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),

--- a/lambdas/reset-identity/build.gradle
+++ b/lambdas/reset-identity/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.nimbusdsOauth2OidcSdk,

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -92,7 +92,7 @@ public class ResetIdentityHandler implements RequestHandler<ProcessRequest, Map<
     @ExcludeFromGeneratedCoverageReport
     public ResetIdentityHandler() {
         this.configService = new ConfigService();
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.criResponseService = new CriResponseService(configService);

--- a/lambdas/restore-vcs/build.gradle
+++ b/lambdas/restore-vcs/build.gradle
@@ -11,10 +11,8 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
-			libs.awsJavaSdkDynamodbEnhanced,
+			libs.awsSdkDynamodbEnhanced,
+			libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),

--- a/lambdas/restore-vcs/build.gradle
+++ b/lambdas/restore-vcs/build.gradle
@@ -10,10 +10,11 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),

--- a/lambdas/restore-vcs/src/main/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandler.java
+++ b/lambdas/restore-vcs/src/main/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandler.java
@@ -77,7 +77,7 @@ public class RestoreVcsHandler implements RequestStreamHandler {
                         VcStoreItem.class,
                         DataStore.getClient(),
                         configService);
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
     }
 
     @Override

--- a/lambdas/revoke-vcs/build.gradle
+++ b/lambdas/revoke-vcs/build.gradle
@@ -11,10 +11,8 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
-			libs.awsJavaSdkDynamodbEnhanced,
+			libs.awsSdkDynamodbEnhanced,
+			libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),

--- a/lambdas/revoke-vcs/build.gradle
+++ b/lambdas/revoke-vcs/build.gradle
@@ -10,10 +10,11 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),

--- a/lambdas/revoke-vcs/src/main/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandler.java
+++ b/lambdas/revoke-vcs/src/main/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandler.java
@@ -78,7 +78,7 @@ public class RevokeVcsHandler implements RequestStreamHandler {
                         VcStoreItem.class,
                         DataStore.getClient(),
                         configService);
-        this.auditService = new AuditService(AuditService.getDefaultSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
     }
 
     @Override

--- a/lambdas/store-identity/build.gradle
+++ b/lambdas/store-identity/build.gradle
@@ -10,8 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
 			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(':libs:journey-uris'),

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkSqs,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkSqs,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			libs.nimbusdsOauth2OidcSdk,

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -11,14 +11,16 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsJavaSdkUrlConnectionClient,
+			libs.awsSdkUrlConnectionClient,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),
 			project(":libs:gpg45-evaluator"),
 			project(":libs:verifiable-credentials")
+
+	api platform(libs.awsSdkBom),
+			libs.awsSdkSqs
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -12,9 +12,10 @@ repositories {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsJavaSdkSqs,
+			libs.awsJavaSdkUrlConnectionClient,
+			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:gpg45-evaluator"),
 			project(":libs:verifiable-credentials")

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
@@ -1,7 +1,7 @@
 package uk.gov.di.ipv.core.library.auditing;
 
-import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
@@ -24,18 +24,16 @@ public class AuditEventUser {
     private final String ipAddress;
 
     public AuditEventUser(
-            @JsonProperty(value = "user_id", required = false) String userId,
-            @JsonProperty(value = "session_id", required = false) String sessionId,
-            @JsonProperty(value = "govuk_signin_journey_id", required = false)
-                    String govukSigninJourneyId,
-            @JsonProperty(value = "ip_address", required = false) String ipAddress) {
+            @JsonProperty(value = "user_id") String userId,
+            @JsonProperty(value = "session_id") String sessionId,
+            @JsonProperty(value = "govuk_signin_journey_id") String govukSigninJourneyId,
+            @JsonProperty(value = "ip_address") String ipAddress) {
         this.userId = userId;
         this.sessionId = sessionId;
-        if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
-            this.govukSigninJourneyId = GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE;
-        } else {
-            this.govukSigninJourneyId = govukSigninJourneyId;
-        }
+        this.govukSigninJourneyId =
+                StringUtils.isBlank(govukSigninJourneyId)
+                        ? GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE
+                        : govukSigninJourneyId;
         this.ipAddress = ipAddress;
     }
 }

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -31,7 +32,10 @@ public class AuditService {
     }
 
     public static SqsClient getSqsClient() {
-        return SqsClient.builder().region(EU_WEST_2).build();
+        return SqsClient.builder()
+                .region(EU_WEST_2)
+                .httpClientBuilder(UrlConnectionHttpClient.builder())
+                .build();
     }
 
     public void sendAuditEvent(AuditEventTypes eventType) throws SqsException {

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -32,10 +31,7 @@ public class AuditService {
     }
 
     public static SqsClient getSqsClient() {
-        return SqsClient.builder()
-                .region(EU_WEST_2)
-                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                .build();
+        return SqsClient.builder().region(EU_WEST_2).build();
     }
 
     public void sendAuditEvent(AuditEventTypes eventType) throws SqsException {

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkLambda,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkLambda,
 			libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -11,8 +11,8 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkLambda,
-			libs.awsJavaSdkUrlConnectionClient,
+			libs.awsSdkLambda,
+			libs.awsSdkUrlConnectionClient,
 			libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsJavaSdkLambda,
+			libs.awsJavaSdkUrlConnectionClient,
 			libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
@@ -58,7 +59,11 @@ public class CiMitService {
 
     @ExcludeFromGeneratedCoverageReport
     public CiMitService(ConfigService configService) {
-        this.lambdaClient = LambdaClient.builder().region(EU_WEST_2).build();
+        this.lambdaClient =
+                LambdaClient.builder()
+                        .region(EU_WEST_2)
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .build();
         this.configService = configService;
         this.verifiableCredentialValidator = new VerifiableCredentialValidator(configService);
     }

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -6,7 +6,6 @@ import com.nimbusds.jose.jwk.ECKey;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
@@ -59,11 +58,7 @@ public class CiMitService {
 
     @ExcludeFromGeneratedCoverageReport
     public CiMitService(ConfigService configService) {
-        this.lambdaClient =
-                LambdaClient.builder()
-                        .region(EU_WEST_2)
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                        .build();
+        this.lambdaClient = LambdaClient.builder().region(EU_WEST_2).build();
         this.configService = configService;
         this.verifiableCredentialValidator = new VerifiableCredentialValidator(configService);
     }

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -10,12 +10,14 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkDynamodb,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkDynamodb,
 			libs.awsJavaSdkLambda,
 			libs.awsLambdaJavaEvents,
+			libs.commonsCodec,
 			libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:journey-uris")

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -11,13 +11,13 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkDynamodb,
-			libs.awsJavaSdkLambda,
 			libs.awsLambdaJavaEvents,
+			libs.awsSdkDynamodb,
+			libs.awsSdkDynamodbEnhanced,
+			libs.awsSdkLambda,
 			libs.commonsCodec,
 			libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:journey-uris")

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -4,11 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.http.HttpStatus;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+
+import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_BAD_REQUEST;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -24,13 +25,13 @@ public class JourneyRequest {
     public URI getJourneyUri() throws HttpResponseExceptionWithErrorBody {
         if (journey == null) {
             throw new HttpResponseExceptionWithErrorBody(
-                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.MISSING_JOURNEY_EVENT);
+                    SC_BAD_REQUEST, ErrorResponse.MISSING_JOURNEY_EVENT);
         }
         try {
             return new URI(journey);
         } catch (URISyntaxException e) {
             throw new HttpResponseExceptionWithErrorBody(
-                    HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_JOURNEY_EVENT);
+                    SC_BAD_REQUEST, ErrorResponse.INVALID_JOURNEY_EVENT);
         }
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/ApiGatewayResponseGenerator.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/ApiGatewayResponseGenerator.java
@@ -3,25 +3,25 @@ package uk.gov.di.ipv.core.library.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.HttpHeaders;
-import org.apache.http.entity.ContentType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.Map;
 
+import static com.nimbusds.common.contenttype.ContentType.APPLICATION_JSON;
+import static software.amazon.awssdk.http.Header.CONTENT_TYPE;
+
 public class ApiGatewayResponseGenerator {
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private ApiGatewayResponseGenerator() {}
 
     public static <T> APIGatewayProxyResponseEvent proxyJsonResponse(int statusCode, T body) {
 
-        Map<String, String> responseHeaders =
-                Map.of(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
+        Map<String, String> responseHeaders = Map.of(CONTENT_TYPE, APPLICATION_JSON.getType());
 
         try {
             return proxyResponse(statusCode, generateResponseBody(body), responseHeaders);
@@ -45,6 +45,6 @@ public class ApiGatewayResponseGenerator {
     }
 
     private static <T> String generateResponseBody(T body) throws JsonProcessingException {
-        return objectMapper.writeValueAsString(body);
+        return OBJECT_MAPPER.writeValueAsString(body);
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -1,8 +1,8 @@
 package uk.gov.di.ipv.core.library.helpers;
 
-import com.amazonaws.util.StringUtils;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import org.apache.logging.log4j.message.StringMapMessage;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
@@ -113,7 +113,7 @@ public class LogHelper {
     }
 
     public static void attachGovukSigninJourneyIdToLogs(String govukSigninJourneyId) {
-        if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
+        if (StringUtils.isBlank(govukSigninJourneyId)) {
             attachFieldToLogs(
                     LogField.LOG_GOVUK_SIGNIN_JOURNEY_ID, GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE);
         } else {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.library.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -41,7 +41,7 @@ class RequestHelperTest {
     private final String TEST_CLIENT_SESSION_ID = "client-session-id";
     private final String TEST_JOURNEY = "/journey/next";
     private static final String CONTEXT = "context";
-    private static final String BANK_ACCOUNT_CONTEXT = "context";
+    private static final String BANK_ACCOUNT_CONTEXT = "bankAccountContext";
     private static final String TEST_JOURNEY_WITH_CONTEXT =
             String.format("claimedIdentity?%s=%s", CONTEXT, BANK_ACCOUNT_CONTEXT);
     private static final String SCOPE = "scope";
@@ -100,7 +100,7 @@ class RequestHelperTest {
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class, () -> getIpvSessionId(event));
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
                 ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
                 exception.getErrorResponse().getMessage());
@@ -116,7 +116,7 @@ class RequestHelperTest {
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class, () -> getIpvSessionId(event));
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
                 ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
                 exception.getErrorResponse().getMessage());
@@ -141,7 +141,7 @@ class RequestHelperTest {
         var exception =
                 assertThrows(HttpResponseExceptionWithErrorBody.class, () -> getIpAddress(event));
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
                 ErrorResponse.MISSING_IP_ADDRESS.getMessage(),
                 exception.getErrorResponse().getMessage());
@@ -156,7 +156,7 @@ class RequestHelperTest {
         var exception =
                 assertThrows(HttpResponseExceptionWithErrorBody.class, () -> getIpAddress(event));
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
                 ErrorResponse.MISSING_IP_ADDRESS.getMessage(),
                 exception.getErrorResponse().getMessage());
@@ -287,7 +287,7 @@ class RequestHelperTest {
                         HttpResponseExceptionWithErrorBody.class,
                         () -> RequestHelper.getJourneyEvent(event));
         assertEquals(ErrorResponse.MISSING_JOURNEY_EVENT, exception.getErrorResponse());
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
     }
 
     @ParameterizedTest
@@ -336,7 +336,7 @@ class RequestHelperTest {
                         HttpResponseExceptionWithErrorBody.class,
                         () -> RequestHelper.getScoreType(processRequest));
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
                 ErrorResponse.MISSING_SCORE_TYPE.getMessage(),
                 exception.getErrorResponse().getMessage());
@@ -360,7 +360,7 @@ class RequestHelperTest {
                         HttpResponseExceptionWithErrorBody.class,
                         () -> RequestHelper.getScoreThreshold(processRequest));
 
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
         assertEquals(
                 ErrorResponse.MISSING_SCORE_THRESHOLD.getMessage(),
                 exception.getErrorResponse().getMessage());

--- a/libs/cri-response-service/build.gradle
+++ b/libs/cri-response-service/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkDynamodbEnhanced,
+			libs.awsSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services")

--- a/libs/cri-response-service/build.gradle
+++ b/libs/cri-response-service/build.gradle
@@ -9,8 +9,9 @@ repositories {
 	mavenCentral()
 }
 
-def var = dependencies {
-	implementation libs.dynamodbEnhanced,
+dependencies {
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services")
@@ -21,7 +22,6 @@ def var = dependencies {
 
 	testRuntimeOnly libs.junitPlatform
 }
-var
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_17

--- a/libs/email-service/build.gradle
+++ b/libs/email-service/build.gradle
@@ -12,9 +12,9 @@ repositories {
 dependencies {
 	implementation libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
+			libs.notificationsJavaClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
-			libs.notificationsJavaClient,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials")
 

--- a/libs/gpg45-evaluator/build.gradle
+++ b/libs/gpg45-evaluator/build.gradle
@@ -11,8 +11,8 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
+			libs.awsSdkDynamodbEnhanced,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services")

--- a/libs/gpg45-evaluator/build.gradle
+++ b/libs/gpg45-evaluator/build.gradle
@@ -10,8 +10,9 @@ repositories {
 }
 
 dependencies {
-	implementation libs.nimbusdsOauth2OidcSdk,
-			libs.dynamodbEnhanced,
+	implementation platform(libs.awsSdkBom),
+			libs.nimbusdsOauth2OidcSdk,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services")

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -10,11 +10,13 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkDynamodb,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkDynamodb,
 			libs.awsLambdaJavaEvents,
+			libs.commonsCodec,
 			libs.gson,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.kms,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -11,13 +11,11 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkDynamodb,
-			libs.awsJavaSdkDynamodbEnhanced,
 			libs.awsLambdaJavaEvents,
-			libs.awsJavaSdkUrlConnectionClient,
+			libs.awsSdkKms,
+			libs.awsSdkUrlConnectionClient,
 			libs.commonsCodec,
 			libs.gson,
-			libs.kms,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -12,12 +12,13 @@ repositories {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsJavaSdkDynamodb,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.awsLambdaJavaEvents,
+			libs.awsJavaSdkUrlConnectionClient,
 			libs.commonsCodec,
 			libs.gson,
-			libs.nimbusdsOauth2OidcSdk,
-			libs.awsJavaSdkDynamodbEnhanced,
 			libs.kms,
+			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services")

--- a/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerFactory.java
+++ b/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerFactory.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.kmses256signer;
 
 import com.nimbusds.jose.JWSSigner;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
@@ -12,7 +13,11 @@ public class KmsEs256SignerFactory {
     private final KmsClient kmsClient;
 
     public KmsEs256SignerFactory() {
-        this.kmsClient = KmsClient.builder().region(EU_WEST_2).build();
+        this.kmsClient =
+                KmsClient.builder()
+                        .region(EU_WEST_2)
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .build();
     }
 
     public JWSSigner getSigner(String kmsKeyId) {

--- a/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerFactory.java
+++ b/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerFactory.java
@@ -1,17 +1,23 @@
 package uk.gov.di.ipv.core.library.kmses256signer;
 
-import com.amazonaws.services.kms.AWSKMS;
-import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import com.nimbusds.jose.JWSSigner;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import static software.amazon.awssdk.regions.Region.EU_WEST_2;
 
 @ExcludeFromGeneratedCoverageReport
 public class KmsEs256SignerFactory {
 
-    private final AWSKMS kmsClient;
+    private final KmsClient kmsClient;
 
     public KmsEs256SignerFactory() {
-        this.kmsClient = AWSKMSClientBuilder.defaultClient();
+        this.kmsClient =
+                KmsClient.builder()
+                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                        .region(EU_WEST_2)
+                        .build();
     }
 
     public JWSSigner getSigner(String kmsKeyId) {

--- a/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerFactory.java
+++ b/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerFactory.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.library.kmses256signer;
 
 import com.nimbusds.jose.JWSSigner;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
@@ -13,11 +12,7 @@ public class KmsEs256SignerFactory {
     private final KmsClient kmsClient;
 
     public KmsEs256SignerFactory() {
-        this.kmsClient =
-                KmsClient.builder()
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                        .region(EU_WEST_2)
-                        .build();
+        this.kmsClient = KmsClient.builder().region(EU_WEST_2).build();
     }
 
     public JWSSigner getSigner(String kmsKeyId) {

--- a/libs/pact-test-helpers/build.gradle
+++ b/libs/pact-test-helpers/build.gradle
@@ -10,12 +10,11 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
+	implementation libs.bundles.awsLambda,
+			libs.jacksonDatabind,
 			libs.mockitoJunit,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.pactConsumerJunit,
-			libs.jacksonDatabind,
 			project(path: ':libs:common-services')
 
 	testImplementation libs.junitJupiter,

--- a/libs/user-identity-service/build.gradle
+++ b/libs/user-identity-service/build.gradle
@@ -11,9 +11,9 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkLambda,
+			libs.awsSdkDynamodbEnhanced,
+			libs.awsSdkLambda,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/user-identity-service/build.gradle
+++ b/libs/user-identity-service/build.gradle
@@ -10,9 +10,10 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkLambda,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkLambda,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.util.CollectionUtils;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -42,6 +41,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_ALWAYS_REQUIRED;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_NON_CI_BREACHING_P0;
@@ -309,7 +309,7 @@ public class UserIdentityService {
                 }
                 addLogMessage(vc, "Names missing from VC: " + missingNames);
                 throw new HttpResponseExceptionWithErrorBody(
-                        HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_NAME_CORRELATION);
+                        SC_SERVER_ERROR, ErrorResponse.FAILED_NAME_CORRELATION);
             }
             identityClaims.add(identityClaim);
         }
@@ -328,8 +328,7 @@ public class UserIdentityService {
                 }
                 addLogMessage(vc, "Birthdate property is missing from VC");
                 throw new HttpResponseExceptionWithErrorBody(
-                        HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                        ErrorResponse.FAILED_BIRTHDATE_CORRELATION);
+                        SC_SERVER_ERROR, ErrorResponse.FAILED_BIRTHDATE_CORRELATION);
             }
             identityClaims.add(identityClaim);
         }
@@ -617,8 +616,7 @@ public class UserIdentityService {
             return getVcClaimNode(vc.getVcString(), VC_CREDENTIAL_SUBJECT).path(detailName);
         } catch (CredentialParseException e) {
             LOGGER.error(LogHelper.buildErrorMessage(errorLog, e));
-            throw new HttpResponseExceptionWithErrorBody(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse);
+            throw new HttpResponseExceptionWithErrorBody(SC_SERVER_ERROR, errorResponse);
         }
     }
 

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -11,9 +11,9 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkLambda,
+			libs.awsSdkDynamodbEnhanced,
+			libs.awsSdkLambda,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -10,9 +10,10 @@ repositories {
 }
 
 dependencies {
-	implementation libs.awsJavaSdkLambda,
+	implementation platform(libs.awsSdkBom),
+			libs.awsJavaSdkLambda,
 			libs.nimbusdsOauth2OidcSdk,
-			libs.dynamodbEnhanced,
+			libs.awsJavaSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -10,12 +10,10 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsJavaSdkSqs,
-			libs.awsLambdaJavaCore,
-			libs.awsLambdaJavaEvents,
-			libs.awsJavaSdkUrlConnectionClient,
+			libs.awsSdkSqs,
+			libs.awsSdkUrlConnectionClient,
+			libs.bundles.awsLambda,
 			libs.bundles.log4j,
-			libs.gson,
 			libs.jacksonDatabind,
 			libs.log4j12Api,
 			libs.spark,

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -9,11 +9,13 @@ repositories {
 }
 
 dependencies {
-	implementation libs.spark,
+	implementation platform(libs.awsSdkBom),
+			libs.spark,
 			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
 			libs.gson,
+			libs.jacksonDatabind,
 			libs.log4j12Api,
 			libs.bundles.log4j,
 			project(":lambdas:build-client-oauth-response"),

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -10,14 +10,15 @@ repositories {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.spark,
 			libs.awsJavaSdkSqs,
 			libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
+			libs.awsJavaSdkUrlConnectionClient,
+			libs.bundles.log4j,
 			libs.gson,
 			libs.jacksonDatabind,
 			libs.log4j12Api,
-			libs.bundles.log4j,
+			libs.spark,
 			project(":lambdas:build-client-oauth-response"),
 			project(":lambdas:build-client-oauth-response"),
 			project(":lambdas:build-cri-oauth-request"),

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsReader.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsReader.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -23,7 +24,11 @@ public class SqsReader implements Runnable {
     private final RequestHandler<SQSEvent, SQSBatchResponse> sqsHandler;
 
     public SqsReader(RequestHandler<SQSEvent, SQSBatchResponse> sqsHandler) {
-        this.sqs = SqsClient.builder().region(EU_WEST_2).build();
+        this.sqs =
+                SqsClient.builder()
+                        .region(EU_WEST_2)
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .build();
         this.queueUrl =
                 String.format(
                         "https://sqs.eu-west-2.amazonaws.com/616199614141/%s",

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsReader.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsReader.java
@@ -3,24 +3,32 @@ package uk.gov.di.ipv.coreback.sqs;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import com.amazonaws.services.sqs.model.Message;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import uk.gov.di.ipv.coreback.domain.CoreContext;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static software.amazon.awssdk.regions.Region.EU_WEST_2;
+
 public class SqsReader implements Runnable {
     private static final Logger LOGGER = LogManager.getLogger();
-    private final AmazonSQS sqs;
+    private final SqsClient sqs;
     private final String queueUrl;
     private final RequestHandler<SQSEvent, SQSBatchResponse> sqsHandler;
 
     public SqsReader(RequestHandler<SQSEvent, SQSBatchResponse> sqsHandler) {
-        this.sqs = AmazonSQSClientBuilder.defaultClient();
+        this.sqs =
+                SqsClient.builder()
+                        .region(EU_WEST_2)
+                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                        .build();
         this.queueUrl =
                 String.format(
                         "https://sqs.eu-west-2.amazonaws.com/616199614141/%s",
@@ -30,20 +38,26 @@ public class SqsReader implements Runnable {
 
     @Override
     public void run() {
-        List<Message> messages = sqs.receiveMessage(queueUrl).getMessages();
+        List<Message> messages =
+                sqs.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build())
+                        .messages();
         if (!messages.isEmpty()) {
             LOGGER.info("Received {} message(s) from F2F SQS queue", messages.size());
             List<SQSEvent.SQSMessage> sqsEventRecords = new ArrayList<>();
             for (Message message : messages) {
                 SQSEvent.SQSMessage sqsMessage = new SQSEvent.SQSMessage();
-                sqsMessage.setMessageId(message.getMessageId());
-                sqsMessage.setReceiptHandle(message.getReceiptHandle());
-                sqsMessage.setBody(message.getBody());
-                sqsMessage.setMd5OfBody(message.getMD5OfBody());
-                sqsMessage.setMd5OfMessageAttributes(message.getMD5OfMessageAttributes());
-                sqsMessage.setAttributes(message.getAttributes());
+                sqsMessage.setMessageId(message.messageId());
+                sqsMessage.setReceiptHandle(message.receiptHandle());
+                sqsMessage.setBody(message.body());
+                sqsMessage.setMd5OfBody(message.md5OfBody());
+                sqsMessage.setMd5OfMessageAttributes(message.md5OfMessageAttributes());
+                sqsMessage.setAttributes(message.attributesAsStrings());
                 sqsEventRecords.add(sqsMessage);
-                sqs.deleteMessage(queueUrl, message.getReceiptHandle());
+                sqs.deleteMessage(
+                        DeleteMessageRequest.builder()
+                                .queueUrl(queueUrl)
+                                .receiptHandle(message.receiptHandle())
+                                .build());
             }
             SQSEvent sqsEvent = new SQSEvent();
             sqsEvent.setRecords(sqsEventRecords);

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsReader.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsReader.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -24,11 +23,7 @@ public class SqsReader implements Runnable {
     private final RequestHandler<SQSEvent, SQSBatchResponse> sqsHandler;
 
     public SqsReader(RequestHandler<SQSEvent, SQSBatchResponse> sqsHandler) {
-        this.sqs =
-                SqsClient.builder()
-                        .region(EU_WEST_2)
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                        .build();
+        this.sqs = SqsClient.builder().region(EU_WEST_2).build();
         this.queueUrl =
                 String.format(
                         "https://sqs.eu-west-2.amazonaws.com/616199614141/%s",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Upgrade AWS SDK to v2

This has passed all the acceptance tests in my dev env

### Why did it change

[PYIC-5635: Upgrade AWS SDK from v1 to v2](https://github.com/govuk-one-login/ipv-core-back/commit/0521bdcdc864b72b9962c1aa6464c7b3fa9c719c)

There are quite a few changes here, but the biggest part is replacing
the sevice clients with new versions, and building the model objects
(mostly request and responses for/from the services) with builders.

For the clients, we now specify the region and the credentials providers
explicitly. This is recommended, as it prevents AWS having to look these
things up and slowing things down.

This also uses the BOM for the sdk, rather than a shared version for
each service sdk. The AWS docs state that whilst the versions across all
services do currently match, that can't be guaranteed in future. Using
the BOM should protect us if that changes.


[PYIC-5635: Don't set credentialsProvider on AWS clients](https://github.com/govuk-one-login/ipv-core-back/commit/c11dd80caf7a0133d26730583cf9ff002bee9486) 

The docs for upgrading from v1 to v2 of the SDK suggest that if you're
using lambdas you should explicitly set the credentialsProvider to env
vars, which are provided by the lambda runtime. This is to avoid the
credential provider chain having to search for credentials in different
places, and makes things faster.

This doesn't work if you're using snapstart. Using snapstart causes the
runtime to use container credentials instead, so no env vars can be
found. Doing this prevents the credentials from expiring before the
function is restored.

https://docs.aws.amazon.com/lambda/latest/dg/snapstart-activate.html#snapstart-credentials

[PYIC-5635: Use UrlConnectionHttpClient for sdk clients](https://github.com/govuk-one-login/ipv-core-back/commit/0b53737db669d621d20aa25a52a69f9c5817c2c9)

The docs suggest that for lambdas you're better to use the more
lightweight UrlConnectionHttpClient, than the default. There is an async
version too, but I'm not sure we need that.

This updates the clients to use the lightweight sync http client. The
recommendation is to pass the sdk client builder a builder for the http
client. This allows the sdk to manage the http clients lifecycle.

This also adds some config to the root gradle project to exclude the
other http clients brought in by the sdk, to keep the classpath smaller
and lighter.

https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/lambda-optimize-starttime.html

[PYIC-5635: Tidy up gradle files](https://github.com/govuk-one-login/ipv-core-back/pull/1837/commits/10138ae5d7101b8a4ffd770ca4b1ea017f99e240)

This does a few things:

* Creates a new bundle for the lambda libs that all lambdas use
* Exports the sqs sdk from the audit service so any lambda using it
  doesn't have to also explicitly import it
* Drops the redundant 'Java' word from the sdk lib definitions
* Orders the imports in the gradle files

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5635](https://govukverify.atlassian.net/browse/PYIC-5635)


[PYIC-5635]: https://govukverify.atlassian.net/browse/PYIC-5635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ