### PR TITLE
BAU: Use correct failure page for COI and 6MFC journeys

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -16,7 +16,7 @@ states:
           ticfCriBeta:
             targetState: CRI_TICF_BEFORE_NO_MATCH
 
-  FAILED_COI:
+  FAILED_CONFIRM_DETAILS:
     events:
       next:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE
@@ -45,43 +45,7 @@ states:
       next:
         targetState: NO_MATCH_PAGE
 
-  FAILED_RFC:
-    events:
-      next:
-        targetState: NO_MATCH_PAGE_RFC
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC
-
-  FAILED_UPDATE_ADDRESS:
-    events:
-      next:
-        # same page as RFC displayed so re-use this state
-        targetState: NO_MATCH_PAGE_RFC
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC
-
   # Journey states
-
-  CRI_TICF_BEFORE_NO_MATCH_PAGE_RFC:
-    response:
-      type: process
-      lambda: call-ticf-cri
-    events:
-      next:
-        targetState: NO_MATCH_PAGE_RFC
-      enhanced-verification:
-        targetState: NO_MATCH_PAGE_RFC
-      alternate-doc-invalid-dl:
-        targetState: NO_MATCH_PAGE_RFC
-      alternate-doc-invalid-passport:
-        targetState: NO_MATCH_PAGE_RFC
-      fail-with-ci:
-        targetState: NO_MATCH_PAGE_RFC
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
 
   CRI_TICF_BEFORE_NO_MATCH:
     response:
@@ -171,15 +135,6 @@ states:
     response:
       type: page
       pageId: pyi-no-match
-    events:
-      next:
-        targetState: RETURN_TO_RP
-
-  NO_MATCH_PAGE_RFC:
-    response:
-      type: page
-      pageId: pyi-no-match
-      context: repeatFraudCheck
     events:
       next:
         targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -17,31 +17,31 @@ states:
     events:
       not-found:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 
@@ -85,7 +85,7 @@ states:
         targetState: EVALUATE_GPG45_SCORES_RFC
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
 
   ADDRESS_AND_FRAUD_RFC:
     nestedJourney: ADDRESS_AND_FRAUD
@@ -94,7 +94,7 @@ states:
         targetState: EVALUATE_GPG45_SCORES_RFC
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
 
   EVALUATE_GPG45_SCORES_RFC:
     response:
@@ -108,10 +108,10 @@ states:
             targetState: CRI_TICF_BEFORE_SUCCESS_RFC
       unmet:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED_RFC
+        targetState: FAILED_CONFIRM_DETAILS
 
   STORE_IDENTITY_BEFORE_SUCCESS:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -17,31 +17,31 @@ states:
     events:
       not-found:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 
@@ -60,7 +60,7 @@ states:
         targetState: CHECK_COI_UPDATE_ADDRESS
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
 
   CHECK_COI_UPDATE_ADDRESS:
     response:
@@ -71,7 +71,7 @@ states:
         targetState: EVALUATE_GPG45_SCORES_UPDATE_ADDRESS
       coi-check-failed:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -88,10 +88,10 @@ states:
             targetState: CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS
       unmet:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_ADDRESS
+        targetState: FAILED_CONFIRM_DETAILS
 
   STORE_IDENTITY_BEFORE_SUCCESS:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -23,31 +23,31 @@ states:
     events:
       not-found:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 
@@ -84,16 +84,16 @@ states:
         targetState: POST_DCMAW_SUCCESS_PAGE_NAME_ONLY
       not-found:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
 
   POST_DCMAW_SUCCESS_PAGE_NAME_ONLY:
     response:
@@ -114,7 +114,7 @@ states:
         targetState: CHECK_COI_UPDATE_NAME
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
 
   # WITH ADDRESS
 
@@ -149,16 +149,16 @@ states:
         targetState: POST_DCMAW_SUCCESS_PAGE_NAME_ADDRESS
       not-found:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
 
   POST_DCMAW_SUCCESS_PAGE_NAME_ADDRESS:
     response:
@@ -176,7 +176,7 @@ states:
         targetState: CHECK_COI_UPDATE_NAME
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
 
   # SHARED STATES
 
@@ -189,7 +189,7 @@ states:
         targetState: EVALUATE_GPG45_SCORES_UPDATE_NAME
       coi-check-failed:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -206,10 +206,10 @@ states:
             targetState: CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS
       unmet:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED_COI
+        targetState: FAILED_CONFIRM_DETAILS
 
   STORE_IDENTITY_BEFORE_SUCCESS_UPDATE_NAME:
     response:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Use correct failure page for COI and 6MFC journeys

### Why did it change

The address change COI and 6MFC journeys were using the pyi-no-match page for failure states, with the context of a repeat fraud check journey. This isn't correct.

The COI journeys, and the 6MFC journey, should be using the new page that has multiple options for the user.

See the designs [in Figma here](https://www.figma.com/design/nglBHtbzJYEeST43Iu1jW3/Identity-Pod---UCD-Hive?node-id=19733-36702&t=YMMvRoSrjRPFCEWJ-0)
