### PR TITLE
PYIC-5809: go back to update details page instead of reuse page when selecting back

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -18,6 +18,11 @@ states:
           coiEnabled:
             targetState: IDENTITY_REUSE_PAGE_COI
 
+  UPDATE_DETAILS_START:
+    events:
+      next:
+        targetState: UPDATE_DETAILS_PAGE
+
   # Journey states
 
   CRI_TICF_BEFORE_REUSE:
@@ -150,8 +155,7 @@ states:
       context: coi
     events:
       end:
-        targetJourney: REUSE_EXISTING_IDENTITY
-        targetState: START
+        targetState: UPDATE_DETAILS_PAGE
 
   RETURN_TO_RP:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -62,9 +62,9 @@ states:
         targetState: RESET_IDENTITY_WITHOUT_ADDRESS
       end:
         targetState: RETURN_TO_RP
-      page-ipv-reuse:
+      back:
         targetJourney: REUSE_EXISTING_IDENTITY
-        targetState: START
+        targetState: UPDATE_DETAILS_START
 
   RESET_IDENTITY_WITHOUT_ADDRESS:
     response:
@@ -129,9 +129,9 @@ states:
         targetState: RESET_IDENTITY_WITH_ADDRESS
       end:
         targetState: RETURN_TO_RP
-      page-ipv-reuse:
+      back:
         targetJourney: REUSE_EXISTING_IDENTITY
-        targetState: START
+        targetState: UPDATE_DETAILS_START
 
   RESET_IDENTITY_WITH_ADDRESS:
     response:


### PR DESCRIPTION
## Proposed changes

### What changed

Changes to the journey routing in reuse-existing-identity and update-name

### Why did it change

The user should get taken back to the update-details page rather than the ipv-reuse page when selecting back from the update name or update name dob pages

### Issue tracking

https://govukverify.atlassian.net/browse/PYIC-5809

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

