### PR TITLE
PYIC-6122: call TICF in FAILED_RFC

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -33,6 +33,9 @@ FAILED_RFC:
   events:
     next:
       targetState: NO_MATCH_PAGE_RFC
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC
 
 FAILED_UPDATE_ADDRESS:
   events:


### PR DESCRIPTION
## Proposed changes
Call TICF when repeat fraud check fails

### What changed

Check for feature flag in RFC_ERROR state

### Why did it change

TICF is not being called if there is an error in the repeat fraud check journey and the flag is set

### Issue tracking

- [PYIC-6122](https://govukverify.atlassian.net/browse/PYIC-6122)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-6122]: https://govukverify.atlassian.net/browse/PYIC-6122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ