### PR TITLE
PYIC-4816: Add mobile confirm page for strategic app triage

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -33,9 +33,9 @@ STRATEGIC_APP_TRIAGE:
     appTriageSmartphone:
       targetState: MAM_SELECT_SMARTPHONE
     appTriageSmartphoneIphone:
-      targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
+      targetState: MOBILE_IPHONE_CONFIRM_PAGE
     appTriageSmartphoneAndroid:
-      targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+      targetState: MOBILE_ANDROID_CONFIRM_PAGE
 
   nestedJourneyStates:
     SELECT_DEVICE_PAGE:
@@ -84,6 +84,16 @@ STRATEGIC_APP_TRIAGE:
         pageId: pyi-triage-desktop-download-app
         context: android
 
+    MOBILE_IPHONE_CONFIRM_PAGE:
+      response:
+        type: page
+        pageId: pyi-triage-mobile-confirm
+      events:
+        next:
+          targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
+        end:
+          exitEventToEmit: end
+
     MOBILE_IPHONE_DOWNLOAD_PAGE:
       response:
         type: page
@@ -92,6 +102,16 @@ STRATEGIC_APP_TRIAGE:
       events:
         next:
           exitEventToEmit: next
+
+    MOBILE_ANDROID_CONFIRM_PAGE:
+      response:
+        type: page
+        pageId: pyi-triage-mobile-confirm
+      events:
+        next:
+          targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+        end:
+          exitEventToEmit: end
 
     MOBILE_ANDROID_DOWNLOAD_PAGE:
       response:


### PR DESCRIPTION
## Proposed changes

### What changed

- Add in a mobile confirmation page to MAM route

### Why did it change

- It is missing and contains important information if the user is device-sniffed and skipped past iphone/ android selection pages
- Missing from tickets already 

### Issue tracking

- [PYIC-4816](https://govukverify.atlassian.net/browse/PYIC-4816)
- [PYIC-5560](https://govukverify.atlassian.net/browse/PYIC-5560)

[PYIC-4816]: https://govukverify.atlassian.net/browse/PYIC-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-5560]: https://govukverify.atlassian.net/browse/PYIC-5560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ