### PR TITLE
PYIC-6057: Add f2f volumes routes

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -16,6 +16,14 @@ states:
           ticfCriBeta:
             targetState: CRI_TICF_BEFORE_NO_MATCH
 
+  FAILED_SKIP_MESSAGE:
+    events:
+      next:
+        targetState: RETURN_TO_RP
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+
   FAILED_CONFIRM_DETAILS:
     events:
       next:
@@ -62,6 +70,25 @@ states:
         targetState: NO_MATCH_PAGE
       fail-with-ci:
         targetState: NO_MATCH_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  CRI_TICF_BEFORE_RETURN_TO_RP:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      enhanced-verification:
+        targetState: RETURN_TO_RP
+      alternate-doc-invalid-dl:
+        targetState: RETURN_TO_RP
+      alternate-doc-invalid-passport:
+        targetState: RETURN_TO_RP
+      fail-with-ci:
+        targetState: RETURN_TO_RP
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -566,7 +566,8 @@ states:
       f2f:
         targetState: F2F_PYI_POST_OFFICE
       returnToRp:
-        targetState: RETURN_TO_RP
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
 
   ADDRESS_AND_FRAUD_J2:
     nestedJourney: ADDRESS_AND_FRAUD
@@ -613,7 +614,8 @@ states:
       f2f:
         targetState: F2F_PYI_POST_OFFICE
       returnToRp:
-        targetState: RETURN_TO_RP
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
 
   ADDRESS_AND_FRAUD_J3:
     nestedJourney: ADDRESS_AND_FRAUD
@@ -1298,7 +1300,8 @@ states:
       back:
         targetState: MITIGATION_PP_CRI_UK_PASSPORT
       returnToRp:
-        targetState: RETURN_TO_RP
+        targetJourney: FAILED
+        targetState: FAILED
 
   # Address and Fraud journey (MITIGATION)
   MITIGATION_PP_ADDRESS_AND_FRAUD:
@@ -1371,7 +1374,8 @@ states:
       back:
         targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
       returnToRp:
-        targetState: RETURN_TO_RP
+        targetJourney: FAILED
+        targetState: FAILED
 
   MITIGATION_DL_ADDRESS_AND_FRAUD:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1301,7 +1301,7 @@ states:
         targetState: MITIGATION_PP_CRI_UK_PASSPORT
       returnToRp:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
 
   # Address and Fraud journey (MITIGATION)
   MITIGATION_PP_ADDRESS_AND_FRAUD:
@@ -1375,7 +1375,7 @@ states:
         targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
       returnToRp:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
 
   MITIGATION_DL_ADDRESS_AND_FRAUD:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -549,8 +549,24 @@ states:
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
+        checkFeatureFlag:
+          f2fVolumesJourneyEnabled:
+            targetState: PROVE_ANOTHER_WAY_J2
       alternate-doc-invalid-passport:
         targetState: MITIGATION_05_OPTIONS
+
+  PROVE_ANOTHER_WAY_J2:
+    response:
+      type: page
+      pageId: prove-identity-another-type-photo-id
+      context: passport
+    events:
+      otherPhotoId:
+        targetState: CRI_DRIVING_LICENCE_J3
+      f2f:
+        targetState: F2F_PYI_POST_OFFICE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   ADDRESS_AND_FRAUD_J2:
     nestedJourney: ADDRESS_AND_FRAUD
@@ -580,8 +596,24 @@ states:
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
+        checkFeatureFlag:
+          f2fVolumesJourneyEnabled:
+            targetState: PROVE_ANOTHER_WAY_J3
       alternate-doc-invalid-dl:
         targetState: MITIGATION_03_OPTIONS
+
+  PROVE_ANOTHER_WAY_J3:
+    response:
+      type: page
+      pageId: prove-identity-another-type-photo-id
+      context: drivingLicence
+    events:
+      otherPhotoId:
+        targetState: CRI_UK_PASSPORT_J2
+      f2f:
+        targetState: F2F_PYI_POST_OFFICE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   ADDRESS_AND_FRAUD_J3:
     nestedJourney: ADDRESS_AND_FRAUD
@@ -1253,6 +1285,20 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED
+        checkFeatureFlag:
+          f2fVolumesJourneyEnabled:
+            targetState: MITIGATION_PP_PROVE_ANOTHER_WAY
+
+  MITIGATION_PP_PROVE_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: prove-identity-no-other-photo-id
+      context: passport
+    events:
+      back:
+        targetState: MITIGATION_PP_CRI_UK_PASSPORT
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   # Address and Fraud journey (MITIGATION)
   MITIGATION_PP_ADDRESS_AND_FRAUD:
@@ -1312,6 +1358,20 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED
+        checkFeatureFlag:
+          f2fVolumesJourneyEnabled:
+            targetState: MITIGATION_DL_PROVE_ANOTHER_WAY
+
+  MITIGATION_DL_PROVE_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: prove-identity-no-other-photo-id
+      context: drivingLicence
+    events:
+      back:
+        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_DL_ADDRESS_AND_FRAUD:
     nestedJourney: ADDRESS_AND_FRAUD


### PR DESCRIPTION
## Proposed changes

### What changed

- Added routes from passport or driving licence cris to new pages designed to reduce f2f volumes

### Why did it change

- To reduce f2f volumes

### Issue tracking

- [PYIC-6057](https://govukverify.atlassian.net/browse/PYIC-6057)

<img width="429" alt="Screenshot 2024-05-20 at 13 13 13" src="https://github.com/govuk-one-login/ipv-core-back/assets/144116535/409a149d-54f4-4367-99ef-98a8ce36f1db">

[PYIC-6057]: https://govukverify.atlassian.net/browse/PYIC-6057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ