### PR TITLE
PYIC-6424: Read from long term store to build P2 identity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -188,7 +188,7 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
-        "line_number": 2021
+        "line_number": 2024
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -197,21 +197,21 @@
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "85d1e7563098941624848ca8a7c731a6c013235b",
         "is_verified": false,
-        "line_number": 220
+        "line_number": 226
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "69facda46567909882c049ea59985c33000974b3",
         "is_verified": false,
-        "line_number": 303
+        "line_number": 309
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "1bb4f6b3cf1f8b05e40be98e555120bbac8bb8a8",
         "is_verified": false,
-        "line_number": 356
+        "line_number": 362
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -1879,5 +1879,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-15T14:18:40Z"
+  "generated_at": "2024-05-20T14:37:12Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1070,6 +1070,7 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
           SESSION_CREDENTIALS_TABLE_NAME: !Ref SessionCredentialsTable
+          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CIMIT_GET_CONTRAINDICATORS_LAMBDA_ARN: !Sub
             - "arn:aws:lambda:eu-west-2:${cimit_account_id}:function:getContraIndicatorCredential-${env}"
@@ -1117,6 +1118,8 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref UserIssuedCredentialsV2Table
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
         - SQSSendMessagePolicy:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Read from long term store to build P2 identity

### Why did it change

When a user is updating their details on the COI journeys they can fail without a CI or abandon their journey in the DCMAW CRI. When the user started the COI journey we removed all VCs from the session credentials store except their address VC. We also have already set their VOT in therr session as P2 due to them already having an identity.

The result of the above scenario is the user is returned to the service with a P2, but only an address VC. This will be rejected by SPOT.

It would be wrong to return them with anything other than a P2, as they still have a succesful identity.

We could detect this scenario and reinstate the required VCs to the session credential store. This may be quite complex though, maybe requiring another lambda.

Alternatively we can update the build-user-identity lambda to use VCs from the long term store when building a P2 identity. This ensures we're only returning VCs that have been checked and confirmed to form an identity.

For P0, PCL200 and PCL250's we can still use the session store. This will mean we don't have to do any filtering of fetched VCs.

We may in future revisit this decision and reimplement it, but it allows for the COI work to progress.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6424](https://govukverify.atlassian.net/browse/PYIC-6424)

[PYIC-6424]: https://govukverify.atlassian.net/browse/PYIC-6424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ