### PR TITLE
PYIC-5707: Remove coreFrontCallBackUrl variable

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -12,7 +12,6 @@ public enum ConfigurationVariable {
     CLIENT_ISSUER("clients/%s/issuer"),
     CLIENT_VALID_REDIRECT_URLS("clients/%s/validRedirectUrls"),
     COMPONENT_ID("self/componentId"),
-    CORE_FRONT_CALLBACK_URL("self/coreFrontCallbackUrl"),
     CORE_VTM_CLAIM("self/coreVtmClaim"),
     CREDENTIAL_ISSUERS("credentialIssuers"),
     CRI_RESPONSE_TTL("self/criResponseTtl"),

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -553,8 +553,6 @@ class ConfigServiceTest {
     @CsvSource({
         "MAX_ALLOWED_AUTH_CLIENT_TTL,",
         "MAX_ALLOWED_AUTH_CLIENT_TTL,FS01",
-        "CORE_FRONT_CALLBACK_URL,",
-        "CORE_FRONT_CALLBACK_URL,FS01",
         "CORE_VTM_CLAIM,",
         "CORE_VTM_CLAIM,FS02",
         "BACKEND_SESSION_TIMEOUT,",
@@ -587,10 +585,6 @@ class ConfigServiceTest {
                 "self/maxAllowedAuthClientTtl",
                 "aClientTokenTtl",
                 Map.of("FS01", "aDifferentClientTokenTtl")),
-        CORE_FRONT_CALLBACK_URL(
-                "self/coreFrontCallbackUrl",
-                "aCoreFrontCallbackUrl",
-                Map.of("FS01", "aDifferentCoreFrontCallbackUrl")),
         CORE_VTM_CLAIM(
                 "self/coreVtmClaim", "aCoreVtmClaim", Map.of("FS02", "aDifferentCoreVtmClaim")),
         BACKEND_SESSION_TIMEOUT(


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove coreFrontCallBackUrl variable

### Why did it change

This variable isn't used, and is going to be removed from the config files, so we can remove it from core-back too.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5707](https://govukverify.atlassian.net/browse/PYIC-5707)


[PYIC-5707]: https://govukverify.atlassian.net/browse/PYIC-5707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ