### PR TITLE
PYIC-5775: pass device information in core back internal, journey engine step function

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -8,7 +8,8 @@
         "journey.$": "$.journey",
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessJourneyStepResult"
     },
@@ -76,7 +77,8 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"
     },
@@ -88,7 +90,8 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"
     },
@@ -100,7 +103,8 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"
     },
@@ -112,7 +116,8 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"
     },
@@ -124,7 +129,8 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"
     },
@@ -136,7 +142,8 @@
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
         "featureSet.$": "$$.Execution.Input.featureSet",
-        "lambdaInput.$": "$.lambdaInput"
+        "lambdaInput.$": "$.lambdaInput",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"
     },
@@ -147,7 +154,8 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"
     },
@@ -157,7 +165,8 @@
       "Parameters": {
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
-        "featureSet.$": "$$.Execution.Input.featureSet"
+        "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"
     },

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -69,6 +69,7 @@ paths:
               "input": "{
               \"journey\":\"/journey/$util.escapeJavaScript($input.params('journeyStep'))?currentPage=$util.escapeJavaScript($input.params().querystring.get('currentPage'))\",
               \"ipAddress\":\"$util.escapeJavaScript($input.params('ip-address'))\",
+              \"deviceInformation\":\"$util.escapeJavaScript($input.params('txma-audit-encoded'))\",
               \"featureSet\":\"$util.escapeJavaScript($input.params('feature-set'))\",
               \"ipvSessionId\":\"$util.escapeJavaScript($input.params('ipv-session-id'))\",
               \"clientOAuthSessionId\":\"$util.escapeJavaScript($input.params('client-session-id'))\"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- pass device information to journey engine step functions

### What changed

- Added device info in internal api, journey engine asl json file.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To pass device info to auditing event

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5775](https://govukverify.atlassian.net/browse/PYIC-5775)

<img width="636" alt="Screenshot 2024-05-21 at 16 05 35" src="https://github.com/govuk-one-login/ipv-core-back/assets/3963744/17f00922-a14a-448a-bf41-80687dd4c1fd">

<img width="591" alt="Screenshot 2024-05-21 at 16 13 25" src="https://github.com/govuk-one-login/ipv-core-back/assets/3963744/5cda924c-c25e-40e6-94a2-a803411bd798">

<img width="618" alt="Screenshot 2024-05-21 at 16 13 34" src="https://github.com/govuk-one-login/ipv-core-back/assets/3963744/c7d1fcb6-c125-4fe3-9408-0db8f2987836">

<img width="582" alt="Screenshot 2024-05-21 at 16 13 48" src="https://github.com/govuk-one-login/ipv-core-back/assets/3963744/419d2148-a7fe-442d-bf9c-3befdd7a250f">

[PYIC-5775]: https://govukverify.atlassian.net/browse/PYIC-5775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ