### PR TITLE
PYIC-5284/5437: Update identity check request for Nino 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1879,9 +1879,5 @@
       }
     ]
   },
-<<<<<<< HEAD
   "generated_at": "2024-05-09T09:06:08Z"
-=======
-  "generated_at": "2024-03-14T11:48:01Z"
->>>>>>> 23fdc0516 (PYIC-5284: Update identity check request for Nino)
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1879,5 +1879,9 @@
       }
     ]
   },
+<<<<<<< HEAD
   "generated_at": "2024-05-09T09:06:08Z"
+=======
+  "generated_at": "2024-03-14T11:48:01Z"
+>>>>>>> 23fdc0516 (PYIC-5284: Update identity check request for Nino)
 }

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -367,7 +367,7 @@ public class BuildCriOauthRequestHandler
             return null;
         }
 
-        return new EvidenceRequest(null, minViableStrengthOpt.getAsInt());
+        return new EvidenceRequest("gpg45", minViableStrengthOpt.getAsInt());
     }
 
     @Tracing

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -69,6 +69,7 @@ import static uk.gov.di.ipv.core.library.domain.CriConstants.ADDRESS_CRI;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.F2F_CRI;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_CONSTRUCT_REDIRECT_URI;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_DETERMINE_CREDENTIAL_TYPE;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_EVIDENCE_REQUESTED;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
@@ -162,7 +163,7 @@ public class BuildCriOauthRequestHandler
 
             String criContext = getJourneyParameter(input, CONTEXT);
             EvidenceRequest criEvidenceRequest =
-                    EvidenceRequest.fromBase64(getJourneyParameter(journeyUri, EVIDENCE_REQUESTED));
+                    EvidenceRequest.fromBase64(getJourneyParameter(input, EVIDENCE_REQUESTED));
             String connection = configService.getActiveConnection(criId);
             OauthCriConfig criConfig =
                     configService.getOauthCriConfigForConnection(connection, criId);
@@ -258,10 +259,9 @@ public class BuildCriOauthRequestHandler
                     SC_INTERNAL_SERVER_ERROR,
                     FAILED_TO_DETERMINE_CREDENTIAL_TYPE);
         } catch (JsonProcessingException e) {
-          return buildJourneyErrorResponse(
-                    "Failed to parse evidenceRequest.", 
+            return buildJourneyErrorResponse(
+                    "Failed to parse evidenceRequest.",
                     e,
-                    JOURNEY_ERROR_PATH,
                     SC_INTERNAL_SERVER_ERROR,
                     FAILED_TO_PARSE_EVIDENCE_REQUESTED);
         }

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -42,10 +42,10 @@ public class AuthorizationRequestHelper {
     private static final String SHARED_CLAIMS = "shared_claims";
     private static final String EVIDENCE_REQUESTED = "evidence_requested";
     private static final String CONTEXT = "context";
-    private static final String SCOPE = "scope";
 
     private AuthorizationRequestHelper() {}
 
+    @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public static SignedJWT createSignedJWT(
             SharedClaimsResponse sharedClaims,
             JWSSigner signer,
@@ -54,9 +54,8 @@ public class AuthorizationRequestHelper {
             String oauthState,
             String userId,
             String govukSigninJourneyId,
-            EvidenceRequest evidence,
-            String context,
-            String scope)
+            EvidenceRequest evidenceRequest,
+            String context)
             throws HttpResponseExceptionWithErrorBody {
         Instant now = Instant.now();
 
@@ -108,16 +107,12 @@ public class AuthorizationRequestHelper {
             }
         }
 
-        if (Objects.nonNull(evidence)) {
-            claimsSetBuilder.claim(EVIDENCE_REQUESTED, evidence);
+        if (Objects.nonNull(evidenceRequest)) {
+            claimsSetBuilder.claim(EVIDENCE_REQUESTED, evidenceRequest);
         }
 
         if (Objects.nonNull(context)) {
             claimsSetBuilder.claim(CONTEXT, context);
-        }
-
-        if (Objects.nonNull(scope)) {
-            claimsSetBuilder.claim(SCOPE, scope);
         }
 
         SignedJWT signedJWT = new SignedJWT(header, claimsSetBuilder.build());

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -1456,9 +1456,9 @@ class BuildCriOauthRequestHandlerTest {
         JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
 
         for (var entry : expectedClaims.entrySet()) {
-            String expectedClaim = objectMapper.writeValueAsString(entry.getValue());
+            String expectedClaim = OBJECT_MAPPER.writeValueAsString(entry.getValue());
             String actualClaim =
-                    objectMapper.writeValueAsString(claimsSet.getClaim(entry.getKey()));
+                    OBJECT_MAPPER.writeValueAsString(claimsSet.getClaim(entry.getKey()));
             assertEquals(
                     expectedClaim,
                     actualClaim,

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -11,10 +11,12 @@ import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.RSADecrypter;
 import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +33,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.EvidenceRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
@@ -110,7 +113,6 @@ class BuildCriOauthRequestHandlerTest {
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
     private static final String TEST_SHARED_CLAIMS = "shared_claims";
-    private static final String TEST_EVIDENCE_REQUESTED = "evidence_requested";
     private static final String JOURNEY_BASE_URL = "/journey/cri/build-oauth-request/%s";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String TEST_NI_NUMBER = "AA000003D";
@@ -118,14 +120,11 @@ class BuildCriOauthRequestHandlerTest {
     private static final String TEST_CONTEXT = "test_context";
     private static final String CRI_WITH_CONTEXT =
             String.format("%s?%s=%s", CLAIMED_IDENTITY_CRI, CONTEXT, TEST_CONTEXT);
-    private static final String SCOPE = "scope";
-    private static final String TEST_SCOPE = "test_scope";
-    private static final String CRI_WITH_SCOPE =
-            String.format("%s?%s=%s", CLAIMED_IDENTITY_CRI, SCOPE, TEST_SCOPE);
-    private static final String CRI_WITH_CONTEXT_AND_SCOPE =
-            String.format(
-                    "%s?%s=%s&%s=%s",
-                    CLAIMED_IDENTITY_CRI, CONTEXT, TEST_CONTEXT, SCOPE, TEST_SCOPE);
+    private static final String EVIDENCE_REQUEST = "evidenceRequest";
+    private static final String EVIDENCE_REQUESTED = "evidence_requested";
+    private static final EvidenceRequest TEST_EVIDENCE_REQUESTED = new EvidenceRequest("gpg45", 2);
+    private static String CRI_WITH_EVIDENCE_REQUEST;
+    private static String CRI_WITH_CONTEXT_AND_EVIDENCE_REQUEST;
 
     private static final String TEST_CLIENT_OAUTH_SESSION_ID =
             SecureTokenHelper.getInstance().generate();
@@ -152,6 +151,22 @@ class BuildCriOauthRequestHandlerTest {
     private OauthCriConfig hmrcKbvOauthCriConfig;
     private ClientOAuthSessionItem clientOAuthSessionItem;
     private final IpvSessionItem ipvSessionItem = new IpvSessionItem();
+
+    @BeforeAll
+    static void setUpAll() throws JsonProcessingException {
+        CRI_WITH_EVIDENCE_REQUEST =
+                String.format(
+                        "%s?%s=%s",
+                        CLAIMED_IDENTITY_CRI, EVIDENCE_REQUEST, TEST_EVIDENCE_REQUESTED.toBase64());
+        CRI_WITH_CONTEXT_AND_EVIDENCE_REQUEST =
+                String.format(
+                        "%s?%s=%s&%s=%s",
+                        CLAIMED_IDENTITY_CRI,
+                        CONTEXT,
+                        TEST_CONTEXT,
+                        EVIDENCE_REQUEST,
+                        TEST_EVIDENCE_REQUESTED.toBase64());
+    }
 
     @BeforeEach
     void setUp() throws URISyntaxException {
@@ -1218,7 +1233,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(1, sharedClaims.get("address").size());
         assertFalse(sharedClaims.has("emailAddress"));
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
-        JsonNode evidenceRequested = claimsSet.get(TEST_EVIDENCE_REQUESTED);
+        JsonNode evidenceRequested = claimsSet.get(EVIDENCE_REQUESTED);
         assertNull(evidenceRequested);
     }
 
@@ -1292,7 +1307,7 @@ class BuildCriOauthRequestHandlerTest {
         assertEquals(2, sharedClaims.get("birthDate").size());
         assertEquals(1, sharedClaims.get("address").size());
         assertEquals(TEST_EMAIL_ADDRESS, sharedClaims.get("emailAddress").asText());
-        JsonNode evidenceRequested = claimsSet.get(TEST_EVIDENCE_REQUESTED);
+        JsonNode evidenceRequested = claimsSet.get(EVIDENCE_REQUESTED);
         assertEquals(3, evidenceRequested.get("strengthScore").asInt());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
     }
@@ -1401,7 +1416,7 @@ class BuildCriOauthRequestHandlerTest {
     @ParameterizedTest
     @MethodSource("journeyUriParameters")
     void shouldIncludeGivenParametersIntoCriResponseIfInJourneyUri(
-            String journeyUri, Map<String, String> expectedClaims) throws Exception {
+            String journeyUri, Map<String, Object> expectedClaims) throws Exception {
         // Arrange
         when(configService.getActiveConnection(CLAIMED_IDENTITY_CRI)).thenReturn(MAIN_CONNECTION);
         when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CLAIMED_IDENTITY_CRI))
@@ -1438,28 +1453,35 @@ class BuildCriOauthRequestHandlerTest {
         jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
 
         SignedJWT signedJWT = SignedJWT.parse(jweObject.getPayload().toString());
-        JsonNode claimsSet = OBJECT_MAPPER.readTree(signedJWT.getJWTClaimsSet().toString());
+        JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
 
-        for (Map.Entry<String, String> entry : expectedClaims.entrySet()) {
+        for (var entry : expectedClaims.entrySet()) {
+            String expectedClaim = objectMapper.writeValueAsString(entry.getValue());
+            String actualClaim =
+                    objectMapper.writeValueAsString(claimsSet.getClaim(entry.getKey()));
             assertEquals(
-                    entry.getValue(),
-                    claimsSet.get(entry.getKey()).asText(),
+                    expectedClaim,
+                    actualClaim,
                     () ->
                             String.format(
                                     "Expected claim for key=%s to be %s, but found %s",
-                                    entry.getKey(),
-                                    entry.getValue(),
-                                    claimsSet.get(entry.getKey()).asText()));
+                                    entry.getKey(), expectedClaim, actualClaim));
         }
     }
 
     private static Stream<Arguments> journeyUriParameters() {
         return Stream.of(
                 Arguments.of(CRI_WITH_CONTEXT, Map.of(CONTEXT, TEST_CONTEXT)),
-                Arguments.of(CRI_WITH_SCOPE, Map.of(SCOPE, TEST_SCOPE)),
                 Arguments.of(
-                        CRI_WITH_CONTEXT_AND_SCOPE,
-                        Map.of(CONTEXT, TEST_CONTEXT, SCOPE, TEST_SCOPE)));
+                        CRI_WITH_EVIDENCE_REQUEST,
+                        Map.of(EVIDENCE_REQUESTED, TEST_EVIDENCE_REQUESTED)),
+                Arguments.of(
+                        CRI_WITH_CONTEXT_AND_EVIDENCE_REQUEST,
+                        Map.of(
+                                CONTEXT,
+                                TEST_CONTEXT,
+                                EVIDENCE_REQUESTED,
+                                TEST_EVIDENCE_REQUESTED)));
     }
 
     private void assertErrorResponse(

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.EvidenceRequest;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.StepResponseException;
 
 import java.net.URI;
@@ -29,7 +32,7 @@ public class CriStepResponse implements StepResponse {
     public static final String CRI_JOURNEY_TEMPLATE = "/journey/cri/build-oauth-request/%s";
     private String criId;
     private String context;
-    private String scope;
+    private EvidenceRequest evidenceRequest;
     private String mitigationStart;
 
     public Map<String, Object> value() {
@@ -38,8 +41,8 @@ public class CriStepResponse implements StepResponse {
             if (Objects.nonNull(context)) {
                 uriBuilder.addParameter("context", context);
             }
-            if (Objects.nonNull(scope)) {
-                uriBuilder.addParameter("scope", scope);
+            if (Objects.nonNull(evidenceRequest)) {
+                uriBuilder.addParameter("evidenceRequest", evidenceRequest.toBase64());
             }
             URI journeyUri = uriBuilder.build();
 
@@ -50,7 +53,10 @@ public class CriStepResponse implements StepResponse {
                             .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), e.getMessage())
                             .with(LOG_CRI_ID.getFieldName(), criId)
                             .with(LOG_CONTEXT.getFieldName(), context)
-                            .with(LOG_SCOPE.getFieldName(), scope));
+                            .with(LOG_SCOPE.getFieldName(), evidenceRequest));
+            throw new StepResponseException(e);
+        } catch (JsonProcessingException e) {
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to serialise evidenceRequest", e));
             throw new StepResponseException(e);
         }
     }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -591,23 +591,6 @@ states:
       enhanced-verification:
         targetState: CHECK_FRAUD_SCORE_J3
 
-CRI_NINO_WITH_SCOPE_M2B:
-  response:
-    type: cri
-    criId: nino
-    evidenceRequest:
-      scoringPolicy: gpg45
-      strengthScore: 2
-  parent: CRI_STATE
-  events:
-    next:
-      targetState: ADDRESS_AND_FRAUD_M2B
-    access-denied:
-      targetState: PYI_ESCAPE_ABANDON_M2B
-    fail-with-ci:
-      targetJourney: FAILED
-      targetState: FAILED_NINO
-
   CHECK_FRAUD_SCORE_J3:
     response:
       type: process
@@ -726,7 +709,9 @@ CRI_NINO_WITH_SCOPE_M2B:
     response:
       type: cri
       criId: nino
-      scope: identityCheck
+      evidenceRequest:
+        scoringPolicy: gpg45
+        strengthScore: 2
     parent: CRI_STATE
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -591,6 +591,23 @@ states:
       enhanced-verification:
         targetState: CHECK_FRAUD_SCORE_J3
 
+CRI_NINO_WITH_SCOPE_M2B:
+  response:
+    type: cri
+    criId: nino
+    evidenceRequest:
+      scoringPolicy: gpg45
+      strengthScore: 2
+  parent: CRI_STATE
+  events:
+    next:
+      targetState: ADDRESS_AND_FRAUD_M2B
+    access-denied:
+      targetState: PYI_ESCAPE_ABANDON_M2B
+    fail-with-ci:
+      targetJourney: FAILED
+      targetState: FAILED_NINO
+
   CHECK_FRAUD_SCORE_J3:
     response:
       type: process

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -48,28 +48,28 @@ states:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE
 
-CRI_STATE_WITH_EVIDENCE_REQUEST:
-  response:
-    type: cri
-    criId: aCriId
-    evidenceRequest:
-      scoringPolicy: gpg45
-      strengthScore: 2
-  events:
-    enterNestedJourneyAtStateOne:
-      targetState: NESTED_JOURNEY_INVOKE_STATE
+  CRI_STATE_WITH_EVIDENCE_REQUEST:
+    response:
+      type: cri
+      criId: aCriId
+      evidenceRequest:
+        scoringPolicy: gpg45
+        strengthScore: 2
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
 
-CRI_STATE_WITH_CONTEXT_AND_EVIDENCE_REQUEST:
-  response:
-    type: cri
-    criId: aCriId
-    context: test_context
-    evidenceRequest:
-      scoringPolicy: gpg45
-      strengthScore: 2
-  events:
-    enterNestedJourneyAtStateOne:
-      targetState: NESTED_JOURNEY_INVOKE_STATE
+  CRI_STATE_WITH_CONTEXT_AND_EVIDENCE_REQUEST:
+    response:
+      type: cri
+      criId: aCriId
+      context: test_context
+      evidenceRequest:
+        scoringPolicy: gpg45
+        strengthScore: 2
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
 
   PAGE_STATE_AT_START_OF_MITIGATION:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -29,10 +29,10 @@ states:
         targetState: NESTED_JOURNEY_INVOKE_STATE
       testWithContext:
         targetState: CRI_STATE_WITH_CONTEXT
-      testWithScope:
-        targetState: CRI_STATE_WITH_SCOPE
-      testWithContextAndScope:
-        targetState: CRI_STATE_WITH_CONTEXT_AND_SCOPE
+      testWithEvidenceRequest:
+        targetState: CRI_STATE_WITH_EVIDENCE_REQUEST
+      testWithContextAndEvidenceRequest:
+        targetState: CRI_STATE_WITH_CONTEXT_AND_EVIDENCE_REQUEST
       testWithMitigationStart:
         targetState: PAGE_STATE_AT_START_OF_MITIGATION
       testJourneyStep:
@@ -48,24 +48,28 @@ states:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE
 
-  CRI_STATE_WITH_SCOPE:
-    response:
-      type: cri
-      criId: aCriId
-      scope: test_scope
-    events:
-      enterNestedJourneyAtStateOne:
-        targetState: NESTED_JOURNEY_INVOKE_STATE
+CRI_STATE_WITH_EVIDENCE_REQUEST:
+  response:
+    type: cri
+    criId: aCriId
+    evidenceRequest:
+      scoringPolicy: gpg45
+      strengthScore: 2
+  events:
+    enterNestedJourneyAtStateOne:
+      targetState: NESTED_JOURNEY_INVOKE_STATE
 
-  CRI_STATE_WITH_CONTEXT_AND_SCOPE:
-    response:
-      type: cri
-      criId: aCriId
-      context: test_context
-      scope: test_scope
-    events:
-      enterNestedJourneyAtStateOne:
-        targetState: NESTED_JOURNEY_INVOKE_STATE
+CRI_STATE_WITH_CONTEXT_AND_EVIDENCE_REQUEST:
+  response:
+    type: cri
+    criId: aCriId
+    context: test_context
+    evidenceRequest:
+      scoringPolicy: gpg45
+      strengthScore: 2
+  events:
+    enterNestedJourneyAtStateOne:
+      targetState: NESTED_JOURNEY_INVOKE_STATE
 
   PAGE_STATE_AT_START_OF_MITIGATION:
     response:

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -424,10 +424,10 @@ class ProcessJourneyEventHandlerTest {
                         "/journey/cri/build-oauth-request/aCriId?context=test_context"),
                 Arguments.of(
                         "testWithScope",
-                        "/journey/cri/build-oauth-request/aCriId?scope=test_scope"),
+                        "/journey/cri/build-oauth-request/aCriId?evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D"),
                 Arguments.of(
                         "testWithContextAndScope",
-                        "/journey/cri/build-oauth-request/aCriId?context=test_context&scope=test_scope"));
+                        "/journey/cri/build-oauth-request/aCriId?context=test_context&evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D"));
     }
 
     @Test

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -423,10 +423,10 @@ class ProcessJourneyEventHandlerTest {
                         "testWithContext",
                         "/journey/cri/build-oauth-request/aCriId?context=test_context"),
                 Arguments.of(
-                        "testWithScope",
+                        "testWithEvidenceRequest",
                         "/journey/cri/build-oauth-request/aCriId?evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D"),
                 Arguments.of(
-                        "testWithContextAndScope",
+                        "testWithContextAndEvidenceRequest",
                         "/journey/cri/build-oauth-request/aCriId?context=test_context&evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D"));
     }
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -35,12 +35,9 @@ class StateMachineInitializerTest {
     void initializeShouldThrowIfJourneyMapNotFound() {
         StateMachineInitializerMode modeMock = mock(StateMachineInitializerMode.class);
         when(modeMock.getPathPart()).thenReturn("some-rubbish");
-        assertThrows(
-                JourneyMapDeserializationException.class,
-                () -> {
-                    new StateMachineInitializer(IpvJourneyTypes.INITIAL_JOURNEY_SELECTION, modeMock)
-                            .initialize();
-                });
+        StateMachineInitializer initializer =
+                new StateMachineInitializer(IpvJourneyTypes.INITIAL_JOURNEY_SELECTION, modeMock);
+        assertThrows(JourneyMapDeserializationException.class, initializer::initialize);
     }
 
     @Test
@@ -71,9 +68,10 @@ class StateMachineInitializerTest {
         BasicState journeyState = (BasicState) journeyMap.get("JOURNEY_STATE");
         BasicState criState = (BasicState) journeyMap.get("CRI_STATE");
         BasicState criWithContextState = (BasicState) journeyMap.get("CRI_STATE_WITH_CONTEXT");
-        BasicState criWithScopeState = (BasicState) journeyMap.get("CRI_STATE_WITH_SCOPE");
-        BasicState criWithContextAndScopeState =
-                (BasicState) journeyMap.get("CRI_STATE_WITH_CONTEXT_AND_SCOPE");
+        BasicState criWithEvidenceRequest =
+                (BasicState) journeyMap.get("CRI_STATE_WITH_EVIDENCE_REQUEST");
+        BasicState criWithContextAndEvidenceRequest =
+                (BasicState) journeyMap.get("CRI_STATE_WITH_CONTEXT_AND_EVIDENCE_REQUEST");
         BasicState errorState = (BasicState) journeyMap.get("ERROR_STATE");
         BasicState processState = (BasicState) journeyMap.get("PROCESS_STATE");
         NestedJourneyInvokeState nestedJourneyInvokeState =
@@ -111,13 +109,13 @@ class StateMachineInitializerTest {
 
         // cri state with scope assertion
         assertEquals(
-                "/journey/cri/build-oauth-request/aCriId?scope=test_scope",
-                criWithScopeState.getResponse().value().get("journey"));
+                "/journey/cri/build-oauth-request/aCriId?evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D",
+                criWithEvidenceRequest.getResponse().value().get("journey"));
 
         // cri state with context and scope assertion
         assertEquals(
-                "/journey/cri/build-oauth-request/aCriId?context=test_context&scope=test_scope",
-                criWithContextAndScopeState.getResponse().value().get("journey"));
+                "/journey/cri/build-oauth-request/aCriId?context=test_context&evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D",
+                criWithContextAndEvidenceRequest.getResponse().value().get("journey"));
 
         // error state assertions
         assertEquals(

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -3,26 +3,27 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.ipv.core.library.domain.EvidenceRequest;
 
 import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CriStepResponseTest {
+class CriStepResponseTest {
 
     @ParameterizedTest
     @MethodSource("journeyUriParameters")
     void valueReturnsExpectedJourneyResponse(
-            String criId, String context, String scope, String expectedJourney) {
-        CriStepResponse response = new CriStepResponse(criId, context, scope, null);
+            String criId, String context, EvidenceRequest evidenceRequest, String expectedJourney) {
+        CriStepResponse response = new CriStepResponse(criId, context, evidenceRequest, null);
         assertEquals(
                 Map.of("journey", expectedJourney),
                 response.value(),
                 () ->
                         String.format(
-                                "Expected journey for criId=%s, context=%s, scope=%s was not as expected",
-                                criId, context, scope));
+                                "Expected journey for criId=%s, context=%s, evidenceRequest=%s was not as expected",
+                                criId, context, evidenceRequest));
     }
 
     private static Stream<Arguments> journeyUriParameters() {
@@ -36,12 +37,12 @@ public class CriStepResponseTest {
                 Arguments.of(
                         "aCriId",
                         null,
-                        "test_scope",
-                        "/journey/cri/build-oauth-request/aCriId?scope=test_scope"),
+                        new EvidenceRequest("gpg45", 2),
+                        "/journey/cri/build-oauth-request/aCriId?evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D"),
                 Arguments.of(
                         "aCriId",
                         "test_context",
-                        "test_scope",
-                        "/journey/cri/build-oauth-request/aCriId?context=test_context&scope=test_scope"));
+                        new EvidenceRequest("gpg45", 2),
+                        "/journey/cri/build-oauth-request/aCriId?context=test_context&evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D"));
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -88,7 +88,7 @@ public enum ErrorResponse {
     FAILED_TO_DELETE_CREDENTIAL(1071, "Failed to delete credential"),
     FAILED_TO_GET_CREDENTIAL(1072, "Failed to get credential"),
     INVALID_JOURNEY_EVENT(1073, "Invalid journey event in input"),
-    FAILED_TO_STORE_IDENTITY(1074, "Failed to store identity");
+    FAILED_TO_STORE_IDENTITY(1074, "Failed to store identity"),
     MITIGATION_ROUTE_CONFIG_NOT_FOUND(
             1069, "No mitigation journey route event found in cimit config"),
     FAILED_TO_PARSE_EVIDENCE_REQUESTED(1070, "Error parsing evidenceRequest for cri oauth request");

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -89,6 +89,9 @@ public enum ErrorResponse {
     FAILED_TO_GET_CREDENTIAL(1072, "Failed to get credential"),
     INVALID_JOURNEY_EVENT(1073, "Invalid journey event in input"),
     FAILED_TO_STORE_IDENTITY(1074, "Failed to store identity");
+    MITIGATION_ROUTE_CONFIG_NOT_FOUND(
+            1069, "No mitigation journey route event found in cimit config"),
+    FAILED_TO_PARSE_EVIDENCE_REQUESTED(1070, "Error parsing evidenceRequest for cri oauth request");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/EvidenceRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/EvidenceRequest.java
@@ -1,19 +1,41 @@
 package uk.gov.di.ipv.core.library.domain;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+import java.util.Base64;
+
+@Getter
+@Builder
+@Jacksonized
+@AllArgsConstructor
 @ExcludeFromGeneratedCoverageReport
-@JsonPropertyOrder({"strengthScore"})
 public class EvidenceRequest {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final String scoringPolicy;
+
     private final int strengthScore;
 
-    public EvidenceRequest(int strengthScore) {
-
-        this.strengthScore = strengthScore;
+    public String toBase64() throws JsonProcessingException {
+        var jsonString = objectMapper.writeValueAsString(this);
+        var jsonBytes = jsonString.getBytes();
+        return Base64.getEncoder().encodeToString(jsonBytes);
     }
 
-    public int getStrengthScore() {
-        return strengthScore;
+    public static EvidenceRequest fromBase64(String base64) throws JsonProcessingException {
+        if (base64 == null) {
+            return null;
+        }
+        var decodedBytes = Base64.getDecoder().decode(base64);
+        var jsonString = new String(decodedBytes);
+        return objectMapper.readValue(jsonString, EvidenceRequest.class);
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

(To protect original PR here: https://github.com/govuk-one-login/ipv-core-back/pull/1752. This has been pulled over into a new PR, rebased with main and fixed up due to many changes going in since the original PR was raised)

- Updated state machine to take evidenceRequest and to convey that information to the BuildCriOauth output JAR
- Other code cleanup

### Why did it change

- We want to be able to specify the evidence request's scoring policy and strength required in for a more detailed request of the CRIs
- Sonarcloud now requires some code cleanup and other issues appear as warnings in committing

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5284](https://govukverify.atlassian.net/browse/PYIC-5284)

- Having deployed the changes, manual tests were done where I temporarily added the updated state response to the passport cri state:
<img width="375" alt="Screenshot 2024-03-14 at 11 37 09" src="https://github.com/govuk-one-login/ipv-core-back/assets/144116535/e878a2ad-7ad8-4cdd-a512-6c9844c3303b">
<img width="1185" alt="Screenshot 2024-03-14 at 11 37 03" src="https://github.com/govuk-one-login/ipv-core-back/assets/144116535/c582767a-d870-44b2-a0c6-04bdafa63b7f">

Here, you can see we see the evidence requested in the CRI stub.

[PYIC-5284]: https://govukverify.atlassian.net/browse/PYIC-5284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ