### PR TITLE
BAU: Clean up alternate doc flag

### DIFF
--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -173,7 +173,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
             ipvSessionItem.setVot(Vot.P0);
 
             return ciMitUtilityService
-                    .getCiMitigationJourneyStep(cis)
+                    .getCiMitigationJourneyResponse(cis)
                     .orElse(JOURNEY_FAIL_WITH_CI)
                     .toObjectMap();
         }

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
@@ -165,7 +165,7 @@ class CallTicfCriHandlerTest {
         when(mockTicfCriService.getTicfVc(clientOAuthSessionItem, spyIpvSessionItem))
                 .thenReturn(List.of(mockVerifiableCredential));
         when(mockCiMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
-        when(mockCiMitUtilityService.getCiMitigationJourneyStep(any()))
+        when(mockCiMitUtilityService.getCiMitigationJourneyResponse(any()))
                 .thenReturn(Optional.of(new JourneyResponse(JOURNEY_ENHANCED_VERIFICATION)));
 
         Map<String, Object> lambdaResult = callTicfCriHandler.handleRequest(input, mockContext);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -351,7 +351,7 @@ public class CheckExistingIdentityHandler
         if (ciMitUtilityService.isBreachingCiThreshold(contraIndicators)) {
             return Optional.of(
                     ciMitUtilityService
-                            .getCiMitigationJourneyStep(contraIndicators)
+                            .getCiMitigationJourneyResponse(contraIndicators)
                             .orElse(JOURNEY_FAIL_WITH_CI));
         }
         return Optional.empty();
@@ -407,7 +407,7 @@ public class CheckExistingIdentityHandler
         if (mitigatedCI.isPresent()) {
             var mitigationJourney =
                     ciMitUtilityService
-                            .getMitigatedCiJourneyStep(mitigatedCI.get())
+                            .getMitigatedCiJourneyResponse(mitigatedCI.get())
                             .map(JourneyResponse::getJourney)
                             .orElseThrow(
                                     () ->
@@ -433,7 +433,7 @@ public class CheckExistingIdentityHandler
         var mitigatedCI = ciMitUtilityService.hasMitigatedContraIndicator(contraIndicators);
         if (mitigatedCI.isPresent()) {
             return ciMitUtilityService
-                    .getMitigatedCiJourneyStep(mitigatedCI.get())
+                    .getMitigatedCiJourneyResponse(mitigatedCI.get())
                     .orElseThrow(
                             () ->
                                     new MitigationRouteException(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -914,7 +914,7 @@ class CheckExistingIdentityHandlerTest {
         when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(testContraIndicators);
         when(ciMitUtilityService.isBreachingCiThreshold(testContraIndicators)).thenReturn(true);
-        when(ciMitUtilityService.getCiMitigationJourneyStep(testContraIndicators))
+        when(ciMitUtilityService.getCiMitigationJourneyResponse(testContraIndicators))
                 .thenReturn(Optional.of(new JourneyResponse(testJourneyResponse)));
 
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -936,7 +936,7 @@ class CheckExistingIdentityHandlerTest {
         when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(testContraIndicators);
         when(ciMitUtilityService.isBreachingCiThreshold(testContraIndicators)).thenReturn(true);
-        when(ciMitUtilityService.getCiMitigationJourneyStep(testContraIndicators))
+        when(ciMitUtilityService.getCiMitigationJourneyResponse(testContraIndicators))
                 .thenReturn(Optional.empty());
 
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -975,7 +975,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(ciMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
-        when(ciMitUtilityService.getCiMitigationJourneyStep(any()))
+        when(ciMitUtilityService.getCiMitigationJourneyResponse(any()))
                 .thenThrow(new ConfigException("Failed to get cimit config"));
 
         JourneyErrorResponse response =
@@ -1146,7 +1146,8 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(testContraIndicators);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
         when(ciMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
-        when(ciMitUtilityService.getCiMitigationJourneyStep(any())).thenReturn(Optional.empty());
+        when(ciMitUtilityService.getCiMitigationJourneyResponse(any()))
+                .thenReturn(Optional.empty());
 
         JourneyResponse journeyResponse =
                 toResponseClass(
@@ -1169,7 +1170,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(testContraIndicators);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
         when(ciMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
-        when(ciMitUtilityService.getCiMitigationJourneyStep(testContraIndicators))
+        when(ciMitUtilityService.getCiMitigationJourneyResponse(testContraIndicators))
                 .thenReturn(Optional.of(new JourneyResponse(testJourneyResponse)));
 
         JourneyResponse journeyResponse =
@@ -1196,7 +1197,7 @@ class CheckExistingIdentityHandlerTest {
 
         when(ciMitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
                 .thenReturn(Optional.of(mitigatedCI));
-        when(ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI))
+        when(ciMitUtilityService.getMitigatedCiJourneyResponse(mitigatedCI))
                 .thenReturn(Optional.of(new JourneyResponse(journey)));
 
         JourneyResponse journeyResponse =
@@ -1225,7 +1226,7 @@ class CheckExistingIdentityHandlerTest {
 
         when(ciMitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
                 .thenReturn(Optional.of(mitigatedCI));
-        when(ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI))
+        when(ciMitUtilityService.getMitigatedCiJourneyResponse(mitigatedCI))
                 .thenReturn(Optional.of(new JourneyResponse(JOURNEY_ENHANCED_VERIFICATION_PATH)));
 
         JourneyResponse journeyResponse =
@@ -1256,7 +1257,7 @@ class CheckExistingIdentityHandlerTest {
 
         when(ciMitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
                 .thenReturn(Optional.of(mitigatedCI));
-        when(ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI))
+        when(ciMitUtilityService.getMitigatedCiJourneyResponse(mitigatedCI))
                 .thenReturn(Optional.empty());
 
         JourneyErrorResponse response =
@@ -1290,7 +1291,7 @@ class CheckExistingIdentityHandlerTest {
 
         when(ciMitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
                 .thenReturn(Optional.of(mitigatedCI));
-        when(ciMitUtilityService.getMitigatedCiJourneyStep(mitigatedCI))
+        when(ciMitUtilityService.getMitigatedCiJourneyResponse(mitigatedCI))
                 .thenReturn(Optional.of(new JourneyResponse(journey)));
 
         JourneyErrorResponse response =

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -228,7 +228,9 @@ public class CriCheckingService {
                         callbackRequest.getIpAddress());
 
         if (ciMitUtilityService.isBreachingCiThreshold(cis)) {
-            return ciMitUtilityService.getCiMitigationJourneyStep(cis).orElse(JOURNEY_FAIL_WITH_CI);
+            return ciMitUtilityService
+                    .getCiMitigationJourneyResponse(cis)
+                    .orElse(JOURNEY_FAIL_WITH_CI);
         }
 
         if (!userIdentityService.areVcsCorrelated(

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -507,7 +507,7 @@ class CriCheckingServiceTest {
         when(mockCiMitService.getContraIndicators(any(), any(), any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
         when(mockCimitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
-        when(mockCimitUtilityService.getCiMitigationJourneyStep(any()))
+        when(mockCimitUtilityService.getCiMitigationJourneyResponse(any()))
                 .thenReturn(Optional.of(new JourneyResponse("/journey/mitigation-journey")));
 
         // Act

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -441,11 +441,7 @@ CRI_UK_PASSPORT_J2:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
     alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED
-      checkFeatureFlag:
-        alternateDocMitigationEnabled:
-          targetState: MITIGATION_05_OPTIONS
+      targetState: MITIGATION_05_OPTIONS
 
 ADDRESS_AND_FRAUD_J2:
   nestedJourney: ADDRESS_AND_FRAUD
@@ -476,11 +472,7 @@ CRI_DRIVING_LICENCE_J3:
         f2f:
           targetState: MULTIPLE_DOC_CHECK_PAGE
     alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED
-      checkFeatureFlag:
-        alternateDocMitigationEnabled:
-          targetState: MITIGATION_03_OPTIONS
+      targetState: MITIGATION_03_OPTIONS
 
 ADDRESS_AND_FRAUD_J3:
   nestedJourney: ADDRESS_AND_FRAUD

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -5,7 +5,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     RESET_IDENTITY("resetIdentity"),
     INHERITED_IDENTITY("inheritedIdentity"),
     REPROVE_IDENTITY_ENABLED("reproveIdentityEnabled"),
-    ALTERNATE_DOC_MITIGATION_ENABLED("alternateDocMitigationEnabled"),
     REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
     TICF_CRI_BETA("ticfCriBeta"),
     SESSION_CREDENTIALS_TABLE_WRITES("sessionCredentialsTableWrites"),

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CiMitUtilityServiceTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.MitigationRoute;
 import uk.gov.di.ipv.core.library.domain.cimitvc.ContraIndicator;
 import uk.gov.di.ipv.core.library.domain.cimitvc.Mitigation;
-import uk.gov.di.ipv.core.library.journeyuris.JourneyUris;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.ALTERNATE_DOC_MITIGATION_ENABLED;
 
 @ExtendWith(MockitoExtension.class)
 class CiMitUtilityServiceTest {
@@ -169,7 +167,7 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
         // act
-        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
+        var result = ciMitUtilityService.getCiMitigationJourneyResponse(cis);
 
         // assert
         assertEquals(Optional.of(new JourneyResponse(journey)), result);
@@ -191,7 +189,7 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
         // act
-        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
+        var result = ciMitUtilityService.getCiMitigationJourneyResponse(cis);
 
         // assert
         assertEquals(Optional.of(new JourneyResponse(journey)), result);
@@ -226,7 +224,7 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
         // assert
-        assertTrue(ciMitUtilityService.getCiMitigationJourneyStep(cis).isEmpty());
+        assertTrue(ciMitUtilityService.getCiMitigationJourneyResponse(cis).isEmpty());
     }
 
     @Test
@@ -238,7 +236,7 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getCimitConfig()).thenReturn(Collections.emptyMap());
 
         // act
-        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
+        var result = ciMitUtilityService.getCiMitigationJourneyResponse(cis);
 
         // assert
         assertEquals(Optional.empty(), result);
@@ -259,7 +257,7 @@ class CiMitUtilityServiceTest {
                 .thenReturn(Map.of(code, List.of(new MitigationRoute("journey", null))));
 
         // act
-        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
+        var result = ciMitUtilityService.getCiMitigationJourneyResponse(cis);
 
         // assert
         assertEquals(Optional.empty(), result);
@@ -280,7 +278,7 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
         // act
-        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
+        var result = ciMitUtilityService.getCiMitigationJourneyResponse(cis);
 
         // assert
         assertEquals(Optional.empty(), result);
@@ -303,66 +301,7 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
         // assert
-        assertTrue(ciMitUtilityService.getCiMitigationJourneyStep(cis).isEmpty());
-    }
-
-    @Test
-    void getMitigationJourneyResponseShouldReturnEmptyWhenCiCanBeMitigatedWithDisableMitigation()
-            throws Exception {
-        // arrange
-        var code = "ci_code";
-        var journey = JourneyUris.JOURNEY_ALTERNATE_DOC_INVALID_DL_PATH;
-        String document = "doc_type/213123";
-        String documentType = "doc_type";
-        var ci =
-                ContraIndicator.builder()
-                        .code(code)
-                        .document(document)
-                        .issuanceDate("some_date")
-                        .build();
-        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
-        when(mockConfigService.getCimitConfig())
-                .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
-        Map<String, ContraIndicatorConfig> ciConfigMap =
-                Map.of(code, new ContraIndicatorConfig(code, 7, -5, "X"));
-        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
-        when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
-        when(mockConfigService.enabled(ALTERNATE_DOC_MITIGATION_ENABLED)).thenReturn(false);
-        // act
-        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
-
-        // assert
-        assertEquals(Optional.empty(), result);
-    }
-
-    @Test
-    void
-            getMitigationJourneyResponseShouldReturnMitigationWhenCiCanBeMitigatedWithEnableMitigation()
-                    throws Exception {
-        // arrange
-        var code = "ci_code";
-        var journey = JourneyUris.JOURNEY_ALTERNATE_DOC_INVALID_DL_PATH;
-        String document = "doc_type/213123";
-        String documentType = "doc_type";
-        var ci =
-                ContraIndicator.builder()
-                        .code(code)
-                        .document(document)
-                        .issuanceDate("some_date")
-                        .build();
-        var cis = ContraIndicators.builder().usersContraIndicators(List.of(ci)).build();
-        when(mockConfigService.getCimitConfig())
-                .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
-        Map<String, ContraIndicatorConfig> ciConfigMap =
-                Map.of(code, new ContraIndicatorConfig(code, 7, -5, "X"));
-        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
-        when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
-        when(mockConfigService.enabled(ALTERNATE_DOC_MITIGATION_ENABLED)).thenReturn(true);
-        // act
-        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
-
-        // assert
-        assertEquals(Optional.of(new JourneyResponse(journey)), result);
+        assertTrue(ciMitUtilityService.getCiMitigationJourneyResponse(cis).isEmpty());
     }
 
     @Test
@@ -400,7 +339,7 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getSsmParameter(CI_SCORING_THRESHOLD)).thenReturn("5");
 
         // act
-        var result = ciMitUtilityService.getCiMitigationJourneyStep(cis);
+        var result = ciMitUtilityService.getCiMitigationJourneyResponse(cis);
 
         // assert
         assertEquals(Optional.empty(), result);
@@ -424,7 +363,7 @@ class CiMitUtilityServiceTest {
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
 
         // act
-        var result = ciMitUtilityService.getMitigatedCiJourneyStep(ci);
+        var result = ciMitUtilityService.getMitigatedCiJourneyResponse(ci);
 
         // assert
         assertEquals(Optional.of(new JourneyResponse(journey)), result);
@@ -438,7 +377,7 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getCimitConfig()).thenReturn(Collections.emptyMap());
 
         // act
-        var result = ciMitUtilityService.getMitigatedCiJourneyStep(ci);
+        var result = ciMitUtilityService.getMitigatedCiJourneyResponse(ci);
 
         // assert
         assertEquals(Optional.empty(), result);
@@ -461,6 +400,6 @@ class CiMitUtilityServiceTest {
         when(mockConfigService.getCimitConfig())
                 .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
 
-        assertTrue(ciMitUtilityService.getMitigatedCiJourneyStep(ci).isEmpty());
+        assertTrue(ciMitUtilityService.getMitigatedCiJourneyResponse(ci).isEmpty());
     }
 }

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -33,8 +33,5 @@ public class JourneyUris {
     public static final String JOURNEY_TEMPORARILY_UNAVAILABLE_PATH =
             "/journey/temporarily-unavailable";
     public static final String JOURNEY_UNMET_PATH = "/journey/unmet";
-    public static final String JOURNEY_ALTERNATE_DOC_PATH = "/journey/alternate-doc";
-    public static final String JOURNEY_ALTERNATE_DOC_INVALID_DL_PATH =
-            JOURNEY_ALTERNATE_DOC_PATH + "-invalid-dl";
     public static final String JOURNEY_REPEAT_FRAUD_CHECK_PATH = "/journey/repeat-fraud-check";
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Clean up alternate doc flag

### Why did it change

We've been running the alternate doc mitigations in prod for a while
now, so it's probably ok to clean up the flag.

Once this is out in prod we can remove the config variables.
