### PR TITLE
PYIC-5948: Filter VC before checking gpg45 match

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -541,7 +541,10 @@ public class CheckExistingIdentityHandler
             if (requestedVot.getProfileType().equals(GPG45)) {
                 if (areGpg45VcsCorrelated) {
                     requestedVotAttained =
-                            achievedWithGpg45Profile(requestedVot, vcs, auditEventUser);
+                            achievedWithGpg45Profile(
+                                    requestedVot,
+                                    VcHelper.filterVCBasedOnProfileType(vcs, GPG45),
+                                    auditEventUser);
                 }
             } else {
                 requestedVotAttained = hasOperationalProfileVc(requestedVot, vcs);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -437,6 +437,7 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(List.of(gpg45Vc, pcl250Vc));
             when(ipvSessionItem.getVcReceivedThisSession())
                     .thenReturn(List.of(pcl250Vc.getVcString()));
+            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             clientOAuthSessionItem.setVtr(List.of(Vot.P2.name(), Vot.PCL250.name()));
 
             JourneyResponse journeyResponse =
@@ -448,6 +449,7 @@ class CheckExistingIdentityHandlerTest {
 
             verify(mockSessionCredentialService)
                     .persistCredentials(List.of(pcl250Vc), ipvSessionItem.getIpvSessionId(), true);
+            verify(gpg45ProfileEvaluator).buildScore(List.of(gpg45Vc));
 
             InOrder inOrder = inOrder(ipvSessionItem, ipvSessionService);
             inOrder.verify(ipvSessionItem).setVot(Vot.PCL250);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -525,7 +525,7 @@ public interface VcFixtures {
                 Instant.ofEpochSecond(1658829758));
     }
 
-    static VerifiableCredential vcExperianFraudScoreOne() {
+    static VerifiableCredential vcExperianFraudScoreTwo() {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder().address(List.of(ADDRESS_3)).build();
         return generateVerifiableCredential(
@@ -576,7 +576,7 @@ public interface VcFixtures {
                 futureInstant);
     }
 
-    static VerifiableCredential vcExperianFraudScoreTwo() {
+    static VerifiableCredential vcExperianFraudScoreOne() {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder()
                         .name(

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -1476,7 +1476,7 @@ class UserIdentityServiceTest {
 
     @Test
     void findIdentityReturnsIdentityClaimWhenEvidenceCheckIsFalse() throws Exception {
-        var vcs = List.of(vcExperianFraudScoreOne());
+        var vcs = List.of(vcExperianFraudScoreTwo());
         Optional<IdentityClaim> result = userIdentityService.findIdentityClaim(vcs, false);
         assertTrue(result.isPresent());
         assertEquals("KENNETH DECERQUEIRA", result.get().getFullName());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Filter VC before checking gpg45 match

### Why did it change

We had a bug where if a user completed a F2F journey, but failed without a CI (no validity score), and then followed that with a hmrc migration journey with evidence, they could incorrectly match an M1A profile.

This is because we weren't filtering out the operational profile when doing gpg45 evaluation. The validity score from the migration VC was contributing and allowing the user to match M1A.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5948](https://govukverify.atlassian.net/browse/PYIC-5948)


[PYIC-5948]: https://govukverify.atlassian.net/browse/PYIC-5948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ