### PR TITLE
PYIC-6397: Add back event to update-details page

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -138,6 +138,8 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
       cancel:
         targetState: RETURN_TO_RP
+      back:
+        targetState: IDENTITY_REUSE_PAGE_COI
 
   DETAILS_DELETED_PAGE:
     response:


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Add back event to update-details page. See the core-front PR that makes use of it here: https://github.com/govuk-one-login/ipv-core-front/pull/1447

### Why did it change

The update details page now has a back link. That link should take the
user back to the reuse landing page.

There are other ways to get to the update details page, but they are all
"back" events from pages a user would reach directly after the update
details page, so we don't want the back link to ever return the user to
those pages.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6397](https://govukverify.atlassian.net/browse/PYIC-6397)


[PYIC-6397]: https://govukverify.atlassian.net/browse/PYIC-6397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ