### PR TITLE
PYIC-6001: reset session identity in f2f handoff

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -435,10 +435,20 @@ STORE_IDENTITY_BEFORE_F2F_HANDOFF:
     lambda: store-identity
   events:
     identity-stored:
-      targetState: F2F_HANDOFF_PAGE
+      targetState: RESET_SESSION_BEFORE_F2F_HANDOFF
     error:
       targetJourney: TECHNICAL_ERROR
       targetState: ERROR
+
+RESET_SESSION_BEFORE_F2F_HANDOFF:
+  response:
+    type: process
+    lambda: reset-session-identity
+  events:
+    next:
+      targetState: F2F_HANDOFF_PAGE
+    error:
+      targetState: F2F_HANDOFF_PAGE
 
 IPV_SUCCESS_PAGE:
   response:


### PR DESCRIPTION
## Proposed changes

### What changed

When the F2F journey ends (gets handed off), clear the session store

### Why did it change

to minimize exposure of session store

### Issue tracking

- [PYIC-6001](https://govukverify.atlassian.net/browse/PYIC-6001)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-6001]: https://govukverify.atlassian.net/browse/PYIC-6001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ