### PR TITLE
PYIC-5799: add journey descriptions

### DIFF
--- a/journey-map/public/index.html
+++ b/journey-map/public/index.html
@@ -48,11 +48,15 @@
                             <input id="expandNestedJourneysInput" name="expandNestedJourneys" type="checkbox">
                             <span>Show all states within <strong>nested journeys</strong></span>
                         </label>
+                        <label>
+                            <input id="showJourneyDescInput" name="showJourneyDesc" type="checkbox" checked>
+                            <span>Show journey <strong>descriptions</strong></span>
+                        </label>
                     </fieldset>
                 </form>
                 <div id="nodeInfo">
                     <h2 id="journeyName"></h2>
-                    <h4 id="journeyDesc"></h4>
+                    <div id="journeyDesc"></div>
                     <h3 id="nodeTitle"></h3>
                     <pre id="nodeDef"></pre>
                     <div id="nodeDesc">

--- a/journey-map/public/index.html
+++ b/journey-map/public/index.html
@@ -56,7 +56,8 @@
                 </form>
                 <div id="nodeInfo">
                     <h2 id="journeyName"></h2>
-                    <h4 id="journeyDesc"></h4>
+                    <p id="journeyDesc"></p>
+                    <hr />
                     <h3 id="nodeTitle"></h3>
                     <pre id="nodeDef"></pre>
                     <div id="nodeDesc">

--- a/journey-map/public/index.html
+++ b/journey-map/public/index.html
@@ -51,7 +51,8 @@
                     </fieldset>
                 </form>
                 <div id="nodeInfo">
-                    <h2>Details</h2>
+                    <h2 id="journeyName"></h2>
+                    <h4 id="journeyDesc"></h4>
                     <h3 id="nodeTitle"></h3>
                     <pre id="nodeDef"></pre>
                     <div id="nodeDesc">

--- a/journey-map/public/index.html
+++ b/journey-map/public/index.html
@@ -56,7 +56,7 @@
                 </form>
                 <div id="nodeInfo">
                     <h2 id="journeyName"></h2>
-                    <div id="journeyDesc"></div>
+                    <h4 id="journeyDesc"></h4>
                     <h3 id="nodeTitle"></h3>
                     <pre id="nodeDef"></pre>
                     <div id="nodeDesc">

--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -127,7 +127,7 @@ const setupOptions = (name, options, fieldset, labels) => {
 
 const updateView = async () => {
     const selectedJourney = new URLSearchParams(window.location.search).get('journeyType') || DEFAULT_JOURNEY_TYPE;
-    journeyName.innerText = journeyMaps[selectedJourney].name || "";
+    journeyName.innerText = journeyMaps[selectedJourney].name || "Details";
     journeyDesc.innerText = journeyMaps[selectedJourney].description || "";
     return renderSvg(selectedJourney);
 };
@@ -184,7 +184,6 @@ const setupMermaidClickHandlers = () => {
     };
 
     window.onStateClick = async (state, encodedDef) => {
-
         const def = JSON.parse(atob(encodedDef));
 
         // Clicking a node twice opens the link

--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -67,6 +67,7 @@ const loadJourneyMaps = async () => {
     await Promise.all(Object.keys(JOURNEY_TYPES).map(async (journeyType) => {
         const journeyResponse = await fetch(`./${encodeURIComponent(upperToKebab(journeyType))}.yaml`);
         journeyMaps[journeyType] = yaml.parse(await journeyResponse.text());
+        console.log(journeyType, journeyMaps[journeyType]);
     }));
     const nestedResponse = await fetch('./nested-journey-definitions.yaml');
     nestedJourneys = yaml.parse(await nestedResponse.text());

--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -128,22 +128,14 @@ const setupOptions = (name, options, fieldset, labels) => {
 const updateView = async () => {
     const selectedJourney = new URLSearchParams(window.location.search).get('journeyType') || DEFAULT_JOURNEY_TYPE;
     journeyName.innerText = journeyMaps[selectedJourney].name || "Details";
-    journeyDesc.innerHTML = "";
     const desc = journeyMaps[selectedJourney].description;
-
     const formData = new FormData(form);
-
     if (desc && formData.has('showJourneyDesc')) {
-        const entries = Object.entries(desc);
-        const elem = document.createElement(entries.length == 1 ? "div" : "ul");
-        elem.id = "journeyDescDetail"
-        for (const [key, value] of entries) {
-            const child = document.createElement(entries.length == 1 ? "p" : "li");
-            child.innerText = entries.length == 1 ? value : key + ": " + value;
-            elem.appendChild(child);
-        }
-        journeyDesc.appendChild(elem);
+        journeyDesc.innerText = desc;
+    } else {
+        journeyDesc.innerText = '';
     }
+
     return renderSvg(selectedJourney, formData);
 };
 
@@ -278,10 +270,6 @@ const setupSearchHandler = () => {
         });
         svgPanZoomInstance.zoom(currentZoom);
     })
-}
-
-const hideDescription = () => {
-    console.log("hideDescription");
 }
 
 const initialize = async () => {

--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -132,7 +132,6 @@ const updateView = async () => {
     return renderSvg(selectedJourney);
 };
 
-
 // Render the journey map SVG
 const renderSvg = async (selectedJourney) => {
     const diagram = render(journeyMaps[selectedJourney], nestedJourneys, new FormData(form));

--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -128,13 +128,28 @@ const setupOptions = (name, options, fieldset, labels) => {
 const updateView = async () => {
     const selectedJourney = new URLSearchParams(window.location.search).get('journeyType') || DEFAULT_JOURNEY_TYPE;
     journeyName.innerText = journeyMaps[selectedJourney].name || "Details";
-    journeyDesc.innerText = journeyMaps[selectedJourney].description || "";
-    return renderSvg(selectedJourney);
+    journeyDesc.innerHTML = "";
+    const desc = journeyMaps[selectedJourney].description;
+
+    const formData = new FormData(form);
+
+    if (desc && formData.has('showJourneyDesc')) {
+        const entries = Object.entries(desc);
+        const elem = document.createElement(entries.length == 1 ? "div" : "ul");
+        elem.id = "journeyDescDetail"
+        for (const [key, value] of entries) {
+            const child = document.createElement(entries.length == 1 ? "p" : "li");
+            child.innerText = entries.length == 1 ? value : key + ": " + value;
+            elem.appendChild(child);
+        }
+        journeyDesc.appendChild(elem);
+    }
+    return renderSvg(selectedJourney, formData);
 };
 
 // Render the journey map SVG
-const renderSvg = async (selectedJourney) => {
-    const diagram = render(journeyMaps[selectedJourney], nestedJourneys, new FormData(form));
+const renderSvg = async (selectedJourney, formData) => {
+    const diagram = render(journeyMaps[selectedJourney], nestedJourneys, formData);
     const diagramElement = document.getElementById('diagram');
     const { svg, bindFunctions } = await mermaid.render('diagramSvg', diagram);
     diagramElement.innerHTML = svg;
@@ -263,6 +278,10 @@ const setupSearchHandler = () => {
         });
         svgPanZoomInstance.zoom(currentZoom);
     })
+}
+
+const hideDescription = () => {
+    console.log("hideDescription");
 }
 
 const initialize = async () => {

--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -238,9 +238,11 @@ const calcOrphanStates = (journeyMap) => {
 export const render = (journeyMap, nestedJourneys, formData = new FormData()) => {
     // Copy to avoid mutating the input
     const journeyMapCopy = JSON.parse(JSON.stringify(journeyMap));
+
     if (formData.has('expandNestedJourneys')) {
         expandNestedJourneys(journeyMapCopy, nestedJourneys);
     }
+
     expandParents(journeyMapCopy.states);
 
     const { transitionsMermaid, states } = formData.has('onlyOrphanStates')

--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -240,13 +240,13 @@ export const render = (journeyMap, nestedJourneys, formData = new FormData()) =>
     if (formData.has('expandNestedJourneys')) {
         expandNestedJourneys(journeyMapCopy, nestedJourneys);
     }
-    expandParents(journeyMapCopy);
+    expandParents(journeyMapCopy.STATES);
 
     const { transitionsMermaid, states } = formData.has('onlyOrphanStates')
-        ? { transitionsMermaid: '', states: calcOrphanStates(journeyMapCopy) }
-        : renderTransitions(journeyMapCopy, formData);
+        ? { transitionsMermaid: '', states: calcOrphanStates(journeyMapCopy.STATES) }
+        : renderTransitions(journeyMapCopy.STATES, formData);
 
-    const { statesMermaid } = renderStates(journeyMapCopy, states);
+    const { statesMermaid } = renderStates(journeyMapCopy.STATES, states);
 
     // These styles should be kept in sync with the key in style.css
     const mermaid =

--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -204,7 +204,8 @@ const renderState = (state, definition) => {
 
 const renderStates = (journeyMap, states) => {
     const mermaids = states.flatMap((state) => {
-        const definition = journeyMap[state];
+        const definition = journeyMap.states[state];
+
         return [
             renderState(state, definition),
             renderClickHandler(state, definition),
@@ -240,13 +241,13 @@ export const render = (journeyMap, nestedJourneys, formData = new FormData()) =>
     if (formData.has('expandNestedJourneys')) {
         expandNestedJourneys(journeyMapCopy, nestedJourneys);
     }
-    expandParents(journeyMapCopy.STATES);
+    expandParents(journeyMapCopy.states);
 
     const { transitionsMermaid, states } = formData.has('onlyOrphanStates')
-        ? { transitionsMermaid: '', states: calcOrphanStates(journeyMapCopy.STATES) }
-        : renderTransitions(journeyMapCopy.STATES, formData);
+        ? { transitionsMermaid: '', states: calcOrphanStates(journeyMapCopy.states) }
+        : renderTransitions(journeyMapCopy.states, formData);
 
-    const { statesMermaid } = renderStates(journeyMapCopy.STATES, states);
+    const { statesMermaid } = renderStates(journeyMapCopy, states);
 
     // These styles should be kept in sync with the key in style.css
     const mermaid =

--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -130,14 +130,6 @@ form fieldset p {
     flex-direction: column;
     gap: 8px;
 }
-#journeyDescDetail {
-    border: 2px solid #ddd;
-    border-radius: 5px;
-    padding-left: 32px;
-    padding-right: 32px;
-    padding-top: 16px;
-    padding-bottom: 16px;
-}
 #key {
     flex: 0 1 525px;
     padding: 16px 32px;

--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -117,6 +117,7 @@ form fieldset p {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    max-width: 60%;
 }
 #nodeDef {
     background: #f3f2f1;
@@ -129,6 +130,10 @@ form fieldset p {
     display: flex;
     flex-direction: column;
     gap: 8px;
+}
+#journeyDesc {
+    max-height: 100px;
+    overflow: auto;
 }
 #key {
     flex: 0 1 525px;

--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -130,6 +130,14 @@ form fieldset p {
     flex-direction: column;
     gap: 8px;
 }
+#journeyDescDetail {
+    border: 2px solid #ddd;
+    border-radius: 5px;
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+}
 #key {
     flex: 0 1 525px;
     padding: 16px 32px;

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
@@ -48,7 +48,7 @@ public class StateMachineInitializer {
 
         initializeJourneyStates();
 
-        return journey.states();
+        return journeyStates;
     }
 
     private void initializeJourneyStates() {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
@@ -20,13 +20,10 @@ import java.io.InputStream;
 import java.util.Map;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION;
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 public class StateMachineInitializer {
     private static final ObjectMapper yamlOm =
-            new ObjectMapper(new YAMLFactory())
-                    .configure(STRICT_DUPLICATE_DETECTION, true)
-                    .configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+            new ObjectMapper(new YAMLFactory()).configure(STRICT_DUPLICATE_DETECTION, true);
     private static final ObjectMapper om = new ObjectMapper();
     private Map<String, State> journeyStates;
     private Map<String, NestedJourneyDefinition> nestedJourneyDefinitions;

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
@@ -10,6 +10,7 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.events.Event;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.events.ExitNestedJourneyEvent;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.JourneyMapDeserializationException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.Journey;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.NestedJourneyDefinition;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.NestedJourneyInvokeState;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
@@ -40,13 +41,14 @@ public class StateMachineInitializer {
     private final IpvJourneyTypes journeyType;
 
     public Map<String, State> initialize() throws IOException {
-        journeyStates = yamlOm.readValue(getJourneyConfig(journeyType), new TypeReference<>() {});
+        Journey journey = yamlOm.readValue(getJourneyConfig(journeyType), new TypeReference<>() {});
+        journeyStates = journey.states();
         nestedJourneyDefinitions =
                 yamlOm.readValue(getNestedJourneyDefinitionsConfig(), new TypeReference<>() {});
 
         initializeJourneyStates();
 
-        return journeyStates;
+        return journey.states();
     }
 
     private void initializeJourneyStates() {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
@@ -20,10 +20,13 @@ import java.io.InputStream;
 import java.util.Map;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 public class StateMachineInitializer {
     private static final ObjectMapper yamlOm =
-            new ObjectMapper(new YAMLFactory()).configure(STRICT_DUPLICATE_DETECTION, true);
+            new ObjectMapper(new YAMLFactory())
+                    .configure(STRICT_DUPLICATE_DETECTION, true)
+                    .configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
     private static final ObjectMapper om = new ObjectMapper();
     private Map<String, State> journeyStates;
     private Map<String, NestedJourneyDefinition> nestedJourneyDefinitions;

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/Journey.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/Journey.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.core.processjourneyevent.statemachine.states;
+
+import java.util.Map;
+
+public record Journey(String name, String description, Map<String, State> states) {}

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/Journey.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/Journey.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.core.processjourneyevent.statemachine.states;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record Journey(Map<String, State> states) {}

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/Journey.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/Journey.java
@@ -2,4 +2,4 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.states;
 
 import java.util.Map;
 
-public record Journey(String name, String description, Map<String, State> states) {}
+public record Journey(Map<String, State> states) {}

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
@@ -1,7 +1,7 @@
 name: Face to Face Failed
 description: >-
   A user chose to prove their identity at the Post Office
-  but their attempt failed. For example: the user might
+  but their attempt failed. For example, they might
   have taken the wrong document or the name they entered
   did not match the name on their document.
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
@@ -1,11 +1,10 @@
 name: Face to Face Failed
-description:
-  FAILED: |
-    A user chose to prove their identity at the Post Office but their attempt failed. For example:
+description: |
+  A user chose to prove their identity at the Post Office but their attempt failed. For example:
 
-      - the user might have taken the wrong document
-      - the name they entered in GOV.UK One Login did not match the name on their document
-      - a technical error might have occurred
+    - the user might have taken the wrong document
+    - the name they entered in GOV.UK One Login did not match the name on their document
+    - a technical error might have occurred
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
@@ -1,10 +1,11 @@
 name: Face to Face Failed
-description: |
-  A user chose to prove their identity at the Post Office but their attempt failed. For example:
+description:
+  FAILED: |
+    A user chose to prove their identity at the Post Office but their attempt failed. For example:
 
-    - the user might have taken the wrong document
-    - the name they entered in GOV.UK One Login did not match the name on their document
-    - a technical error might have occurred
+      - the user might have taken the wrong document
+      - the name they entered in GOV.UK One Login did not match the name on their document
+      - a technical error might have occurred
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
@@ -1,24 +1,28 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-FAILED:
-  events:
-    next:
-      targetState: F2F_FAILED_PAGE
+STATES:
+  # Entry points
 
-# Journey states
+  FAILED:
+    events:
+      next:
+        targetState: F2F_FAILED_PAGE
 
-F2F_FAILED_PAGE:
-  response:
-    type: page
-    pageId: pyi-f2f-technical
-  events:
-    next:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: START
-    end:
-      targetState: RETURN_TO_RP
+  # Journey states
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  F2F_FAILED_PAGE:
+    response:
+      type: page
+      pageId: pyi-f2f-technical
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: START
+      end:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
@@ -1,7 +1,12 @@
-NAME: NAME
-DESCRIPTION: DESC
+name: Face to Face Failed
+description: |
+  A user chose to prove their identity at the Post Office but their attempt failed. For example:
 
-STATES:
+    - the user might have taken the wrong document
+    - the name they entered in GOV.UK One Login did not match the name on their document
+    - a technical error might have occurred
+
+states:
   # Entry points
 
   FAILED:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
@@ -1,10 +1,9 @@
 name: Face to Face Failed
-description: |
-  A user chose to prove their identity at the Post Office but their attempt failed. For example:
-
-    - the user might have taken the wrong document
-    - the name they entered in GOV.UK One Login did not match the name on their document
-    - a technical error might have occurred
+description: >-
+  A user chose to prove their identity at the Post Office
+  but their attempt failed. For example: the user might
+  have taken the wrong document or the name they entered
+  did not match the name on their document.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
@@ -1,10 +1,9 @@
 name: Face to Face Pending
-description:
-  PENDING: |
-    A user chose to prove their identity at the Post Office in a previous session but returns to GOV.UK One Login before either:
+description: |
+  A user chose to prove their identity at the Post Office in a previous session but returns to GOV.UK One Login before either:
 
-    - they have visited the Post Office for in-person checks
-    - their in-person checks have been processed
+  - they have visited the Post Office for in-person checks
+  - their in-person checks have been processed
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
@@ -1,76 +1,80 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-PENDING:
-  events:
-    next:
-      targetState: PENDING_PAGE
-      checkFeatureFlag:
-        deleteDetailsEnabled:
-          targetState: PENDING_PAGE_TEST
+STATES:
+  # Entry points
 
-# Journey states
+  PENDING:
+    events:
+      next:
+        targetState: PENDING_PAGE
+        checkFeatureFlag:
+          deleteDetailsEnabled:
+            targetState: PENDING_PAGE_TEST
 
-PENDING_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-pending
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  # Journey states
 
-PENDING_PAGE_TEST:
-  response:
-    type: page
-    context: f2f-delete-details
-    pageId: page-ipv-pending
-  events:
-    next:
-      targetState: F2F_DELETE_PAGE
+  PENDING_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-pending
+    events:
+      next:
+        targetState: RETURN_TO_RP
 
-F2F_DELETE_PAGE:
-  response:
-    type: page
-    pageId: pyi-f2f-delete-details
-  events:
-    next:
-      targetState:
-        CONFIRM_DELETE_DETAILS_PAGE
-    end:
-      targetState:
-        PENDING_PAGE_TEST
+  PENDING_PAGE_TEST:
+    response:
+      type: page
+      context: f2f-delete-details
+      pageId: page-ipv-pending
+    events:
+      next:
+        targetState: F2F_DELETE_PAGE
 
-CONFIRM_DELETE_DETAILS_PAGE:
-  response:
-    type: page
-    context: f2f
-    pageId: pyi-confirm-delete-details
-  events:
-    next:
-      targetState:
-        RESET_SESSION_IDENTITY
-    end:
-      targetState:
-        PENDING_PAGE_TEST
+  F2F_DELETE_PAGE:
+    response:
+      type: page
+      pageId: pyi-f2f-delete-details
+    events:
+      next:
+        targetState:
+          CONFIRM_DELETE_DETAILS_PAGE
+      end:
+        targetState:
+          PENDING_PAGE_TEST
 
-RESET_SESSION_IDENTITY:
-  response:
-    type: process
-    lambda: reset-session-identity
-  events:
-    next:
-      targetState: DETAILS_DELETED_PAGE
+  CONFIRM_DELETE_DETAILS_PAGE:
+    response:
+      type: page
+      context: f2f
+      pageId: pyi-confirm-delete-details
+    events:
+      next:
+        targetState:
+          RESET_SESSION_IDENTITY
+      end:
+        targetState:
+          PENDING_PAGE_TEST
 
-DETAILS_DELETED_PAGE:
-  response:
-    type: page
-    context: f2f
-    pageId: pyi-details-deleted
-  events:
-    next:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: START
+  RESET_SESSION_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+    events:
+      next:
+        targetState: DETAILS_DELETED_PAGE
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  DETAILS_DELETED_PAGE:
+    response:
+      type: page
+      context: f2f
+      pageId: pyi-details-deleted
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: START
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
@@ -1,9 +1,10 @@
 name: Face to Face Pending
-description: |
-  A user chose to prove their identity at the Post Office in a previous session but returns to GOV.UK One Login before either:
+description:
+  PENDING: |
+    A user chose to prove their identity at the Post Office in a previous session but returns to GOV.UK One Login before either:
 
-  - they have visited the Post Office for in-person checks
-  - their in-person checks have been processed
+    - they have visited the Post Office for in-person checks
+    - their in-person checks have been processed
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
@@ -1,7 +1,11 @@
-NAME: NAME
-DESCRIPTION: DESC
+name: Face to Face Pending
+description: |
+  A user chose to prove their identity at the Post Office in a previous session but returns to GOV.UK One Login before either:
 
-STATES:
+  - they have visited the Post Office for in-person checks
+  - their in-person checks have been processed
+
+states:
   # Entry points
 
   PENDING:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
@@ -1,9 +1,9 @@
 name: Face to Face Pending
-description: |
-  A user chose to prove their identity at the Post Office in a previous session but returns to GOV.UK One Login before either:
-
-  - they have visited the Post Office for in-person checks
-  - their in-person checks have been processed
+description: >-
+  A user chose to prove their identity at the Post Office in
+  a previous session but returns to GOV.UK One Login before
+  they have visited the Post Office for in-person checks
+  or their in-person checks have been processed.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -1,6 +1,8 @@
 name: Failed Journey
 
-description: A user fails part of the identity journey. For example, they answer knowledge-based verification questions incorrectly.
+description: >-
+  A user fails part of the identity journey. For example, they answer
+  knowledge-based verification questions incorrectly.
 
 states:
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -1,9 +1,8 @@
 name: Failed Journey
 
-description:
-  FAILED: >-
-    A user fails part of the identity journey. For example, they answer
-    knowledge-based verification questions incorrectly.
+description: >-
+  A user fails part of the identity journey. For example, they answer
+  knowledge-based verification questions incorrectly.
 
 states:
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -1,8 +1,9 @@
 name: Failed Journey
 
-description: >-
-  A user fails part of the identity journey. For example, they answer
-  knowledge-based verification questions incorrectly.
+description:
+  FAILED: >-
+    A user fails part of the identity journey. For example, they answer
+    knowledge-based verification questions incorrectly.
 
 states:
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -1,3 +1,7 @@
+name: Failed Journey
+
+description: A user fails part of the identity journey. For example, they answer knowledge-based verification questions incorrectly.
+
 states:
 
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -1,165 +1,170 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-FAILED:
-  events:
-    next:
-      targetState: NO_MATCH_PAGE
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_NO_MATCH
+STATES:
 
-FAILED_BAV:
-  events:
-    next:
-      targetState: NO_MATCH_PAGE_BAV
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
+  # Entry points
 
-FAILED_NINO:
-  events:
-    next:
-      targetState: NO_MATCH_PAGE_NINO
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_NO_MATCH_NINO
+  FAILED:
+    events:
+      next:
+        targetState: NO_MATCH_PAGE
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_NO_MATCH
 
-FAILED_NO_TICF:
-  events:
-    next:
-      targetState: NO_MATCH_PAGE
+  FAILED_BAV:
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_BAV
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
 
-FAILED_RFC:
-  events:
-    next:
-      targetState: NO_MATCH_PAGE_RFC
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC
+  FAILED_NINO:
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_NINO
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_NO_MATCH_NINO
 
-FAILED_UPDATE_ADDRESS:
-  events:
-    next:
-      # same page as RFC displayed so re-use this state
-      targetState: NO_MATCH_PAGE_RFC
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC
+  FAILED_NO_TICF:
+    events:
+      next:
+        targetState: NO_MATCH_PAGE
 
-# Journey states
+  FAILED_RFC:
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_RFC
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC
 
-CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: NO_MATCH_PAGE_RFC
-    enhanced-verification:
-      targetState: NO_MATCH_PAGE_RFC
-    alternate-doc-invalid-dl:
-      targetState: NO_MATCH_PAGE_RFC
-    alternate-doc-invalid-passport:
-      targetState: NO_MATCH_PAGE_RFC
-    fail-with-ci:
-      targetState: NO_MATCH_PAGE_RFC
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  FAILED_UPDATE_ADDRESS:
+    events:
+      next:
+        # same page as RFC displayed so re-use this state
+        targetState: NO_MATCH_PAGE_RFC
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC
 
-CRI_TICF_BEFORE_NO_MATCH:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: NO_MATCH_PAGE
-    enhanced-verification:
-      targetState: NO_MATCH_PAGE
-    alternate-doc-invalid-dl:
-      targetState: NO_MATCH_PAGE
-    alternate-doc-invalid-passport:
-      targetState: NO_MATCH_PAGE
-    fail-with-ci:
-      targetState: NO_MATCH_PAGE
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  # Journey states
 
-CRI_TICF_BEFORE_NO_MATCH_BAV:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: NO_MATCH_PAGE_BAV
-    enhanced-verification:
-      targetState: NO_MATCH_PAGE_BAV
-    alternate-doc-invalid-dl:
-      targetState: NO_MATCH_PAGE_BAV
-    alternate-doc-invalid-passport:
-      targetState: NO_MATCH_PAGE_BAV
-    fail-with-ci:
-      targetState: NO_MATCH_PAGE_BAV
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_RFC
+      enhanced-verification:
+        targetState: NO_MATCH_PAGE_RFC
+      alternate-doc-invalid-dl:
+        targetState: NO_MATCH_PAGE_RFC
+      alternate-doc-invalid-passport:
+        targetState: NO_MATCH_PAGE_RFC
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE_RFC
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-CRI_TICF_BEFORE_NO_MATCH_NINO:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: NO_MATCH_PAGE_NINO
-    enhanced-verification:
-      targetState: NO_MATCH_PAGE_NINO
-    alternate-doc-invalid-dl:
-      targetState: NO_MATCH_PAGE_NINO
-    alternate-doc-invalid-passport:
-      targetState: NO_MATCH_PAGE_NINO
-    fail-with-ci:
-      targetState: NO_MATCH_PAGE_NINO
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  CRI_TICF_BEFORE_NO_MATCH:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: NO_MATCH_PAGE
+      enhanced-verification:
+        targetState: NO_MATCH_PAGE
+      alternate-doc-invalid-dl:
+        targetState: NO_MATCH_PAGE
+      alternate-doc-invalid-passport:
+        targetState: NO_MATCH_PAGE
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-NO_MATCH_PAGE:
-  response:
-    type: page
-    pageId: pyi-no-match
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  CRI_TICF_BEFORE_NO_MATCH_BAV:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_BAV
+      enhanced-verification:
+        targetState: NO_MATCH_PAGE_BAV
+      alternate-doc-invalid-dl:
+        targetState: NO_MATCH_PAGE_BAV
+      alternate-doc-invalid-passport:
+        targetState: NO_MATCH_PAGE_BAV
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE_BAV
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-NO_MATCH_PAGE_RFC:
-  response:
-    type: page
-    pageId: pyi-no-match
-    context: repeatFraudCheck
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  CRI_TICF_BEFORE_NO_MATCH_NINO:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_NINO
+      enhanced-verification:
+        targetState: NO_MATCH_PAGE_NINO
+      alternate-doc-invalid-dl:
+        targetState: NO_MATCH_PAGE_NINO
+      alternate-doc-invalid-passport:
+        targetState: NO_MATCH_PAGE_NINO
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE_NINO
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-NO_MATCH_PAGE_BAV:
-  response:
-    type: page
-    pageId: pyi-no-match
-    context: bankAccount
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  NO_MATCH_PAGE:
+    response:
+      type: page
+      pageId: pyi-no-match
+    events:
+      next:
+        targetState: RETURN_TO_RP
 
-NO_MATCH_PAGE_NINO:
-  response:
-    type: page
-    pageId: pyi-no-match
-    context: nino
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  NO_MATCH_PAGE_RFC:
+    response:
+      type: page
+      pageId: pyi-no-match
+      context: repeatFraudCheck
+    events:
+      next:
+        targetState: RETURN_TO_RP
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  NO_MATCH_PAGE_BAV:
+    response:
+      type: page
+      pageId: pyi-no-match
+      context: bankAccount
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  NO_MATCH_PAGE_NINO:
+    response:
+      type: page
+      pageId: pyi-no-match
+      context: nino
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -1,7 +1,4 @@
-NAME: NAME
-DESCRIPTION: DESC
-
-STATES:
+states:
 
   # Entry points
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -1,3 +1,7 @@
+name: Ineligible Journey
+
+description: A user does not have the correct evidence to prove their identity.
+
 states:
   # Entry points
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -1,77 +1,81 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-INELIGIBLE:
-  events:
-    next:
-      targetState: ANOTHER_WAY_PAGE
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_ANOTHER_WAY
+STATES:
+  # Entry points
 
-INELIGIBLE_NO_TICF:
-  events:
-    next:
-      targetState: ANOTHER_WAY_PAGE
+  INELIGIBLE:
+    events:
+      next:
+        targetState: ANOTHER_WAY_PAGE
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_ANOTHER_WAY
 
-INELIGIBLE_SKIP_MESSAGE:
-  events:
-    next:
-      targetState: RETURN_TO_RP
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+  INELIGIBLE_NO_TICF:
+    events:
+      next:
+        targetState: ANOTHER_WAY_PAGE
 
-# Journey states
+  INELIGIBLE_SKIP_MESSAGE:
+    events:
+      next:
+        targetState: RETURN_TO_RP
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_RETURN_TO_RP
 
-CRI_TICF_BEFORE_ANOTHER_WAY:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: ANOTHER_WAY_PAGE
-    enhanced-verification:
-      targetState: ANOTHER_WAY_PAGE
-    alternate-doc-invalid-dl:
-      targetState: ANOTHER_WAY_PAGE
-    alternate-doc-invalid-passport:
-      targetState: ANOTHER_WAY_PAGE
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  # Journey states
 
-CRI_TICF_BEFORE_RETURN_TO_RP:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: RETURN_TO_RP
-    enhanced-verification:
-      targetState: RETURN_TO_RP
-    alternate-doc-invalid-dl:
-      targetState: RETURN_TO_RP
-    alternate-doc-invalid-passport:
-      targetState: RETURN_TO_RP
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  CRI_TICF_BEFORE_ANOTHER_WAY:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: ANOTHER_WAY_PAGE
+      enhanced-verification:
+        targetState: ANOTHER_WAY_PAGE
+      alternate-doc-invalid-dl:
+        targetState: ANOTHER_WAY_PAGE
+      alternate-doc-invalid-passport:
+        targetState: ANOTHER_WAY_PAGE
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-ANOTHER_WAY_PAGE:
-  response:
-    type: page
-    pageId: pyi-another-way
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  CRI_TICF_BEFORE_RETURN_TO_RP:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      enhanced-verification:
+        targetState: RETURN_TO_RP
+      alternate-doc-invalid-dl:
+        targetState: RETURN_TO_RP
+      alternate-doc-invalid-passport:
+        targetState: RETURN_TO_RP
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  ANOTHER_WAY_PAGE:
+    response:
+      type: page
+      pageId: pyi-another-way
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -1,7 +1,6 @@
 name: Ineligible Journey
 
-description:
-  INELIGIBLE: A user does not have the correct evidence to prove their identity.
+description: A user does not have the correct evidence to prove their identity.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -1,6 +1,7 @@
 name: Ineligible Journey
 
-description: A user does not have the correct evidence to prove their identity.
+description:
+  INELIGIBLE: A user does not have the correct evidence to prove their identity.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -1,7 +1,7 @@
 name: Ineligible Journey
 
 description: >-
-  A user does not have (or chose not to use) a piece
+  A user does not have or chose not to use a piece
   of evidence needed to prove their identity.
 
 states:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -1,6 +1,8 @@
 name: Ineligible Journey
 
-description: A user does not have the correct evidence to prove their identity.
+description: >-
+  A user does not have (or chose not to use) a piece
+  of evidence needed to prove their identity.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -1,7 +1,4 @@
-NAME: NAME
-DESCRIPTION: DESC
-
-STATES:
+states:
   # Entry points
 
   INELIGIBLE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -1,7 +1,4 @@
-NAME: NAME
-DESCRIPTION: DESC
-
-STATES:
+states:
   # Entry points
 
   START:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -1,56 +1,60 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-START:
-  events:
-    next:
-      targetState: CHECK_EXISTING_IDENTITY
+STATES:
+  # Entry points
 
-# Journey states
+  START:
+    events:
+      next:
+        targetState: CHECK_EXISTING_IDENTITY
 
-CHECK_EXISTING_IDENTITY:
-  response:
-    type: process
-    lambda: check-existing-identity
-  events:
-    ipv-gpg45-medium:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: START
-    reuse:
-      targetJourney: REUSE_EXISTING_IDENTITY
-      targetState: START
-    operational-profile-reuse:
-      targetJourney: OPERATIONAL_PROFILE_REUSE
-      targetState: START
-    in-migration-reuse:
-      targetJourney: OPERATIONAL_PROFILE_MIGRATION
-      targetState: START
-    pending:
-      targetJourney: F2F_PENDING
-      targetState: PENDING
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED
-    f2f-fail:
-      targetJourney: F2F_FAILED
-      targetState: FAILED
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    enhanced-verification:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: ENHANCED_VERIFICATION
-    alternate-doc-invalid-dl:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: ALTERNATE_DOC_PASSPORT
-    alternate-doc-invalid-passport:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: ALTERNATE_DOC_DL
-    enhanced-verification-f2f-fail:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: ENHANCED_VERIFICATION_F2F_FAIL
-    repeat-fraud-check:
-      targetJourney: REPEAT_FRAUD_CHECK
-      targetState: START
-    reprove-identity:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: REPROVE_IDENTITY
+  # Journey states
+
+  CHECK_EXISTING_IDENTITY:
+    response:
+      type: process
+      lambda: check-existing-identity
+    events:
+      ipv-gpg45-medium:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: START
+      reuse:
+        targetJourney: REUSE_EXISTING_IDENTITY
+        targetState: START
+      operational-profile-reuse:
+        targetJourney: OPERATIONAL_PROFILE_REUSE
+        targetState: START
+      in-migration-reuse:
+        targetJourney: OPERATIONAL_PROFILE_MIGRATION
+        targetState: START
+      pending:
+        targetJourney: F2F_PENDING
+        targetState: PENDING
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      f2f-fail:
+        targetJourney: F2F_FAILED
+        targetState: FAILED
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      enhanced-verification:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: ENHANCED_VERIFICATION
+      alternate-doc-invalid-dl:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: ALTERNATE_DOC_PASSPORT
+      alternate-doc-invalid-passport:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: ALTERNATE_DOC_DL
+      enhanced-verification-f2f-fail:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: ENHANCED_VERIFICATION_F2F_FAIL
+      repeat-fraud-check:
+        targetJourney: REPEAT_FRAUD_CHECK
+        targetState: START
+      reprove-identity:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: REPROVE_IDENTITY

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1,6 +1,24 @@
 name: New P2 Identity
-description: >-
-  The routes the user is restricted to when they need to mitigate a contra-indicator from the web-based verification process.
+description:
+  START: >-
+    The routes a user can take to prove their identity to a medium
+    confidence level (P2).
+  ENHANCED_VERIFICATION: >-
+    The routes the user is restricted to when they need to mitigate
+    a contra-indicator from the web-based verification process.
+  ALTERNATE_DOC_PASSPORT: >-
+    The routes the user is restricted to when they need to mitigate
+    a contra-indicator from the web-based document checking process.
+  ALTERNATE_DOC_DL: >-
+    The routes the user is restricted to when they need to mitigate
+    a contra-indicator from the web-based document checking process.
+  ENHANCED_VERIFICATION_F2F_FAIL: >-
+    The routes a user is restricted to when they need to mitigate a
+    contra-indicator from the web-based verification process but have
+    tried, and failed, to mitigate it using face-to-face verification.
+  REPROVE_IDENTITY: >-
+    The route a user must take to reprove their identity after an
+    account intervention.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1,8 +1,8 @@
-NAME: NAME
-DESCRIPTION: DESC
+name: New P2 Identity
+description: >-
+  The routes the user is restricted to when they need to mitigate a contra-indicator from the web-based verification process.
 
-STATES:
-
+states:
   # Entry points
 
   START:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1,1394 +1,1399 @@
 
-# Entry points
-
-START:
-  events:
-    next:
-      targetState: IDENTITY_START_PAGE
-
-ENHANCED_VERIFICATION:
-  events:
-    next:
-      targetState: MITIGATION_01_IDENTITY_START_PAGE
-
-ALTERNATE_DOC_PASSPORT:
-  events:
-    next:
-      targetState: MITIGATION_04_DL_NO_MATCH_PAGE
-
-ALTERNATE_DOC_DL:
-  events:
-    next:
-      targetState: MITIGATION_06_PASSPORT_NO_MATCH_PAGE
-
-ENHANCED_VERIFICATION_F2F_FAIL:
-  events:
-    next:
-      targetState: F2F_FAILED_MITIGATION_PAGE
-
-REPROVE_IDENTITY:
-  events:
-    next:
-      targetState: REPROVE_IDENTITY_START
-
-# Parent states
-
-CRI_STATE:
-  events:
-    not-found:
-      targetJourney: FAILED
-      targetState: FAILED
-    fail-with-no-ci:
-      targetJourney: FAILED
-      targetState: FAILED
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    access-denied:
-      targetJourney: FAILED
-      targetState: FAILED
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-    temporarily-unavailable:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED
-
-CRI_TICF_STATE:
-  events:
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
-
-# Journey states
-REPROVE_IDENTITY_START:
-  response:
-    type: page
-    pageId: reprove-identity-start
-  events:
-    next:
-      targetState: IDENTITY_START_PAGE
-
-RESET_SESSION_IDENTITY:
-  response:
-    type: process
-    lambda: reset-session-identity
-    lambdaInput:
-      isUserInitiated: false
-  events:
-    next:
-      targetState: IDENTITY_START_PAGE
-
-IDENTITY_START_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-identity-document-start
-  events:
-    appTriage:
-      targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
-    appTriageSmartphone:
-      targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
-    end:
-      targetState: F2F_START_PAGE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-STRATEGIC_APP_TRIAGE:
-  nestedJourney: STRATEGIC_APP_TRIAGE
-  exitEvents:
-    next:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    end:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-
-F2F_START_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-identity-postoffice-start
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-    end:
-      targetState: BANK_ACCOUNT_START_PAGE
-      checkIfDisabled:
-        bav:
-          targetState: PYI_ESCAPE
-
-F2F_PYI_POST_OFFICE:
-  response:
-    type: page
-    pageId: pyi-post-office
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-    end:
-      targetState: BANK_ACCOUNT_START_PAGE
-      checkIfDisabled:
-        bav:
-          targetState: PYI_ESCAPE
-
-BANK_ACCOUNT_START_PAGE:
-  response:
-    type: page
-    pageId: prove-identity-bank-account
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_M2B
-    end:
-      targetState: PYI_ESCAPE_M2B
-
-CRI_F2F:
-  response:
-    type: cri
-    criId: f2f
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-    enhanced-verification:
-      targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-    access-denied:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_NO_TICF
-    not-found:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-no-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
-    temporarily-unavailable:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
-
-F2F_HANDOFF_PAGE:
-  response:
-    type: page
-    pageId: page-face-to-face-handoff
-
-CRI_DCMAW:
-  response:
-    type: cri
-    criId: dcmaw
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: POST_DCMAW_SUCCESS_PAGE
-    not-found:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    access-denied:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    temporarily-unavailable:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    fail-with-no-ci:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-
-MULTIPLE_DOC_CHECK_PAGE:
-  response:
-    type: page
-    pageId: page-multiple-doc-check
-  events:
-    ukPassport:
-      targetState: CRI_UK_PASSPORT_J2
-    drivingLicence:
-      targetState: CRI_DRIVING_LICENCE_J3
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-MULTIPLE_DOC_F2F_CHECK_PAGE:
-  response:
-    type: page
-    context: f2f
-    pageId: page-multiple-doc-check
-  events:
-    ukPassport:
-      targetState: CRI_UK_PASSPORT_J2
-    drivingLicence:
-      targetState: CRI_DRIVING_LICENCE_J3
-    end:
-      targetState: F2F_PYI_POST_OFFICE
-
-PYI_ESCAPE:
-  response:
-    type: page
-    pageId: pyi-escape
-  events:
-    next:
-      targetState: RESET_SESSION_IDENTITY
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-PYI_CRI_ESCAPE:
-  response:
-    type: page
-    pageId: pyi-cri-escape
-  events:
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-
-PYI_CRI_ESCAPE_NO_F2F:
-  response:
-    type: page
-    pageId: pyi-cri-escape-no-f2f
-  events:
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-EVALUATE_GPG45_SCORES:
-  response:
-    type: process
-    lambda: evaluate-gpg45-scores
-  events:
-    met:
-      targetState: STORE_IDENTITY_BEFORE_SUCCESS
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_SUCCESS
-    unmet:
-      targetJourney: FAILED
-      targetState: FAILED
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED
-
-STORE_IDENTITY_BEFORE_SUCCESS:
-  response:
-    type: process
-    lambda: store-identity
-  events:
-    identity-stored:
-      targetState: IPV_SUCCESS_PAGE
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-
-STORE_IDENTITY_BEFORE_F2F_HANDOFF:
-  response:
-    type: process
-    lambda: store-identity
-  events:
-    identity-stored:
-      targetState: RESET_SESSION_BEFORE_F2F_HANDOFF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-
-RESET_SESSION_BEFORE_F2F_HANDOFF:
-  response:
-    type: process
-    lambda: reset-session-identity
-  events:
-    next:
-      targetState: F2F_HANDOFF_PAGE
-    error:
-      targetState: F2F_HANDOFF_PAGE
-
-IPV_SUCCESS_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-success
-  events:
-    next:
-      targetState: RETURN_TO_RP
-
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
-
-CRI_TICF_BEFORE_SUCCESS:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  parent: CRI_TICF_STATE
-  events:
-    next:
-      targetState: STORE_IDENTITY_BEFORE_SUCCESS
-
-CRI_TICF_BEFORE_F2F:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  parent: CRI_TICF_STATE
-  events:
-    next:
-      targetState: CRI_F2F
-    enhanced-verification:
-      targetState: CRI_F2F
-
-# Common pages
-PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-  response:
-    type: page
-    pageId: page-pre-experian-kbv-transition
-  events:
-    next:
-      targetState: CRI_EXPERIAN_KBV
-
-CRI_EXPERIAN_KBV:
-  response:
-    type: cri
-    criId: kbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: PYI_CRI_ESCAPE
-      checkIfDisabled:
-        f2f:
-          targetState: PYI_CRI_ESCAPE_NO_F2F
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetState: MITIGATION_02_OPTIONS_WITH_F2F
-      checkIfDisabled:
-        f2f:
-          targetState: MITIGATION_02_OPTIONS
-
-# DCMAW journey (J1)
-POST_DCMAW_SUCCESS_PAGE:
-  response:
-    type: page
-    pageId: page-dcmaw-success
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J1
-
-ADDRESS_AND_FRAUD_J1:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# Passport journey (J2)
-CRI_UK_PASSPORT_J2:
-  response:
-    type: cri
-    criId: ukPassport
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J2
-    access-denied:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    alternate-doc-invalid-passport:
-      targetState: MITIGATION_05_OPTIONS
-
-ADDRESS_AND_FRAUD_J2:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: CRI_NINO_J6
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    enhanced-verification:
-      targetState: CRI_NINO_J6
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-# Driving licence journey (J3)
-CRI_DRIVING_LICENCE_J3:
-  response:
-    type: cri
-    criId: drivingLicence
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J3
-    access-denied:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    alternate-doc-invalid-dl:
-      targetState: MITIGATION_03_OPTIONS
-
-ADDRESS_AND_FRAUD_J3:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: CHECK_FRAUD_SCORE_J3
-    enhanced-verification:
-      targetState: CHECK_FRAUD_SCORE_J3
-
-CHECK_FRAUD_SCORE_J3:
-  response:
-    type: process
-    lambda: check-gpg45-score
-    lambdaInput:
-      scoreType: fraud
-      scoreThreshold: 2
-  events:
-    met:
-      targetState: CRI_NINO_J6
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    unmet:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# F2F journey (J4)
-CRI_CLAIMED_IDENTITY_J4:
-  response:
-    type: cri
-    criId: claimedIdentity
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J4
-    enhanced-verification:
-      targetState: ADDRESS_AND_FRAUD_J4
-
-ADDRESS_AND_FRAUD_J4:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    enhanced-verification:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-
-# HMRC KBV journey (J6)
-CRI_NINO_J6:
-  response:
-    type: cri
-    criId: nino
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_HMRC_KBV_J6
-    fail-with-no-ci:
-      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-CRI_HMRC_KBV_J6:
-  response:
-    type: cri
-    criId: hmrcKbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetState: MITIGATION_02_OPTIONS_WITH_F2F
-      checkIfDisabled:
-        f2f:
-          targetState: MITIGATION_02_OPTIONS
-
-CRI_HMRC_KBV_M2B:
-  response:
-    type: cri
-    criId: hmrcKbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
-      checkIfDisabled:
-        f2f:
-          targetState: MITIGATION_02_OPTIONS
-
-# No photo id journey (M2B)
-CRI_CLAIMED_IDENTITY_M2B:
-  response:
-    type: cri
-    criId: claimedIdentity
-    context: bank_account
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_BANK_ACCOUNT_M2B
-    enhanced-verification:
-      targetState: CRI_BANK_ACCOUNT_M2B
-
-CRI_BANK_ACCOUNT_M2B:
-  response:
-    type: cri
-    criId: bav
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_NINO_WITH_SCOPE_M2B
-    access-denied:
-      targetState: PYI_ESCAPE_ABANDON_M2B
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_BAV
-
-CRI_NINO_WITH_SCOPE_M2B:
-  response:
-    type: cri
-    criId: nino
-    scope: identityCheck
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_M2B
-    access-denied:
-      targetState: PYI_ESCAPE_ABANDON_M2B
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NINO
-
-ADDRESS_AND_FRAUD_M2B:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: CRI_HMRC_KBV_M2B
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
-    enhanced-verification:
-      targetState: CRI_HMRC_KBV_M2B
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
-
-PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B:
-  response:
-    type: page
-    pageId: page-pre-experian-kbv-transition
-  events:
-    next:
-      targetState: CRI_EXPERIAN_KBV_M2B
-
-CRI_EXPERIAN_KBV_M2B:
-  response:
-    type: cri
-    criId: kbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: PYI_KBV_DROPOUT_M2B
-      checkIfDisabled:
-        f2f:
-          targetState: PYI_CRI_ESCAPE_NO_F2F
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetState: MITIGATION_KBV_FAIL_M2B
-      checkIfDisabled:
-        f2f:
-          targetState: MITIGATION_02_OPTIONS
-
-MITIGATION_KBV_FAIL_M2B:
-  response:
-    mitigationStart: enhanced-verification
-    type: page
-    pageId: no-photo-id-security-questions-find-another-way
-  events:
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-PYI_ESCAPE_M2B:
-  response:
-    type: page
-    pageId: no-photo-id-exit-find-another-way
-  events:
-    next:
-      targetState: IDENTITY_START_PAGE
-    bankAccount:
-      targetState: BANK_ACCOUNT_START_PAGE
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-PYI_ESCAPE_ABANDON_M2B:
-  response:
-    type: page
-    context: abandon
-    pageId: no-photo-id-exit-find-another-way
-  events:
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-    next:
-      targetState: RESET_SESSION_IDENTITY
-
-PYI_KBV_DROPOUT_M2B:
-  response:
-    type: page
-    pageId: no-photo-id-security-questions-find-another-way
-    context: dropout
-  events:
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-# Mitigation journey (01)
-MITIGATION_01_IDENTITY_START_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-identity-document-start
-    mitigationStart: enhanced-verification
-  events:
-    appTriage:
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetState: MITIGATION_01_F2F_START_PAGE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-MITIGATION_01_STRATEGIC_APP_TRIAGE:
-  nestedJourney: STRATEGIC_APP_TRIAGE
-  exitEvents:
-    next:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    end:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-MITIGATION_01_CRI_DCMAW:
-  response:
-    type: cri
-    criId: dcmaw
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: POST_DCMAW_SUCCESS_PAGE
-    not-found:
-      targetJourney: FAILED
-      targetState: FAILED
-    access-denied:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    temporarily-unavailable:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    fail-with-no-ci:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    enhanced-verification:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-MITIGATION_01_F2F_START_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-identity-postoffice-start
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_CLAIMED_IDENTITY_J4
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-MITIGATION_01_PYI_POST_OFFICE:
-  response:
-    type: page
-    pageId: pyi-post-office
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_CLAIMED_IDENTITY_J4
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-# Mitigation journey (02)
-MITIGATION_02_OPTIONS:
-  response:
-    type: page
-    pageId: pyi-suggest-other-options-no-f2f
-    mitigationStart: enhanced-verification
-  events:
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
-  nestedJourney: STRATEGIC_APP_TRIAGE
-  exitEvents:
-    next:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    end:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-CRI_DCMAW_PYI_ESCAPE:
-  response:
-    type: cri
-    criId: dcmaw
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    not-found:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: FAILED
-          targetState: FAILED
-    access-denied:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    temporarily-unavailable:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    fail-with-no-ci:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    enhanced-verification:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-MITIGATION_02_OPTIONS_WITH_F2F:
-  response:
-    type: page
-    pageId: pyi-suggest-other-options
-    mitigationStart: enhanced-verification
-  events:
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-
-MITIGATION_02_OPTIONS_WITH_F2F_M2B:
-  response:
-    type: page
-    pageId: pyi-suggest-other-options
-    context: no-photo-id
-    mitigationStart: enhanced-verification
-  events:
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-
-PYI_POST_OFFICE:
-  response:
-    type: page
-    pageId: pyi-post-office
-  events:
-    next:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-# Mitigation journey (03) same session - invalid-dl
-MITIGATION_03_OPTIONS:
-  response:
-    type: page
-    pageId: pyi-driving-licence-no-match-another-way
-    mitigationStart: invalid-dl
-  events:
-    next:
-      targetState: MITIGATION_PP_CRI_UK_PASSPORT
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-# Mitigation journey (04) separate session - invalid-dl
-MITIGATION_04_DL_NO_MATCH_PAGE:
-  response:
-    type: page
-    pageId: pyi-driving-licence-no-match
-  events:
-    next:
-      targetState: MITIGATION_04_IDENTITY_START_PAGE
-
-MITIGATION_04_IDENTITY_START_PAGE:
-  response:
-    type: page
-    pageId: pyi-continue-with-passport
-    mitigationStart: invalid-dl
-  events:
-    next:
-      targetState: MITIGATION_PP_CRI_UK_PASSPORT
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-# Passport journey (MITIGATION)
-MITIGATION_PP_CRI_UK_PASSPORT:
-  response:
-    type: cri
-    criId: ukPassport
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
-    access-denied:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# Address and Fraud journey (MITIGATION)
-MITIGATION_PP_ADDRESS_AND_FRAUD:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: MITIGATION_PP_CRI_NINO
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# Mitigation journey (05) same session - invalid-passport
-MITIGATION_05_OPTIONS:
-  response:
-    type: page
-    pageId: pyi-passport-no-match-another-way
-    mitigationStart: invalid-passport
-  events:
-    next:
-      targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-# Mitigation journey (06) separate session - invalid-passport
-MITIGATION_06_PASSPORT_NO_MATCH_PAGE:
-  response:
-    type: page
-    pageId: pyi-passport-no-match
-  events:
-    next:
-      targetState: MITIGATION_06_IDENTITY_START_PAGE
-
-MITIGATION_06_IDENTITY_START_PAGE:
-  response:
-    type: page
-    pageId: pyi-continue-with-driving-licence
-    mitigationStart: invalid-passport
-  events:
-    next:
-      targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-MITIGATION_DL_CRI_DRIVING_LICENCE:
-  response:
-    type: cri
-    criId: drivingLicence
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
-    access-denied:
-      targetJourney: FAILED
-      targetState: FAILED
-
-MITIGATION_DL_ADDRESS_AND_FRAUD:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: MITIGATION_CHECK_FRAUD_SCORE
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-MITIGATION_CHECK_FRAUD_SCORE:
-  response:
-    type: process
-    lambda: check-gpg45-score
-    lambdaInput:
-      scoreType: fraud
-      scoreThreshold: 2
-  events:
-    met:
-      targetState: MITIGATION_PP_CRI_NINO
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    unmet:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# Common Mitigation states - invalid-dl/invalid-passport
-MITIGATION_PP_CRI_NINO:
-  response:
-    type: cri
-    criId: nino
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: MITIGATION_CRI_HMRC_KBV
-    fail-with-no-ci:
-      targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-  response:
-    type: page
-    pageId: page-pre-experian-kbv-transition
-  events:
-    next:
-      targetState: MITIGATION_CRI_EXPERIAN_KBV
-
-MITIGATION_CRI_EXPERIAN_KBV:
-  response:
-    type: cri
-    criId: kbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-MITIGATION_CRI_HMRC_KBV:
-  response:
-    type: cri
-    criId: hmrcKbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-F2F_FAILED_MITIGATION_PAGE:
-  response:
-    type: page
-    pageId: pyi-f2f-technical
-  events:
-    next:
-      targetState: MITIGATION_01_IDENTITY_START_PAGE
-    end:
-      targetState: RETURN_TO_RP
+name: New P2 Identity
+description: >-
+  The routes the user is restricted to when they need to mitigate a contra-indicator from the web-based verification process.
+
+states:
+  # Entry points
+
+  START:
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  ENHANCED_VERIFICATION:
+    events:
+      next:
+        targetState: MITIGATION_01_IDENTITY_START_PAGE
+
+  ALTERNATE_DOC_PASSPORT:
+    events:
+      next:
+        targetState: MITIGATION_04_DL_NO_MATCH_PAGE
+
+  ALTERNATE_DOC_DL:
+    events:
+      next:
+        targetState: MITIGATION_06_PASSPORT_NO_MATCH_PAGE
+
+  ENHANCED_VERIFICATION_F2F_FAIL:
+    events:
+      next:
+        targetState: F2F_FAILED_MITIGATION_PAGE
+
+  REPROVE_IDENTITY:
+    events:
+      next:
+        targetState: REPROVE_IDENTITY_START
+
+  # Parent states
+
+  CRI_STATE:
+    events:
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  CRI_TICF_STATE:
+    events:
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  # Journey states
+  REPROVE_IDENTITY_START:
+    response:
+      type: page
+      pageId: reprove-identity-start
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  RESET_SESSION_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        isUserInitiated: false
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-document-start
+    events:
+      appTriage:
+        targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
+      appTriageSmartphone:
+        targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
+      end:
+        targetState: F2F_START_PAGE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+
+  F2F_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-postoffice-start
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetState: BANK_ACCOUNT_START_PAGE
+        checkIfDisabled:
+          bav:
+            targetState: PYI_ESCAPE
+
+  F2F_PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetState: BANK_ACCOUNT_START_PAGE
+        checkIfDisabled:
+          bav:
+            targetState: PYI_ESCAPE
+
+  BANK_ACCOUNT_START_PAGE:
+    response:
+      type: page
+      pageId: prove-identity-bank-account
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_M2B
+      end:
+        targetState: PYI_ESCAPE_M2B
+
+  CRI_F2F:
+    response:
+      type: cri
+      criId: f2f
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      enhanced-verification:
+        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      access-denied:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_NO_TICF
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  F2F_HANDOFF_PAGE:
+    response:
+      type: page
+      pageId: page-face-to-face-handoff
+
+  CRI_DCMAW:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      not-found:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      temporarily-unavailable:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      fail-with-no-ci:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+
+  MULTIPLE_DOC_CHECK_PAGE:
+    response:
+      type: page
+      pageId: page-multiple-doc-check
+    events:
+      ukPassport:
+        targetState: CRI_UK_PASSPORT_J2
+      drivingLicence:
+        targetState: CRI_DRIVING_LICENCE_J3
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  MULTIPLE_DOC_F2F_CHECK_PAGE:
+    response:
+      type: page
+      context: f2f
+      pageId: page-multiple-doc-check
+    events:
+      ukPassport:
+        targetState: CRI_UK_PASSPORT_J2
+      drivingLicence:
+        targetState: CRI_DRIVING_LICENCE_J3
+      end:
+        targetState: F2F_PYI_POST_OFFICE
+
+  PYI_ESCAPE:
+    response:
+      type: page
+      pageId: pyi-escape
+    events:
+      next:
+        targetState: RESET_SESSION_IDENTITY
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  PYI_CRI_ESCAPE:
+    response:
+      type: page
+      pageId: pyi-cri-escape
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+
+  PYI_CRI_ESCAPE_NO_F2F:
+    response:
+      type: page
+      pageId: pyi-cri-escape-no-f2f
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  EVALUATE_GPG45_SCORES:
+    response:
+      type: process
+      lambda: evaluate-gpg45-scores
+    events:
+      met:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_SUCCESS
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  STORE_IDENTITY_BEFORE_SUCCESS:
+    response:
+      type: process
+      lambda: store-identity
+    events:
+      identity-stored:
+        targetState: IPV_SUCCESS_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  STORE_IDENTITY_BEFORE_F2F_HANDOFF:
+    response:
+      type: process
+      lambda: store-identity
+    events:
+      identity-stored:
+        targetState: RESET_SESSION_BEFORE_F2F_HANDOFF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  RESET_SESSION_BEFORE_F2F_HANDOFF:
+    response:
+      type: process
+      lambda: reset-session-identity
+    events:
+      next:
+        targetState: F2F_HANDOFF_PAGE
+      error:
+        targetState: F2F_HANDOFF_PAGE
+
+  IPV_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-success
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response
+
+  CRI_TICF_BEFORE_SUCCESS:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+
+  CRI_TICF_BEFORE_F2F:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: CRI_F2F
+      enhanced-verification:
+        targetState: CRI_F2F
+
+  # Common pages
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV
+
+  CRI_EXPERIAN_KBV:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PYI_CRI_ESCAPE
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+
+  # DCMAW journey (J1)
+  POST_DCMAW_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-dcmaw-success
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J1
+
+  ADDRESS_AND_FRAUD_J1:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Passport journey (J2)
+  CRI_UK_PASSPORT_J2:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J2
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-passport:
+        targetState: MITIGATION_05_OPTIONS
+
+  ADDRESS_AND_FRAUD_J2:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_NINO_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: CRI_NINO_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  # Driving licence journey (J3)
+  CRI_DRIVING_LICENCE_J3:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J3
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-dl:
+        targetState: MITIGATION_03_OPTIONS
+
+  ADDRESS_AND_FRAUD_J3:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CHECK_FRAUD_SCORE_J3
+      enhanced-verification:
+        targetState: CHECK_FRAUD_SCORE_J3
+
+  CHECK_FRAUD_SCORE_J3:
+    response:
+      type: process
+      lambda: check-gpg45-score
+      lambdaInput:
+        scoreType: fraud
+        scoreThreshold: 2
+    events:
+      met:
+        targetState: CRI_NINO_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # F2F journey (J4)
+  CRI_CLAIMED_IDENTITY_J4:
+    response:
+      type: cri
+      criId: claimedIdentity
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J4
+      enhanced-verification:
+        targetState: ADDRESS_AND_FRAUD_J4
+
+  ADDRESS_AND_FRAUD_J4:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      enhanced-verification:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+
+  # HMRC KBV journey (J6)
+  CRI_NINO_J6:
+    response:
+      type: cri
+      criId: nino
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_HMRC_KBV_J6
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  CRI_HMRC_KBV_J6:
+    response:
+      type: cri
+      criId: hmrcKbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+
+  CRI_HMRC_KBV_M2B:
+    response:
+      type: cri
+      criId: hmrcKbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+
+  # No photo id journey (M2B)
+  CRI_CLAIMED_IDENTITY_M2B:
+    response:
+      type: cri
+      criId: claimedIdentity
+      context: bank_account
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_BANK_ACCOUNT_M2B
+      enhanced-verification:
+        targetState: CRI_BANK_ACCOUNT_M2B
+
+  CRI_BANK_ACCOUNT_M2B:
+    response:
+      type: cri
+      criId: bav
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_NINO_WITH_SCOPE_M2B
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_M2B
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_BAV
+
+  CRI_NINO_WITH_SCOPE_M2B:
+    response:
+      type: cri
+      criId: nino
+      scope: identityCheck
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_M2B
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_M2B
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NINO
+
+  ADDRESS_AND_FRAUD_M2B:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_HMRC_KBV_M2B
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+      enhanced-verification:
+        targetState: CRI_HMRC_KBV_M2B
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV_M2B
+
+  CRI_EXPERIAN_KBV_M2B:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PYI_KBV_DROPOUT_M2B
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetState: MITIGATION_KBV_FAIL_M2B
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+
+  MITIGATION_KBV_FAIL_M2B:
+    response:
+      mitigationStart: enhanced-verification
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+    events:
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  PYI_ESCAPE_M2B:
+    response:
+      type: page
+      pageId: no-photo-id-exit-find-another-way
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+      bankAccount:
+        targetState: BANK_ACCOUNT_START_PAGE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  PYI_ESCAPE_ABANDON_M2B:
+    response:
+      type: page
+      context: abandon
+      pageId: no-photo-id-exit-find-another-way
+    events:
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+      next:
+        targetState: RESET_SESSION_IDENTITY
+
+  PYI_KBV_DROPOUT_M2B:
+    response:
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+      context: dropout
+    events:
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  # Mitigation journey (01)
+  MITIGATION_01_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-document-start
+      mitigationStart: enhanced-verification
+    events:
+      appTriage:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetState: MITIGATION_01_F2F_START_PAGE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_CRI_DCMAW:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED
+      access-denied:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      temporarily-unavailable:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      fail-with-no-ci:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      enhanced-verification:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_F2F_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-postoffice-start
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  MITIGATION_01_PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  # Mitigation journey (02)
+  MITIGATION_02_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options-no-f2f
+      mitigationStart: enhanced-verification
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  CRI_DCMAW_PYI_ESCAPE:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      not-found:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: FAILED
+            targetState: FAILED
+      access-denied:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      temporarily-unavailable:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      fail-with-no-ci:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      enhanced-verification:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_02_OPTIONS_WITH_F2F:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+      mitigationStart: enhanced-verification
+    events:
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  MITIGATION_02_OPTIONS_WITH_F2F_M2B:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+      context: no-photo-id
+      mitigationStart: enhanced-verification
+    events:
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  # Mitigation journey (03) same session - invalid-dl
+  MITIGATION_03_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-driving-licence-no-match-another-way
+      mitigationStart: invalid-dl
+    events:
+      next:
+        targetState: MITIGATION_PP_CRI_UK_PASSPORT
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Mitigation journey (04) separate session - invalid-dl
+  MITIGATION_04_DL_NO_MATCH_PAGE:
+    response:
+      type: page
+      pageId: pyi-driving-licence-no-match
+    events:
+      next:
+        targetState: MITIGATION_04_IDENTITY_START_PAGE
+
+  MITIGATION_04_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: pyi-continue-with-passport
+      mitigationStart: invalid-dl
+    events:
+      next:
+        targetState: MITIGATION_PP_CRI_UK_PASSPORT
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Passport journey (MITIGATION)
+  MITIGATION_PP_CRI_UK_PASSPORT:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Address and Fraud journey (MITIGATION)
+  MITIGATION_PP_ADDRESS_AND_FRAUD:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: MITIGATION_PP_CRI_NINO
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Mitigation journey (05) same session - invalid-passport
+  MITIGATION_05_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-passport-no-match-another-way
+      mitigationStart: invalid-passport
+    events:
+      next:
+        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Mitigation journey (06) separate session - invalid-passport
+  MITIGATION_06_PASSPORT_NO_MATCH_PAGE:
+    response:
+      type: page
+      pageId: pyi-passport-no-match
+    events:
+      next:
+        targetState: MITIGATION_06_IDENTITY_START_PAGE
+
+  MITIGATION_06_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: pyi-continue-with-driving-licence
+      mitigationStart: invalid-passport
+    events:
+      next:
+        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  MITIGATION_DL_CRI_DRIVING_LICENCE:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_DL_ADDRESS_AND_FRAUD:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: MITIGATION_CHECK_FRAUD_SCORE
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_CHECK_FRAUD_SCORE:
+    response:
+      type: process
+      lambda: check-gpg45-score
+      lambdaInput:
+        scoreType: fraud
+        scoreThreshold: 2
+    events:
+      met:
+        targetState: MITIGATION_PP_CRI_NINO
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Common Mitigation states - invalid-dl/invalid-passport
+  MITIGATION_PP_CRI_NINO:
+    response:
+      type: cri
+      criId: nino
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_CRI_HMRC_KBV
+      fail-with-no-ci:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: MITIGATION_CRI_EXPERIAN_KBV
+
+  MITIGATION_CRI_EXPERIAN_KBV:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_CRI_HMRC_KBV:
+    response:
+      type: cri
+      criId: hmrcKbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  F2F_FAILED_MITIGATION_PAGE:
+    response:
+      type: page
+      pageId: pyi-f2f-technical
+    events:
+      next:
+        targetState: MITIGATION_01_IDENTITY_START_PAGE
+      end:
+        targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1,1388 +1,1394 @@
-name: New P2 Identity
-description: >-
-  The routes the user is restricted to when they need to mitigate a contra-indicator from the web-based verification process.
-
-states:
-  # Entry points
-
-  START:
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
-
-  ENHANCED_VERIFICATION:
-    events:
-      next:
-        targetState: MITIGATION_01_IDENTITY_START_PAGE
-
-  ALTERNATE_DOC_PASSPORT:
-    events:
-      next:
-        targetState: MITIGATION_04_DL_NO_MATCH_PAGE
-
-  ALTERNATE_DOC_DL:
-    events:
-      next:
-        targetState: MITIGATION_06_PASSPORT_NO_MATCH_PAGE
-
-  ENHANCED_VERIFICATION_F2F_FAIL:
-    events:
-      next:
-        targetState: F2F_FAILED_MITIGATION_PAGE
-
-  REPROVE_IDENTITY:
-    events:
-      next:
-        targetState: REPROVE_IDENTITY_START
-
-  # Parent states
-
-  CRI_STATE:
-    events:
-      not-found:
-        targetJourney: FAILED
-        targetState: FAILED
-      fail-with-no-ci:
-        targetJourney: FAILED
-        targetState: FAILED
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      access-denied:
-        targetJourney: FAILED
-        targetState: FAILED
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-      temporarily-unavailable:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED
-      vcs-not-correlated:
-        targetJourney: FAILED
-        targetState: FAILED
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  CRI_TICF_STATE:
-    events:
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-
-  # Journey states
-  REPROVE_IDENTITY_START:
-    response:
-      type: page
-      pageId: reprove-identity-start
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
-
-  RESET_SESSION_IDENTITY:
-    response:
-      type: process
-      lambda: reset-session-identity
-      lambdaInput:
-        isUserInitiated: false
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
-
-  IDENTITY_START_PAGE:
-    response:
-      type: page
-      pageId: page-ipv-identity-document-start
-    events:
-      appTriage:
-        targetState: CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-            checkIfDisabled:
-              f2f:
-                targetState: MULTIPLE_DOC_CHECK_PAGE
-      appTriageSmartphone:
-        targetState: CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-            checkIfDisabled:
-              f2f:
-                targetState: MULTIPLE_DOC_CHECK_PAGE
-      appTriageSmartphoneIphone:
-        targetState: CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-            checkIfDisabled:
-              f2f:
-                targetState: MULTIPLE_DOC_CHECK_PAGE
-      appTriageSmartphoneAndroid:
-        targetState: CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-            checkIfDisabled:
-              f2f:
-                targetState: MULTIPLE_DOC_CHECK_PAGE
-      end:
-        targetState: F2F_START_PAGE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-
-  STRATEGIC_APP_TRIAGE:
-    nestedJourney: STRATEGIC_APP_TRIAGE
-    exitEvents:
-      next:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      end:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-
-  F2F_START_PAGE:
-    response:
-      type: page
-      pageId: page-ipv-identity-postoffice-start
-    events:
-      next:
-        targetState: CRI_CLAIMED_IDENTITY_J4
-      end:
-        targetState: BANK_ACCOUNT_START_PAGE
-        checkIfDisabled:
-          bav:
-            targetState: PYI_ESCAPE
-
-  F2F_PYI_POST_OFFICE:
-    response:
-      type: page
-      pageId: pyi-post-office
-    events:
-      next:
-        targetState: CRI_CLAIMED_IDENTITY_J4
-      end:
-        targetState: BANK_ACCOUNT_START_PAGE
-        checkIfDisabled:
-          bav:
-            targetState: PYI_ESCAPE
-
-  BANK_ACCOUNT_START_PAGE:
-    response:
-      type: page
-      pageId: prove-identity-bank-account
-    events:
-      next:
-        targetState: CRI_CLAIMED_IDENTITY_M2B
-      end:
-        targetState: PYI_ESCAPE_M2B
-
-  CRI_F2F:
-    response:
-      type: cri
-      criId: f2f
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-      enhanced-verification:
-        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-      access-denied:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_NO_TICF
-      not-found:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      fail-with-no-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      vcs-not-correlated:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-      temporarily-unavailable:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-
-  F2F_HANDOFF_PAGE:
-    response:
-      type: page
-      pageId: page-face-to-face-handoff
-
-  CRI_DCMAW:
-    response:
-      type: cri
-      criId: dcmaw
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: POST_DCMAW_SUCCESS_PAGE
-      not-found:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-      access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-      temporarily-unavailable:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-      fail-with-no-ci:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-
-  MULTIPLE_DOC_CHECK_PAGE:
-    response:
-      type: page
-      pageId: page-multiple-doc-check
-    events:
-      ukPassport:
-        targetState: CRI_UK_PASSPORT_J2
-      drivingLicence:
-        targetState: CRI_DRIVING_LICENCE_J3
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-
-  MULTIPLE_DOC_F2F_CHECK_PAGE:
-    response:
-      type: page
-      context: f2f
-      pageId: page-multiple-doc-check
-    events:
-      ukPassport:
-        targetState: CRI_UK_PASSPORT_J2
-      drivingLicence:
-        targetState: CRI_DRIVING_LICENCE_J3
-      end:
-        targetState: F2F_PYI_POST_OFFICE
-
-  PYI_ESCAPE:
-    response:
-      type: page
-      pageId: pyi-escape
-    events:
-      next:
-        targetState: RESET_SESSION_IDENTITY
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-
-  PYI_CRI_ESCAPE:
-    response:
-      type: page
-      pageId: pyi-cri-escape
-    events:
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneIphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneAndroid:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
-
-  PYI_CRI_ESCAPE_NO_F2F:
-    response:
-      type: page
-      pageId: pyi-cri-escape-no-f2f
-    events:
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneIphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneAndroid:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-
-  EVALUATE_GPG45_SCORES:
-    response:
-      type: process
-      lambda: evaluate-gpg45-scores
-    events:
-      met:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_SUCCESS
-      unmet:
-        targetJourney: FAILED
-        targetState: FAILED
-      vcs-not-correlated:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  STORE_IDENTITY_BEFORE_SUCCESS:
-    response:
-      type: process
-      lambda: store-identity
-    events:
-      identity-stored:
-        targetState: IPV_SUCCESS_PAGE
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
-  STORE_IDENTITY_BEFORE_F2F_HANDOFF:
-    response:
-      type: process
-      lambda: store-identity
-    events:
-      identity-stored:
-        targetState: F2F_HANDOFF_PAGE
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
-  IPV_SUCCESS_PAGE:
-    response:
-      type: page
-      pageId: page-ipv-success
-    events:
-      next:
-        targetState: RETURN_TO_RP
-
-  RETURN_TO_RP:
-    response:
-      type: process
-      lambda: build-client-oauth-response
-
-  CRI_TICF_BEFORE_SUCCESS:
-    response:
-      type: process
-      lambda: call-ticf-cri
-    parent: CRI_TICF_STATE
-    events:
-      next:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-
-  CRI_TICF_BEFORE_F2F:
-    response:
-      type: process
-      lambda: call-ticf-cri
-    parent: CRI_TICF_STATE
-    events:
-      next:
-        targetState: CRI_F2F
-      enhanced-verification:
-        targetState: CRI_F2F
-
-  # Common pages
-  PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: CRI_EXPERIAN_KBV
-
-  CRI_EXPERIAN_KBV:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
-      fail-with-no-ci:
-        targetState: PYI_CRI_ESCAPE
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-
-  # DCMAW journey (J1)
-  POST_DCMAW_SUCCESS_PAGE:
-    response:
-      type: page
-      pageId: page-dcmaw-success
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_J1
-
-  ADDRESS_AND_FRAUD_J1:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  # Passport journey (J2)
-  CRI_UK_PASSPORT_J2:
-    response:
-      type: cri
-      criId: ukPassport
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_J2
-      access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-      alternate-doc-invalid-passport:
-        targetState: MITIGATION_05_OPTIONS
-
-  ADDRESS_AND_FRAUD_J2:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: CRI_NINO_J6
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      enhanced-verification:
-        targetState: CRI_NINO_J6
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  # Driving licence journey (J3)
-  CRI_DRIVING_LICENCE_J3:
-    response:
-      type: cri
-      criId: drivingLicence
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_J3
-      access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-      alternate-doc-invalid-dl:
-        targetState: MITIGATION_03_OPTIONS
-
-  ADDRESS_AND_FRAUD_J3:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: CHECK_FRAUD_SCORE_J3
-      enhanced-verification:
-        targetState: CHECK_FRAUD_SCORE_J3
-
-  CHECK_FRAUD_SCORE_J3:
-    response:
-      type: process
-      lambda: check-gpg45-score
-      lambdaInput:
-        scoreType: fraud
-        scoreThreshold: 2
-    events:
-      met:
-        targetState: CRI_NINO_J6
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      unmet:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  # F2F journey (J4)
-  CRI_CLAIMED_IDENTITY_J4:
-    response:
-      type: cri
-      criId: claimedIdentity
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_J4
-      enhanced-verification:
-        targetState: ADDRESS_AND_FRAUD_J4
-
-  ADDRESS_AND_FRAUD_J4:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
-      enhanced-verification:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
-
-  # HMRC KBV journey (J6)
-  CRI_NINO_J6:
-    response:
-      type: cri
-      criId: nino
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CRI_HMRC_KBV_J6
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  CRI_HMRC_KBV_J6:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-
-  CRI_HMRC_KBV_M2B:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-
-  # No photo id journey (M2B)
-  CRI_CLAIMED_IDENTITY_M2B:
-    response:
-      type: cri
-      criId: claimedIdentity
-      context: bank_account
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CRI_BANK_ACCOUNT_M2B
-      enhanced-verification:
-        targetState: CRI_BANK_ACCOUNT_M2B
-
-  CRI_BANK_ACCOUNT_M2B:
-    response:
-      type: cri
-      criId: bav
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CRI_NINO_WITH_SCOPE_M2B
-      access-denied:
-        targetState: PYI_ESCAPE_ABANDON_M2B
-      fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_BAV
-
-  CRI_NINO_WITH_SCOPE_M2B:
-    response:
-      type: cri
-      criId: nino
-      scope: identityCheck
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_M2B
-      access-denied:
-        targetState: PYI_ESCAPE_ABANDON_M2B
-      fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NINO
-
-  ADDRESS_AND_FRAUD_M2B:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: CRI_HMRC_KBV_M2B
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
-      enhanced-verification:
-        targetState: CRI_HMRC_KBV_M2B
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
-
-  PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: CRI_EXPERIAN_KBV_M2B
-
-  CRI_EXPERIAN_KBV_M2B:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
-      fail-with-no-ci:
-        targetState: PYI_KBV_DROPOUT_M2B
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-      enhanced-verification:
-        targetState: MITIGATION_KBV_FAIL_M2B
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-
-  MITIGATION_KBV_FAIL_M2B:
-    response:
-      mitigationStart: enhanced-verification
-      type: page
-      pageId: no-photo-id-security-questions-find-another-way
-    events:
-      f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneIphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneAndroid:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-
-  PYI_ESCAPE_M2B:
-    response:
-      type: page
-      pageId: no-photo-id-exit-find-another-way
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
-      bankAccount:
-        targetState: BANK_ACCOUNT_START_PAGE
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-
-  PYI_ESCAPE_ABANDON_M2B:
-    response:
-      type: page
-      context: abandon
-      pageId: no-photo-id-exit-find-another-way
-    events:
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-      next:
-        targetState: RESET_SESSION_IDENTITY
-
-  PYI_KBV_DROPOUT_M2B:
-    response:
-      type: page
-      pageId: no-photo-id-security-questions-find-another-way
-      context: dropout
-    events:
-      f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneIphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneAndroid:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-
-  # Mitigation journey (01)
-  MITIGATION_01_IDENTITY_START_PAGE:
-    response:
-      type: page
-      pageId: page-ipv-identity-document-start
-      mitigationStart: enhanced-verification
-    events:
-      appTriage:
-        targetState: MITIGATION_01_CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphone:
-        targetState: MITIGATION_01_CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneIphone:
-        targetState: MITIGATION_01_CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneAndroid:
-        targetState: MITIGATION_01_CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetState: MITIGATION_01_F2F_START_PAGE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-
-  MITIGATION_01_STRATEGIC_APP_TRIAGE:
-    nestedJourney: STRATEGIC_APP_TRIAGE
-    exitEvents:
-      next:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      end:
-        targetState: MITIGATION_01_PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-
-  MITIGATION_01_CRI_DCMAW:
-    response:
-      type: cri
-      criId: dcmaw
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: POST_DCMAW_SUCCESS_PAGE
-      not-found:
-        targetJourney: FAILED
-        targetState: FAILED
-      access-denied:
-        targetState: MITIGATION_01_PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      temporarily-unavailable:
-        targetState: MITIGATION_01_PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      fail-with-no-ci:
-        targetState: MITIGATION_01_PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      enhanced-verification:
-        targetState: MITIGATION_01_PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-
-  MITIGATION_01_F2F_START_PAGE:
-    response:
-      type: page
-      pageId: page-ipv-identity-postoffice-start
-    events:
-      next:
-        targetState: CRI_CLAIMED_IDENTITY_J4
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_CLAIMED_IDENTITY_J4
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-
-  MITIGATION_01_PYI_POST_OFFICE:
-    response:
-      type: page
-      pageId: pyi-post-office
-    events:
-      next:
-        targetState: CRI_CLAIMED_IDENTITY_J4
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_CLAIMED_IDENTITY_J4
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-
-  # Mitigation journey (02)
-  MITIGATION_02_OPTIONS:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options-no-f2f
-      mitigationStart: enhanced-verification
-    events:
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneIphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneAndroid:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-
-  STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
-    nestedJourney: STRATEGIC_APP_TRIAGE
-    exitEvents:
-      next:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      end:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-
-  CRI_DCMAW_PYI_ESCAPE:
-    response:
-      type: cri
-      criId: dcmaw
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-      not-found:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: FAILED
-            targetState: FAILED
-      access-denied:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      temporarily-unavailable:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      fail-with-no-ci:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      enhanced-verification:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-
-  MITIGATION_02_OPTIONS_WITH_F2F:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options
-      mitigationStart: enhanced-verification
-    events:
-      f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneIphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphoneAndroid:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-
-  MITIGATION_02_OPTIONS_WITH_F2F_M2B:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options
-      context: no-photo-id
-      mitigationStart: enhanced-verification
-    events:
-      f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriageSmartphone:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-
-  PYI_POST_OFFICE:
-    response:
-      type: page
-      pageId: pyi-post-office
-    events:
-      next:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-
-  # Mitigation journey (03) same session - invalid-dl
-  MITIGATION_03_OPTIONS:
-    response:
-      type: page
-      pageId: pyi-driving-licence-no-match-another-way
-      mitigationStart: invalid-dl
-    events:
-      next:
-        targetState: MITIGATION_PP_CRI_UK_PASSPORT
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-
-  # Mitigation journey (04) separate session - invalid-dl
-  MITIGATION_04_DL_NO_MATCH_PAGE:
-    response:
-      type: page
-      pageId: pyi-driving-licence-no-match
-    events:
-      next:
-        targetState: MITIGATION_04_IDENTITY_START_PAGE
-
-  MITIGATION_04_IDENTITY_START_PAGE:
-    response:
-      type: page
-      pageId: pyi-continue-with-passport
-      mitigationStart: invalid-dl
-    events:
-      next:
-        targetState: MITIGATION_PP_CRI_UK_PASSPORT
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-
-  # Passport journey (MITIGATION)
-  MITIGATION_PP_CRI_UK_PASSPORT:
-    response:
-      type: cri
-      criId: ukPassport
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
-      access-denied:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  # Address and Fraud journey (MITIGATION)
-  MITIGATION_PP_ADDRESS_AND_FRAUD:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: MITIGATION_PP_CRI_NINO
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  # Mitigation journey (05) same session - invalid-passport
-  MITIGATION_05_OPTIONS:
-    response:
-      type: page
-      pageId: pyi-passport-no-match-another-way
-      mitigationStart: invalid-passport
-    events:
-      next:
-        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-
-  # Mitigation journey (06) separate session - invalid-passport
-  MITIGATION_06_PASSPORT_NO_MATCH_PAGE:
-    response:
-      type: page
-      pageId: pyi-passport-no-match
-    events:
-      next:
-        targetState: MITIGATION_06_IDENTITY_START_PAGE
-
-  MITIGATION_06_IDENTITY_START_PAGE:
-    response:
-      type: page
-      pageId: pyi-continue-with-driving-licence
-      mitigationStart: invalid-passport
-    events:
-      next:
-        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-
-  MITIGATION_DL_CRI_DRIVING_LICENCE:
-    response:
-      type: cri
-      criId: drivingLicence
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
-      access-denied:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  MITIGATION_DL_ADDRESS_AND_FRAUD:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: MITIGATION_CHECK_FRAUD_SCORE
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  MITIGATION_CHECK_FRAUD_SCORE:
-    response:
-      type: process
-      lambda: check-gpg45-score
-      lambdaInput:
-        scoreType: fraud
-        scoreThreshold: 2
-    events:
-      met:
-        targetState: MITIGATION_PP_CRI_NINO
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      unmet:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  # Common Mitigation states - invalid-dl/invalid-passport
-  MITIGATION_PP_CRI_NINO:
-    response:
-      type: cri
-      criId: nino
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: MITIGATION_CRI_HMRC_KBV
-      fail-with-no-ci:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: MITIGATION_CRI_EXPERIAN_KBV
-
-  MITIGATION_CRI_EXPERIAN_KBV:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
-      fail-with-no-ci:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  MITIGATION_CRI_HMRC_KBV:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      fail-with-no-ci:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  F2F_FAILED_MITIGATION_PAGE:
-    response:
-      type: page
-      pageId: pyi-f2f-technical
-    events:
-      next:
-        targetState: MITIGATION_01_IDENTITY_START_PAGE
-      end:
-        targetState: RETURN_TO_RP
+
+# Entry points
+
+START:
+  events:
+    next:
+      targetState: IDENTITY_START_PAGE
+
+ENHANCED_VERIFICATION:
+  events:
+    next:
+      targetState: MITIGATION_01_IDENTITY_START_PAGE
+
+ALTERNATE_DOC_PASSPORT:
+  events:
+    next:
+      targetState: MITIGATION_04_DL_NO_MATCH_PAGE
+
+ALTERNATE_DOC_DL:
+  events:
+    next:
+      targetState: MITIGATION_06_PASSPORT_NO_MATCH_PAGE
+
+ENHANCED_VERIFICATION_F2F_FAIL:
+  events:
+    next:
+      targetState: F2F_FAILED_MITIGATION_PAGE
+
+REPROVE_IDENTITY:
+  events:
+    next:
+      targetState: REPROVE_IDENTITY_START
+
+# Parent states
+
+CRI_STATE:
+  events:
+    not-found:
+      targetJourney: FAILED
+      targetState: FAILED
+    fail-with-no-ci:
+      targetJourney: FAILED
+      targetState: FAILED
+    error:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
+    access-denied:
+      targetJourney: FAILED
+      targetState: FAILED
+    enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED
+    temporarily-unavailable:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
+    fail-with-ci:
+      targetJourney: FAILED
+      targetState: FAILED
+    vcs-not-correlated:
+      targetJourney: FAILED
+      targetState: FAILED
+    alternate-doc-invalid-dl:
+      targetJourney: FAILED
+      targetState: FAILED
+    alternate-doc-invalid-passport:
+      targetJourney: FAILED
+      targetState: FAILED
+
+CRI_TICF_STATE:
+  events:
+    enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    alternate-doc-invalid-dl:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    alternate-doc-invalid-passport:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    fail-with-ci:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    error:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR_NO_TICF
+
+# Journey states
+REPROVE_IDENTITY_START:
+  response:
+    type: page
+    pageId: reprove-identity-start
+  events:
+    next:
+      targetState: IDENTITY_START_PAGE
+
+RESET_SESSION_IDENTITY:
+  response:
+    type: process
+    lambda: reset-session-identity
+    lambdaInput:
+      isUserInitiated: false
+  events:
+    next:
+      targetState: IDENTITY_START_PAGE
+
+IDENTITY_START_PAGE:
+  response:
+    type: page
+    pageId: page-ipv-identity-document-start
+  events:
+    appTriage:
+      targetState: CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+          checkIfDisabled:
+            f2f:
+              targetState: MULTIPLE_DOC_CHECK_PAGE
+    appTriageSmartphone:
+      targetState: CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+          checkIfDisabled:
+            f2f:
+              targetState: MULTIPLE_DOC_CHECK_PAGE
+    appTriageSmartphoneIphone:
+      targetState: CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+          checkIfDisabled:
+            f2f:
+              targetState: MULTIPLE_DOC_CHECK_PAGE
+    appTriageSmartphoneAndroid:
+      targetState: CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+          checkIfDisabled:
+            f2f:
+              targetState: MULTIPLE_DOC_CHECK_PAGE
+    end:
+      targetState: F2F_START_PAGE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+
+STRATEGIC_APP_TRIAGE:
+  nestedJourney: STRATEGIC_APP_TRIAGE
+  exitEvents:
+    next:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
+    end:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
+
+F2F_START_PAGE:
+  response:
+    type: page
+    pageId: page-ipv-identity-postoffice-start
+  events:
+    next:
+      targetState: CRI_CLAIMED_IDENTITY_J4
+    end:
+      targetState: BANK_ACCOUNT_START_PAGE
+      checkIfDisabled:
+        bav:
+          targetState: PYI_ESCAPE
+
+F2F_PYI_POST_OFFICE:
+  response:
+    type: page
+    pageId: pyi-post-office
+  events:
+    next:
+      targetState: CRI_CLAIMED_IDENTITY_J4
+    end:
+      targetState: BANK_ACCOUNT_START_PAGE
+      checkIfDisabled:
+        bav:
+          targetState: PYI_ESCAPE
+
+BANK_ACCOUNT_START_PAGE:
+  response:
+    type: page
+    pageId: prove-identity-bank-account
+  events:
+    next:
+      targetState: CRI_CLAIMED_IDENTITY_M2B
+    end:
+      targetState: PYI_ESCAPE_M2B
+
+CRI_F2F:
+  response:
+    type: cri
+    criId: f2f
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+    enhanced-verification:
+      targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+    access-denied:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_NO_TICF
+    not-found:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    fail-with-no-ci:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    fail-with-ci:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    vcs-not-correlated:
+      targetJourney: FAILED
+      targetState: FAILED_NO_TICF
+    error:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR_NO_TICF
+    temporarily-unavailable:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR_NO_TICF
+
+F2F_HANDOFF_PAGE:
+  response:
+    type: page
+    pageId: page-face-to-face-handoff
+
+CRI_DCMAW:
+  response:
+    type: cri
+    criId: dcmaw
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: POST_DCMAW_SUCCESS_PAGE
+    not-found:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
+    access-denied:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
+    temporarily-unavailable:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
+    fail-with-no-ci:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
+
+MULTIPLE_DOC_CHECK_PAGE:
+  response:
+    type: page
+    pageId: page-multiple-doc-check
+  events:
+    ukPassport:
+      targetState: CRI_UK_PASSPORT_J2
+    drivingLicence:
+      targetState: CRI_DRIVING_LICENCE_J3
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+
+MULTIPLE_DOC_F2F_CHECK_PAGE:
+  response:
+    type: page
+    context: f2f
+    pageId: page-multiple-doc-check
+  events:
+    ukPassport:
+      targetState: CRI_UK_PASSPORT_J2
+    drivingLicence:
+      targetState: CRI_DRIVING_LICENCE_J3
+    end:
+      targetState: F2F_PYI_POST_OFFICE
+
+PYI_ESCAPE:
+  response:
+    type: page
+    pageId: pyi-escape
+  events:
+    next:
+      targetState: RESET_SESSION_IDENTITY
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+
+PYI_CRI_ESCAPE:
+  response:
+    type: page
+    pageId: pyi-cri-escape
+  events:
+    appTriage:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneIphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneAndroid:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    f2f:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+
+PYI_CRI_ESCAPE_NO_F2F:
+  response:
+    type: page
+    pageId: pyi-cri-escape-no-f2f
+  events:
+    appTriage:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneIphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneAndroid:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+
+EVALUATE_GPG45_SCORES:
+  response:
+    type: process
+    lambda: evaluate-gpg45-scores
+  events:
+    met:
+      targetState: STORE_IDENTITY_BEFORE_SUCCESS
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_SUCCESS
+    unmet:
+      targetJourney: FAILED
+      targetState: FAILED
+    vcs-not-correlated:
+      targetJourney: FAILED
+      targetState: FAILED
+
+STORE_IDENTITY_BEFORE_SUCCESS:
+  response:
+    type: process
+    lambda: store-identity
+  events:
+    identity-stored:
+      targetState: IPV_SUCCESS_PAGE
+    error:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
+
+STORE_IDENTITY_BEFORE_F2F_HANDOFF:
+  response:
+    type: process
+    lambda: store-identity
+  events:
+    identity-stored:
+      targetState: RESET_SESSION_BEFORE_F2F_HANDOFF
+    error:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
+
+RESET_SESSION_BEFORE_F2F_HANDOFF:
+  response:
+    type: process
+    lambda: reset-session-identity
+  events:
+    next:
+      targetState: F2F_HANDOFF_PAGE
+    error:
+      targetState: F2F_HANDOFF_PAGE
+
+IPV_SUCCESS_PAGE:
+  response:
+    type: page
+    pageId: page-ipv-success
+  events:
+    next:
+      targetState: RETURN_TO_RP
+
+RETURN_TO_RP:
+  response:
+    type: process
+    lambda: build-client-oauth-response
+
+CRI_TICF_BEFORE_SUCCESS:
+  response:
+    type: process
+    lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
+  events:
+    next:
+      targetState: STORE_IDENTITY_BEFORE_SUCCESS
+
+CRI_TICF_BEFORE_F2F:
+  response:
+    type: process
+    lambda: call-ticf-cri
+  parent: CRI_TICF_STATE
+  events:
+    next:
+      targetState: CRI_F2F
+    enhanced-verification:
+      targetState: CRI_F2F
+
+# Common pages
+PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+  response:
+    type: page
+    pageId: page-pre-experian-kbv-transition
+  events:
+    next:
+      targetState: CRI_EXPERIAN_KBV
+
+CRI_EXPERIAN_KBV:
+  response:
+    type: cri
+    criId: kbv
+  parent: CRI_STATE
+  events:
+    fail-with-no-ci:
+      targetState: PYI_CRI_ESCAPE
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_CRI_ESCAPE_NO_F2F
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
+      targetState: MITIGATION_02_OPTIONS_WITH_F2F
+      checkIfDisabled:
+        f2f:
+          targetState: MITIGATION_02_OPTIONS
+
+# DCMAW journey (J1)
+POST_DCMAW_SUCCESS_PAGE:
+  response:
+    type: page
+    pageId: page-dcmaw-success
+  events:
+    next:
+      targetState: ADDRESS_AND_FRAUD_J1
+
+ADDRESS_AND_FRAUD_J1:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED
+
+# Passport journey (J2)
+CRI_UK_PASSPORT_J2:
+  response:
+    type: cri
+    criId: ukPassport
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: ADDRESS_AND_FRAUD_J2
+    access-denied:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
+    alternate-doc-invalid-passport:
+      targetState: MITIGATION_05_OPTIONS
+
+ADDRESS_AND_FRAUD_J2:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
+    next:
+      targetState: CRI_NINO_J6
+      checkIfDisabled:
+        hmrcKbv:
+          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+    enhanced-verification:
+      targetState: CRI_NINO_J6
+      checkIfDisabled:
+        hmrcKbv:
+          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+# Driving licence journey (J3)
+CRI_DRIVING_LICENCE_J3:
+  response:
+    type: cri
+    criId: drivingLicence
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: ADDRESS_AND_FRAUD_J3
+    access-denied:
+      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+      checkIfDisabled:
+        f2f:
+          targetState: MULTIPLE_DOC_CHECK_PAGE
+    alternate-doc-invalid-dl:
+      targetState: MITIGATION_03_OPTIONS
+
+ADDRESS_AND_FRAUD_J3:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
+    next:
+      targetState: CHECK_FRAUD_SCORE_J3
+    enhanced-verification:
+      targetState: CHECK_FRAUD_SCORE_J3
+
+CHECK_FRAUD_SCORE_J3:
+  response:
+    type: process
+    lambda: check-gpg45-score
+    lambdaInput:
+      scoreType: fraud
+      scoreThreshold: 2
+  events:
+    met:
+      targetState: CRI_NINO_J6
+      checkIfDisabled:
+        hmrcKbv:
+          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+    unmet:
+      targetJourney: FAILED
+      targetState: FAILED
+
+# F2F journey (J4)
+CRI_CLAIMED_IDENTITY_J4:
+  response:
+    type: cri
+    criId: claimedIdentity
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: ADDRESS_AND_FRAUD_J4
+    enhanced-verification:
+      targetState: ADDRESS_AND_FRAUD_J4
+
+ADDRESS_AND_FRAUD_J4:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
+    next:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+    enhanced-verification:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+
+# HMRC KBV journey (J6)
+CRI_NINO_J6:
+  response:
+    type: cri
+    criId: nino
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: CRI_HMRC_KBV_J6
+    fail-with-no-ci:
+      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+CRI_HMRC_KBV_J6:
+  response:
+    type: cri
+    criId: hmrcKbv
+  parent: CRI_STATE
+  events:
+    fail-with-no-ci:
+      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
+      targetState: MITIGATION_02_OPTIONS_WITH_F2F
+      checkIfDisabled:
+        f2f:
+          targetState: MITIGATION_02_OPTIONS
+
+CRI_HMRC_KBV_M2B:
+  response:
+    type: cri
+    criId: hmrcKbv
+  parent: CRI_STATE
+  events:
+    fail-with-no-ci:
+      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
+      targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+      checkIfDisabled:
+        f2f:
+          targetState: MITIGATION_02_OPTIONS
+
+# No photo id journey (M2B)
+CRI_CLAIMED_IDENTITY_M2B:
+  response:
+    type: cri
+    criId: claimedIdentity
+    context: bank_account
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: CRI_BANK_ACCOUNT_M2B
+    enhanced-verification:
+      targetState: CRI_BANK_ACCOUNT_M2B
+
+CRI_BANK_ACCOUNT_M2B:
+  response:
+    type: cri
+    criId: bav
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: CRI_NINO_WITH_SCOPE_M2B
+    access-denied:
+      targetState: PYI_ESCAPE_ABANDON_M2B
+    fail-with-ci:
+      targetJourney: FAILED
+      targetState: FAILED_BAV
+
+CRI_NINO_WITH_SCOPE_M2B:
+  response:
+    type: cri
+    criId: nino
+    scope: identityCheck
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: ADDRESS_AND_FRAUD_M2B
+    access-denied:
+      targetState: PYI_ESCAPE_ABANDON_M2B
+    fail-with-ci:
+      targetJourney: FAILED
+      targetState: FAILED_NINO
+
+ADDRESS_AND_FRAUD_M2B:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
+    next:
+      targetState: CRI_HMRC_KBV_M2B
+      checkIfDisabled:
+        hmrcKbv:
+          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+    enhanced-verification:
+      targetState: CRI_HMRC_KBV_M2B
+      checkIfDisabled:
+        hmrcKbv:
+          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+
+PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B:
+  response:
+    type: page
+    pageId: page-pre-experian-kbv-transition
+  events:
+    next:
+      targetState: CRI_EXPERIAN_KBV_M2B
+
+CRI_EXPERIAN_KBV_M2B:
+  response:
+    type: cri
+    criId: kbv
+  parent: CRI_STATE
+  events:
+    fail-with-no-ci:
+      targetState: PYI_KBV_DROPOUT_M2B
+      checkIfDisabled:
+        f2f:
+          targetState: PYI_CRI_ESCAPE_NO_F2F
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
+      targetState: MITIGATION_KBV_FAIL_M2B
+      checkIfDisabled:
+        f2f:
+          targetState: MITIGATION_02_OPTIONS
+
+MITIGATION_KBV_FAIL_M2B:
+  response:
+    mitigationStart: enhanced-verification
+    type: page
+    pageId: no-photo-id-security-questions-find-another-way
+  events:
+    f2f:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+    appTriage:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneIphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneAndroid:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE
+
+PYI_ESCAPE_M2B:
+  response:
+    type: page
+    pageId: no-photo-id-exit-find-another-way
+  events:
+    next:
+      targetState: IDENTITY_START_PAGE
+    bankAccount:
+      targetState: BANK_ACCOUNT_START_PAGE
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+
+PYI_ESCAPE_ABANDON_M2B:
+  response:
+    type: page
+    context: abandon
+    pageId: no-photo-id-exit-find-another-way
+  events:
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+    next:
+      targetState: RESET_SESSION_IDENTITY
+
+PYI_KBV_DROPOUT_M2B:
+  response:
+    type: page
+    pageId: no-photo-id-security-questions-find-another-way
+    context: dropout
+  events:
+    f2f:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+    appTriage:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneIphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneAndroid:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE
+
+# Mitigation journey (01)
+MITIGATION_01_IDENTITY_START_PAGE:
+  response:
+    type: page
+    pageId: page-ipv-identity-document-start
+    mitigationStart: enhanced-verification
+  events:
+    appTriage:
+      targetState: MITIGATION_01_CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphone:
+      targetState: MITIGATION_01_CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneIphone:
+      targetState: MITIGATION_01_CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneAndroid:
+      targetState: MITIGATION_01_CRI_DCMAW
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    end:
+      targetState: MITIGATION_01_F2F_START_PAGE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+
+MITIGATION_01_STRATEGIC_APP_TRIAGE:
+  nestedJourney: STRATEGIC_APP_TRIAGE
+  exitEvents:
+    next:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
+    end:
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+
+MITIGATION_01_CRI_DCMAW:
+  response:
+    type: cri
+    criId: dcmaw
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: POST_DCMAW_SUCCESS_PAGE
+    not-found:
+      targetJourney: FAILED
+      targetState: FAILED
+    access-denied:
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+    temporarily-unavailable:
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+    fail-with-no-ci:
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+    enhanced-verification:
+      targetState: MITIGATION_01_PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+
+MITIGATION_01_F2F_START_PAGE:
+  response:
+    type: page
+    pageId: page-ipv-identity-postoffice-start
+  events:
+    next:
+      targetState: CRI_CLAIMED_IDENTITY_J4
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_CLAIMED_IDENTITY_J4
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE
+
+MITIGATION_01_PYI_POST_OFFICE:
+  response:
+    type: page
+    pageId: pyi-post-office
+  events:
+    next:
+      targetState: CRI_CLAIMED_IDENTITY_J4
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_CLAIMED_IDENTITY_J4
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE
+
+# Mitigation journey (02)
+MITIGATION_02_OPTIONS:
+  response:
+    type: page
+    pageId: pyi-suggest-other-options-no-f2f
+    mitigationStart: enhanced-verification
+  events:
+    appTriage:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneIphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneAndroid:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE
+
+STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
+  nestedJourney: STRATEGIC_APP_TRIAGE
+  exitEvents:
+    next:
+      targetJourney: TECHNICAL_ERROR
+      targetState: ERROR
+    end:
+      targetState: PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+
+CRI_DCMAW_PYI_ESCAPE:
+  response:
+    type: cri
+    criId: dcmaw
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    not-found:
+      targetState: PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: FAILED
+          targetState: FAILED
+    access-denied:
+      targetState: PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+    temporarily-unavailable:
+      targetState: PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+    fail-with-no-ci:
+      targetState: PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+    enhanced-verification:
+      targetState: PYI_POST_OFFICE
+      checkIfDisabled:
+        f2f:
+          targetJourney: INELIGIBLE
+          targetState: INELIGIBLE
+
+MITIGATION_02_OPTIONS_WITH_F2F:
+  response:
+    type: page
+    pageId: pyi-suggest-other-options
+    mitigationStart: enhanced-verification
+  events:
+    f2f:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+    appTriage:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneIphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphoneAndroid:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+
+MITIGATION_02_OPTIONS_WITH_F2F_M2B:
+  response:
+    type: page
+    pageId: pyi-suggest-other-options
+    context: no-photo-id
+    mitigationStart: enhanced-verification
+  events:
+    f2f:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+    appTriage:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+    appTriageSmartphone:
+      targetState: CRI_DCMAW_PYI_ESCAPE
+      checkFeatureFlag:
+        strategicAppEnabled:
+          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+      checkIfDisabled:
+        dcmaw:
+          targetJourney: TECHNICAL_ERROR
+          targetState: ERROR
+
+PYI_POST_OFFICE:
+  response:
+    type: page
+    pageId: pyi-post-office
+  events:
+    next:
+      targetState: CRI_F2F
+      checkFeatureFlag:
+        ticfCriBeta:
+          targetState: CRI_TICF_BEFORE_F2F
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE
+
+# Mitigation journey (03) same session - invalid-dl
+MITIGATION_03_OPTIONS:
+  response:
+    type: page
+    pageId: pyi-driving-licence-no-match-another-way
+    mitigationStart: invalid-dl
+  events:
+    next:
+      targetState: MITIGATION_PP_CRI_UK_PASSPORT
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+
+# Mitigation journey (04) separate session - invalid-dl
+MITIGATION_04_DL_NO_MATCH_PAGE:
+  response:
+    type: page
+    pageId: pyi-driving-licence-no-match
+  events:
+    next:
+      targetState: MITIGATION_04_IDENTITY_START_PAGE
+
+MITIGATION_04_IDENTITY_START_PAGE:
+  response:
+    type: page
+    pageId: pyi-continue-with-passport
+    mitigationStart: invalid-dl
+  events:
+    next:
+      targetState: MITIGATION_PP_CRI_UK_PASSPORT
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+
+# Passport journey (MITIGATION)
+MITIGATION_PP_CRI_UK_PASSPORT:
+  response:
+    type: cri
+    criId: ukPassport
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
+    access-denied:
+      targetJourney: FAILED
+      targetState: FAILED
+
+# Address and Fraud journey (MITIGATION)
+MITIGATION_PP_ADDRESS_AND_FRAUD:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
+    next:
+      targetState: MITIGATION_PP_CRI_NINO
+      checkIfDisabled:
+        hmrcKbv:
+          targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+    enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED
+
+# Mitigation journey (05) same session - invalid-passport
+MITIGATION_05_OPTIONS:
+  response:
+    type: page
+    pageId: pyi-passport-no-match-another-way
+    mitigationStart: invalid-passport
+  events:
+    next:
+      targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+
+# Mitigation journey (06) separate session - invalid-passport
+MITIGATION_06_PASSPORT_NO_MATCH_PAGE:
+  response:
+    type: page
+    pageId: pyi-passport-no-match
+  events:
+    next:
+      targetState: MITIGATION_06_IDENTITY_START_PAGE
+
+MITIGATION_06_IDENTITY_START_PAGE:
+  response:
+    type: page
+    pageId: pyi-continue-with-driving-licence
+    mitigationStart: invalid-passport
+  events:
+    next:
+      targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+    end:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE_SKIP_MESSAGE
+
+MITIGATION_DL_CRI_DRIVING_LICENCE:
+  response:
+    type: cri
+    criId: drivingLicence
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
+    access-denied:
+      targetJourney: FAILED
+      targetState: FAILED
+
+MITIGATION_DL_ADDRESS_AND_FRAUD:
+  nestedJourney: ADDRESS_AND_FRAUD
+  exitEvents:
+    next:
+      targetState: MITIGATION_CHECK_FRAUD_SCORE
+    enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED
+
+MITIGATION_CHECK_FRAUD_SCORE:
+  response:
+    type: process
+    lambda: check-gpg45-score
+    lambdaInput:
+      scoreType: fraud
+      scoreThreshold: 2
+  events:
+    met:
+      targetState: MITIGATION_PP_CRI_NINO
+      checkIfDisabled:
+        hmrcKbv:
+          targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+    unmet:
+      targetJourney: FAILED
+      targetState: FAILED
+
+# Common Mitigation states - invalid-dl/invalid-passport
+MITIGATION_PP_CRI_NINO:
+  response:
+    type: cri
+    criId: nino
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: MITIGATION_CRI_HMRC_KBV
+    fail-with-no-ci:
+      targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+  response:
+    type: page
+    pageId: page-pre-experian-kbv-transition
+  events:
+    next:
+      targetState: MITIGATION_CRI_EXPERIAN_KBV
+
+MITIGATION_CRI_EXPERIAN_KBV:
+  response:
+    type: cri
+    criId: kbv
+  parent: CRI_STATE
+  events:
+    fail-with-no-ci:
+      targetJourney: INELIGIBLE
+      targetState: INELIGIBLE
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED
+
+MITIGATION_CRI_HMRC_KBV:
+  response:
+    type: cri
+    criId: hmrcKbv
+  parent: CRI_STATE
+  events:
+    fail-with-no-ci:
+      targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+    next:
+      targetState: EVALUATE_GPG45_SCORES
+    enhanced-verification:
+      targetJourney: FAILED
+      targetState: FAILED
+
+F2F_FAILED_MITIGATION_PAGE:
+  response:
+    type: page
+    pageId: pyi-f2f-technical
+  events:
+    next:
+      targetState: MITIGATION_01_IDENTITY_START_PAGE
+    end:
+      targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1,24 +1,7 @@
 name: New P2 Identity
-description:
-  START: >-
-    The routes a user can take to prove their identity to a medium
-    confidence level (P2).
-  ENHANCED_VERIFICATION: >-
-    The routes the user is restricted to when they need to mitigate
-    a contra-indicator from the web-based verification process.
-  ALTERNATE_DOC_PASSPORT: >-
-    The routes the user is restricted to when they need to mitigate
-    a contra-indicator from the web-based document checking process.
-  ALTERNATE_DOC_DL: >-
-    The routes the user is restricted to when they need to mitigate
-    a contra-indicator from the web-based document checking process.
-  ENHANCED_VERIFICATION_F2F_FAIL: >-
-    The routes a user is restricted to when they need to mitigate a
-    contra-indicator from the web-based verification process but have
-    tried, and failed, to mitigate it using face-to-face verification.
-  REPROVE_IDENTITY: >-
-    The route a user must take to reprove their identity after an
-    account intervention.
+description: >-
+  The routes a user can take to prove their identity to a medium
+  confidence level (P2).
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1,1383 +1,1388 @@
-# Entry points
-
-START:
-  events:
-    next:
-      targetState: IDENTITY_START_PAGE
-
-ENHANCED_VERIFICATION:
-  events:
-    next:
-      targetState: MITIGATION_01_IDENTITY_START_PAGE
-
-ALTERNATE_DOC_PASSPORT:
-  events:
-    next:
-      targetState: MITIGATION_04_DL_NO_MATCH_PAGE
-
-ALTERNATE_DOC_DL:
-  events:
-    next:
-      targetState: MITIGATION_06_PASSPORT_NO_MATCH_PAGE
-
-ENHANCED_VERIFICATION_F2F_FAIL:
-  events:
-    next:
-      targetState: F2F_FAILED_MITIGATION_PAGE
-
-REPROVE_IDENTITY:
-  events:
-    next:
-      targetState: REPROVE_IDENTITY_START
-
-# Parent states
-
-CRI_STATE:
-  events:
-    not-found:
-      targetJourney: FAILED
-      targetState: FAILED
-    fail-with-no-ci:
-      targetJourney: FAILED
-      targetState: FAILED
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    access-denied:
-      targetJourney: FAILED
-      targetState: FAILED
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-    temporarily-unavailable:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED
-
-CRI_TICF_STATE:
-  events:
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
-
-# Journey states
-REPROVE_IDENTITY_START:
-  response:
-    type: page
-    pageId: reprove-identity-start
-  events:
-    next:
-      targetState: IDENTITY_START_PAGE
-
-RESET_SESSION_IDENTITY:
-  response:
-    type: process
-    lambda: reset-session-identity
-    lambdaInput:
-      isUserInitiated: false
-  events:
-    next:
-      targetState: IDENTITY_START_PAGE
-
-IDENTITY_START_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-identity-document-start
-  events:
-    appTriage:
-      targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
-    appTriageSmartphone:
-      targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-          checkIfDisabled:
-            f2f:
-              targetState: MULTIPLE_DOC_CHECK_PAGE
-    end:
-      targetState: F2F_START_PAGE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-STRATEGIC_APP_TRIAGE:
-  nestedJourney: STRATEGIC_APP_TRIAGE
-  exitEvents:
-    next:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    end:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-
-F2F_START_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-identity-postoffice-start
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-    end:
-      targetState: BANK_ACCOUNT_START_PAGE
-      checkIfDisabled:
-        bav:
-          targetState: PYI_ESCAPE
-
-F2F_PYI_POST_OFFICE:
-  response:
-    type: page
-    pageId: pyi-post-office
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-    end:
-      targetState: BANK_ACCOUNT_START_PAGE
-      checkIfDisabled:
-        bav:
-          targetState: PYI_ESCAPE
-
-BANK_ACCOUNT_START_PAGE:
-  response:
-    type: page
-    pageId: prove-identity-bank-account
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_M2B
-    end:
-      targetState: PYI_ESCAPE_M2B
-
-CRI_F2F:
-  response:
-    type: cri
-    criId: f2f
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-    enhanced-verification:
-      targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-    access-denied:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_NO_TICF
-    not-found:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-no-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
-    temporarily-unavailable:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
-
-F2F_HANDOFF_PAGE:
-  response:
-    type: page
-    pageId: page-face-to-face-handoff
-
-CRI_DCMAW:
-  response:
-    type: cri
-    criId: dcmaw
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: POST_DCMAW_SUCCESS_PAGE
-    not-found:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    access-denied:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    temporarily-unavailable:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    fail-with-no-ci:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-
-MULTIPLE_DOC_CHECK_PAGE:
-  response:
-    type: page
-    pageId: page-multiple-doc-check
-  events:
-    ukPassport:
-      targetState: CRI_UK_PASSPORT_J2
-    drivingLicence:
-      targetState: CRI_DRIVING_LICENCE_J3
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-MULTIPLE_DOC_F2F_CHECK_PAGE:
-  response:
-    type: page
-    context: f2f
-    pageId: page-multiple-doc-check
-  events:
-    ukPassport:
-      targetState: CRI_UK_PASSPORT_J2
-    drivingLicence:
-      targetState: CRI_DRIVING_LICENCE_J3
-    end:
-      targetState: F2F_PYI_POST_OFFICE
-
-PYI_ESCAPE:
-  response:
-    type: page
-    pageId: pyi-escape
-  events:
-    next:
-      targetState: RESET_SESSION_IDENTITY
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-PYI_CRI_ESCAPE:
-  response:
-    type: page
-    pageId: pyi-cri-escape
-  events:
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-
-PYI_CRI_ESCAPE_NO_F2F:
-  response:
-    type: page
-    pageId: pyi-cri-escape-no-f2f
-  events:
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-EVALUATE_GPG45_SCORES:
-  response:
-    type: process
-    lambda: evaluate-gpg45-scores
-  events:
-    met:
-      targetState: STORE_IDENTITY_BEFORE_SUCCESS
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_SUCCESS
-    unmet:
-      targetJourney: FAILED
-      targetState: FAILED
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED
-
-STORE_IDENTITY_BEFORE_SUCCESS:
-  response:
-    type: process
-    lambda: store-identity
-  events:
-    identity-stored:
-      targetState: IPV_SUCCESS_PAGE
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-
-STORE_IDENTITY_BEFORE_F2F_HANDOFF:
-  response:
-    type: process
-    lambda: store-identity
-  events:
-    identity-stored:
-      targetState: F2F_HANDOFF_PAGE
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-
-IPV_SUCCESS_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-success
-  events:
-    next:
-      targetState: RETURN_TO_RP
-
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
-
-CRI_TICF_BEFORE_SUCCESS:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  parent: CRI_TICF_STATE
-  events:
-    next:
-      targetState: STORE_IDENTITY_BEFORE_SUCCESS
-
-CRI_TICF_BEFORE_F2F:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  parent: CRI_TICF_STATE
-  events:
-    next:
-      targetState: CRI_F2F
-    enhanced-verification:
-      targetState: CRI_F2F
-
-# Common pages
-PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-  response:
-    type: page
-    pageId: page-pre-experian-kbv-transition
-  events:
-    next:
-      targetState: CRI_EXPERIAN_KBV
-
-CRI_EXPERIAN_KBV:
-  response:
-    type: cri
-    criId: kbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: PYI_CRI_ESCAPE
-      checkIfDisabled:
-        f2f:
-          targetState: PYI_CRI_ESCAPE_NO_F2F
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetState: MITIGATION_02_OPTIONS_WITH_F2F
-      checkIfDisabled:
-        f2f:
-          targetState: MITIGATION_02_OPTIONS
-
-# DCMAW journey (J1)
-POST_DCMAW_SUCCESS_PAGE:
-  response:
-    type: page
-    pageId: page-dcmaw-success
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J1
-
-ADDRESS_AND_FRAUD_J1:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# Passport journey (J2)
-CRI_UK_PASSPORT_J2:
-  response:
-    type: cri
-    criId: ukPassport
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J2
-    access-denied:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    alternate-doc-invalid-passport:
-      targetState: MITIGATION_05_OPTIONS
-
-ADDRESS_AND_FRAUD_J2:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: CRI_NINO_J6
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    enhanced-verification:
-      targetState: CRI_NINO_J6
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-# Driving licence journey (J3)
-CRI_DRIVING_LICENCE_J3:
-  response:
-    type: cri
-    criId: drivingLicence
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J3
-    access-denied:
-      targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-      checkIfDisabled:
-        f2f:
-          targetState: MULTIPLE_DOC_CHECK_PAGE
-    alternate-doc-invalid-dl:
-      targetState: MITIGATION_03_OPTIONS
-
-ADDRESS_AND_FRAUD_J3:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: CHECK_FRAUD_SCORE_J3
-    enhanced-verification:
-      targetState: CHECK_FRAUD_SCORE_J3
-
-CHECK_FRAUD_SCORE_J3:
-  response:
-    type: process
-    lambda: check-gpg45-score
-    lambdaInput:
-      scoreType: fraud
-      scoreThreshold: 2
-  events:
-    met:
-      targetState: CRI_NINO_J6
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    unmet:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# F2F journey (J4)
-CRI_CLAIMED_IDENTITY_J4:
-  response:
-    type: cri
-    criId: claimedIdentity
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_J4
-    enhanced-verification:
-      targetState: ADDRESS_AND_FRAUD_J4
-
-ADDRESS_AND_FRAUD_J4:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    enhanced-verification:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-
-# HMRC KBV journey (J6)
-CRI_NINO_J6:
-  response:
-    type: cri
-    criId: nino
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_HMRC_KBV_J6
-    fail-with-no-ci:
-      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-CRI_HMRC_KBV_J6:
-  response:
-    type: cri
-    criId: hmrcKbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetState: MITIGATION_02_OPTIONS_WITH_F2F
-      checkIfDisabled:
-        f2f:
-          targetState: MITIGATION_02_OPTIONS
-
-CRI_HMRC_KBV_M2B:
-  response:
-    type: cri
-    criId: hmrcKbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
-      checkIfDisabled:
-        f2f:
-          targetState: MITIGATION_02_OPTIONS
-
-# No photo id journey (M2B)
-CRI_CLAIMED_IDENTITY_M2B:
-  response:
-    type: cri
-    criId: claimedIdentity
-    context: bank_account
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_BANK_ACCOUNT_M2B
-    enhanced-verification:
-      targetState: CRI_BANK_ACCOUNT_M2B
-
-CRI_BANK_ACCOUNT_M2B:
-  response:
-    type: cri
-    criId: bav
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: CRI_NINO_WITH_SCOPE_M2B
-    access-denied:
-      targetState: PYI_ESCAPE_ABANDON_M2B
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_BAV
-
-CRI_NINO_WITH_SCOPE_M2B:
-  response:
-    type: cri
-    criId: nino
-    scope: identityCheck
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_M2B
-    access-denied:
-      targetState: PYI_ESCAPE_ABANDON_M2B
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NINO
-
-ADDRESS_AND_FRAUD_M2B:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: CRI_HMRC_KBV_M2B
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
-    enhanced-verification:
-      targetState: CRI_HMRC_KBV_M2B
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
-
-PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B:
-  response:
-    type: page
-    pageId: page-pre-experian-kbv-transition
-  events:
-    next:
-      targetState: CRI_EXPERIAN_KBV_M2B
-
-CRI_EXPERIAN_KBV_M2B:
-  response:
-    type: cri
-    criId: kbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: PYI_KBV_DROPOUT_M2B
-      checkIfDisabled:
-        f2f:
-          targetState: PYI_CRI_ESCAPE_NO_F2F
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetState: MITIGATION_KBV_FAIL_M2B
-      checkIfDisabled:
-        f2f:
-          targetState: MITIGATION_02_OPTIONS
-
-MITIGATION_KBV_FAIL_M2B:
-  response:
-    mitigationStart: enhanced-verification
-    type: page
-    pageId: no-photo-id-security-questions-find-another-way
-  events:
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-PYI_ESCAPE_M2B:
-  response:
-    type: page
-    pageId: no-photo-id-exit-find-another-way
-  events:
-    next:
-      targetState: IDENTITY_START_PAGE
-    bankAccount:
-      targetState: BANK_ACCOUNT_START_PAGE
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-PYI_ESCAPE_ABANDON_M2B:
-  response:
-    type: page
-    context: abandon
-    pageId: no-photo-id-exit-find-another-way
-  events:
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-    next:
-      targetState: RESET_SESSION_IDENTITY
-
-PYI_KBV_DROPOUT_M2B:
-  response:
-    type: page
-    pageId: no-photo-id-security-questions-find-another-way
-    context: dropout
-  events:
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-# Mitigation journey (01)
-MITIGATION_01_IDENTITY_START_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-identity-document-start
-    mitigationStart: enhanced-verification
-  events:
-    appTriage:
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: MITIGATION_01_CRI_DCMAW
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetState: MITIGATION_01_F2F_START_PAGE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-MITIGATION_01_STRATEGIC_APP_TRIAGE:
-  nestedJourney: STRATEGIC_APP_TRIAGE
-  exitEvents:
-    next:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    end:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-MITIGATION_01_CRI_DCMAW:
-  response:
-    type: cri
-    criId: dcmaw
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: POST_DCMAW_SUCCESS_PAGE
-    not-found:
-      targetJourney: FAILED
-      targetState: FAILED
-    access-denied:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    temporarily-unavailable:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    fail-with-no-ci:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    enhanced-verification:
-      targetState: MITIGATION_01_PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-MITIGATION_01_F2F_START_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-identity-postoffice-start
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_CLAIMED_IDENTITY_J4
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-MITIGATION_01_PYI_POST_OFFICE:
-  response:
-    type: page
-    pageId: pyi-post-office
-  events:
-    next:
-      targetState: CRI_CLAIMED_IDENTITY_J4
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_CLAIMED_IDENTITY_J4
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-# Mitigation journey (02)
-MITIGATION_02_OPTIONS:
-  response:
-    type: page
-    pageId: pyi-suggest-other-options-no-f2f
-    mitigationStart: enhanced-verification
-  events:
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
-  nestedJourney: STRATEGIC_APP_TRIAGE
-  exitEvents:
-    next:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    end:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-CRI_DCMAW_PYI_ESCAPE:
-  response:
-    type: cri
-    criId: dcmaw
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    not-found:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: FAILED
-          targetState: FAILED
-    access-denied:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    temporarily-unavailable:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    fail-with-no-ci:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-    enhanced-verification:
-      targetState: PYI_POST_OFFICE
-      checkIfDisabled:
-        f2f:
-          targetJourney: INELIGIBLE
-          targetState: INELIGIBLE
-
-MITIGATION_02_OPTIONS_WITH_F2F:
-  response:
-    type: page
-    pageId: pyi-suggest-other-options
-    mitigationStart: enhanced-verification
-  events:
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneIphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphoneAndroid:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-
-MITIGATION_02_OPTIONS_WITH_F2F_M2B:
-  response:
-    type: page
-    pageId: pyi-suggest-other-options
-    context: no-photo-id
-    mitigationStart: enhanced-verification
-  events:
-    f2f:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    appTriage:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-    appTriageSmartphone:
-      targetState: CRI_DCMAW_PYI_ESCAPE
-      checkFeatureFlag:
-        strategicAppEnabled:
-          targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-      checkIfDisabled:
-        dcmaw:
-          targetJourney: TECHNICAL_ERROR
-          targetState: ERROR
-
-PYI_POST_OFFICE:
-  response:
-    type: page
-    pageId: pyi-post-office
-  events:
-    next:
-      targetState: CRI_F2F
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_F2F
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-
-# Mitigation journey (03) same session - invalid-dl
-MITIGATION_03_OPTIONS:
-  response:
-    type: page
-    pageId: pyi-driving-licence-no-match-another-way
-    mitigationStart: invalid-dl
-  events:
-    next:
-      targetState: MITIGATION_PP_CRI_UK_PASSPORT
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-# Mitigation journey (04) separate session - invalid-dl
-MITIGATION_04_DL_NO_MATCH_PAGE:
-  response:
-    type: page
-    pageId: pyi-driving-licence-no-match
-  events:
-    next:
-      targetState: MITIGATION_04_IDENTITY_START_PAGE
-
-MITIGATION_04_IDENTITY_START_PAGE:
-  response:
-    type: page
-    pageId: pyi-continue-with-passport
-    mitigationStart: invalid-dl
-  events:
-    next:
-      targetState: MITIGATION_PP_CRI_UK_PASSPORT
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-# Passport journey (MITIGATION)
-MITIGATION_PP_CRI_UK_PASSPORT:
-  response:
-    type: cri
-    criId: ukPassport
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
-    access-denied:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# Address and Fraud journey (MITIGATION)
-MITIGATION_PP_ADDRESS_AND_FRAUD:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: MITIGATION_PP_CRI_NINO
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# Mitigation journey (05) same session - invalid-passport
-MITIGATION_05_OPTIONS:
-  response:
-    type: page
-    pageId: pyi-passport-no-match-another-way
-    mitigationStart: invalid-passport
-  events:
-    next:
-      targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-# Mitigation journey (06) separate session - invalid-passport
-MITIGATION_06_PASSPORT_NO_MATCH_PAGE:
-  response:
-    type: page
-    pageId: pyi-passport-no-match
-  events:
-    next:
-      targetState: MITIGATION_06_IDENTITY_START_PAGE
-
-MITIGATION_06_IDENTITY_START_PAGE:
-  response:
-    type: page
-    pageId: pyi-continue-with-driving-licence
-    mitigationStart: invalid-passport
-  events:
-    next:
-      targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
-    end:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE_SKIP_MESSAGE
-
-MITIGATION_DL_CRI_DRIVING_LICENCE:
-  response:
-    type: cri
-    criId: drivingLicence
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
-    access-denied:
-      targetJourney: FAILED
-      targetState: FAILED
-
-MITIGATION_DL_ADDRESS_AND_FRAUD:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: MITIGATION_CHECK_FRAUD_SCORE
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-MITIGATION_CHECK_FRAUD_SCORE:
-  response:
-    type: process
-    lambda: check-gpg45-score
-    lambdaInput:
-      scoreType: fraud
-      scoreThreshold: 2
-  events:
-    met:
-      targetState: MITIGATION_PP_CRI_NINO
-      checkIfDisabled:
-        hmrcKbv:
-          targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    unmet:
-      targetJourney: FAILED
-      targetState: FAILED
-
-# Common Mitigation states - invalid-dl/invalid-passport
-MITIGATION_PP_CRI_NINO:
-  response:
-    type: cri
-    criId: nino
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: MITIGATION_CRI_HMRC_KBV
-    fail-with-no-ci:
-      targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-  response:
-    type: page
-    pageId: page-pre-experian-kbv-transition
-  events:
-    next:
-      targetState: MITIGATION_CRI_EXPERIAN_KBV
-
-MITIGATION_CRI_EXPERIAN_KBV:
-  response:
-    type: cri
-    criId: kbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetJourney: INELIGIBLE
-      targetState: INELIGIBLE
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-MITIGATION_CRI_HMRC_KBV:
-  response:
-    type: cri
-    criId: hmrcKbv
-  parent: CRI_STATE
-  events:
-    fail-with-no-ci:
-      targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-    next:
-      targetState: EVALUATE_GPG45_SCORES
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED
-
-F2F_FAILED_MITIGATION_PAGE:
-  response:
-    type: page
-    pageId: pyi-f2f-technical
-  events:
-    next:
-      targetState: MITIGATION_01_IDENTITY_START_PAGE
-    end:
-      targetState: RETURN_TO_RP
+NAME: NAME
+DESCRIPTION: DESC
+
+STATES:
+
+  # Entry points
+
+  START:
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  ENHANCED_VERIFICATION:
+    events:
+      next:
+        targetState: MITIGATION_01_IDENTITY_START_PAGE
+
+  ALTERNATE_DOC_PASSPORT:
+    events:
+      next:
+        targetState: MITIGATION_04_DL_NO_MATCH_PAGE
+
+  ALTERNATE_DOC_DL:
+    events:
+      next:
+        targetState: MITIGATION_06_PASSPORT_NO_MATCH_PAGE
+
+  ENHANCED_VERIFICATION_F2F_FAIL:
+    events:
+      next:
+        targetState: F2F_FAILED_MITIGATION_PAGE
+
+  REPROVE_IDENTITY:
+    events:
+      next:
+        targetState: REPROVE_IDENTITY_START
+
+  # Parent states
+
+  CRI_STATE:
+    events:
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  CRI_TICF_STATE:
+    events:
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  # Journey states
+  REPROVE_IDENTITY_START:
+    response:
+      type: page
+      pageId: reprove-identity-start
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  RESET_SESSION_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        isUserInitiated: false
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-document-start
+    events:
+      appTriage:
+        targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
+      appTriageSmartphone:
+        targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
+      end:
+        targetState: F2F_START_PAGE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+
+  F2F_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-postoffice-start
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetState: BANK_ACCOUNT_START_PAGE
+        checkIfDisabled:
+          bav:
+            targetState: PYI_ESCAPE
+
+  F2F_PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetState: BANK_ACCOUNT_START_PAGE
+        checkIfDisabled:
+          bav:
+            targetState: PYI_ESCAPE
+
+  BANK_ACCOUNT_START_PAGE:
+    response:
+      type: page
+      pageId: prove-identity-bank-account
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_M2B
+      end:
+        targetState: PYI_ESCAPE_M2B
+
+  CRI_F2F:
+    response:
+      type: cri
+      criId: f2f
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      enhanced-verification:
+        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      access-denied:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_NO_TICF
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  F2F_HANDOFF_PAGE:
+    response:
+      type: page
+      pageId: page-face-to-face-handoff
+
+  CRI_DCMAW:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      not-found:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      temporarily-unavailable:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      fail-with-no-ci:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+
+  MULTIPLE_DOC_CHECK_PAGE:
+    response:
+      type: page
+      pageId: page-multiple-doc-check
+    events:
+      ukPassport:
+        targetState: CRI_UK_PASSPORT_J2
+      drivingLicence:
+        targetState: CRI_DRIVING_LICENCE_J3
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  MULTIPLE_DOC_F2F_CHECK_PAGE:
+    response:
+      type: page
+      context: f2f
+      pageId: page-multiple-doc-check
+    events:
+      ukPassport:
+        targetState: CRI_UK_PASSPORT_J2
+      drivingLicence:
+        targetState: CRI_DRIVING_LICENCE_J3
+      end:
+        targetState: F2F_PYI_POST_OFFICE
+
+  PYI_ESCAPE:
+    response:
+      type: page
+      pageId: pyi-escape
+    events:
+      next:
+        targetState: RESET_SESSION_IDENTITY
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  PYI_CRI_ESCAPE:
+    response:
+      type: page
+      pageId: pyi-cri-escape
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+
+  PYI_CRI_ESCAPE_NO_F2F:
+    response:
+      type: page
+      pageId: pyi-cri-escape-no-f2f
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  EVALUATE_GPG45_SCORES:
+    response:
+      type: process
+      lambda: evaluate-gpg45-scores
+    events:
+      met:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_SUCCESS
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  STORE_IDENTITY_BEFORE_SUCCESS:
+    response:
+      type: process
+      lambda: store-identity
+    events:
+      identity-stored:
+        targetState: IPV_SUCCESS_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  STORE_IDENTITY_BEFORE_F2F_HANDOFF:
+    response:
+      type: process
+      lambda: store-identity
+    events:
+      identity-stored:
+        targetState: F2F_HANDOFF_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  IPV_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-success
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response
+
+  CRI_TICF_BEFORE_SUCCESS:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+
+  CRI_TICF_BEFORE_F2F:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: CRI_F2F
+      enhanced-verification:
+        targetState: CRI_F2F
+
+  # Common pages
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV
+
+  CRI_EXPERIAN_KBV:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PYI_CRI_ESCAPE
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+
+  # DCMAW journey (J1)
+  POST_DCMAW_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-dcmaw-success
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J1
+
+  ADDRESS_AND_FRAUD_J1:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Passport journey (J2)
+  CRI_UK_PASSPORT_J2:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J2
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-passport:
+        targetState: MITIGATION_05_OPTIONS
+
+  ADDRESS_AND_FRAUD_J2:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_NINO_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: CRI_NINO_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  # Driving licence journey (J3)
+  CRI_DRIVING_LICENCE_J3:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J3
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-dl:
+        targetState: MITIGATION_03_OPTIONS
+
+  ADDRESS_AND_FRAUD_J3:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CHECK_FRAUD_SCORE_J3
+      enhanced-verification:
+        targetState: CHECK_FRAUD_SCORE_J3
+
+  CHECK_FRAUD_SCORE_J3:
+    response:
+      type: process
+      lambda: check-gpg45-score
+      lambdaInput:
+        scoreType: fraud
+        scoreThreshold: 2
+    events:
+      met:
+        targetState: CRI_NINO_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # F2F journey (J4)
+  CRI_CLAIMED_IDENTITY_J4:
+    response:
+      type: cri
+      criId: claimedIdentity
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J4
+      enhanced-verification:
+        targetState: ADDRESS_AND_FRAUD_J4
+
+  ADDRESS_AND_FRAUD_J4:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      enhanced-verification:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+
+  # HMRC KBV journey (J6)
+  CRI_NINO_J6:
+    response:
+      type: cri
+      criId: nino
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_HMRC_KBV_J6
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  CRI_HMRC_KBV_J6:
+    response:
+      type: cri
+      criId: hmrcKbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+
+  CRI_HMRC_KBV_M2B:
+    response:
+      type: cri
+      criId: hmrcKbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+
+  # No photo id journey (M2B)
+  CRI_CLAIMED_IDENTITY_M2B:
+    response:
+      type: cri
+      criId: claimedIdentity
+      context: bank_account
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_BANK_ACCOUNT_M2B
+      enhanced-verification:
+        targetState: CRI_BANK_ACCOUNT_M2B
+
+  CRI_BANK_ACCOUNT_M2B:
+    response:
+      type: cri
+      criId: bav
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_NINO_WITH_SCOPE_M2B
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_M2B
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_BAV
+
+  CRI_NINO_WITH_SCOPE_M2B:
+    response:
+      type: cri
+      criId: nino
+      scope: identityCheck
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_M2B
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_M2B
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NINO
+
+  ADDRESS_AND_FRAUD_M2B:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_HMRC_KBV_M2B
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+      enhanced-verification:
+        targetState: CRI_HMRC_KBV_M2B
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV_M2B
+
+  CRI_EXPERIAN_KBV_M2B:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PYI_KBV_DROPOUT_M2B
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetState: MITIGATION_KBV_FAIL_M2B
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+
+  MITIGATION_KBV_FAIL_M2B:
+    response:
+      mitigationStart: enhanced-verification
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+    events:
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  PYI_ESCAPE_M2B:
+    response:
+      type: page
+      pageId: no-photo-id-exit-find-another-way
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+      bankAccount:
+        targetState: BANK_ACCOUNT_START_PAGE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  PYI_ESCAPE_ABANDON_M2B:
+    response:
+      type: page
+      context: abandon
+      pageId: no-photo-id-exit-find-another-way
+    events:
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+      next:
+        targetState: RESET_SESSION_IDENTITY
+
+  PYI_KBV_DROPOUT_M2B:
+    response:
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+      context: dropout
+    events:
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  # Mitigation journey (01)
+  MITIGATION_01_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-document-start
+      mitigationStart: enhanced-verification
+    events:
+      appTriage:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetState: MITIGATION_01_F2F_START_PAGE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_CRI_DCMAW:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED
+      access-denied:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      temporarily-unavailable:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      fail-with-no-ci:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      enhanced-verification:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_F2F_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-postoffice-start
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  MITIGATION_01_PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  # Mitigation journey (02)
+  MITIGATION_02_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options-no-f2f
+      mitigationStart: enhanced-verification
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  CRI_DCMAW_PYI_ESCAPE:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      not-found:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: FAILED
+            targetState: FAILED
+      access-denied:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      temporarily-unavailable:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      fail-with-no-ci:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      enhanced-verification:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_02_OPTIONS_WITH_F2F:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+      mitigationStart: enhanced-verification
+    events:
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneIphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphoneAndroid:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  MITIGATION_02_OPTIONS_WITH_F2F_M2B:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+      context: no-photo-id
+      mitigationStart: enhanced-verification
+    events:
+      f2f:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriageSmartphone:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  # Mitigation journey (03) same session - invalid-dl
+  MITIGATION_03_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-driving-licence-no-match-another-way
+      mitigationStart: invalid-dl
+    events:
+      next:
+        targetState: MITIGATION_PP_CRI_UK_PASSPORT
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Mitigation journey (04) separate session - invalid-dl
+  MITIGATION_04_DL_NO_MATCH_PAGE:
+    response:
+      type: page
+      pageId: pyi-driving-licence-no-match
+    events:
+      next:
+        targetState: MITIGATION_04_IDENTITY_START_PAGE
+
+  MITIGATION_04_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: pyi-continue-with-passport
+      mitigationStart: invalid-dl
+    events:
+      next:
+        targetState: MITIGATION_PP_CRI_UK_PASSPORT
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Passport journey (MITIGATION)
+  MITIGATION_PP_CRI_UK_PASSPORT:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Address and Fraud journey (MITIGATION)
+  MITIGATION_PP_ADDRESS_AND_FRAUD:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: MITIGATION_PP_CRI_NINO
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Mitigation journey (05) same session - invalid-passport
+  MITIGATION_05_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-passport-no-match-another-way
+      mitigationStart: invalid-passport
+    events:
+      next:
+        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Mitigation journey (06) separate session - invalid-passport
+  MITIGATION_06_PASSPORT_NO_MATCH_PAGE:
+    response:
+      type: page
+      pageId: pyi-passport-no-match
+    events:
+      next:
+        targetState: MITIGATION_06_IDENTITY_START_PAGE
+
+  MITIGATION_06_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: pyi-continue-with-driving-licence
+      mitigationStart: invalid-passport
+    events:
+      next:
+        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  MITIGATION_DL_CRI_DRIVING_LICENCE:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_DL_ADDRESS_AND_FRAUD:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: MITIGATION_CHECK_FRAUD_SCORE
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_CHECK_FRAUD_SCORE:
+    response:
+      type: process
+      lambda: check-gpg45-score
+      lambdaInput:
+        scoreType: fraud
+        scoreThreshold: 2
+    events:
+      met:
+        targetState: MITIGATION_PP_CRI_NINO
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Common Mitigation states - invalid-dl/invalid-passport
+  MITIGATION_PP_CRI_NINO:
+    response:
+      type: cri
+      criId: nino
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_CRI_HMRC_KBV
+      fail-with-no-ci:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: MITIGATION_CRI_EXPERIAN_KBV
+
+  MITIGATION_CRI_EXPERIAN_KBV:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_CRI_HMRC_KBV:
+    response:
+      type: cri
+      criId: hmrcKbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  F2F_FAILED_MITIGATION_PAGE:
+    response:
+      type: page
+      pageId: pyi-f2f-technical
+    events:
+      next:
+        targetState: MITIGATION_01_IDENTITY_START_PAGE
+      end:
+        targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
@@ -1,5 +1,8 @@
 name: Operational Profile Migration
-description: A user has an operational profile from a government service to prove their identity.
+description:
+  START: >-
+    A user has an operational profile from a government service
+    to prove their identity.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
@@ -1,7 +1,7 @@
-NAME: NAME
-DESCRIPTION: DESC
+name: Operational Profile Migration
+description: A user has an operational profile from a government service to prove their identity.
 
-STATES:
+states:
   # Entry points
 
   START:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
@@ -1,39 +1,43 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-START:
-  events:
-    next:
-      targetState: RETURN_TO_RP
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+STATES:
+  # Entry points
 
-# Journey states
+  START:
+    events:
+      next:
+        targetState: RETURN_TO_RP
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_RETURN_TO_RP
 
-CRI_TICF_BEFORE_RETURN_TO_RP:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: RETURN_TO_RP
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  # Journey states
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  CRI_TICF_BEFORE_RETURN_TO_RP:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
@@ -1,8 +1,7 @@
 name: Operational Profile Migration
-description:
-  START: >-
-    A user has an operational profile from a government service
-    to prove their identity.
+description: >-
+  A user has an operational profile from a government service
+  to prove their identity.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -1,39 +1,43 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-START:
-  events:
-    next:
-      targetState: RETURN_TO_RP
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+STATES:
+  # Entry points
 
-# Journey states
+  START:
+    events:
+      next:
+        targetState: RETURN_TO_RP
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_RETURN_TO_RP
 
-CRI_TICF_BEFORE_RETURN_TO_RP:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: RETURN_TO_RP
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  # Journey states
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  CRI_TICF_BEFORE_RETURN_TO_RP:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -1,8 +1,7 @@
 name: Operational Profile Reuse
-description:
-  START: >-
-    A user returns to GOV.UK One Login after proving their identity
-    with an operational profile in another user session.
+description: >-
+  A user returns to GOV.UK One Login after proving their identity
+  with an operational profile in another user session.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -1,7 +1,7 @@
-NAME: NAME
-DESCRIPTION: DESC
+name: Operational Profile Reuse
+description: A user returns to GOV.UK One Login after proving their identity with an operational profile in another user session.
 
-STATES:
+states:
   # Entry points
 
   START:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -1,5 +1,8 @@
 name: Operational Profile Reuse
-description: A user returns to GOV.UK One Login after proving their identity with an operational profile in another user session.
+description:
+  START: >-
+    A user returns to GOV.UK One Login after proving their identity
+    with an operational profile in another user session.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -1,7 +1,7 @@
-NAME: NAME
-DESCRIPTION: DESC
+name: Repeat Fraud Check
+description: The route a returning user must take whose last fraud check was more than 6 months ago.
 
-STATES:
+states:
 # Entry points
 
   START:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -1,5 +1,8 @@
 name: Repeat Fraud Check
-description: The route a returning user must take whose last fraud check was more than 6 months ago.
+description:
+  START: >-
+    The route a returning user must take whose last fraud
+    check was more than 6 months ago.
 
 states:
 # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -1,8 +1,7 @@
 name: Repeat Fraud Check
-description:
-  START: >-
-    The route a returning user must take whose last fraud
-    check was more than 6 months ago.
+description: >-
+  The route a returning user must take whose last fraud
+  check was more than 6 months ago.
 
 states:
 # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -1,7 +1,7 @@
 name: Repeat Fraud Check
 description: >-
-  The route a returning user must take whose last fraud
-  check was more than 6 months ago.
+  The route a returning user must take if
+  their last fraud check has expired.
 
 states:
 # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -1,156 +1,160 @@
+NAME: NAME
+DESCRIPTION: DESC
+
+STATES:
 # Entry points
 
-START:
-  events:
-    next:
-      targetState: CONFIRM_NAME_DOB
+  START:
+    events:
+      next:
+        targetState: CONFIRM_NAME_DOB
 
-# Parent States
+  # Parent States
 
-CRI_STATE:
-  events:
-    not-found:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
-    fail-with-no-ci:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    access-denied:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
-    temporarily-unavailable:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
+  CRI_STATE:
+    events:
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
 
-# Journey States
+  # Journey States
 
-CONFIRM_NAME_DOB:
-  response:
-    type: page
-    pageId: confirm-name-date-birth
-  events:
-    next:
-      targetState: CONFIRM_ADDRESS
-    end:
-      targetState: UPDATE_NAME_DOB
+  CONFIRM_NAME_DOB:
+    response:
+      type: page
+      pageId: confirm-name-date-birth
+    events:
+      next:
+        targetState: CONFIRM_ADDRESS
+      end:
+        targetState: UPDATE_NAME_DOB
 
-CONFIRM_ADDRESS:
-  response:
-    type: page
-    pageId: confirm-address
-  events:
-    address-current:
-      targetState: FRAUD_CHECK_RFC
-    next:
-      targetState: ADDRESS_AND_FRAUD_RFC
-    back:
-      targetState: CONFIRM_NAME_DOB
+  CONFIRM_ADDRESS:
+    response:
+      type: page
+      pageId: confirm-address
+    events:
+      address-current:
+        targetState: FRAUD_CHECK_RFC
+      next:
+        targetState: ADDRESS_AND_FRAUD_RFC
+      back:
+        targetState: CONFIRM_NAME_DOB
 
-UPDATE_NAME_DOB:
-  response:
-    type: page
-    pageId: update-name-date-birth
-  events:
-    end:
-      targetState: CONFIRM_NAME_DOB
+  UPDATE_NAME_DOB:
+    response:
+      type: page
+      pageId: update-name-date-birth
+    events:
+      end:
+        targetState: CONFIRM_NAME_DOB
 
-FRAUD_CHECK_RFC:
-  response:
-    type: cri
-    criId: fraud
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: EVALUATE_GPG45_SCORES_RFC
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
+  FRAUD_CHECK_RFC:
+    response:
+      type: cri
+      criId: fraud
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES_RFC
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
 
-ADDRESS_AND_FRAUD_RFC:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: EVALUATE_GPG45_SCORES_RFC
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
+  ADDRESS_AND_FRAUD_RFC:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: EVALUATE_GPG45_SCORES_RFC
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
 
-EVALUATE_GPG45_SCORES_RFC:
-  response:
-    type: process
-    lambda: evaluate-gpg45-scores
-  events:
-    met:
-      targetState: STORE_IDENTITY_BEFORE_SUCCESS
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_SUCCESS_RFC
-    unmet:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED_RFC
+  EVALUATE_GPG45_SCORES_RFC:
+    response:
+      type: process
+      lambda: evaluate-gpg45-scores
+    events:
+      met:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_SUCCESS_RFC
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_RFC
 
-STORE_IDENTITY_BEFORE_SUCCESS:
-  response:
-    type: process
-    lambda: store-identity
-  events:
-    identity-stored:
-      targetState: IPV_SUCCESS_PAGE_RFC
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
+  STORE_IDENTITY_BEFORE_SUCCESS:
+    response:
+      type: process
+      lambda: store-identity
+    events:
+      identity-stored:
+        targetState: IPV_SUCCESS_PAGE_RFC
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
-CRI_TICF_BEFORE_SUCCESS_RFC:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: STORE_IDENTITY_BEFORE_SUCCESS
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  CRI_TICF_BEFORE_SUCCESS_RFC:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-IPV_SUCCESS_PAGE_RFC:
-  response:
-    type: page
-    pageId: page-ipv-success
-    context: repeatFraudCheck
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  IPV_SUCCESS_PAGE_RFC:
+    response:
+      type: page
+      pageId: page-ipv-success
+      context: repeatFraudCheck
+    events:
+      next:
+        targetState: RETURN_TO_RP
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -1,8 +1,7 @@
 name: Reuse Existing Identity
-description:
-  START: >-
-    A user returns to GOV.UK One Login after proving
-    their identity in another user session.
+description: >-
+  A user returns to GOV.UK One Login after proving
+  their identity in another user session.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -1,97 +1,101 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-START:
-  events:
-    next:
-      targetState: IDENTITY_REUSE_PAGE
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_REUSE
-        deleteDetailsEnabled:
-          targetState: IDENTITY_REUSE_PAGE_TEST
+STATES:
+  # Entry points
 
-# Journey states
+  START:
+    events:
+      next:
+        targetState: IDENTITY_REUSE_PAGE
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_REUSE
+          deleteDetailsEnabled:
+            targetState: IDENTITY_REUSE_PAGE_TEST
 
-CRI_TICF_BEFORE_REUSE:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: IDENTITY_REUSE_PAGE
-      checkFeatureFlag:
-        deleteDetailsEnabled:
-          targetState: IDENTITY_REUSE_PAGE_TEST
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  # Journey states
 
-IDENTITY_REUSE_PAGE:
-  response:
-    type: page
-    pageId: page-ipv-reuse
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  CRI_TICF_BEFORE_REUSE:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: IDENTITY_REUSE_PAGE
+        checkFeatureFlag:
+          deleteDetailsEnabled:
+            targetState: IDENTITY_REUSE_PAGE_TEST
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-IDENTITY_REUSE_PAGE_TEST:
-  response:
-    type: page
-    pageId: page-ipv-reuse
-  events:
-    next:
-      targetState: NEW_DETAILS_PAGE
+  IDENTITY_REUSE_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-reuse
+    events:
+      next:
+        targetState: RETURN_TO_RP
 
-NEW_DETAILS_PAGE:
-  response:
-    type: page
-    pageId: pyi-new-details
-  events:
-    next:
-      targetState: CONFIRM_DELETE_DETAILS_PAGE
-    end:
-      targetState: IDENTITY_REUSE_PAGE
+  IDENTITY_REUSE_PAGE_TEST:
+    response:
+      type: page
+      pageId: page-ipv-reuse
+    events:
+      next:
+        targetState: NEW_DETAILS_PAGE
 
-CONFIRM_DELETE_DETAILS_PAGE:
-  response:
-    type: page
-    pageId: pyi-confirm-delete-details
-  events:
-    next:
-      targetState: RESET_SESSION_IDENTITY
-    end:
-      targetState: IDENTITY_REUSE_PAGE
+  NEW_DETAILS_PAGE:
+    response:
+      type: page
+      pageId: pyi-new-details
+    events:
+      next:
+        targetState: CONFIRM_DELETE_DETAILS_PAGE
+      end:
+        targetState: IDENTITY_REUSE_PAGE
 
-RESET_SESSION_IDENTITY:
-  response:
-    type: process
-    lambda: reset-session-identity
-  events:
-    next:
-      targetState: DETAILS_DELETED_PAGE
+  CONFIRM_DELETE_DETAILS_PAGE:
+    response:
+      type: page
+      pageId: pyi-confirm-delete-details
+    events:
+      next:
+        targetState: RESET_SESSION_IDENTITY
+      end:
+        targetState: IDENTITY_REUSE_PAGE
 
-DETAILS_DELETED_PAGE:
-  response:
-    type: page
-    pageId: pyi-details-deleted
-  events:
-    next:
-      targetJourney: NEW_P2_IDENTITY
-      targetState: START
+  RESET_SESSION_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+    events:
+      next:
+        targetState: DETAILS_DELETED_PAGE
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  DETAILS_DELETED_PAGE:
+    response:
+      type: page
+      pageId: pyi-details-deleted
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: START
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -1,5 +1,8 @@
 name: Reuse Existing Identity
-description: A user returns to GOV.UK One Login after proving their identity in another user session.
+description:
+  START: >-
+    A user returns to GOV.UK One Login after proving
+    their identity in another user session.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -1,7 +1,7 @@
-NAME: NAME
-DESCRIPTION: DESC
+name: Reuse Existing Identity
+description: A user returns to GOV.UK One Login after proving their identity in another user session.
 
-STATES:
+states:
   # Entry points
 
   START:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
@@ -1,6 +1,9 @@
 name: Session Timeout
 
-description: A user’s session either expired or they ended their session without proving their identity.
+description:
+  CORE_SESSION_TIMEOUT: >-
+    A user’s session either expired or they ended
+    their session without proving their identity.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
@@ -1,21 +1,25 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-CORE_SESSION_TIMEOUT:
-  events:
-    next:
-      targetState: TIMEOUT_UNRECOVERABLE_PAGE
+STATES:
+  # Entry points
 
-# Journey states
+  CORE_SESSION_TIMEOUT:
+    events:
+      next:
+        targetState: TIMEOUT_UNRECOVERABLE_PAGE
 
-TIMEOUT_UNRECOVERABLE_PAGE:
-  response:
-    type: page
-    pageId: pyi-timeout-unrecoverable
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  # Journey states
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  TIMEOUT_UNRECOVERABLE_PAGE:
+    response:
+      type: page
+      pageId: pyi-timeout-unrecoverable
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
@@ -1,7 +1,4 @@
-NAME: NAME
-DESCRIPTION: DESC
-
-STATES:
+states:
   # Entry points
 
   CORE_SESSION_TIMEOUT:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
@@ -1,9 +1,8 @@
 name: Session Timeout
 
-description:
-  CORE_SESSION_TIMEOUT: >-
-    A user’s session either expired or they ended
-    their session without proving their identity.
+description: >-
+  A user’s session either expired or they ended
+  their session without proving their identity.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
@@ -1,3 +1,7 @@
+name: Session Timeout
+
+description: A user’s session either expired or they ended their session without proving their identity.
+
 states:
   # Entry points
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -1,7 +1,4 @@
-NAME: NAME
-DESCRIPTION: DESC
-
-STATES:
+states:
   # Entry points
 
   ERROR:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -1,9 +1,8 @@
 name: Technical Error
 
-description:
-  ERROR: >-
-    A user cannot complete their identity journey
-    because of a technical error.
+description: >-
+  A user cannot complete their identity journey
+  because of a technical error.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -1,49 +1,53 @@
-# Entry points
+NAME: NAME
+DESCRIPTION: DESC
 
-ERROR:
-  events:
-    next:
-      targetState: ERROR_PAGE
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_ERROR
+STATES:
+  # Entry points
 
-ERROR_NO_TICF:
-  events:
-    next:
-      targetState: ERROR_PAGE
+  ERROR:
+    events:
+      next:
+        targetState: ERROR_PAGE
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_ERROR
 
-# Journey states
+  ERROR_NO_TICF:
+    events:
+      next:
+        targetState: ERROR_PAGE
 
-CRI_TICF_BEFORE_ERROR:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: ERROR_PAGE
-    enhanced-verification:
-      targetState: ERROR_PAGE
-    alternate-doc-invalid-dl:
-      targetState: ERROR_PAGE
-    alternate-doc-invalid-passport:
-      targetState: ERROR_PAGE
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetState: ERROR_PAGE
+  # Journey states
 
-ERROR_PAGE:
-  response:
-    type: error
-    pageId: pyi-technical
-    statusCode: 500
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  CRI_TICF_BEFORE_ERROR:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: ERROR_PAGE
+      enhanced-verification:
+        targetState: ERROR_PAGE
+      alternate-doc-invalid-dl:
+        targetState: ERROR_PAGE
+      alternate-doc-invalid-passport:
+        targetState: ERROR_PAGE
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetState: ERROR_PAGE
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  ERROR_PAGE:
+    response:
+      type: error
+      pageId: pyi-technical
+      statusCode: 500
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -1,6 +1,9 @@
 name: Technical Error
 
-description: A user cannot complete their identity journey because of a technical error.
+description:
+  ERROR: >-
+    A user cannot complete their identity journey
+    because of a technical error.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -1,3 +1,7 @@
+name: Technical Error
+
+description: A user cannot complete their identity journey because of a technical error.
+
 states:
   # Entry points
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -1,8 +1,7 @@
 name: Update Address
-description:
-  START: >-
-    The route a returning user must take to update
-    their address
+description: >-
+  The route a returning user must take to update
+  their address
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -1,5 +1,8 @@
 name: Update Address
-description: Upate address of user
+description:
+  START: >-
+    The route a returning user must take to update
+    their address
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -1,7 +1,7 @@
-NAME: UPDATE_ADDRESS
-DESCRIPTION: Upate address of user
+name: Update Address
+description: Upate address of user
 
-STATES:
+states:
   # Entry points
 
   START:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -1,120 +1,124 @@
-# Entry points
+NAME: UPDATE_ADDRESS
+DESCRIPTION: Upate address of user
 
-START:
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
+STATES:
+  # Entry points
 
-# Parent States
+  START:
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
 
-CRI_STATE:
-  events:
-    not-found:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
-    fail-with-no-ci:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    access-denied:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
-    temporarily-unavailable:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
+  # Parent States
 
-# Journey States
+  CRI_STATE:
+    events:
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
 
-ADDRESS_AND_FRAUD_UPDATE_ADDRESS:
-  nestedJourney: ADDRESS_AND_FRAUD
-  exitEvents:
-    next:
-      targetState: EVALUATE_GPG45_SCORES_UPDATE_ADDRESS
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
+  # Journey States
 
-EVALUATE_GPG45_SCORES_UPDATE_ADDRESS:
-  response:
-    type: process
-    lambda: evaluate-gpg45-scores
-  events:
-    met:
-      targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS
-      checkFeatureFlag:
-        ticfCriBeta:
-          targetState: CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS
-        sessionCredentialsTableReads:
-          targetState: STORE_IDENTITY_BEFORE_SUCCESS
-    unmet:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
-    vcs-not-correlated:
-      targetJourney: FAILED
-      targetState: FAILED_UPDATE_ADDRESS
+  ADDRESS_AND_FRAUD_UPDATE_ADDRESS:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: EVALUATE_GPG45_SCORES_UPDATE_ADDRESS
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
 
-STORE_IDENTITY_BEFORE_SUCCESS:
-  response:
-    type: process
-    lambda: store-identity
-  events:
-    identity-stored:
-      targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
+  EVALUATE_GPG45_SCORES_UPDATE_ADDRESS:
+    response:
+      type: process
+      lambda: evaluate-gpg45-scores
+    events:
+      met:
+        targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS
+          sessionCredentialsTableReads:
+            targetState: STORE_IDENTITY_BEFORE_SUCCESS
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_ADDRESS
 
-CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS:
-  response:
-    type: process
-    lambda: call-ticf-cri
-  events:
-    next:
-      targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS
-      checkFeatureFlag:
-        sessionCredentialsTableReads:
-          targetState: STORE_IDENTITY_BEFORE_SUCCESS
-    enhanced-verification:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-dl:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    alternate-doc-invalid-passport:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NO_TICF
-    error:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR_NO_TICF
+  STORE_IDENTITY_BEFORE_SUCCESS:
+    response:
+      type: process
+      lambda: store-identity
+    events:
+      identity-stored:
+        targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
-IPV_SUCCESS_PAGE_UPDATE_ADDRESS:
-  response:
-    type: page
-    pageId: page-ipv-success
-    # same page as RFC displayed so re-use this context
-    context: repeatFraudCheck
-  events:
-    next:
-      targetState: RETURN_TO_RP
+  CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS
+        checkFeatureFlag:
+          sessionCredentialsTableReads:
+            targetState: STORE_IDENTITY_BEFORE_SUCCESS
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
-RETURN_TO_RP:
-  response:
-    type: process
-    lambda: build-client-oauth-response
+  IPV_SUCCESS_PAGE_UPDATE_ADDRESS:
+    response:
+      type: page
+      pageId: page-ipv-success
+      # same page as RFC displayed so re-use this context
+      context: repeatFraudCheck
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -1,7 +1,7 @@
 name: Update Address
 description: >-
   The route a returning user must take to update
-  their address
+  their address.
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -1,107 +1,108 @@
-# This file is for simple config to easily test the state machine initializer
-PARENT_STATE:
-  events:
-    parentEvent:
-      targetState: CRI_STATE
+states:
+  # This file is for simple config to easily test the state machine initializer
+  PARENT_STATE:
+    events:
+      parentEvent:
+        targetState: CRI_STATE
 
-PAGE_STATE:
-  response:
-    type: page
-    pageId: page-id-for-some-page
-    context: test
-  parent: PARENT_STATE
-  events:
-    eventOne:
-      targetState: JOURNEY_STATE
-    eventTwo:
-      targetState: CRI_STATE
-      checkIfDisabled:
-        aCriId:
-          targetState: ERROR_STATE
+  PAGE_STATE:
+    response:
+      type: page
+      pageId: page-id-for-some-page
+      context: test
+    parent: PARENT_STATE
+    events:
+      eventOne:
+        targetState: JOURNEY_STATE
+      eventTwo:
+        targetState: CRI_STATE
+        checkIfDisabled:
+          aCriId:
+            targetState: ERROR_STATE
 
-CRI_STATE:
-  response:
-    type: cri
-    criId: aCriId
-  events:
-    enterNestedJourneyAtStateOne:
-      targetState: NESTED_JOURNEY_INVOKE_STATE
-    testWithContext:
-      targetState: CRI_STATE_WITH_CONTEXT
-    testWithScope:
-      targetState: CRI_STATE_WITH_SCOPE
-    testWithContextAndScope:
-      targetState: CRI_STATE_WITH_CONTEXT_AND_SCOPE
-    testWithMitigationStart:
-      targetState: PAGE_STATE_AT_START_OF_MITIGATION
-    testJourneyStep:
-      targetJourney: TECHNICAL_ERROR
-      targetState: ERROR
+  CRI_STATE:
+    response:
+      type: cri
+      criId: aCriId
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
+      testWithContext:
+        targetState: CRI_STATE_WITH_CONTEXT
+      testWithScope:
+        targetState: CRI_STATE_WITH_SCOPE
+      testWithContextAndScope:
+        targetState: CRI_STATE_WITH_CONTEXT_AND_SCOPE
+      testWithMitigationStart:
+        targetState: PAGE_STATE_AT_START_OF_MITIGATION
+      testJourneyStep:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
-CRI_STATE_WITH_CONTEXT:
-  response:
-    type: cri
-    criId: aCriId
-    context: test_context
-  events:
-    enterNestedJourneyAtStateOne:
-      targetState: NESTED_JOURNEY_INVOKE_STATE
+  CRI_STATE_WITH_CONTEXT:
+    response:
+      type: cri
+      criId: aCriId
+      context: test_context
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
 
-CRI_STATE_WITH_SCOPE:
-  response:
-    type: cri
-    criId: aCriId
-    scope: test_scope
-  events:
-    enterNestedJourneyAtStateOne:
-      targetState: NESTED_JOURNEY_INVOKE_STATE
+  CRI_STATE_WITH_SCOPE:
+    response:
+      type: cri
+      criId: aCriId
+      scope: test_scope
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
 
-CRI_STATE_WITH_CONTEXT_AND_SCOPE:
-  response:
-    type: cri
-    criId: aCriId
-    context: test_context
-    scope: test_scope
-  events:
-    enterNestedJourneyAtStateOne:
-      targetState: NESTED_JOURNEY_INVOKE_STATE
+  CRI_STATE_WITH_CONTEXT_AND_SCOPE:
+    response:
+      type: cri
+      criId: aCriId
+      context: test_context
+      scope: test_scope
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
 
-PAGE_STATE_AT_START_OF_MITIGATION:
-  response:
-    type: page
-    pageId: page-id-for-some-page
-    mitigationStart: a-mitigation-type
-  events:
-    enterNestedJourneyAtStateOne:
-      targetState: NESTED_JOURNEY_INVOKE_STATE
+  PAGE_STATE_AT_START_OF_MITIGATION:
+    response:
+      type: page
+      pageId: page-id-for-some-page
+      mitigationStart: a-mitigation-type
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
 
-ERROR_STATE:
-  response:
-    type: error
-    pageId: page-error
-    statusCode: 500
-  events:
-    enterNestedJourneyAtStateTwo:
-      targetState: NESTED_JOURNEY_INVOKE_STATE
+  ERROR_STATE:
+    response:
+      type: error
+      pageId: page-error
+      statusCode: 500
+    events:
+      enterNestedJourneyAtStateTwo:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
 
-PROCESS_STATE:
-  response:
-    type: process
-    lambda: a-lambda-to-invoke
-    lambdaInput:
-      input1: the-first-input
-      input2: 2
-      input3: true
-  events:
-    met:
-      targetState: CRI_STATE
-    unmet:
-      targetState: ERROR_STATE
+  PROCESS_STATE:
+    response:
+      type: process
+      lambda: a-lambda-to-invoke
+      lambdaInput:
+        input1: the-first-input
+        input2: 2
+        input3: true
+    events:
+      met:
+        targetState: CRI_STATE
+      unmet:
+        targetState: ERROR_STATE
 
-NESTED_JOURNEY_INVOKE_STATE:
-  nestedJourney: NESTED_JOURNEY_DEFINITION
-  exitEvents:
-    exitEventFromNestedStateTwo:
-      targetState: JOURNEY_STATE
-    exitEventFromDoublyNestedInvokeState:
-      targetState: ERROR_STATE
+  NESTED_JOURNEY_INVOKE_STATE:
+    nestedJourney: NESTED_JOURNEY_DEFINITION
+    exitEvents:
+      exitEventFromNestedStateTwo:
+        targetState: JOURNEY_STATE
+      exitEventFromDoublyNestedInvokeState:
+        targetState: ERROR_STATE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/journey-map-with-duplicate-keys.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/journey-map-with-duplicate-keys.yaml
@@ -1,9 +1,10 @@
-DUPLICATE_PAGE:
-  response:
-    type: page
-    pageId: duplicate-page
+states:
+  DUPLICATE_PAGE:
+    response:
+      type: page
+      pageId: duplicate-page
 
-DUPLICATE_PAGE:
-  response:
-    type: page
-    pageId: this-seems-familiar
+  DUPLICATE_PAGE:
+    response:
+      type: page
+      pageId: this-seems-familiar

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/technical-error.yaml
@@ -1,9 +1,10 @@
-ERROR:
-  events:
-    next:
-      targetState: TECHNICAL_ERROR_PAGE
+states:
+  ERROR:
+    events:
+      next:
+        targetState: TECHNICAL_ERROR_PAGE
 
-TECHNICAL_ERROR_PAGE:
-  response:
-    type: page
-    pageId: technical-error-page
+  TECHNICAL_ERROR_PAGE:
+    response:
+      type: page
+      pageId: technical-error-page

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -1,6 +1,6 @@
 package uk.gov.di.ipv.core.processjourneyevent.statemachine;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -51,10 +51,10 @@ class StateMachineInitializerTest {
         var stateMachineInitializer =
                 new StateMachineInitializer(journeyTypeMock, StateMachineInitializerMode.TEST);
 
-        var jsonParseException =
-                assertThrows(JsonParseException.class, stateMachineInitializer::initialize);
+        var jsonMappingException =
+                assertThrows(JsonMappingException.class, stateMachineInitializer::initialize);
 
-        assertTrue(jsonParseException.getMessage().contains("Duplicate field 'DUPLICATE_PAGE'"));
+        assertTrue(jsonMappingException.getMessage().contains("Duplicate field 'DUPLICATE_PAGE'"));
     }
 
     @java.lang.SuppressWarnings("java:S5961") // Too many assertions


### PR DESCRIPTION
## Proposed changes

Adds a name and description to the journey config and puts the states in a 'states' fields

### What changed

Changes to the journey map configurations, the journey map UI (to parse and display the name/desc) and the lambda StateMachineInitializer that loads the configuration from the yaml files. 

Added a new java record to wrap the states in a journey and changes the the initialiser to read this

<img width="1911" alt="Screenshot 2024-05-07 at 09 02 38" src="https://github.com/govuk-one-login/ipv-core-back/assets/7995998/edebd38a-a404-4801-9bb0-1436493402b2">


### Why did it change

In order to keep descriptions and journey map configurations in one place rather than here and on the team manual

- [PYIC-5799](https://govukverify.atlassian.net/browse/PYIC-5799)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-5799]: https://govukverify.atlassian.net/browse/PYIC-5799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ