### PR TITLE
PYIC-4816: Clear up unused events

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -108,14 +108,6 @@ IDENTITY_START_PAGE:
     type: page
     pageId: page-ipv-identity-document-start
   events:
-    next: # TODO: Remove after PYIC-5264
-      targetState: CRI_DCMAW
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
     appTriage:
       targetState: CRI_DCMAW
       checkFeatureFlag:
@@ -307,12 +299,6 @@ PYI_CRI_ESCAPE:
     type: page
     pageId: pyi-cri-escape
   events:
-    dcmaw: # TODO: Remove after PYIC-5264
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
@@ -342,12 +328,6 @@ PYI_CRI_ESCAPE_NO_F2F:
     type: page
     pageId: pyi-cri-escape-no-f2f
   events:
-    next: # TODO: Remove after PYIC-5264
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
@@ -731,12 +711,6 @@ MITIGATION_KBV_FAIL_M2B:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_F2F
-    dcmaw: # TODO: Remove after 5624
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
@@ -795,12 +769,6 @@ PYI_KBV_DROPOUT_M2B:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_F2F
-    dcmaw: # TODO: Remove after PYIC-5264
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
@@ -841,16 +809,6 @@ MITIGATION_01_IDENTITY_START_PAGE:
     type: page
     pageId: page-ipv-identity-document-start
   events:
-    next: # TODO: Remove after PYIC-5624
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     appTriage:
       targetState: MITIGATION_01_CRI_DCMAW
       checkFeatureFlag:
@@ -960,16 +918,6 @@ MITIGATION_02_OPTIONS:
     pageId: pyi-suggest-other-options-no-f2f
     mitigationStart: enhanced-verification
   events:
-    next: # TODO: Remove after PYIC-5624
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
@@ -1055,12 +1003,6 @@ MITIGATION_02_OPTIONS_WITH_F2F:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_F2F
-    dcmaw: # TODO: Remove after PYIC-5264
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:
@@ -1092,12 +1034,6 @@ MITIGATION_02_OPTIONS_WITH_F2F_M2B:
       checkFeatureFlag:
         ticfCriBeta:
           targetState: CRI_TICF_BEFORE_F2F
-    dcmaw: # TODO: Remove after PYIC-5264
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
     appTriage:
       targetState: CRI_DCMAW_PYI_ESCAPE
       checkFeatureFlag:


### PR DESCRIPTION
## Proposed changes

### What changed

- Clear up unused dcmaw or next events from pages where the only options are `appTriage`, `appTriageSmartphone`, `end`, and maybe `f2f`

### Issue tracking

- [PYIC-4816](https://govukverify.atlassian.net/browse/PYIC-4816)

[PYIC-4816]: https://govukverify.atlassian.net/browse/PYIC-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ