### PR TITLE
BAU: Fix journey map checkboxes

### DIFF
--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -22,7 +22,7 @@ export const getOptions = (journeyMaps) => {
     const featureFlagOptions = [];
 
     Object.values(journeyMaps).forEach((journeyMap) => {
-        Object.values(journeyMap).forEach((definition) => {
+        Object.values(journeyMap.states).forEach((definition) => {
             const events = definition.events || definition.exitEvents || {};
             Object.values(events).forEach((def) => {
                 addDefinitionOptions(def, disabledOptions, featureFlagOptions);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix journey map checkboxes

### Why did it change

The structure of the journey maps has changed recently - the states are now defined under a `states` key. The logic to generate the options for the checkboxes needed updating to look for the states there.
