### PR TITLE
PYIC-5663: remove gson 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-json
       - id: end-of-file-fixer
@@ -16,13 +16,13 @@ repos:
         args: ["--baseline", ".secrets.baseline"]
 
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.80.4 # The version of cfn-lint to use
+    rev: v0.86.3 # The version of cfn-lint to use
     hooks:
       - id: cfn-python-lint
         files: .template\.yaml$
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '2.5.4'
+    rev: '3.2.73'
     hooks:
       - id: checkov
         verbose: true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1714,7 +1714,7 @@
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java",
         "hashed_secret": "d1d4766fd2a2f73940b46f0d7ccabba3dd98e2cd",
         "is_verified": false,
-        "line_number": 67
+        "line_number": 68
       }
     ],
     "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java": [
@@ -1886,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-18T10:10:40Z"
+  "generated_at": "2024-04-22T09:51:18Z"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ awsSdkLambda = { module = "software.amazon.awssdk:lambda" }
 awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
 awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
 commonsCodec = "commons-codec:commons-codec:1.16.0"
-gson = "com.google.code.gson:gson:2.10.1"
 hamcrest = "org.hamcrest:hamcrest:2.2"
 jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 			libs.powertoolsTracing,
 			libs.aspectj
 
-	testImplementation libs.gson,
+	testImplementation libs.jacksonDatabind,
 			libs.junitJupiter,
 			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')

--- a/lambdas/check-gpg45-score/build.gradle
+++ b/lambdas/check-gpg45-score/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 			libs.powertoolsTracing,
 			libs.aspectj
 
-	testImplementation libs.gson,
+	testImplementation libs.jacksonDatabind,
 			libs.junitJupiter,
 			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -24,8 +24,7 @@ dependencies {
 			libs.powertoolsTracing,
 			libs.aspectj
 
-	testImplementation libs.gson,
-			libs.junitJupiter,
+	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests')
 

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 			libs.powertoolsTracing,
 			libs.aspectj
 
-	testImplementation libs.gson,
+	testImplementation libs.jacksonDatabind,
 			libs.junitJupiter,
 			project(path: ':libs:common-services', configuration: 'tests')
 

--- a/lambdas/reset-identity/build.gradle
+++ b/lambdas/reset-identity/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 			libs.powertoolsTracing,
 			libs.aspectj
 
-	testImplementation libs.gson,
+	testImplementation libs.jacksonDatabind,
 			libs.junitJupiter,
 			libs.mockitoJunit,
 			project(":libs:common-services").sourceSets.test.output

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkLambda,
 			libs.awsSdkUrlConnectionClient,
-			libs.gson,
+			libs.jacksonDatabind,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/domain/GetCiRequest.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/domain/GetCiRequest.java
@@ -1,16 +1,16 @@
 package uk.gov.di.ipv.core.library.cimit.domain;
 
-import com.google.gson.annotations.SerializedName;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 public class GetCiRequest {
-    @SerializedName(value = "govuk_signin_journey_id")
+    @JsonProperty("govuk_signin_journey_id")
     private final String govukSigninJourneyId;
 
-    @SerializedName(value = "ip_address")
+    @JsonProperty("ip_address")
     private final String ipAddress;
 
-    @SerializedName(value = "user_id")
+    @JsonProperty("user_id")
     private final String userId;
 }

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/domain/PostCiMitigationRequest.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/domain/PostCiMitigationRequest.java
@@ -1,18 +1,18 @@
 package uk.gov.di.ipv.core.library.cimit.domain;
 
-import com.google.gson.annotations.SerializedName;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
 public class PostCiMitigationRequest {
-    @SerializedName(value = "govuk_signin_journey_id")
+    @JsonProperty("govuk_signin_journey_id")
     private final String govukSigninJourneyId;
 
-    @SerializedName(value = "ip_address")
+    @JsonProperty("ip_address")
     private final String ipAddress;
 
-    @SerializedName(value = "signed_jwts")
+    @JsonProperty("signed_jwts")
     private final List<String> signedJwtList;
 }

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/domain/PutCiRequest.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/domain/PutCiRequest.java
@@ -1,16 +1,16 @@
 package uk.gov.di.ipv.core.library.cimit.domain;
 
-import com.google.gson.annotations.SerializedName;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 public class PutCiRequest {
-    @SerializedName(value = "govuk_signin_journey_id")
+    @JsonProperty("govuk_signin_journey_id")
     private final String govukSigninJourneyId;
 
-    @SerializedName(value = "ip_address")
+    @JsonProperty("ip_address")
     private final String ipAddress;
 
-    @SerializedName(value = "signed_jwt")
+    @JsonProperty("signed_jwt")
     private final String signedJwt;
 }

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -1,7 +1,7 @@
 package uk.gov.di.ipv.core.library.service;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.jwk.ECKey;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -51,7 +51,7 @@ import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_STATUS_C
 
 public class CiMitService {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final Gson GSON = new Gson();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String FAILED_LAMBDA_MESSAGE = "Lambda execution failed";
     private final LambdaClient lambdaClient;
     private final ConfigService configService;
@@ -79,17 +79,22 @@ public class CiMitService {
 
     public void submitVC(VerifiableCredential vc, String govukSigninJourneyId, String ipAddress)
             throws CiPutException {
+
+        String payload;
+        try {
+            payload =
+                    OBJECT_MAPPER.writeValueAsString(
+                            new PutCiRequest(govukSigninJourneyId, ipAddress, vc.getVcString()));
+
+        } catch (JsonProcessingException e) {
+            throw new CiPutException("Failed to serialize PutCiRequest");
+        }
+
         var invokeRequest =
                 InvokeRequest.builder()
                         .functionName(
                                 configService.getEnvironmentVariable(CI_STORAGE_PUT_LAMBDA_ARN))
-                        .payload(
-                                SdkBytes.fromUtf8String(
-                                        GSON.toJson(
-                                                new PutCiRequest(
-                                                        govukSigninJourneyId,
-                                                        ipAddress,
-                                                        vc.getVcString()))))
+                        .payload(SdkBytes.fromUtf8String(payload))
                         .build();
 
         LOGGER.info(LogHelper.buildLogMessage("Sending VC to CIMIT."));
@@ -105,22 +110,24 @@ public class CiMitService {
             List<VerifiableCredential> vcs, String govukSigninJourneyId, String ipAddress)
             throws CiPostMitigationsException {
 
+        String payload;
+        try {
+            payload =
+                    OBJECT_MAPPER.writeValueAsString(
+                            new PostCiMitigationRequest(
+                                    govukSigninJourneyId,
+                                    ipAddress,
+                                    vcs.stream().map(VerifiableCredential::getVcString).toList()));
+        } catch (JsonProcessingException e) {
+            throw new CiPostMitigationsException("Failed to serialize PostCiMitigationRequest");
+        }
+
         var invokeRequest =
                 InvokeRequest.builder()
                         .functionName(
                                 configService.getEnvironmentVariable(
                                         CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN))
-                        .payload(
-                                SdkBytes.fromUtf8String(
-                                        GSON.toJson(
-                                                new PostCiMitigationRequest(
-                                                        govukSigninJourneyId,
-                                                        ipAddress,
-                                                        vcs.stream()
-                                                                .map(
-                                                                        VerifiableCredential
-                                                                                ::getVcString)
-                                                                .toList()))))
+                        .payload(SdkBytes.fromUtf8String(payload))
                         .build();
 
         LOGGER.info(LogHelper.buildLogMessage("Sending mitigating VCs to CIMIT."));
@@ -155,10 +162,15 @@ public class CiMitService {
             String userId, String govukSigninJourneyId, String ipAddress)
             throws CiRetrievalException {
         var response = invokeClientToGetCIResult(govukSigninJourneyId, ipAddress, userId);
-        ContraIndicatorCredentialDto contraIndicatorCredential =
-                GSON.fromJson(
-                        response.payload().asUtf8String(), ContraIndicatorCredentialDto.class);
-        return extractAndValidateContraIndicatorsJwt(contraIndicatorCredential.getVc(), userId);
+
+        try {
+            ContraIndicatorCredentialDto contraIndicatorCredential =
+                    OBJECT_MAPPER.readValue(
+                            response.payload().asUtf8String(), ContraIndicatorCredentialDto.class);
+            return extractAndValidateContraIndicatorsJwt(contraIndicatorCredential.getVc(), userId);
+        } catch (JsonProcessingException e) {
+            throw new CiRetrievalException("Failed to deserialize ContraIndicatorCredentialDto");
+        }
     }
 
     private InvokeResponse invokeClientToGetCIResult(
@@ -166,16 +178,21 @@ public class CiMitService {
             throws CiRetrievalException {
         LOGGER.info(LogHelper.buildLogMessage("Retrieving CIs from CIMIT system"));
 
+        String payload;
+        try {
+            payload =
+                    OBJECT_MAPPER.writeValueAsString(
+                            new GetCiRequest(govukSigninJourneyId, ipAddress, userId));
+        } catch (JsonProcessingException e) {
+            throw new CiRetrievalException("Failed to serialize GetCiRequest");
+        }
+
         var invokeRequest =
                 InvokeRequest.builder()
                         .functionName(
                                 configService.getEnvironmentVariable(
                                         CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN))
-                        .payload(
-                                SdkBytes.fromUtf8String(
-                                        GSON.toJson(
-                                                new GetCiRequest(
-                                                        govukSigninJourneyId, ipAddress, userId))))
+                        .payload(SdkBytes.fromUtf8String(payload))
                         .build();
 
         InvokeResponse response;
@@ -226,9 +243,19 @@ public class CiMitService {
 
         var claimSetJsonObject = vc.getClaimsSet().toJSONObject();
 
-        CiMitJwt ciMitJwt =
-                GSON.fromJson(
-                        GSON.toJson(claimSetJsonObject), new TypeToken<CiMitJwt>() {}.getType());
+        String valueAsString;
+        try {
+            valueAsString = OBJECT_MAPPER.writeValueAsString(claimSetJsonObject);
+        } catch (JsonProcessingException e) {
+            throw new CiRetrievalException("Failed to serialize claim set");
+        }
+        CiMitJwt ciMitJwt;
+        try {
+            ciMitJwt = OBJECT_MAPPER.readValue(valueAsString, CiMitJwt.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            throw new CiRetrievalException("Failed to deserialize CiMitJwt");
+        }
 
         CiMitVc vcClaim = ciMitJwt.getVc();
         if (vcClaim == null) {

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -242,21 +242,7 @@ public class CiMitService {
             throws CiRetrievalException {
 
         var claimSetJsonObject = vc.getClaimsSet().toJSONObject();
-
-        String valueAsString;
-        try {
-            valueAsString = OBJECT_MAPPER.writeValueAsString(claimSetJsonObject);
-        } catch (JsonProcessingException e) {
-            throw new CiRetrievalException("Failed to serialize claim set");
-        }
-        CiMitJwt ciMitJwt;
-        try {
-            ciMitJwt = OBJECT_MAPPER.readValue(valueAsString, CiMitJwt.class);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            throw new CiRetrievalException("Failed to deserialize CiMitJwt");
-        }
-
+        CiMitJwt ciMitJwt = OBJECT_MAPPER.convertValue(claimSetJsonObject, CiMitJwt.class);
         CiMitVc vcClaim = ciMitJwt.getVc();
         if (vcClaim == null) {
             String message = "VC claim not found in CiMit JWT";

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -243,6 +243,11 @@ public class CiMitService {
 
         var claimSetJsonObject = vc.getClaimsSet().toJSONObject();
         CiMitJwt ciMitJwt = OBJECT_MAPPER.convertValue(claimSetJsonObject, CiMitJwt.class);
+        if (ciMitJwt == null) {
+            String message = "Failed to convert claim set object to CiMitJwt";
+            LOGGER.error(LogHelper.buildLogMessage(message));
+            throw new CiRetrievalException(message);
+        }
         CiMitVc vcClaim = ciMitJwt.getVc();
         if (vcClaim == null) {
             String message = "VC claim not found in CiMit JWT";

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 			libs.awsSdkDynamodbEnhanced,
 			libs.awsSdkLambda,
 			libs.commonsCodec,
-			libs.gson,
+			libs.jacksonDatabind,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/CiMitJwt.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/CiMitJwt.java
@@ -1,8 +1,10 @@
 package uk.gov.di.ipv.core.library.domain.cimitvc;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @ExcludeFromGeneratedCoverageReport
 @Getter
 public class CiMitJwt {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/ContraIndicator.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/ContraIndicator.java
@@ -1,11 +1,15 @@
 package uk.gov.di.ipv.core.library.domain.cimitvc;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.util.List;
 
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
 @Getter
 @Builder
 @ToString

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/EvidenceItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/EvidenceItem.java
@@ -1,10 +1,12 @@
 package uk.gov.di.ipv.core.library.domain.cimitvc;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @ExcludeFromGeneratedCoverageReport
 @Getter
 public class EvidenceItem {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/MitigatingCredential.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/MitigatingCredential.java
@@ -1,10 +1,14 @@
 package uk.gov.di.ipv.core.library.domain.cimitvc;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
 @Getter
 @Builder
 @ExcludeFromGeneratedCoverageReport

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/Mitigation.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/cimitvc/Mitigation.java
@@ -1,12 +1,16 @@
 package uk.gov.di.ipv.core.library.domain.cimitvc;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.util.List;
 
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
 @Getter
 @Builder
 @ExcludeFromGeneratedCoverageReport

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -1,6 +1,6 @@
 package uk.gov.di.ipv.core.library.service;
 
-import com.google.gson.Gson;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -77,7 +78,7 @@ class ConfigServiceTest {
 
     private ConfigService configService;
 
-    private final Gson gson = new Gson();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
@@ -381,8 +382,15 @@ class ConfigServiceTest {
     void getCriPrivateApiKeyForActiveConnectionShouldReturnApiKeySecret() {
         environmentVariables.set("ENVIRONMENT", "test");
         Map<String, String> apiKeySecret = Map.of("apiKey", "api-key-value");
+
+        String json =
+                assertDoesNotThrow(
+                        () -> {
+                            return OBJECT_MAPPER.writeValueAsString(apiKeySecret);
+                        });
+
         when(secretsProvider.get("/test/credential-issuers/ukPassport/connections/stub/api-key"))
-                .thenReturn(gson.toJson(apiKeySecret));
+                .thenReturn(json);
         when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                 .thenReturn("stub");
 
@@ -394,7 +402,14 @@ class ConfigServiceTest {
     @Test
     void shouldGetSecretValueFromSecretsManager() {
         Map<String, String> apiKeySecret = Map.of("apiKey", "api-key-value");
-        when(secretsProvider.get(any())).thenReturn(gson.toJson(apiKeySecret));
+
+        String json =
+                assertDoesNotThrow(
+                        () -> {
+                            return OBJECT_MAPPER.writeValueAsString(apiKeySecret);
+                        });
+
+        when(secretsProvider.get(any())).thenReturn(json);
 
         String apiKey = configService.getCriPrivateApiKey(CRI_OAUTH_SESSION_ITEM);
 

--- a/libs/email-service/build.gradle
+++ b/libs/email-service/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-	implementation libs.gson,
+	implementation libs.jacksonDatabind,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.notificationsJavaClient,
 			libs.powertoolsLogging,

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 			libs.awsSdkKms,
 			libs.awsSdkUrlConnectionClient,
 			libs.commonsCodec,
-			libs.gson,
+			libs.jacksonDatabind,
 			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,


### PR DESCRIPTION
Consolidate JSON parsing into one library by removing GSON and replacing any instances it used with jackson. 

## Proposed changes

### What changed

 - Removed GSON library
 - Replaced GSON methods with equivalent Jackson methods

### Why did it change

To reduce dependencies and simplify development

### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-5663



## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

