### PR TITLE
BAU: Read from session credentials table in check-gpg45-scores

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -195,7 +195,7 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
-        "line_number": 2120
+        "line_number": 2123
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -1886,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-16T15:58:25Z"
+  "generated_at": "2024-04-18T10:10:40Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1974,6 +1974,7 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
+          SESSION_CREDENTIALS_TABLE_NAME: !Ref SessionCredentialsTable
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -1988,6 +1989,8 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref UserIssuedCredentialsV2Table
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionCredentialsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
         - SSMParameterReadPolicy:

--- a/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
+++ b/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.gpg45.exception.UnknownEvidenceTypeException;
 import uk.gov.di.ipv.core.library.gpg45.exception.UnknownScoreTypeException;
@@ -27,11 +28,13 @@ import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
+import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SESSION_CREDENTIALS_TABLE_READS;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_SCORE_TYPE;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -39,15 +42,16 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_MET_PAT
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_UNMET_PATH;
 
 public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Map<String, Object>> {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final String FRAUD = "fraud";
+    private static final String ACTIVITY = "activity";
+    private static final String VERIFICATION = "verification";
     private final ConfigService configService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final Gpg45ProfileEvaluator gpg45ProfileEvaluator;
     private final IpvSessionService ipvSessionService;
     private final VerifiableCredentialService verifiableCredentialService;
-    private static final Logger LOGGER = LogManager.getLogger();
-    private static final String FRAUD = "fraud";
-    private static final String ACTIVITY = "activity";
-    private static final String VERIFICATION = "verification";
+    private final SessionCredentialsService sessionCredentialsService;
 
     @SuppressWarnings("unused") // Used by tests through injection
     public CheckGpg45ScoreHandler(
@@ -56,12 +60,14 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
             Gpg45ProfileEvaluator gpg45ProfileEvaluator,
             IpvSessionService ipvSessionService,
             UserIdentityService userIdentityService,
-            VerifiableCredentialService verifiableCredentialService) {
+            VerifiableCredentialService verifiableCredentialService,
+            SessionCredentialsService sessionCredentialsService) {
         this.configService = configService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
         this.gpg45ProfileEvaluator = gpg45ProfileEvaluator;
         this.ipvSessionService = ipvSessionService;
         this.verifiableCredentialService = verifiableCredentialService;
+        this.sessionCredentialsService = sessionCredentialsService;
     }
 
     @SuppressWarnings("unused") // Used by AWS
@@ -72,6 +78,7 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
         this.ipvSessionService = new IpvSessionService(configService);
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator();
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
+        this.sessionCredentialsService = new SessionCredentialsService(configService);
     }
 
     @Override
@@ -102,8 +109,8 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
                                 .with(LOG_SCORE_TYPE.getFieldName(), scoreType));
                 return new JourneyResponse(JOURNEY_UNMET_PATH).toObjectMap();
             }
-        } catch (HttpResponseExceptionWithErrorBody e) {
-            LOGGER.error(LogHelper.buildErrorMessage("Received HTTP response exception", e));
+        } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
+            LOGGER.error(LogHelper.buildErrorMessage("Received exception", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();
@@ -135,7 +142,7 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
 
     private int getScore(String ipvSessionId, String scoreType)
             throws UnknownEvidenceTypeException, UnknownScoreTypeException,
-                    CredentialParseException {
+                    CredentialParseException, VerifiableCredentialException {
         var vcs = getParsedCredentials(ipvSessionId);
         var gpg45Scores = gpg45ProfileEvaluator.buildScore(vcs);
         return switch (scoreType) {
@@ -147,7 +154,7 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
     }
 
     private List<VerifiableCredential> getParsedCredentials(String ipvSessionId)
-            throws CredentialParseException {
+            throws CredentialParseException, VerifiableCredentialException {
         IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
         ClientOAuthSessionItem clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.getClientOAuthSession(
@@ -155,7 +162,8 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
         String userId = clientOAuthSessionItem.getUserId();
         LogHelper.attachGovukSigninJourneyIdToLogs(
                 clientOAuthSessionItem.getGovukSigninJourneyId());
-
-        return verifiableCredentialService.getVcs(userId);
+        return configService.enabled(SESSION_CREDENTIALS_TABLE_READS)
+                ? sessionCredentialsService.getCredentials(ipvSessionId, userId)
+                : verifiableCredentialService.getVcs(userId);
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Read from session credentials table in check-gpg45-scores

### Why did it change

The check-gpg45-scores lambda reads the users current VCs. We should be reading from the new session credentials table instead, depending on the flag. This use was missed in the original PR to read from the new table.
