### PR TITLE
PYIC-6218: Add ecvs config for local running orch stub

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -1834,11 +1830,32 @@
         "line_number": 25
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "local-running/compose.yaml",
+        "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "local-running/compose.yaml",
+        "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "local-running/compose.yaml",
+        "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
         "type": "Secret Keyword",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "a622a83e16c56c242e78d8f0b6cfc639005c7e85",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 49
       }
     ],
     "local-running/setConfigForLocalOrCloudRunning.py": [
@@ -1872,5 +1889,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-23T12:31:29Z"
+  "generated_at": "2024-05-28T15:43:36Z"
 }

--- a/local-running/compose.yaml
+++ b/local-running/compose.yaml
@@ -28,6 +28,9 @@ services:
       ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_KEY: ${ORCHESTRATOR_DEFAULT_JAR_ENCRYPTION_PUBLIC_KEY}
       ORCHESTRATOR_PORT: 3000
       ORCHESTRATOR_REDIRECT_URL: http://localhost:3000/callback
+      EVCS_ACCESS_TOKEN_ENDPOINT: https://mock.credential-store.build.account.gov.uk/generate
+      EVCS_ACCESS_TOKEN_TTL: 60
+      EVCS_ACCESS_TOKEN_SIGNING_KEY_JWK: '{"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}'
       JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5000
     ports:
       - "3000:3000"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add ecvs config for local running orch stub

### Why did it change

The orch stub will be generating access tokens for the evcs system. The local running orch-stub will need this config.

Accounts bravo have confirmed they don't mind the endpoint being public.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6218](https://govukverify.atlassian.net/browse/PYIC-6218)


[PYIC-6218]: https://govukverify.atlassian.net/browse/PYIC-6218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ