### PR TITLE
PYIC-6092: Update core-back to reference new pages

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -186,7 +186,7 @@ F2F_PYI_POST_OFFICE:
 BANK_ACCOUNT_START_PAGE:
   response:
     type: page
-    pageId: page-ipv-bank-account-start
+    pageId: prove-identity-bank-account
   events:
     next:
       targetState: CRI_CLAIMED_IDENTITY_M2B
@@ -724,7 +724,7 @@ MITIGATION_KBV_FAIL_M2B:
   response:
     mitigationStart: enhanced-verification
     type: page
-    pageId: pyi-kbv-escape-m2b
+    pageId: no-photo-id-security-questions-find-another-way
   events:
     f2f:
       targetState: CRI_F2F
@@ -762,7 +762,7 @@ MITIGATION_KBV_FAIL_M2B:
 PYI_ESCAPE_M2B:
   response:
     type: page
-    pageId: pyi-escape-m2b
+    pageId: no-photo-id-exit-find-another-way
   events:
     next:
       targetState: IDENTITY_START_PAGE
@@ -776,7 +776,7 @@ PYI_ESCAPE_ABANDON_M2B:
   response:
     type: page
     context: abandon
-    pageId: pyi-escape-m2b
+    pageId: no-photo-id-exit-find-another-way
   events:
     end:
       targetJourney: INELIGIBLE
@@ -787,7 +787,7 @@ PYI_ESCAPE_ABANDON_M2B:
 PYI_KBV_DROPOUT_M2B:
   response:
     type: page
-    pageId: pyi-kbv-escape-m2b
+    pageId: no-photo-id-security-questions-find-another-way
     context: dropout
   events:
     f2f:


### PR DESCRIPTION
## Proposed changes

### What changed

- Changed references in core-back to new pages based on design changes

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6000](https://govukverify.atlassian.net/browse/PYIC-6000)
- [PYIC-6092](https://govukverify.atlassian.net/browse/PYIC-6092)

Results of testing this deployed with core-front with PYIC-6091 changes:
- E2E tests pass
<img width="419" alt="Screenshot 2024-04-25 at 16 24 59" src="https://github.com/govuk-one-login/ipv-core-back/assets/144116535/7b452b68-68d4-4159-8ae7-5e48e4cbc5cc">


[PYIC-6000]: https://govukverify.atlassian.net/browse/PYIC-6000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-6092]: https://govukverify.atlassian.net/browse/PYIC-6092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ