### PR TITLE
PYIC-5809: add page-update-name step to update name

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -150,7 +150,8 @@ states:
       context: coi
     events:
       end:
-        targetState: UPDATE_DETAILS_PAGE
+        targetJourney: REUSE_EXISTING_IDENTITY
+        targetState: START
 
   RETURN_TO_RP:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -99,7 +99,7 @@ states:
     response:
       type: page
       pageId: page-dcmaw-success
-      context: coi-no-address
+      context: coiNoAddress
     events:
       next:
         targetState: FRAUD_CHECK_UPDATE_NAME
@@ -166,7 +166,7 @@ states:
     response:
       type: page
       pageId: page-dcmaw-success
-      context: coi-address
+      context: coiAddress
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_UPDATE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -10,12 +10,12 @@ states:
   UPDATE_NAME_WITH_ADDRESS_START:
     events:
       next:
-        targetState: RESET_IDENTITY_WITH_ADDRESS
+        targetState: UPDATE_NAME_PAGE_WITH_ADDRESS
 
   UPDATE_NAME_WITHOUT_ADDRESS_START:
     events:
       next:
-        targetState: RESET_IDENTITY_WITHOUT_ADDRESS
+        targetState: UPDATE_NAME_PAGE_WITHOUT_ADDRESS
 
   # Parent States
 
@@ -51,7 +51,20 @@ states:
 
   # Journey States
 
-  # WITHOUT ADDRESS
+   # WITHOUT ADDRESS
+
+  UPDATE_NAME_PAGE_WITHOUT_ADDRESS:
+    response:
+      type: page
+      pageId: page-update-name
+    events:
+      update-name:
+        targetState: RESET_IDENTITY_WITHOUT_ADDRESS
+      end:
+        targetState: RETURN_TO_RP
+      page-ipv-reuse:
+        targetJourney: REUSE_EXISTING_IDENTITY
+        targetState: START
 
   RESET_IDENTITY_WITHOUT_ADDRESS:
     response:
@@ -106,6 +119,19 @@ states:
         targetState: FAILED_COI
 
   # WITH ADDRESS
+
+  UPDATE_NAME_PAGE_WITH_ADDRESS:
+    response:
+      type: page
+      pageId: page-update-name
+    events:
+      update-name:
+        targetState: RESET_IDENTITY_WITH_ADDRESS
+      end:
+        targetState: RETURN_TO_RP
+      page-ipv-reuse:
+        targetJourney: REUSE_EXISTING_IDENTITY
+        targetState: START
 
   RESET_IDENTITY_WITH_ADDRESS:
     response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The update name subjourney is missing a step that takes it to the page-update-name before going through the steps to initiate a name change. This page gives the user an opportunity to cancel/go back

The context sent to the dcmaw-success page also need changing to reflect what the front end is expecting - this was preventing the contact us details being shown for this journey

I've also updated the UPDATE_NAME_DOB_PAGE state action for cancelling  in the reuse-identity journey to go be consistent with the update-name subjourney and go back  to the reuse-identity start when selecting 'go back and check your details'


### Issue tracking
- https://govukverify.atlassian.net/browse/PYIC-5809

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
