### PR TITLE
PYIC-6028: Stop dual writing credentials

### DIFF
--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -36,7 +36,6 @@ import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
-import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
 import java.util.Map;
 
@@ -74,7 +73,6 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
                         configService,
                         new AuditService(AuditService.getSqsClient(), configService),
                         null,
-                        new VerifiableCredentialService(configService),
                         new SessionCredentialsService(configService),
                         ciMitService);
     }

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -115,7 +115,6 @@ public class ProcessCriCallbackHandler
         clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
 
         var auditService = new AuditService(AuditService.getSqsClient(), configService);
-        var verifiableCredentialService = new VerifiableCredentialService(configService);
         var sessionCredentialsService = new SessionCredentialsService(configService);
         var ciMitService = new CiMitService(configService);
 
@@ -132,14 +131,13 @@ public class ProcessCriCallbackHandler
                         new UserIdentityService(configService),
                         ciMitService,
                         new CiMitUtilityService(configService),
-                        verifiableCredentialService,
+                        new VerifiableCredentialService(configService),
                         sessionCredentialsService);
         criStoringService =
                 new CriStoringService(
                         configService,
                         auditService,
                         new CriResponseService(configService),
-                        verifiableCredentialService,
                         sessionCredentialsService,
                         ciMitService);
 

--- a/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
+++ b/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
@@ -30,7 +30,6 @@ import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredenti
 import uk.gov.di.ipv.core.library.verifiablecredential.dto.VerifiableCredentialResponseDto;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
-import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
 import java.util.List;
 
@@ -44,7 +43,6 @@ public class CriStoringService {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final CriResponseService criResponseService;
-    private final VerifiableCredentialService verifiableCredentialService;
     private final SessionCredentialsService sessionCredentialsService;
     private final AuditService auditService;
     private final CiMitService ciMitService;
@@ -55,13 +53,11 @@ public class CriStoringService {
             ConfigService configService,
             AuditService auditService,
             CriResponseService criResponseService,
-            VerifiableCredentialService verifiableCredentialService,
             SessionCredentialsService sessionCredentialsService,
             CiMitService ciMitService) {
         this.configService = configService;
         this.auditService = auditService;
         this.criResponseService = criResponseService;
-        this.verifiableCredentialService = verifiableCredentialService;
         this.sessionCredentialsService = sessionCredentialsService;
         this.ciMitService = ciMitService;
         VcHelper.setConfigService(configService);
@@ -128,7 +124,6 @@ public class CriStoringService {
             if (criId.equals(TICF_CRI)) {
                 ipvSessionItem.setRiskAssessmentCredential(vc.getVcString());
             } else {
-                verifiableCredentialService.persistUserCredentials(vc);
                 if (criId.equals(ADDRESS_CRI)) {
                     // Remove any existing address VC from session credentials - for 6MFC
                     sessionCredentialsService.deleteSessionCredentialsForCri(

--- a/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
+++ b/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
@@ -25,7 +25,6 @@ import uk.gov.di.ipv.core.library.service.CriResponseService;
 import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialStatus;
 import uk.gov.di.ipv.core.library.verifiablecredential.dto.VerifiableCredentialResponseDto;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
-import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
 import java.util.List;
 
@@ -53,7 +52,6 @@ class CriStoringServiceTest {
     @Mock private ConfigService mockConfigService;
     @Mock private AuditService mockAuditService;
     @Mock private CriResponseService mockCriResponseService;
-    @Mock private VerifiableCredentialService mockVerifiableCredentialService;
     @Mock private SessionCredentialsService mockSessionCredentialsService;
     @Mock private CiMitService mockCiMitService;
     @Mock private IpvSessionItem mockIpvSessionItem;
@@ -157,7 +155,6 @@ class CriStoringServiceTest {
         assertEquals(
                 AuditEventTypes.IPV_CORE_CRI_RESOURCE_RETRIEVED, secondAuditEvent.getEventName());
 
-        verify(mockVerifiableCredentialService).persistUserCredentials(vc);
         verify(mockSessionCredentialsService, never()).deleteSessionCredentialsForCri(any(), any());
         verify(mockSessionCredentialsService)
                 .persistCredentials(List.of(vc), mockIpvSessionItem.getIpvSessionId(), true);
@@ -182,7 +179,6 @@ class CriStoringServiceTest {
                 mockIpvSessionItem);
 
         // Assert
-        verify(mockVerifiableCredentialService).persistUserCredentials(vc);
         verify(mockSessionCredentialsService)
                 .deleteSessionCredentialsForCri(mockIpvSessionItem.getIpvSessionId(), ADDRESS_CRI);
         verify(mockSessionCredentialsService)
@@ -231,7 +227,6 @@ class CriStoringServiceTest {
         assertEquals(
                 AuditEventTypes.IPV_CORE_CRI_RESOURCE_RETRIEVED, secondAuditEvent.getEventName());
 
-        verify(mockVerifiableCredentialService, never()).persistUserCredentials(vc);
         verify(mockSessionCredentialsService, never())
                 .persistCredentials(List.of(vc), mockIpvSessionItem.getIpvSessionId(), true);
         verify(mockIpvSessionItem, times(0)).addVcReceivedThisSession(vc);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Stop dual writing credentials

### Why did it change

This stops core from dual writing VCs to the session-credentials table and the user-issued-credentials table.

This was previously covered in [PR#1845](https://github.com/govuk-one-login/ipv-core-back/pull/1845), however I've noticed that deploying that PR with live traffic results in errors.

It appears the permissions removal on that PR happens before the new version of the process-cri-callback lambda is active - with about a 4 minute window where the outgoing lambda is trying to write to the user-issued-credentials table but without the correct permissions, resulting in a technical error. This could affect a lot of users.

I may split that PR further to ensure all permission changes go out separately to the code changes that require them.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6028](https://govukverify.atlassian.net/browse/PYIC-6028)


[PYIC-6028]: https://govukverify.atlassian.net/browse/PYIC-6028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ