### PR TITLE
BAU: Supply region for datastore DDB client

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -24,6 +24,8 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import java.time.Instant;
 import java.util.List;
 
+import static software.amazon.awssdk.regions.Region.EU_WEST_2;
+
 public class DataStore<T extends DynamodbItem> {
 
     private static final Logger LOGGER = LogManager.getLogger();
@@ -43,7 +45,11 @@ public class DataStore<T extends DynamodbItem> {
 
     @ExcludeFromGeneratedCoverageReport
     public static DynamoDbEnhancedClient getClient() {
-        var client = DynamoDbClient.builder().httpClient(UrlConnectionHttpClient.create()).build();
+        var client =
+                DynamoDbClient.builder()
+                        .region(EU_WEST_2)
+                        .httpClient(UrlConnectionHttpClient.create())
+                        .build();
 
         return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Supply region for datastore DDB client

### Why did it change

It's recommended to supply the region when building the clients with lambda. It prevents the SDK having to do some internal logic, and makes things faster.

This should have been included in a previous PR but was missed.
