### PR TITLE
PYIC-5169: add evcs read/write flags to BE

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -6,7 +6,9 @@ public enum CoreFeatureFlag implements FeatureFlag {
     INHERITED_IDENTITY("inheritedIdentity"),
     REPROVE_IDENTITY_ENABLED("reproveIdentityEnabled"),
     REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
-    TICF_CRI_BETA("ticfCriBeta");
+    TICF_CRI_BETA("ticfCriBeta"),
+    EVCS_WRITE_ENABLED("evcsWriteEnabled"),
+    EVCS_READ_ENABLED("evcsReadEnabled");
 
     private final String name;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Adds `evcsReadEnabled` and `evcsWriteEnabled` flags to `CoreFeatureFlag` enum

### Why did it change
Allows for toggle flags to be used in the BE to control use of EVCS.
Related config change [here](https://github.com/govuk-one-login/ipv-core-common-infra/pull/932).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5169](https://govukverify.atlassian.net/browse/PYIC-5169)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

[PYIC-5169]: https://govukverify.atlassian.net/browse/PYIC-5169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ