### PR TITLE
BAU: Fix back after repeat fraud check

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -60,16 +60,16 @@ states:
         targetState: UPDATE_NAME_DOB
       given-names-only:
         targetJourney: UPDATE_NAME
-        targetState: UPDATE_NAME_WITHOUT_ADDRESS_START
+        targetState: UPDATE_NAME_WITHOUT_ADDRESS_AFTER_RFC_START
       family-name-only:
         targetJourney: UPDATE_NAME
-        targetState: UPDATE_NAME_WITHOUT_ADDRESS_START
+        targetState: UPDATE_NAME_WITHOUT_ADDRESS_AFTER_RFC_START
       given-names-and-address:
         targetJourney: UPDATE_NAME
-        targetState: UPDATE_NAME_WITH_ADDRESS_START
+        targetState: UPDATE_NAME_WITH_ADDRESS_AFTER_RFC_START
       family-name-and-address:
         targetJourney: UPDATE_NAME
-        targetState: UPDATE_NAME_WITH_ADDRESS_START
+        targetState: UPDATE_NAME_WITH_ADDRESS_AFTER_RFC_START
       next:
         targetState: FRAUD_CHECK_RFC
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -7,15 +7,25 @@ description: >-
 states:
 # Entry points
 
-  UPDATE_NAME_WITH_ADDRESS_START:
+  UPDATE_NAME_WITH_ADDRESS_AFTER_REUSE_START:
     events:
       next:
-        targetState: UPDATE_NAME_PAGE_WITH_ADDRESS
+        targetState: UPDATE_NAME_PAGE_WITH_ADDRESS_AFTER_REUSE
 
-  UPDATE_NAME_WITHOUT_ADDRESS_START:
+  UPDATE_NAME_WITH_ADDRESS_AFTER_RFC_START:
     events:
       next:
-        targetState: UPDATE_NAME_PAGE_WITHOUT_ADDRESS
+        targetState: UPDATE_NAME_PAGE_WITH_ADDRESS_AFTER_RFC
+
+  UPDATE_NAME_WITHOUT_ADDRESS_AFTER_REUSE_START:
+    events:
+      next:
+        targetState: UPDATE_NAME_PAGE_WITHOUT_ADDRESS_AFTER_REUSE
+
+  UPDATE_NAME_WITHOUT_ADDRESS_AFTER_RFC_START:
+    events:
+      next:
+        targetState: UPDATE_NAME_PAGE_WITHOUT_ADDRESS_AFTER_RFC
 
   # Parent States
 
@@ -53,7 +63,7 @@ states:
 
    # WITHOUT ADDRESS
 
-  UPDATE_NAME_PAGE_WITHOUT_ADDRESS:
+  UPDATE_NAME_PAGE_WITHOUT_ADDRESS_AFTER_REUSE:
     response:
       type: page
       pageId: page-update-name
@@ -65,6 +75,19 @@ states:
       back:
         targetJourney: REUSE_EXISTING_IDENTITY
         targetState: UPDATE_DETAILS_START
+
+  UPDATE_NAME_PAGE_WITHOUT_ADDRESS_AFTER_RFC:
+    response:
+      type: page
+      pageId: page-update-name
+    events:
+      update-name:
+        targetState: RESET_IDENTITY_WITHOUT_ADDRESS
+      end:
+        targetState: RETURN_TO_RP
+      back:
+        targetJourney: REPEAT_FRAUD_CHECK
+        targetState: START
 
   RESET_IDENTITY_WITHOUT_ADDRESS:
     response:
@@ -118,7 +141,7 @@ states:
 
   # WITH ADDRESS
 
-  UPDATE_NAME_PAGE_WITH_ADDRESS:
+  UPDATE_NAME_PAGE_WITH_ADDRESS_AFTER_REUSE:
     response:
       type: page
       pageId: page-update-name
@@ -130,6 +153,19 @@ states:
       back:
         targetJourney: REUSE_EXISTING_IDENTITY
         targetState: UPDATE_DETAILS_START
+
+  UPDATE_NAME_PAGE_WITH_ADDRESS_AFTER_RFC:
+    response:
+      type: page
+      pageId: page-update-name
+    events:
+      update-name:
+        targetState: RESET_IDENTITY_WITH_ADDRESS
+      end:
+        targetState: RETURN_TO_RP
+      back:
+        targetJourney: REPEAT_FRAUD_CHECK
+        targetState: START
 
   RESET_IDENTITY_WITH_ADDRESS:
     response:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix back after repeat fraud check

### Why did it change

When a user was on a 6MFC journey they could choose to go back to check their details again, after having said they wanted to change their details.

That was routing them to the COI journey start, which is incorrect.

This introduces a couple of extra states so we can handle the back event correctly.
