### PR TITLE
BAU: Check ipvSessionId is not empty string

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -51,7 +51,7 @@ import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_REDIRECT
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getClientOAuthSessionId;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionIdAllowNull;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionIdAllowBlank;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 
 public class BuildClientOauthResponseHandler
@@ -93,7 +93,7 @@ public class BuildClientOauthResponseHandler
         LogHelper.attachComponentId(configService);
 
         try {
-            String ipvSessionId = getIpvSessionIdAllowNull(input);
+            String ipvSessionId = getIpvSessionIdAllowBlank(input);
             String ipAddress = getIpAddress(input);
             String clientSessionId = getClientOAuthSessionId(input);
             List<String> featureSet = getFeatureSet(input);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -34,7 +34,7 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getHeaderByKey;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionIdAllowNull;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionIdAllowBlank;
 
 class RequestHelperTest {
     private final String TEST_IPV_SESSION_ID = "a-session-id";
@@ -76,7 +76,7 @@ class RequestHelperTest {
     }
 
     @Test
-    void getIpvSessionIdShouldReturnSessionIdFromJourney()
+    void getIpvSessionIdShouldReturnSessionIdFromJourneyEvent()
             throws HttpResponseExceptionWithErrorBody {
         var event =
                 JourneyRequest.builder()
@@ -91,7 +91,49 @@ class RequestHelperTest {
     }
 
     @Test
-    void getIpvSessionIdShouldThrowIfSessionIdIsNull() {
+    void getIpvSessionIdShouldThrowIfSessionIdIsNullInJourneyEvent() {
+        var event =
+                JourneyRequest.builder()
+                        .ipvSessionId(null)
+                        .ipAddress(TEST_IP_ADDRESS)
+                        .clientOAuthSessionId(TEST_CLIENT_SESSION_ID)
+                        .journey(TEST_JOURNEY)
+                        .featureSet(TEST_FEATURE_SET)
+                        .build();
+
+        var exception =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class, () -> getIpvSessionId(event));
+
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                exception.getErrorResponse().getMessage());
+    }
+
+    @Test
+    void getIpvSessionIdShouldThrowIfSessionIdIsEmptyStringInJourneyEvent() {
+        var event =
+                JourneyRequest.builder()
+                        .ipvSessionId("")
+                        .ipAddress(TEST_IP_ADDRESS)
+                        .clientOAuthSessionId(TEST_CLIENT_SESSION_ID)
+                        .journey(TEST_JOURNEY)
+                        .featureSet(TEST_FEATURE_SET)
+                        .build();
+
+        var exception =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class, () -> getIpvSessionId(event));
+
+        assertEquals(SC_BAD_REQUEST, exception.getResponseCode());
+        assertEquals(
+                ErrorResponse.MISSING_IPV_SESSION_ID.getMessage(),
+                exception.getErrorResponse().getMessage());
+    }
+
+    @Test
+    void getIpvSessionIdShouldThrowIfSessionIdIsNullInEvent() {
         var event = new APIGatewayProxyRequestEvent();
         HashMap<String, String> headers = new HashMap<>();
         headers.put(IPV_SESSION_ID_HEADER, null);
@@ -109,7 +151,7 @@ class RequestHelperTest {
     }
 
     @Test
-    void getIpvSessionIdShouldThrowIfSessionIdIsEmptyString() {
+    void getIpvSessionIdShouldThrowIfSessionIdIsEmptyStringInEvent() {
         var event = new APIGatewayProxyRequestEvent();
 
         event.setHeaders(Map.of(IPV_SESSION_ID_HEADER, ""));
@@ -226,7 +268,7 @@ class RequestHelperTest {
                         .featureSet(featureSet)
                         .build();
 
-        assertNull(getIpvSessionIdAllowNull(event));
+        assertNull(getIpvSessionIdAllowBlank(event));
     }
 
     @Test


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Check ipvSessionId is not empty string

### Why did it change

We were already throwing if an ipvSessionId in a JourneyRequest was null, but not if blank.

Recent changes to the velocity template in the API gateway mean that if core-front fails to set the session ID, as recently happened, it will appear in core-back as an empty string.
