### PR TITLE
BAU: Give step function execute perms for reset-session-identity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -188,14 +188,14 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "fdaca2b5dd9f9e4b35406a33c1d14aa098a8d676",
         "is_verified": false,
-        "line_number": 1728
+        "line_number": 1730
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
-        "line_number": 2101
+        "line_number": 2103
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -1886,5 +1886,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-29T07:39:56Z"
+  "generated_at": "2024-04-29T13:31:48Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1223,6 +1223,8 @@ Resources:
             FunctionName: !Ref CallTicfCriFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref StoreIdentityFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref ResetSessionIdentityFunction
         - Statement:
             - Sid: CloudWatchLogsAccess
               Effect: Allow


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Give step function execute perms for reset-session-identity

### Why did it change

The reset-session-identity lambda has been included in the journey engine step function, but is missing the permission to invoke it.
