### PR TITLE
BAU: Cleanup implementation of nimbusdsOauth2OidcSdk library

### DIFF
--- a/lambdas/build-client-oauth-response/build.gradle
+++ b/lambdas/build-client-oauth-response/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
 
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:audit-service")

--- a/lambdas/build-cri-oauth-request/build.gradle
+++ b/lambdas/build-cri-oauth-request/build.gradle
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:kms-es256-signer"),
 			project(":libs:journey-uris"),

--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials"),
 			project(":libs:user-identity-service")

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
 
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),
 			project(":libs:audit-service"),

--- a/lambdas/call-ticf-cri/build.gradle
+++ b/lambdas/call-ticf-cri/build.gradle
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:audit-service"),
 			project(":libs:cimit-service"),
 			project(":libs:common-services"),

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),
 			project(":libs:journey-uris"),

--- a/lambdas/check-gpg45-score/build.gradle
+++ b/lambdas/check-gpg45-score/build.gradle
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:audit-service"),
 			project(":libs:journey-uris"),

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
 
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:audit-service"),

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 
 	implementation libs.bundles.awsLambda,
 			libs.awsSdkKms,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials"),

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkDynamodbEnhanced,
 			libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services")
 
 	aspect libs.powertoolsLogging,

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:cimit-service"),
 			project(":libs:cri-response-service"),

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
 
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:audit-service"),
 			project(":libs:cimit-service"),
 			project(":libs:common-services"),

--- a/lambdas/process-journey-event/build.gradle
+++ b/lambdas/process-journey-event/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
 	implementation libs.bundles.awsLambda,
 			libs.jacksonDataformatYaml,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:audit-service")
 

--- a/lambdas/reset-session-identity/build.gradle
+++ b/lambdas/reset-session-identity/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
 	implementation libs.awsLambdaJavaCore,
 			libs.awsLambdaJavaEvents,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:verifiable-credentials")

--- a/lambdas/restore-vcs/build.gradle
+++ b/lambdas/restore-vcs/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkDynamodbEnhanced,
 			libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:cri-response-service"),

--- a/lambdas/revoke-vcs/build.gradle
+++ b/lambdas/revoke-vcs/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkDynamodbEnhanced,
 			libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
 			project(":libs:cri-response-service"),

--- a/lambdas/store-identity/build.gradle
+++ b/lambdas/store-identity/build.gradle
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			project(":libs:audit-service"),
 			project(":libs:common-services"),
 			project(':libs:journey-uris'),

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkUrlConnectionClient,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 			libs.awsSdkLambda,
 			libs.awsSdkUrlConnectionClient,
 			libs.jacksonDatabind,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -10,6 +10,7 @@ repositories {
 }
 
 dependencies {
+	api libs.nimbusdsOauth2OidcSdk
 	implementation platform(libs.awsSdkBom),
 			libs.awsLambdaJavaEvents,
 			libs.awsSdkDynamodb,
@@ -17,7 +18,6 @@ dependencies {
 			libs.awsSdkLambda,
 			libs.commonsCodec,
 			libs.jacksonDatabind,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:journey-uris")

--- a/libs/cri-storing-service/build.gradle
+++ b/libs/cri-storing-service/build.gradle
@@ -9,8 +9,7 @@ repositories {
 }
 
 dependencies {
-	implementation libs.nimbusdsOauth2OidcSdk,
-			libs.powertoolsLogging,
+	implementation libs.powertoolsLogging,
 			project(":libs:audit-service"),
 			project(":libs:cimit-service"),
 			project(":libs:common-services"),

--- a/libs/email-service/build.gradle
+++ b/libs/email-service/build.gradle
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
 	implementation libs.jacksonDatabind,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.notificationsJavaClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/gpg45-evaluator/build.gradle
+++ b/libs/gpg45-evaluator/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkDynamodbEnhanced,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services")

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -16,7 +16,6 @@ dependencies {
 			libs.awsSdkUrlConnectionClient,
 			libs.commonsCodec,
 			libs.jacksonDatabind,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services")

--- a/libs/pact-test-helpers/build.gradle
+++ b/libs/pact-test-helpers/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 	implementation libs.bundles.awsLambda,
 			libs.jacksonDatabind,
 			libs.mockitoJunit,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.pactConsumerJunit,
 			project(path: ':libs:common-services')
 

--- a/libs/user-identity-service/build.gradle
+++ b/libs/user-identity-service/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkDynamodbEnhanced,
 			libs.awsSdkLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkDynamodbEnhanced,
 			libs.awsSdkLambda,
-			libs.nimbusdsOauth2OidcSdk,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Cleans up how the `nimbusdsOauth2OidcSdk` library is implemented

### What changed

<!-- Describe the changes in detail - the "what"-->

Changed how `nimbusdsOauth2OidcSdk` library dependency is exposed consumers of common-services.

- Moves the `nimbusdsOauth2OidcSdk` dependency to the api level configuration in `common-services`

- Removes the `nimbusdsOauth2OidcSdk` dependency from the implementation in lambdas that implement the `common-services` library

### Why did it change

By moving the dependecy to the `api` level configurations the `nimbusdsOauth2OidcSdk` will  be transitively exposed to consumers of the library. This would speed up compilation and makes it cleaner for lambdas as they do not directly implement this libary

Some benefits include:

- Reduces duplication across the dependency declaration
- Faster compilation
- Less recompilations when implementation dependencies change
- Less dependency leaks
- Cleaner publishing

Also helps when new lambdas are created - no need to implement a library that is not directky used 
😅

<!-- Describe the reason these changes were made - the "why" -->

