### PR TITLE
PYIC-5932: Handle not found mitigation routes

### DIFF
--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -22,7 +22,6 @@ import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
-import uk.gov.di.ipv.core.library.exceptions.MitigationRouteConfigNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -125,7 +124,6 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
                 | CiRetrievalException
                 | ConfigException
                 | UnrecognisedVotException
-                | MitigationRouteConfigNotFoundException
                 | CredentialParseException e) {
             LOGGER.error(LogHelper.buildErrorMessage("Error processing response from TICF CRI", e));
             return new JourneyErrorResponse(
@@ -144,8 +142,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
     private Map<String, Object> callTicfCri(IpvSessionItem ipvSessionItem, ProcessRequest request)
             throws TicfCriServiceException, CiRetrievalException, SqsException,
                     VerifiableCredentialException, CiPostMitigationsException, CiPutException,
-                    ConfigException, UnrecognisedVotException,
-                    MitigationRouteConfigNotFoundException, CredentialParseException {
+                    ConfigException, UnrecognisedVotException, CredentialParseException {
         configService.setFeatureSet(RequestHelper.getFeatureSet(request));
         ClientOAuthSessionItem clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.getClientOAuthSession(

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
@@ -21,7 +21,6 @@ import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.Vot;
-import uk.gov.di.ipv.core.library.exceptions.MitigationRouteConfigNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -177,35 +176,6 @@ class CallTicfCriHandlerTest {
         inOrder.verifyNoMoreInteractions();
 
         assertEquals(JOURNEY_ENHANCED_VERIFICATION, lambdaResult.get("journey"));
-    }
-
-    @Test
-    void handleRequestShouldReturnJourneyErrorResponseIfCimitUtilityServiceThrows()
-            throws Exception {
-        when(mockIpvSessionService.getIpvSession("a-session-id")).thenReturn(spyIpvSessionItem);
-        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem))
-                .thenReturn(List.of(mockVerifiableCredential));
-        when(mockCiMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
-        when(mockCiMitUtilityService.getCiMitigationJourneyStep(any()))
-                .thenThrow(new MitigationRouteConfigNotFoundException("Config Error"));
-
-        Map<String, Object> lambdaResult = callTicfCriHandler.handleRequest(input, mockContext);
-
-        InOrder inOrder = inOrder(spyIpvSessionItem, mockIpvSessionService);
-        inOrder.verify(spyIpvSessionItem).setVot(Vot.P0);
-        inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
-        inOrder.verifyNoMoreInteractions();
-
-        assertEquals("/journey/error", lambdaResult.get("journey"));
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, lambdaResult.get("statusCode"));
-        assertEquals(
-                ErrorResponse.ERROR_PROCESSING_TICF_CRI_RESPONSE.getCode(),
-                lambdaResult.get("code"));
-        assertEquals(
-                ErrorResponse.ERROR_PROCESSING_TICF_CRI_RESPONSE.getMessage(),
-                lambdaResult.get("message"));
     }
 
     @Test

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -8,7 +8,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
-import uk.gov.di.ipv.core.checkexistingidentity.exceptions.UnsupportedMitigationRouteException;
+import uk.gov.di.ipv.core.checkexistingidentity.exceptions.MitigationRouteException;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
@@ -27,7 +27,6 @@ import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
-import uk.gov.di.ipv.core.library.exceptions.MitigationRouteConfigNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -287,10 +286,8 @@ public class CheckExistingIdentityHandler
             return buildErrorResponse(ErrorResponse.FAILED_TO_PARSE_CONFIG, e);
         } catch (UnrecognisedCiException e) {
             return buildErrorResponse(ErrorResponse.UNRECOGNISED_CI_CODE, e);
-        } catch (MitigationRouteConfigNotFoundException e) {
-            return buildErrorResponse(ErrorResponse.MITIGATION_ROUTE_CONFIG_NOT_FOUND, e);
-        } catch (UnsupportedMitigationRouteException e) {
-            return buildErrorResponse(ErrorResponse.UNSUPPORTED_MITIGATION_ROUTE, e);
+        } catch (MitigationRouteException e) {
+            return buildErrorResponse(ErrorResponse.FAILED_TO_FIND_MITIGATION_ROUTE, e);
         }
     }
 
@@ -348,7 +345,7 @@ public class CheckExistingIdentityHandler
 
     @Tracing
     private Optional<JourneyResponse> checkForCIScoringFailure(ContraIndicators contraIndicators)
-            throws ConfigException, MitigationRouteConfigNotFoundException {
+            throws ConfigException {
 
         // CI scoring failure
         if (ciMitUtilityService.isBreachingCiThreshold(contraIndicators)) {
@@ -399,8 +396,7 @@ public class CheckExistingIdentityHandler
             boolean areGpg45VcsCorrelated,
             AuditEventUser auditEventUser,
             ContraIndicators contraIndicators)
-            throws SqsException, MitigationRouteConfigNotFoundException, ConfigException,
-                    UnsupportedMitigationRouteException {
+            throws SqsException, ConfigException, MitigationRouteException {
         LOGGER.info(LogHelper.buildLogMessage("F2F return - failed to match a profile."));
         sendAuditEvent(
                 !areGpg45VcsCorrelated
@@ -409,17 +405,21 @@ public class CheckExistingIdentityHandler
                 auditEventUser);
         var mitigatedCI = ciMitUtilityService.hasMitigatedContraIndicator(contraIndicators);
         if (mitigatedCI.isPresent()) {
-            var mitigationRoute = ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI.get());
-            if (mitigationRoute.isPresent()) {
-                JourneyResponse journeyResponse = mitigationRoute.get();
-                if (!JOURNEY_ENHANCED_VERIFICATION_PATH.equals(journeyResponse.getJourney())) {
-                    throw new UnsupportedMitigationRouteException(
-                            String.format(
-                                    "Unsupported mitigation route: %s",
-                                    journeyResponse.getJourney()));
-                }
-                return JOURNEY_ENHANCED_VERIFICATION_F2F_FAIL;
+            var mitigationJourney =
+                    ciMitUtilityService
+                            .getMitigatedCiJourneyStep(mitigatedCI.get())
+                            .map(JourneyResponse::getJourney)
+                            .orElseThrow(
+                                    () ->
+                                            new MitigationRouteException(
+                                                    String.format(
+                                                            "Empty mitigation route for mitigated CI: %s",
+                                                            mitigatedCI.get())));
+            if (!JOURNEY_ENHANCED_VERIFICATION_PATH.equals(mitigationJourney)) {
+                throw new MitigationRouteException(
+                        String.format("Unsupported mitigation route: %s", mitigationJourney));
             }
+            return JOURNEY_ENHANCED_VERIFICATION_F2F_FAIL;
         }
         return JOURNEY_F2F_FAIL;
     }
@@ -428,8 +428,7 @@ public class CheckExistingIdentityHandler
             List<VerifiableCredential> verifiableCredentials,
             AuditEventUser auditEventUser,
             ContraIndicators contraIndicators)
-            throws SqsException, MitigationRouteConfigNotFoundException, ConfigException,
-                    UnsupportedMitigationRouteException {
+            throws SqsException, ConfigException, MitigationRouteException {
 
         var mitigatedCI = ciMitUtilityService.hasMitigatedContraIndicator(contraIndicators);
         if (mitigatedCI.isPresent()) {
@@ -437,7 +436,7 @@ public class CheckExistingIdentityHandler
                     .getMitigatedCiJourneyStep(mitigatedCI.get())
                     .orElseThrow(
                             () ->
-                                    new UnsupportedMitigationRouteException(
+                                    new MitigationRouteException(
                                             String.format(
                                                     "Empty mitigation route for mitigated CI: %s",
                                                     mitigatedCI.get())));

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/exceptions/MitigationRouteException.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/exceptions/MitigationRouteException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.checkexistingidentity.exceptions;
+
+public class MitigationRouteException extends Exception {
+    public MitigationRouteException(String message) {
+        super(message);
+    }
+}

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/exceptions/UnsupportedMitigationRouteException.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/exceptions/UnsupportedMitigationRouteException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.ipv.core.checkexistingidentity.exceptions;
-
-public class UnsupportedMitigationRouteException extends Exception {
-    public UnsupportedMitigationRouteException(String message) {
-        super(message);
-    }
-}

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -40,7 +40,6 @@ import uk.gov.di.ipv.core.library.dto.ContraIndicatorMitigationDetailsDto;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
-import uk.gov.di.ipv.core.library.exceptions.MitigationRouteConfigNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -991,29 +990,6 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturn500IfFailedToGetMitigationRouteFromCimitConfig() throws Exception {
-        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(ciMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
-        when(ciMitUtilityService.getCiMitigationJourneyStep(any()))
-                .thenThrow(
-                        new MitigationRouteConfigNotFoundException(
-                                "mitigation route event not found"));
-
-        JourneyErrorResponse response =
-                toResponseClass(
-                        checkExistingIdentityHandler.handleRequest(event, context),
-                        JourneyErrorResponse.class);
-
-        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
-        assertEquals(ErrorResponse.MITIGATION_ROUTE_CONFIG_NOT_FOUND.getCode(), response.getCode());
-        assertEquals(
-                ErrorResponse.MITIGATION_ROUTE_CONFIG_NOT_FOUND.getMessage(),
-                response.getMessage());
-    }
-
-    @Test
     void shouldReturn500IfUnrecognisedCiReceived() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
@@ -1262,8 +1238,41 @@ class CheckExistingIdentityHandlerTest {
 
     @Test
     void
-            shouldThrowUnsupportedMitigationRouteExceptionWhenCiMitigationJourneyStepPresentButNotSupported()
+            shouldReturnErrorResponseIfNoMitigationRouteFoundForAlreadyMitigatedCiWhenBuildingF2FNoMatchResponse()
                     throws Exception {
+        var mitigatedCI =
+                ContraIndicator.builder().mitigation(List.of(Mitigation.builder().build())).build();
+        var testContraIndicators =
+                ContraIndicators.builder().usersContraIndicators(List.of(mitigatedCI)).build();
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
+        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
+        when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
+                .thenReturn(testContraIndicators);
+        when(ciMitUtilityService.isBreachingCiThreshold(testContraIndicators)).thenReturn(false);
+
+        when(ciMitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
+                .thenReturn(Optional.of(mitigatedCI));
+        when(ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI))
+                .thenReturn(Optional.empty());
+
+        JourneyErrorResponse response =
+                toResponseClass(
+                        checkExistingIdentityHandler.handleRequest(event, context),
+                        JourneyErrorResponse.class);
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(ErrorResponse.FAILED_TO_FIND_MITIGATION_ROUTE.getCode(), response.getCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_FIND_MITIGATION_ROUTE.getMessage(), response.getMessage());
+    }
+
+    @Test
+    void shouldReturnErrorResponseWhenCiMitigationJourneyStepPresentButNotSupported()
+            throws Exception {
         var journey = "unsupported_mitigation";
         var mitigatedCI =
                 ContraIndicator.builder().mitigation(List.of(Mitigation.builder().build())).build();
@@ -1290,9 +1299,9 @@ class CheckExistingIdentityHandlerTest {
                         JourneyErrorResponse.class);
 
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
-        assertEquals(ErrorResponse.UNSUPPORTED_MITIGATION_ROUTE.getCode(), response.getCode());
+        assertEquals(ErrorResponse.FAILED_TO_FIND_MITIGATION_ROUTE.getCode(), response.getCode());
         assertEquals(
-                ErrorResponse.UNSUPPORTED_MITIGATION_ROUTE.getMessage(), response.getMessage());
+                ErrorResponse.FAILED_TO_FIND_MITIGATION_ROUTE.getMessage(), response.getMessage());
     }
 
     @Test

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -26,7 +26,6 @@ import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
-import uk.gov.di.ipv.core.library.exceptions.MitigationRouteConfigNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -229,11 +228,6 @@ public class ProcessCriCallbackHandler
                         HttpStatus.SC_OK, JOURNEY_NOT_FOUND);
             }
             return buildErrorResponse(e, e.getHttpStatusCode(), e.getErrorResponse());
-        } catch (MitigationRouteConfigNotFoundException e) {
-            return buildErrorResponse(
-                    e,
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                    ErrorResponse.MITIGATION_ROUTE_CONFIG_NOT_FOUND);
         }
     }
 
@@ -256,7 +250,7 @@ public class ProcessCriCallbackHandler
                     HttpResponseExceptionWithErrorBody, ConfigException, CiRetrievalException,
                     CriApiException, VerifiableCredentialException, CiPostMitigationsException,
                     CiPutException, CredentialParseException, InvalidCriCallbackRequestException,
-                    UnrecognisedVotException, MitigationRouteConfigNotFoundException {
+                    UnrecognisedVotException {
         // Validate callback sessions
         criCheckingService.validateSessionIds(callbackRequest);
 

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -19,7 +19,6 @@ import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
-import uk.gov.di.ipv.core.library.exceptions.MitigationRouteConfigNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -221,8 +220,7 @@ public class CriCheckingService {
             ClientOAuthSessionItem clientOAuthSessionItem,
             String ipvSessionId)
             throws CiRetrievalException, ConfigException, HttpResponseExceptionWithErrorBody,
-                    CredentialParseException, MitigationRouteConfigNotFoundException,
-                    VerifiableCredentialException {
+                    CredentialParseException, VerifiableCredentialException {
         var cis =
                 ciMitService.getContraIndicators(
                         clientOAuthSessionItem.getUserId(),

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
@@ -12,7 +12,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
-import uk.gov.di.ipv.core.library.exceptions.MitigationRouteConfigNotFoundException;
+import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.fixtures.TestFixtures;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
@@ -212,12 +212,10 @@ class ProcessCriCallbackHandlerTest {
                         eq(callbackRequest),
                         eq(clientOAuthSessionItem),
                         eq(TEST_IPV_SESSION_ID)))
-                .thenThrow(
-                        new MitigationRouteConfigNotFoundException(
-                                "mitigation route event not found"));
+                .thenThrow(new ConfigException("bad config"));
         // Assert
         assertThrows(
-                MitigationRouteConfigNotFoundException.class,
+                ConfigException.class,
                 () -> processCriCallbackHandler.getJourneyResponse(callbackRequest));
     }
 

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -24,7 +24,6 @@ import uk.gov.di.ipv.core.library.domain.cimitvc.ContraIndicator;
 import uk.gov.di.ipv.core.library.domain.cimitvc.Mitigation;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
-import uk.gov.di.ipv.core.library.exceptions.MitigationRouteConfigNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -518,31 +517,6 @@ class CriCheckingServiceTest {
 
         // Assert
         assertEquals(new JourneyResponse("/journey/mitigation-journey"), result);
-    }
-
-    @Test
-    void checkVcResponseShouldThrowExceptionWhenCimitUtilityThrows() throws Exception {
-        // Arrange for CI mitigation possibility
-        var callbackRequest = buildValidCallbackRequest();
-        var vcResponse = VerifiableCredentialResponse.builder().userId(TEST_USER_ID).build();
-        var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
-        when(mockCiMitService.getContraIndicators(any(), any(), any()))
-                .thenReturn(TEST_CONTRA_INDICATORS);
-        when(mockCimitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
-        when(mockCimitUtilityService.getCiMitigationJourneyStep(any()))
-                .thenThrow(
-                        new MitigationRouteConfigNotFoundException(
-                                "mitigation route event not found"));
-
-        // assert
-        assertThrows(
-                MitigationRouteConfigNotFoundException.class,
-                () ->
-                        criCheckingService.checkVcResponse(
-                                List.of(),
-                                callbackRequest,
-                                clientOAuthSessionItem,
-                                TEST_IPV_SESSION_ID));
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -84,9 +84,7 @@ public enum ErrorResponse {
     FAILED_TO_PARSE_CRI_CALLBACK_REQUEST(1066, "Failed to parse cri callback request."),
     ERROR_PROCESSING_TICF_CRI_RESPONSE(1067, "Error processing response from the TICF CRI"),
     MISSING_IS_RESET_DELETE_GPG45_ONLY_PARAMETER(1068, "Missing deleteOnlyGPG45VCs in request"),
-    MITIGATION_ROUTE_CONFIG_NOT_FOUND(
-            1069, "No mitigation journey route event found in cimit config"),
-    UNSUPPORTED_MITIGATION_ROUTE(1070, "Unsupported mitigation route"),
+    FAILED_TO_FIND_MITIGATION_ROUTE(1070, "Failed to find mitigation route"),
     FAILED_TO_DELETE_CREDENTIAL(1071, "Failed to delete credential"),
     FAILED_TO_GET_CREDENTIAL(1072, "Failed to get credential"),
     INVALID_JOURNEY_EVENT(1073, "Invalid journey event in input"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/MitigationRouteConfigNotFoundException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/MitigationRouteConfigNotFoundException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.ipv.core.library.exceptions;
-
-public class MitigationRouteConfigNotFoundException extends Exception {
-    public MitigationRouteConfigNotFoundException(String errorMessage) {
-        super(errorMessage);
-    }
-}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handle not found mitigation routes

### Why did it change

We have logic that finds a mitigation route for a users CI based on the dcoument type associated with the CI. Previously we were throwing an error if a mitigation route couldn't be found. This was because we assumed that there were no circumstances where a particular CI could be issued that we wouldn't be able to mitigate.

The NINO CRI has broken that rule - we don't mitigate a particular CI from NINO. So rather than throwing, we should just not find a mitigation route and allow the usual failure event to be issued instead.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5932](https://govukverify.atlassian.net/browse/PYIC-5932)


[PYIC-5932]: https://govukverify.atlassian.net/browse/PYIC-5932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ