### PR TITLE
PYIC-5809: added journey config for update details to reuse-existing identity

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -45,6 +45,8 @@ IDENTITY_REUSE_PAGE:
   events:
     next:
       targetState: RETURN_TO_RP
+    update-details:
+      targetState: UPDATE_DETAILS_PAGE
 
 IDENTITY_REUSE_PAGE_TEST:
   response:
@@ -53,6 +55,8 @@ IDENTITY_REUSE_PAGE_TEST:
   events:
     next:
       targetState: NEW_DETAILS_PAGE
+    update-details:
+      targetState: UPDATE_DETAILS_PAGE
 
 NEW_DETAILS_PAGE:
   response:
@@ -90,6 +94,35 @@ DETAILS_DELETED_PAGE:
     next:
       targetJourney: NEW_P2_IDENTITY
       targetState: START
+
+UPDATE_DETAILS_PAGE:
+  response:
+    type: page
+    pageId: update-details
+  events:
+    address:
+      targetJourney: UPDATE_ADDRESS
+      targetState: START
+    name:
+      # TODO replace with UPDATE_NAME_ADDRESS when it is complete
+      targetJourney: UPDATE_ADDRESS
+      targetState: START
+    name-address:
+      # TODO replace with UPDATE_NAME_ADDRESS when it is complete
+      targetJourney: UPDATE_ADDRESS
+      targetState: START
+    names-dob:
+      targetState: UPDATE_NAME_DOB_PAGE
+    cancel:
+      targetState: RETURN_TO_RP
+
+UPDATE_NAME_DOB_PAGE:
+  response:
+    type: page
+    pageId: update-name-date-birth
+  events:
+    end:
+      targetState: UPDATE_DETAILS_PAGE
 
 RETURN_TO_RP:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -22,6 +22,8 @@ CRI_TICF_BEFORE_REUSE:
       checkFeatureFlag:
         deleteDetailsEnabled:
           targetState: IDENTITY_REUSE_PAGE_TEST
+        coiEnabled:
+          targetState: IDENTITY_REUSE_PAGE_COI
     enhanced-verification:
       targetJourney: FAILED
       targetState: FAILED_NO_TICF
@@ -45,6 +47,15 @@ IDENTITY_REUSE_PAGE:
   events:
     next:
       targetState: RETURN_TO_RP
+
+IDENTITY_REUSE_PAGE_COI:
+  response:
+    type: page
+    pageId: page-ipv-reuse
+    context: coi
+  events:
+    next:
+      targetState: RETURN_TO_RP
     update-details:
       targetState: UPDATE_DETAILS_PAGE
 
@@ -55,8 +66,6 @@ IDENTITY_REUSE_PAGE_TEST:
   events:
     next:
       targetState: NEW_DETAILS_PAGE
-    update-details:
-      targetState: UPDATE_DETAILS_PAGE
 
 NEW_DETAILS_PAGE:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -9,6 +9,8 @@ START:
           targetState: CRI_TICF_BEFORE_REUSE
         deleteDetailsEnabled:
           targetState: IDENTITY_REUSE_PAGE_TEST
+        coiEnabled:
+          targetState: IDENTITY_REUSE_PAGE_COI
 
 # Journey states
 
@@ -76,6 +78,9 @@ NEW_DETAILS_PAGE:
       targetState: CONFIRM_DELETE_DETAILS_PAGE
     end:
       targetState: IDENTITY_REUSE_PAGE
+      checkFeatureFlag:
+        coiEnabled:
+          targetState: IDENTITY_REUSE_PAGE_COI
 
 CONFIRM_DELETE_DETAILS_PAGE:
   response:
@@ -86,6 +91,9 @@ CONFIRM_DELETE_DETAILS_PAGE:
       targetState: RESET_SESSION_IDENTITY
     end:
       targetState: IDENTITY_REUSE_PAGE
+      checkFeatureFlag:
+        coiEnabled:
+          targetState: IDENTITY_REUSE_PAGE_COI
 
 RESET_SESSION_IDENTITY:
   response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -137,6 +137,7 @@ UPDATE_NAME_DOB_PAGE:
   response:
     type: page
     pageId: update-name-date-birth
+    context: coi
   events:
     end:
       targetState: UPDATE_DETAILS_PAGE


### PR DESCRIPTION
## Proposed changes

Adds journey configuration for starting a change of name/address/dob from the re-use identity page

### Why did it change

Required for continuity of identity work

### Issue tracking

- [PYIC-5809](https://govukverify.atlassian.net/browse/PYIC-5809)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-5809]: https://govukverify.atlassian.net/browse/PYIC-5809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ