### PR TITLE
PYIC-5776: rename device information header to match frontend

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -235,7 +235,7 @@ public class ProcessCriCallbackHandler
             callbackRequest.setIpvSessionId(input.getHeaders().get("ipv-session-id"));
             callbackRequest.setFeatureSet(RequestHelper.getFeatureSet(input.getHeaders()));
             callbackRequest.setIpAddress(input.getHeaders().get("ip-address"));
-            callbackRequest.setDeviceInformation(input.getHeaders().get("Txma-Audit-Encoded"));
+            callbackRequest.setDeviceInformation(input.getHeaders().get("txma-audit-encoded"));
             return callbackRequest;
         } catch (JsonProcessingException e) {
             throw new ParseCriCallbackRequestException(e);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -25,7 +25,7 @@ public class RequestHelper {
 
     public static final String IPV_SESSION_ID_HEADER = "ipv-session-id";
     public static final String IP_ADDRESS_HEADER = "ip-address";
-    public static final String ENCODED_DEVICE_INFORMATION_HEADER = "Txma-Audit-Encoded";
+    public static final String ENCODED_DEVICE_INFORMATION_HEADER = "txma-audit-encoded";
     public static final String FEATURE_SET_HEADER = "feature-set";
     public static final String IS_USER_INITIATED = "isUserInitiated";
     public static final String DELETE_ONLY_GPG45_VCS = "deleteOnlyGPG45VCs";

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -31,7 +31,7 @@ public class JourneyEngineHandler {
     public static final String JOURNEY = "journey";
     public static final String IPV_SESSION_ID = "ipv-session-id";
     public static final String IP_ADDRESS = "ip-address";
-    public static final String ENCODED_DEVICE_INFORMATION = "Txma-Audit-Encoded";
+    public static final String ENCODED_DEVICE_INFORMATION = "txma-audit-encoded";
     public static final String CLIENT_SESSION_ID = "client-session-id";
     public static final String FEATURE_SET = "feature-set";
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Rename `Txma-Audit-Encoded` to `txma-audit-encoded`

### What changed

- Renamed txma header to `txma-audit-encoded`

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To match frontend header [package link](https://github.com/govuk-one-login/frontend-passthrough-headers/blob/main/src/index.ts#L7)

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5776](https://govukverify.atlassian.net/browse/PYIC-5776)

<img width="629" alt="Screenshot 2024-05-20 at 13 09 55" src="https://github.com/govuk-one-login/ipv-core-back/assets/3963744/e0d47f31-bae0-44c1-a9b8-1b6bcd251e06">

[PYIC-5776]: https://govukverify.atlassian.net/browse/PYIC-5776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ