### PR TITLE
PYIC-5953: Clean up session credential table switch

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -285,21 +289,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 107
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 107
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 107
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1882,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-22T16:29:37Z"
+  "generated_at": "2024-04-25T09:39:08Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -174,28 +170,28 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "49edc8e5cce3d7f30610b919b21c6722f4553131",
         "is_verified": false,
-        "line_number": 942
+        "line_number": 936
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 944
+        "line_number": 938
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1745
+        "line_number": 1731
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
-        "line_number": 2123
+        "line_number": 2105
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -204,21 +200,21 @@
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "85d1e7563098941624848ca8a7c731a6c013235b",
         "is_verified": false,
-        "line_number": 219
+        "line_number": 215
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "69facda46567909882c049ea59985c33000974b3",
         "is_verified": false,
-        "line_number": 302
+        "line_number": 298
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "1bb4f6b3cf1f8b05e40be98e555120bbac8bb8a8",
         "is_verified": false,
-        "line_number": 355
+        "line_number": 351
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -227,7 +223,7 @@
         "filename": "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 36
       }
     ],
     "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java": [
@@ -236,42 +232,42 @@
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
         "is_verified": false,
-        "line_number": 57
+        "line_number": 55
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 58
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 58
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 58
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 91
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 91
       }
     ],
     "lambdas/call-ticf-cri/src/test/resources/dvlaVc/body.json": [
@@ -1886,5 +1882,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-22T09:51:18Z"
+  "generated_at": "2024-04-22T16:29:37Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -654,7 +654,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub initialise-ipv-session-${Environment}
-          IPV_SESSIONS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt SessionsTable.Arn ] ]
+          IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
@@ -752,7 +752,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub build-cri-oauth-request-${Environment}
-          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
@@ -781,8 +780,6 @@ Resources:
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBReadPolicy:
-            TableName: !Ref UserIssuedCredentialsV2Table
         - DynamoDBReadPolicy:
             TableName: !Ref SessionCredentialsTable
         - DynamoDBReadPolicy:
@@ -850,7 +847,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub process-cri-callback-${Environment}
-          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
@@ -928,8 +924,6 @@ Resources:
             TableName: !Ref CriOAuthSessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref UserIssuedCredentialsV2Table
         - DynamoDBCrudPolicy:
             TableName: !Ref CRIResponseTable
         - DynamoDBCrudPolicy:
@@ -1073,7 +1067,6 @@ Resources:
         Variables:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub build-user-identity-${Environment}
-          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           SESSION_CREDENTIALS_TABLE_NAME: !Ref SessionCredentialsTable
@@ -1116,10 +1109,6 @@ Resources:
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBReadPolicy:
-            TableName: !Ref UserIssuedCredentialsV2Table
-        - DynamoDBWritePolicy:
-            TableName: !Ref UserIssuedCredentialsV2Table
         - DynamoDBReadPolicy:
             TableName: !Ref SessionCredentialsTable
         - DynamoDBReadPolicy:
@@ -1482,7 +1471,6 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub build-proven-user-identity-details-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
-          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           SESSION_CREDENTIALS_TABLE_NAME: !Ref SessionCredentialsTable
       VpcConfig:
@@ -1516,8 +1504,6 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
-        - DynamoDBReadPolicy:
-            TableName: !Ref UserIssuedCredentialsV2Table
         - DynamoDBReadPolicy:
             TableName: !Ref SessionCredentialsTable
         - DynamoDBReadPolicy:
@@ -1777,8 +1763,8 @@ Resources:
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
-          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt UserIssuedCredentialsV2Table.Arn ] ]
-          CRI_RESPONSE_TABLE_NAME: !Select [ 1, !Split [ '/', !GetAtt CRIResponseTable.Arn ] ]
+          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
+          CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
           SIGNING_KEY_ID_PARAM: !Sub "/${Environment}/core/self/signingKeyId"
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub process-async-cri-credential-${Environment}
@@ -1837,9 +1823,11 @@ Resources:
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBCrudPolicy:
+        - DynamoDBWritePolicy:
             TableName: !Ref UserIssuedCredentialsV2Table
-        - DynamoDBCrudPolicy:
+        - DynamoDBReadPolicy:
+            TableName: !Ref CRIResponseTable
+        - DynamoDBWritePolicy:
             TableName: !Ref CRIResponseTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
@@ -1972,7 +1960,6 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub check-gpg45-score-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
-          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           SESSION_CREDENTIALS_TABLE_NAME: !Ref SessionCredentialsTable
       VpcConfig:
@@ -1987,8 +1974,6 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
-        - DynamoDBReadPolicy:
-            TableName: !Ref UserIssuedCredentialsV2Table
         - DynamoDBReadPolicy:
             TableName: !Ref SessionCredentialsTable
         - DynamoDBReadPolicy:
@@ -2045,7 +2030,6 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub call-ticf-cri-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
-          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           SESSION_CREDENTIALS_TABLE_NAME: !Ref SessionCredentialsTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
@@ -2109,8 +2093,6 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBCrudPolicy:
             TableName: !Ref SessionsTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref UserIssuedCredentialsV2Table
         - DynamoDBReadPolicy:
             TableName: !Ref SessionCredentialsTable
         - DynamoDBReadPolicy:

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -17,6 +17,8 @@ import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.EvidenceRequest;
 import uk.gov.di.ipv.core.library.domain.NinoSharedClaimsResponseDto;
@@ -24,6 +26,7 @@ import uk.gov.di.ipv.core.library.domain.SharedClaimsResponse;
 import uk.gov.di.ipv.core.library.domain.SharedClaimsResponseDto;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.time.Instant;
@@ -35,13 +38,10 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
 
 public class AuthorizationRequestHelper {
-
+    private static final Logger LOGGER = LogManager.getLogger();
     private static final String SHARED_CLAIMS = "shared_claims";
-
     private static final String EVIDENCE_REQUESTED = "evidence_requested";
-
     private static final String CONTEXT = "context";
-
     private static final String SCOPE = "scope";
 
     private AuthorizationRequestHelper() {}
@@ -124,6 +124,7 @@ public class AuthorizationRequestHelper {
         try {
             signedJWT.sign(signer);
         } catch (JOSEException e) {
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to sign shared attributes", e));
             throw new HttpResponseExceptionWithErrorBody(
                     500, ErrorResponse.FAILED_TO_SIGN_SHARED_ATTRIBUTES);
         }

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -47,13 +47,11 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
-import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SESSION_CREDENTIALS_TABLE_READS;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.TICF_CRI_BETA;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_VOT;
@@ -70,7 +68,6 @@ public class BuildUserIdentityHandler
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final CiMitService ciMitService;
     private final CiMitUtilityService ciMitUtilityService;
-    private final VerifiableCredentialService verifiableCredentialService;
     private final SessionCredentialsService sessionCredentialsService;
 
     @SuppressWarnings("java:S107") // Methods should not have too many parameters
@@ -82,7 +79,6 @@ public class BuildUserIdentityHandler
             ClientOAuthSessionDetailsService clientOAuthSessionDetailsService,
             CiMitService ciMitService,
             CiMitUtilityService ciMitUtilityService,
-            VerifiableCredentialService verifiableCredentialService,
             SessionCredentialsService sessionCredentialsService) {
         this.userIdentityService = userIdentityService;
         this.ipvSessionService = ipvSessionService;
@@ -91,7 +87,6 @@ public class BuildUserIdentityHandler
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
         this.ciMitService = ciMitService;
         this.ciMitUtilityService = ciMitUtilityService;
-        this.verifiableCredentialService = verifiableCredentialService;
         this.sessionCredentialsService = sessionCredentialsService;
     }
 
@@ -104,7 +99,6 @@ public class BuildUserIdentityHandler
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.ciMitService = new CiMitService(configService);
         this.ciMitUtilityService = new CiMitUtilityService(configService);
-        this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.sessionCredentialsService = new SessionCredentialsService(configService);
     }
 
@@ -167,10 +161,7 @@ public class BuildUserIdentityHandler
 
             var contraIndicators = ciMitService.getContraIndicators(contraIndicatorsVc);
 
-            var vcs =
-                    configService.enabled(SESSION_CREDENTIALS_TABLE_READS)
-                            ? sessionCredentialsService.getCredentials(ipvSessionId, userId)
-                            : verifiableCredentialService.getVcs(userId);
+            var vcs = sessionCredentialsService.getCredentials(ipvSessionId, userId);
 
             UserIdentity userIdentity =
                     userIdentityService.generateUserIdentity(

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
@@ -38,7 +38,6 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
-import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -128,8 +127,6 @@ class BuildUserIdentityHandlerTest {
 
         when(mockVcStore.getItems("dummyOAuthUserId")).thenReturn(vcs);
 
-        var verifiableCredentialService = new VerifiableCredentialService(mockVcStore);
-
         // Set up the web server for the tests
         var handler =
                 new BuildUserIdentityHandler(
@@ -140,7 +137,6 @@ class BuildUserIdentityHandlerTest {
                         clientOAuthSessionDetailsService,
                         mockCiMitService,
                         mockCiMitUtilityService,
-                        verifiableCredentialService,
                         mockSessionCredentialsService);
 
         httpServer = new LambdaHttpServer(handler, "/user-identity", PORT);

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -27,7 +27,6 @@ import java.net.http.HttpResponse;
 import java.text.ParseException;
 import java.util.List;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SESSION_CREDENTIALS_TABLE_READS;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.TICF_CRI;
 
 public class TicfCriService {
@@ -83,16 +82,14 @@ public class TicfCriService {
                             TRUSTMARK,
                             clientOAuthSessionItem.getUserId(),
                             clientOAuthSessionItem.getGovukSigninJourneyId(),
-                            configService.enabled(SESSION_CREDENTIALS_TABLE_READS)
-                                    ? sessionCredentialsService
-                                            .getCredentials(
-                                                    ipvSessionItem.getIpvSessionId(),
-                                                    clientOAuthSessionItem.getUserId(),
-                                                    true)
-                                            .stream()
-                                            .map(VerifiableCredential::getVcString)
-                                            .toList()
-                                    : ipvSessionItem.getVcReceivedThisSession());
+                            sessionCredentialsService
+                                    .getCredentials(
+                                            ipvSessionItem.getIpvSessionId(),
+                                            clientOAuthSessionItem.getUserId(),
+                                            true)
+                                    .stream()
+                                    .map(VerifiableCredential::getVcString)
+                                    .toList());
 
             HttpRequest.Builder httpRequestBuilder =
                     HttpRequest.newBuilder()

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -470,20 +470,16 @@ public class CheckExistingIdentityHandler
         ipvSessionService.updateIpvSession(ipvSessionItem);
 
         if (attainedVot.getProfileType() == OPERATIONAL_HMRC) {
-            // the only VC we should possibly have collected this session at this point is a
-            // migration VC
-            var vcReceivedThisSession = ipvSessionItem.getVcReceivedThisSession();
-            boolean isOpProfileReuse =
-                    vcReceivedThisSession == null || vcReceivedThisSession.isEmpty();
+            boolean isCurrentlyMigrating = ipvSessionItem.isInheritedIdentityReceivedThisSession();
 
             sessionCredentialsService.persistCredentials(
                     VcHelper.filterVCBasedOnProfileType(vcs, OPERATIONAL_HMRC),
                     auditEventUser.getSessionId(),
-                    !isOpProfileReuse);
+                    isCurrentlyMigrating);
 
-            return isOpProfileReuse
-                    ? JOURNEY_OPERATIONAL_PROFILE_REUSE
-                    : JOURNEY_IN_MIGRATION_REUSE;
+            return isCurrentlyMigrating
+                    ? JOURNEY_IN_MIGRATION_REUSE
+                    : JOURNEY_OPERATIONAL_PROFILE_REUSE;
         }
 
         sessionCredentialsService.persistCredentials(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -325,13 +325,12 @@ class CheckExistingIdentityHandlerTest {
         }
 
         @Test // User returning after migration
-        void
-                shouldReturnJourneyOpProfileReuseResponseIfPCL200RequestedAndMetWhenNoVcInCurrentSession()
-                        throws Exception {
+        void shouldReturnJourneyOpProfileReuseResponseIfPCL200RequestedAndMetWhenNotInMigration()
+                throws Exception {
             when(mockVerifiableCredentialService.getVcs(any()))
                     .thenReturn(List.of(gpg45Vc, pcl200Vc));
             clientOAuthSessionItem.setVtr(List.of(P2.name(), Vot.PCL250.name(), Vot.PCL200.name()));
-            ipvSessionItem.setVcReceivedThisSession(List.of());
+            ipvSessionItem.setInheritedIdentityReceivedThisSession(false);
 
             JourneyResponse journeyResponse =
                     toResponseClass(
@@ -351,13 +350,12 @@ class CheckExistingIdentityHandlerTest {
         }
 
         @Test // User returning after migration
-        void
-                shouldReturnJourneyOpProfileReuseResponseIfPCL250RequestedAndMetWhenNoVcInCurrentSession()
-                        throws Exception {
+        void shouldReturnJourneyOpProfileReuseResponseIfPCL250RequestedAndMetWhenNotInMigration()
+                throws Exception {
             when(mockVerifiableCredentialService.getVcs(any()))
                     .thenReturn(List.of(gpg45Vc, pcl250Vc));
             clientOAuthSessionItem.setVtr(List.of(P2.name(), Vot.PCL250.name()));
-            ipvSessionItem.setVcReceivedThisSession(List.of());
+            ipvSessionItem.setInheritedIdentityReceivedThisSession(false);
 
             JourneyResponse journeyResponse =
                     toResponseClass(
@@ -383,7 +381,7 @@ class CheckExistingIdentityHandlerTest {
             when(mockVerifiableCredentialService.getVcs(any())).thenReturn(List.of(pcl250Vc));
 
             clientOAuthSessionItem.setVtr(List.of(P2.name(), Vot.PCL250.name()));
-            ipvSessionItem.setVcReceivedThisSession(List.of());
+            ipvSessionItem.setInheritedIdentityReceivedThisSession(false);
 
             JourneyResponse journeyResponse =
                     toResponseClass(
@@ -400,15 +398,11 @@ class CheckExistingIdentityHandlerTest {
         }
 
         @Test // User in process of migration
-        void
-                shouldReturnJourneyInMigrationReuseResponseIfPCL200RequestedAndMetWhenVcInCurrentSession()
-                        throws Exception {
+        void shouldReturnJourneyInMigrationReuseResponseIfPCL200RequestedAndMet() throws Exception {
             when(mockVerifiableCredentialService.getVcs(any()))
                     .thenReturn(List.of(gpg45Vc, pcl200Vc));
-            when(ipvSessionItem.getVcReceivedThisSession())
-                    .thenReturn(List.of(pcl200Vc.getVcString()));
+            ipvSessionItem.setInheritedIdentityReceivedThisSession(true);
             clientOAuthSessionItem.setVtr(List.of(P2.name(), Vot.PCL250.name(), Vot.PCL200.name()));
-            ipvSessionItem.setVcReceivedThisSession(List.of(pcl200Vc.getVcString()));
 
             JourneyResponse journeyResponse =
                     toResponseClass(
@@ -428,15 +422,12 @@ class CheckExistingIdentityHandlerTest {
         }
 
         @Test // User in process of migration
-        void
-                shouldReturnJourneyInMigrationReuseResponseIfPCL250RequestedAndMetWhenVcInCurrentSession()
-                        throws Exception {
+        void shouldReturnJourneyInMigrationReuseResponseIfPCL250RequestedAndMet() throws Exception {
             when(mockVerifiableCredentialService.getVcs(any()))
                     .thenReturn(List.of(gpg45Vc, pcl250Vc));
-            when(ipvSessionItem.getVcReceivedThisSession())
-                    .thenReturn(List.of(pcl250Vc.getVcString()));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             clientOAuthSessionItem.setVtr(List.of(P2.name(), Vot.PCL250.name()));
+            ipvSessionItem.setInheritedIdentityReceivedThisSession(true);
 
             JourneyResponse journeyResponse =
                     toResponseClass(

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SESSION_CREDENTIALS_TABLE_READS;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_JOURNEY_RESPONSE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -128,10 +127,7 @@ public class EvaluateGpg45ScoresHandler
             String govukSigninJourneyId = clientOAuthSessionItem.getGovukSigninJourneyId();
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
-            var vcs =
-                    configService.enabled(SESSION_CREDENTIALS_TABLE_READS)
-                            ? sessionCredentialsService.getCredentials(ipvSessionId, userId)
-                            : verifiableCredentialService.getVcs(userId);
+            var vcs = sessionCredentialsService.getCredentials(ipvSessionId, userId);
 
             if (!userIdentityService.areVcsCorrelated(vcs)) {
                 return JOURNEY_VCS_NOT_CORRELATED.toObjectMap();

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -373,7 +373,7 @@ public class InitialiseIpvSessionHandler
             throws RecoverableJarValidationException, ParseException {
         try {
             verifiableCredentialService.persistUserCredentials(inheritedIdentityVc);
-            ipvSessionItem.addVcReceivedThisSession(inheritedIdentityVc);
+            ipvSessionItem.setInheritedIdentityReceivedThisSession(true);
             ipvSessionService.updateIpvSession(ipvSessionItem);
             LOGGER.info(LogHelper.buildLogMessage("Migration VC successfully persisted"));
         } catch (VerifiableCredentialException e) {

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -80,6 +80,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -475,9 +476,7 @@ class InitialiseIpvSessionHandlerTest {
             assertEquals(PCL250_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
 
             verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
-            assertEquals(
-                    ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
-                    List.of(PCL250_MIGRATION_VC.getVcString()));
+            assertTrue(ipvSessionItem.isInheritedIdentityReceivedThisSession());
         }
 
         @Test
@@ -531,9 +530,7 @@ class InitialiseIpvSessionHandlerTest {
             assertEquals(PCL200_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
 
             verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
-            assertEquals(
-                    ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
-                    List.of(PCL200_MIGRATION_VC.getVcString()));
+            assertTrue(ipvSessionItem.isInheritedIdentityReceivedThisSession());
         }
 
         @Test
@@ -717,9 +714,7 @@ class InitialiseIpvSessionHandlerTest {
             assertEquals(PCL200_MIGRATION_VC, verifiableCredentialArgumentCaptor.getValue());
 
             verify(mockIpvSessionService).updateIpvSession(ipvSessionItemCaptor.capture());
-            assertEquals(
-                    ipvSessionItemCaptor.getValue().getVcReceivedThisSession(),
-                    List.of(PCL200_MIGRATION_VC.getVcString()));
+            assertTrue(ipvSessionItem.isInheritedIdentityReceivedThisSession());
         }
 
         @Test

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -51,7 +51,6 @@ import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredenti
 import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialStatus;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
-import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialValidator;
 import uk.gov.di.ipv.core.processcricallback.exception.CriApiException;
 import uk.gov.di.ipv.core.processcricallback.exception.InvalidCriCallbackRequestException;
@@ -131,7 +130,6 @@ public class ProcessCriCallbackHandler
                         new UserIdentityService(configService),
                         ciMitService,
                         new CiMitUtilityService(configService),
-                        new VerifiableCredentialService(configService),
                         sessionCredentialsService);
         criStoringService =
                 new CriStoringService(

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -34,14 +34,12 @@ import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialResponse;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
-import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 import uk.gov.di.ipv.core.processcricallback.exception.InvalidCriCallbackRequestException;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SESSION_CREDENTIALS_TABLE_READS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ACCESS_DENIED_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -78,7 +76,6 @@ public class CriCheckingService {
     private final CiMitService ciMitService;
     private final CiMitUtilityService ciMitUtilityService;
     private final ConfigService configService;
-    private final VerifiableCredentialService verifiableCredentialService;
     private final SessionCredentialsService sessionCredentialsService;
 
     @ExcludeFromGeneratedCoverageReport
@@ -88,14 +85,12 @@ public class CriCheckingService {
             UserIdentityService userIdentityService,
             CiMitService ciMitService,
             CiMitUtilityService ciMitUtilityService,
-            VerifiableCredentialService verifiableCredentialService,
             SessionCredentialsService sessionCredentialsService) {
         this.configService = configService;
         this.auditService = auditService;
         this.userIdentityService = userIdentityService;
         this.ciMitService = ciMitService;
         this.ciMitUtilityService = ciMitUtilityService;
-        this.verifiableCredentialService = verifiableCredentialService;
         this.sessionCredentialsService = sessionCredentialsService;
     }
 
@@ -234,10 +229,8 @@ public class CriCheckingService {
         }
 
         if (!userIdentityService.areVcsCorrelated(
-                configService.enabled(SESSION_CREDENTIALS_TABLE_READS)
-                        ? sessionCredentialsService.getCredentials(
-                                ipvSessionId, clientOAuthSessionItem.getUserId())
-                        : verifiableCredentialService.getVcs(clientOAuthSessionItem.getUserId()))) {
+                sessionCredentialsService.getCredentials(
+                        ipvSessionId, clientOAuthSessionItem.getUserId()))) {
             return JOURNEY_VCS_NOT_CORRELATED;
         }
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -200,15 +200,9 @@ CRI_F2F:
   parent: CRI_STATE
   events:
     next:
-      targetState: F2F_HANDOFF_PAGE
-      checkFeatureFlag:
-        sessionCredentialsTableReads:
-          targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
     enhanced-verification:
-      targetState: F2F_HANDOFF_PAGE
-      checkFeatureFlag:
-        sessionCredentialsTableReads:
-          targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
     access-denied:
       targetJourney: INELIGIBLE
       targetState: INELIGIBLE_NO_TICF
@@ -376,13 +370,10 @@ EVALUATE_GPG45_SCORES:
     lambda: evaluate-gpg45-scores
   events:
     met:
-      targetState: IPV_SUCCESS_PAGE
+      targetState: STORE_IDENTITY_BEFORE_SUCCESS
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_SUCCESS
-        sessionCredentialsTableReads:
-          targetState: STORE_IDENTITY_BEFORE_SUCCESS
-
     unmet:
       targetJourney: FAILED
       targetState: FAILED
@@ -432,10 +423,7 @@ CRI_TICF_BEFORE_SUCCESS:
   parent: CRI_TICF_STATE
   events:
     next:
-      targetState: IPV_SUCCESS_PAGE
-      checkFeatureFlag:
-        sessionCredentialsTableReads:
-          targetState: STORE_IDENTITY_BEFORE_SUCCESS
+      targetState: STORE_IDENTITY_BEFORE_SUCCESS
 
 CRI_TICF_BEFORE_F2F:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -96,12 +96,10 @@ EVALUATE_GPG45_SCORES_RFC:
     lambda: evaluate-gpg45-scores
   events:
     met:
-      targetState: IPV_SUCCESS_PAGE_RFC
+      targetState: STORE_IDENTITY_BEFORE_SUCCESS
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_SUCCESS_RFC
-        sessionCredentialsTableReads:
-          targetState: STORE_IDENTITY_BEFORE_SUCCESS
     unmet:
       targetJourney: FAILED
       targetState: FAILED_RFC
@@ -126,10 +124,7 @@ CRI_TICF_BEFORE_SUCCESS_RFC:
     lambda: call-ticf-cri
   events:
     next:
-      targetState: IPV_SUCCESS_PAGE_RFC
-      checkFeatureFlag:
-        sessionCredentialsTableReads:
-          targetState: STORE_IDENTITY_BEFORE_SUCCESS
+      targetState: STORE_IDENTITY_BEFORE_SUCCESS
     enhanced-verification:
       targetJourney: FAILED
       targetState: FAILED_NO_TICF

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -6,9 +6,7 @@ public enum CoreFeatureFlag implements FeatureFlag {
     INHERITED_IDENTITY("inheritedIdentity"),
     REPROVE_IDENTITY_ENABLED("reproveIdentityEnabled"),
     REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
-    TICF_CRI_BETA("ticfCriBeta"),
-    SESSION_CREDENTIALS_TABLE_WRITES("sessionCredentialsTableWrites"),
-    SESSION_CREDENTIALS_TABLE_READS("sessionCredentialsTableReads");
+    TICF_CRI_BETA("ticfCriBeta");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -6,13 +6,11 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.dto.ContraIndicatorMitigationDetailsDto;
 import uk.gov.di.ipv.core.library.enums.Vot;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +39,7 @@ public class IpvSessionItem implements DynamodbItem {
     // Only for passing the featureSet to the external API lambdas at the end of the user journey.
     // Not for general use.
     private String featureSet;
-    private List<String> vcReceivedThisSession;
+    private boolean inheritedIdentityReceivedThisSession;
     private String riskAssessmentCredential;
 
     @DynamoDbPartitionKey
@@ -57,13 +55,6 @@ public class IpvSessionItem implements DynamodbItem {
     @DynamoDbSecondaryPartitionKey(indexNames = "accessToken")
     public String getAccessToken() {
         return accessToken;
-    }
-
-    public void addVcReceivedThisSession(VerifiableCredential vc) {
-        if (vcReceivedThisSession == null) {
-            vcReceivedThisSession = new ArrayList<>();
-        }
-        vcReceivedThisSession.add(vc.getVcString());
     }
 
     public List<String> getFeatureSetAsList() {

--- a/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
+++ b/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
@@ -131,7 +131,6 @@ public class CriStoringService {
                 }
                 sessionCredentialsService.persistCredentials(
                         List.of(vc), ipvSessionItem.getIpvSessionId(), true);
-                ipvSessionItem.addVcReceivedThisSession(vc);
             }
         }
 

--- a/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
+++ b/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
@@ -158,7 +158,6 @@ class CriStoringServiceTest {
         verify(mockSessionCredentialsService, never()).deleteSessionCredentialsForCri(any(), any());
         verify(mockSessionCredentialsService)
                 .persistCredentials(List.of(vc), mockIpvSessionItem.getIpvSessionId(), true);
-        verify(mockIpvSessionItem).addVcReceivedThisSession(vc);
         verify(mockIpvSessionItem, times(0)).setRiskAssessmentCredential(vc.getVcString());
     }
 
@@ -183,7 +182,6 @@ class CriStoringServiceTest {
                 .deleteSessionCredentialsForCri(mockIpvSessionItem.getIpvSessionId(), ADDRESS_CRI);
         verify(mockSessionCredentialsService)
                 .persistCredentials(List.of(vc), mockIpvSessionItem.getIpvSessionId(), true);
-        verify(mockIpvSessionItem).addVcReceivedThisSession(vc);
         verify(mockIpvSessionItem, times(0)).setRiskAssessmentCredential(vc.getVcString());
     }
 
@@ -229,7 +227,6 @@ class CriStoringServiceTest {
 
         verify(mockSessionCredentialsService, never())
                 .persistCredentials(List.of(vc), mockIpvSessionItem.getIpvSessionId(), true);
-        verify(mockIpvSessionItem, times(0)).addVcReceivedThisSession(vc);
         verify(mockIpvSessionItem).setRiskAssessmentCredential(vc.getVcString());
     }
 
@@ -272,8 +269,6 @@ class CriStoringServiceTest {
                                 List.of(PASSPORT_NON_DCMAW_SUCCESSFUL_VC),
                                 clientOAuthSessionItem,
                                 mockIpvSessionItem));
-
-        verify(mockIpvSessionItem, never()).setVcReceivedThisSession(any());
     }
 
     @Test
@@ -296,8 +291,6 @@ class CriStoringServiceTest {
                                 List.of(PASSPORT_NON_DCMAW_SUCCESSFUL_VC),
                                 clientOAuthSessionItem,
                                 mockIpvSessionItem));
-
-        verify(mockIpvSessionItem, never()).setVcReceivedThisSession(any());
     }
 
     @Test
@@ -317,8 +310,6 @@ class CriStoringServiceTest {
                                 List.of(PASSPORT_NON_DCMAW_SUCCESSFUL_VC),
                                 clientOAuthSessionItem,
                                 mockIpvSessionItem));
-
-        verify(mockIpvSessionItem, never()).setVcReceivedThisSession(any());
     }
 
     private CriCallbackRequest buildValidCallbackRequest() {

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -97,22 +97,18 @@ public class UserIdentityService {
     }
 
     public UserIdentity generateUserIdentity(
-            List<VerifiableCredential> verifiableCredentials,
-            String sub,
-            Vot vot,
-            ContraIndicators contraIndicators)
+            List<VerifiableCredential> vcs, String sub, Vot vot, ContraIndicators contraIndicators)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException,
                     UnrecognisedCiException {
         var profileType = vot.getProfileType();
-        var filteredVcs = VcHelper.filterVCBasedOnProfileType(verifiableCredentials, profileType);
-        var vcJwts = filteredVcs.stream().map(VerifiableCredential::getVcString).toList();
+        var vcJwts = vcs.stream().map(VerifiableCredential::getVcString).toList();
 
         var vtm = configService.getSsmParameter(CORE_VTM_CLAIM);
 
         var userIdentityBuilder = UserIdentity.builder().vcs(vcJwts).sub(sub).vot(vot).vtm(vtm);
 
         buildUserIdentityBasedOnProfileType(
-                vot, contraIndicators, profileType, filteredVcs, userIdentityBuilder);
+                vot, contraIndicators, profileType, vcs, userIdentityBuilder);
 
         return userIdentityBuilder.build();
     }

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -1408,7 +1408,7 @@ class UserIdentityServiceTest {
     void shouldReturnCredentialsFromDataStoreForGPGProfile() throws Exception {
         var passportVc = PASSPORT_NON_DCMAW_SUCCESSFUL_VC;
         var fraudVc = vcExperianFraudScoreOne();
-        var vcs = List.of(passportVc, fraudVc, vcHmrcMigration());
+        var vcs = List.of(passportVc, fraudVc);
 
         mockParamStoreCalls(paramsToMockForP2);
         mockCredentialIssuerConfig();
@@ -1431,7 +1431,7 @@ class UserIdentityServiceTest {
     @Test
     void shouldReturnCredentialsFromDataStoreForOperationalProfile() throws Exception {
         var hmrcVc = vcHmrcMigration();
-        var vcs = List.of(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, vcExperianFraudScoreOne(), hmrcVc);
+        var vcs = List.of(hmrcVc);
 
         var credentials =
                 userIdentityService.generateUserIdentity(

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -18,23 +18,17 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import java.util.ArrayList;
 import java.util.List;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SESSION_CREDENTIALS_TABLE_WRITES;
-
 public class SessionCredentialsService {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String RECEIVED_THIS_SESSION = "receivedThisSession";
     private final DataStore<SessionCredentialItem> dataStore;
-    private final ConfigService configService;
 
-    public SessionCredentialsService(
-            DataStore<SessionCredentialItem> dataStore, ConfigService configService) {
+    public SessionCredentialsService(DataStore<SessionCredentialItem> dataStore) {
         this.dataStore = dataStore;
-        this.configService = configService;
     }
 
     @ExcludeFromGeneratedCoverageReport
     public SessionCredentialsService(ConfigService configService) {
-        this.configService = configService;
         this.dataStore =
                 new DataStore<>(
                         configService.getEnvironmentVariable(
@@ -82,12 +76,10 @@ public class SessionCredentialsService {
             boolean receivedThisSession)
             throws VerifiableCredentialException {
         try {
-            if (configService.enabled(SESSION_CREDENTIALS_TABLE_WRITES)) {
-                for (var credential : credentials) {
-                    dataStore.create(
-                            credential.toSessionCredentialItem(ipvSessionId, receivedThisSession),
-                            ConfigurationVariable.SESSION_CREDENTIALS_TTL);
-                }
+            for (var credential : credentials) {
+                dataStore.create(
+                        credential.toSessionCredentialItem(ipvSessionId, receivedThisSession),
+                        ConfigurationVariable.SESSION_CREDENTIALS_TTL);
             }
         } catch (Exception e) {
             LOGGER.error(LogHelper.buildErrorMessage("Error persisting session credential", e));

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.library.verifiablecredential.service;
 
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +15,6 @@ import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
-import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -28,11 +26,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SESSION_CREDENTIALS_TABLE_WRITES;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_DELETE_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
@@ -50,36 +46,13 @@ class SessionCredentialsServiceTest {
     private static final String CRI_ID_1 = "criId1";
     private static final String CRI_ID_2 = "criId2";
     private static final String CRI_ID_3 = "criId3";
-    @Mock private static ConfigService mockConfigService;
     @Captor private ArgumentCaptor<SessionCredentialItem> sessionCredentialItemArgumentCaptor;
     @Captor private ArgumentCaptor<String> ipvSessionIdArgumentCaptor;
     @Mock private DataStore<SessionCredentialItem> mockDataStore;
     @InjectMocks private SessionCredentialsService sessionCredentialService;
 
     @Nested
-    class WritesWithFeatureFlagDisabled {
-        @BeforeEach
-        void setUp() {
-            when(mockConfigService.enabled(SESSION_CREDENTIALS_TABLE_WRITES)).thenReturn(false);
-        }
-
-        @Test
-        void persistCredentialsShouldNotCreateItemsInDataStore() throws Exception {
-            List<VerifiableCredential> credentialsToStore =
-                    List.of(CREDENTIAL_1, CREDENTIAL_2, CREDENTIAL_3);
-            sessionCredentialService.persistCredentials(credentialsToStore, SESSION_ID, false);
-
-            verify(mockDataStore, never()).create(any(), any());
-        }
-    }
-
-    @Nested
-    class WritesWithFeatureFlagEnabled {
-        @BeforeEach
-        void setUp() {
-            when(mockConfigService.enabled(SESSION_CREDENTIALS_TABLE_WRITES)).thenReturn(true);
-        }
-
+    class Writes {
         @Test
         void persistCredentialsShouldStoreAllCredentials() throws Exception {
             List<VerifiableCredential> credentialsToStore =


### PR DESCRIPTION
**Not to be merged until https://github.com/govuk-one-login/ipv-core-common-infra/pull/906, and we're happy with the changes running in prod**

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Clean up session credential table switch

### Why did it change

This should be merged once the reads from the sessions credenentials table are happening in prod, and we're happy. It does a few things:

* Removes use of the sessionCredentialsTableReads feature flag
* Stops dual writing VCs. This stops writing to the user-issued-credentials-table during a journey. It's now only written to at the end of a journey
* Removes now unneccesary AWS perms from some lambdas
* Removes some now unncessary filtering from the "working" set of VCs. We should be operating on VCs of a know profile type when creating shared attributes and building identities


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5953](https://govukverify.atlassian.net/browse/PYIC-5953)


[PYIC-5954]: https://govukverify.atlassian.net/browse/PYIC-5954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PYIC-5953]: https://govukverify.atlassian.net/browse/PYIC-5953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ