### PR TITLE
PYIC-6527 Update storeIdentity lambda to use EVCSService to store user VCs in EVCS

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -191,7 +191,7 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
         "is_verified": false,
-        "line_number": 2490
+        "line_number": 2489
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -285,21 +285,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 116
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 116
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 116
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1921,5 +1921,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-03T13:38:16Z"
+  "generated_at": "2024-06-03T19:58:43Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -185,6 +185,13 @@
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
         "line_number": 2021
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
+        "is_verified": false,
+        "line_number": 2490
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -278,21 +285,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 114
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 114
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 114
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1914,5 +1921,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-31T11:42:22Z"
+  "generated_at": "2024-06-03T13:38:16Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -285,21 +285,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 117
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 117
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 117
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1921,5 +1921,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-03T19:58:43Z"
+  "generated_at": "2024-06-04T08:12:19Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -285,21 +285,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 118
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 118
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 118
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1921,5 +1921,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-04T08:12:19Z"
+  "generated_at": "2024-06-04T11:43:36Z"
 }

--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -166,6 +166,7 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "featureSet.$": "$$.Execution.Input.featureSet",
+        "lambdaInput.$": "$.lambdaInput",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessNextJourney"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2453,6 +2453,7 @@ Resources:
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
+          CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       VpcConfig:
         SubnetIds:
@@ -2485,6 +2486,8 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/evcs/api-key-*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - DynamoDBCrudPolicy:
@@ -2495,6 +2498,8 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref CRIResponseTable
       AutoPublishAlias: live
 
   StoreIdentityFunctionLogGroup:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2453,7 +2453,6 @@ Resources:
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       VpcConfig:
         SubnetIds:
@@ -2498,8 +2497,6 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
-        - DynamoDBReadPolicy:
-            TableName: !Ref CRIResponseTable
       AutoPublishAlias: live
 
   StoreIdentityFunctionLogGroup:

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -196,7 +196,10 @@ public class InitialiseIpvSessionHandler
             if (configService.enabled(EVCS_READ_ENABLED)
                     || configService.enabled(EVCS_WRITE_ENABLED)) {
                 validateEvcsAccessToken(jarUserInfoClaim, claimsSet);
-                evcsAccessToken = jarUserInfoClaim.get().evcsAccessToken().values().get(0);
+                evcsAccessToken =
+                        jarUserInfoClaim.isPresent()
+                                ? jarUserInfoClaim.get().evcsAccessToken().values().get(0)
+                                : null;
             }
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.generateClientSessionDetails(

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -20,9 +20,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
-import uk.gov.di.ipv.core.initialiseipvsession.domain.InheritedIdentityJwtClaim;
 import uk.gov.di.ipv.core.initialiseipvsession.domain.JarClaims;
-import uk.gov.di.ipv.core.initialiseipvsession.domain.JarUserInfo;
+import uk.gov.di.ipv.core.initialiseipvsession.domain.ListOfStringValues;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.JarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.service.KmsRsaDecrypter;
@@ -70,6 +69,7 @@ import static uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsIpvJo
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAudit;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForInheritedIdentity;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JAR_KMS_ENCRYPTION_KEY_ID;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.HMRC_MIGRATION_CRI;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
@@ -87,6 +87,8 @@ public class InitialiseIpvSessionHandler
     private static final List<Vot> HMRC_PROFILES_BY_STRENGTH = List.of(Vot.PCL250, Vot.PCL200);
     private static final ErrorObject INVALID_INHERITED_IDENTITY_ERROR_OBJECT =
             new ErrorObject("invalid_inherited_identity");
+    private static final ErrorObject EVCS_ACCESS_TOKEN_ERROR_OBJECT =
+            new ErrorObject("invalid_evcs_access_token");
     private final ConfigService configService;
     private final IpvSessionService ipvSessionService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionService;
@@ -188,11 +190,21 @@ public class InitialiseIpvSessionHandler
                     ipvSessionService.generateIpvSession(
                             clientOAuthSessionId, null, emailAddress, isReverification);
 
+            Optional<ListOfStringValues> evcsAccessTokenClaim = Optional.empty();
+            if (configService.enabled(EVCS_READ_ENABLED)) {
+                evcsAccessTokenClaim = getStringListClaim(claimsSet, false);
+                if (evcsAccessTokenClaim.isPresent()) {
+                    validateEvcsAccessToken(evcsAccessTokenClaim.get(), claimsSet);
+                }
+            }
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.generateClientSessionDetails(
                             clientOAuthSessionId,
                             claimsSet,
-                            sessionParams.get(CLIENT_ID_PARAM_KEY));
+                            sessionParams.get(CLIENT_ID_PARAM_KEY),
+                            evcsAccessTokenClaim
+                                    .map(listOfStringValues -> listOfStringValues.values().get(0))
+                                    .orElse(null));
 
             AuditEventUser auditEventUser =
                     new AuditEventUser(
@@ -201,7 +213,7 @@ public class InitialiseIpvSessionHandler
                             govukSigninJourneyId,
                             ipAddress);
 
-            var inheritedIdentityJwtClaim = getInheritedIdentityClaim(claimsSet);
+            var inheritedIdentityJwtClaim = getStringListClaim(claimsSet, true);
             if (inheritedIdentityJwtClaim.isPresent()) {
                 validateAndStoreHMRCInheritedIdentity(
                         clientOAuthSessionItem.getUserId(),
@@ -291,7 +303,8 @@ public class InitialiseIpvSessionHandler
         }
     }
 
-    private Optional<InheritedIdentityJwtClaim> getInheritedIdentityClaim(JWTClaimsSet claimsSet)
+    private Optional<ListOfStringValues> getStringListClaim(
+            JWTClaimsSet claimsSet, boolean isForInheritedIdentityClaim)
             throws ParseException, RecoverableJarValidationException {
         if (!configService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)) {
             return Optional.empty();
@@ -301,7 +314,11 @@ public class InitialiseIpvSessionHandler
                             OBJECT_MAPPER.convertValue(
                                     claimsSet.getJSONObjectClaim(CLAIMS_CLAIM), JarClaims.class))
                     .map(JarClaims::userInfo)
-                    .map(JarUserInfo::inheritedIdentityClaim);
+                    .map(
+                            jarUserInfo ->
+                                    (isForInheritedIdentityClaim
+                                            ? jarUserInfo.inheritedIdentityClaim()
+                                            : jarUserInfo.evcsAccessToken()));
         } catch (IllegalArgumentException | ParseException e) {
             throw new RecoverableJarValidationException(
                     OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
@@ -324,7 +341,7 @@ public class InitialiseIpvSessionHandler
     @Tracing
     private void validateAndStoreHMRCInheritedIdentity(
             String userId,
-            InheritedIdentityJwtClaim inheritedIdentityJwtClaim,
+            ListOfStringValues inheritedIdentityJwtClaim,
             JWTClaimsSet claimsSet,
             IpvSessionItem ipvSessionItem,
             AuditEventUser auditEventUser,
@@ -350,8 +367,33 @@ public class InitialiseIpvSessionHandler
         }
     }
 
+    @Tracing
+    private void validateEvcsAccessToken(
+            ListOfStringValues evcsAccessTokenClaim, JWTClaimsSet claimsSet)
+            throws RecoverableJarValidationException, ParseException {
+        try {
+            // Validate JAR claims structure is valid
+            var evcsAccessTokenList =
+                    Optional.ofNullable(evcsAccessTokenClaim.values())
+                            .orElseThrow(
+                                    () ->
+                                            new JarValidationException(
+                                                    EVCS_ACCESS_TOKEN_ERROR_OBJECT.setDescription(
+                                                            "Evcs access token jwt claim received but value is null")));
+            if (evcsAccessTokenList.size() != 1) {
+                throw new JarValidationException(
+                        EVCS_ACCESS_TOKEN_ERROR_OBJECT.setDescription(
+                                String.format(
+                                        "%d EVCS access token received - one expected",
+                                        evcsAccessTokenList.size())));
+            }
+        } catch (JarValidationException e) {
+            throw new RecoverableJarValidationException(e.getErrorObject(), claimsSet, e);
+        }
+    }
+
     private VerifiableCredential validateHmrcInheritedIdentity(
-            String userId, InheritedIdentityJwtClaim inheritedIdentityJwtClaim)
+            String userId, ListOfStringValues inheritedIdentityJwtClaim)
             throws JarValidationException, ParseException, VerifiableCredentialException {
         // Validate JAR claims structure is valid
         var inheritedIdentityJwtList =

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -198,9 +198,9 @@ public class InitialiseIpvSessionHandler
             if ((configService.enabled(EVCS_READ_ENABLED)
                             || configService.enabled(EVCS_WRITE_ENABLED))
                     && (jarUserInfoClaim.isPresent())) {
-                StringListClaim evcsAccessTokenList = jarUserInfoClaim.get().evcsAccessToken();
-                validateEvcsAccessToken(Optional.ofNullable(evcsAccessTokenList), claimsSet);
-                evcsAccessToken = evcsAccessTokenList.values().get(0);
+                evcsAccessToken =
+                        validateEvcsAccessToken(
+                                jarUserInfoClaim.map(JarUserInfo::evcsAccessToken), claimsSet);
             }
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.generateClientSessionDetails(
@@ -220,7 +220,7 @@ public class InitialiseIpvSessionHandler
                     && (jarUserInfoClaim.isPresent())) {
                 validateAndStoreHMRCInheritedIdentity(
                         clientOAuthSessionItem.getUserId(),
-                        Optional.ofNullable(jarUserInfoClaim.get().inheritedIdentityClaim()),
+                        jarUserInfoClaim.map(JarUserInfo::inheritedIdentityClaim),
                         claimsSet,
                         ipvSessionItem,
                         auditEventUser,
@@ -362,7 +362,7 @@ public class InitialiseIpvSessionHandler
     }
 
     @Tracing
-    private void validateEvcsAccessToken(
+    private String validateEvcsAccessToken(
             Optional<StringListClaim> evcsAccessTokenClaim, JWTClaimsSet claimsSet)
             throws RecoverableJarValidationException, ParseException {
         try {
@@ -389,6 +389,7 @@ public class InitialiseIpvSessionHandler
                                         "%d EVCS access token received - one expected",
                                         evcsAccessTokenList.size())));
             }
+            return evcsAccessTokenList.get(0);
         } catch (JarValidationException e) {
             throw new RecoverableJarValidationException(e.getErrorObject(), claimsSet, e);
         }

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -70,6 +70,7 @@ import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForInheritedIdentity;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JAR_KMS_ENCRYPTION_KEY_ID;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.HMRC_MIGRATION_CRI;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
@@ -191,7 +192,8 @@ public class InitialiseIpvSessionHandler
                             clientOAuthSessionId, null, emailAddress, isReverification);
 
             Optional<ListOfStringValues> evcsAccessTokenClaim = Optional.empty();
-            if (configService.enabled(EVCS_READ_ENABLED)) {
+            if (configService.enabled(EVCS_READ_ENABLED)
+                    || configService.enabled(EVCS_WRITE_ENABLED)) {
                 evcsAccessTokenClaim = getStringListClaim(claimsSet, false);
                 if (evcsAccessTokenClaim.isPresent()) {
                     validateEvcsAccessToken(evcsAccessTokenClaim.get(), claimsSet);
@@ -306,7 +308,8 @@ public class InitialiseIpvSessionHandler
     private Optional<ListOfStringValues> getStringListClaim(
             JWTClaimsSet claimsSet, boolean isForInheritedIdentityClaim)
             throws ParseException, RecoverableJarValidationException {
-        if (!configService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)) {
+        if (isForInheritedIdentityClaim
+                && !configService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)) {
             return Optional.empty();
         }
         try {

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/JarUserInfo.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/JarUserInfo.java
@@ -14,6 +14,6 @@ public record JarUserInfo(
         @JsonProperty(value = ADDRESS_CLAIM_NAME) Essential addressClaim,
         @JsonProperty(value = CORE_IDENTITY_JWT_CLAIM_NAME) Essential coreIdentityJwtClaim,
         @JsonProperty(value = INHERITED_IDENTITY_JWT_CLAIM_NAME)
-                ListOfStringValues inheritedIdentityClaim,
-        @JsonProperty(value = EVCS_ACCESS_TOKEN_CLAIM_NAME) ListOfStringValues evcsAccessToken,
+                StringListClaim inheritedIdentityClaim,
+        @JsonProperty(value = EVCS_ACCESS_TOKEN_CLAIM_NAME) StringListClaim evcsAccessToken,
         @JsonProperty(value = PASSPORT_CLAIM_NAME) Essential passportClaim) {}

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/JarUserInfo.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/JarUserInfo.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.ADDRESS_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.CORE_IDENTITY_JWT_CLAIM_NAME;
+import static uk.gov.di.ipv.core.library.domain.VocabConstants.EVCS_ACCESS_TOKEN_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.INHERITED_IDENTITY_JWT_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.PASSPORT_CLAIM_NAME;
 
@@ -13,5 +14,6 @@ public record JarUserInfo(
         @JsonProperty(value = ADDRESS_CLAIM_NAME) Essential addressClaim,
         @JsonProperty(value = CORE_IDENTITY_JWT_CLAIM_NAME) Essential coreIdentityJwtClaim,
         @JsonProperty(value = INHERITED_IDENTITY_JWT_CLAIM_NAME)
-                InheritedIdentityJwtClaim inheritedIdentityClaim,
+                ListOfStringValues inheritedIdentityClaim,
+        @JsonProperty(value = EVCS_ACCESS_TOKEN_CLAIM_NAME) ListOfStringValues evcsAccessToken,
         @JsonProperty(value = PASSPORT_CLAIM_NAME) Essential passportClaim) {}

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/ListOfStringValues.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/ListOfStringValues.java
@@ -2,4 +2,4 @@ package uk.gov.di.ipv.core.initialiseipvsession.domain;
 
 import java.util.List;
 
-public record InheritedIdentityJwtClaim(List<String> values) {}
+public record ListOfStringValues(List<String> values) {}

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/StringListClaim.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/StringListClaim.java
@@ -2,4 +2,4 @@ package uk.gov.di.ipv.core.initialiseipvsession.domain;
 
 import java.util.List;
 
-public record ListOfStringValues(List<String> values) {}
+public record StringListClaim(List<String> values) {}

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -91,6 +91,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -897,6 +898,8 @@ class InitialiseIpvSessionHandlerTest {
 
         @Test
         void shouldRecoverIfClaimsClaimCanNotBeConverted() throws Exception {
+            reset(mockConfigService);
+            reset(mockClientOAuthSessionDetailsService);
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
@@ -22,9 +22,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
-import uk.gov.di.ipv.core.initialiseipvsession.domain.InheritedIdentityJwtClaim;
 import uk.gov.di.ipv.core.initialiseipvsession.domain.JarClaims;
 import uk.gov.di.ipv.core.initialiseipvsession.domain.JarUserInfo;
+import uk.gov.di.ipv.core.initialiseipvsession.domain.ListOfStringValues;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.JarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.service.KmsRsaDecrypter;
@@ -727,7 +727,8 @@ class JarValidatorTest {
                         new JarUserInfo(
                                 null,
                                 null,
-                                new InheritedIdentityJwtClaim(List.of("DEFO.A.JWT")),
+                                new ListOfStringValues(List.of("DEFO.A.JWT")),
+                                new ListOfStringValues(List.of("EVCS_ACCESS_TOKEN")),
                                 null)));
         return validClaims;
     }

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
@@ -24,7 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.ipv.core.initialiseipvsession.domain.JarClaims;
 import uk.gov.di.ipv.core.initialiseipvsession.domain.JarUserInfo;
-import uk.gov.di.ipv.core.initialiseipvsession.domain.ListOfStringValues;
+import uk.gov.di.ipv.core.initialiseipvsession.domain.StringListClaim;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.JarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.service.KmsRsaDecrypter;
@@ -727,8 +727,8 @@ class JarValidatorTest {
                         new JarUserInfo(
                                 null,
                                 null,
-                                new ListOfStringValues(List.of("DEFO.A.JWT")),
-                                new ListOfStringValues(List.of("EVCS_ACCESS_TOKEN")),
+                                new StringListClaim(List.of("DEFO.A.JWT")),
+                                new StringListClaim(List.of("EVCS_ACCESS_TOKEN")),
                                 null)));
         return validClaims;
     }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -102,8 +102,6 @@ states:
     response:
       type: process
       lambda: reset-session-identity
-      lambdaInput:
-        isUserInitiated: false
     events:
       next:
         targetState: IDENTITY_START_PAGE
@@ -428,6 +426,8 @@ states:
     response:
       type: process
       lambda: store-identity
+      lambdaInput:
+        isCompletedIdentity: true
     events:
       identity-stored:
         targetState: IPV_SUCCESS_PAGE
@@ -439,6 +439,8 @@ states:
     response:
       type: process
       lambda: store-identity
+      lambdaInput:
+        isCompletedIdentity: false
     events:
       identity-stored:
         targetState: RESET_SESSION_BEFORE_F2F_HANDOFF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -148,6 +148,8 @@ states:
     response:
       type: process
       lambda: store-identity
+      lambdaInput:
+        isCompletedIdentity: true
     events:
       identity-stored:
         targetState: IPV_SUCCESS_PAGE_RFC

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -83,6 +83,8 @@ states:
     response:
       type: process
       lambda: store-identity
+      lambdaInput:
+        isCompletedIdentity: true
     events:
       identity-stored:
         targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -251,6 +251,8 @@ states:
     response:
       type: process
       lambda: store-identity
+      lambdaInput:
+        isCompletedIdentity: true
     events:
       identity-stored:
         targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS

--- a/lambdas/store-identity/build.gradle
+++ b/lambdas/store-identity/build.gradle
@@ -15,7 +15,6 @@ dependencies {
 			project(":libs:common-services"),
 			project(':libs:journey-uris'),
 			project(":libs:verifiable-credentials"),
-			project(":libs:cri-response-service"),
 			project(':libs:evcs-service')
 
 	aspect libs.powertoolsLogging,

--- a/lambdas/store-identity/build.gradle
+++ b/lambdas/store-identity/build.gradle
@@ -14,7 +14,9 @@ dependencies {
 			project(":libs:audit-service"),
 			project(":libs:common-services"),
 			project(':libs:journey-uris'),
-			project(":libs:verifiable-credentials")
+			project(":libs:verifiable-credentials"),
+			project(":libs:cri-response-service"),
+			project(':libs:evcs-service')
 
 	aspect libs.powertoolsLogging,
 			libs.powertoolsTracing,

--- a/lambdas/store-identity/src/main/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandler.java
+++ b/lambdas/store-identity/src/main/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandler.java
@@ -15,7 +15,9 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
+import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -25,14 +27,17 @@ import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.service.EvcsService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
 import static uk.gov.di.ipv.core.library.auditing.AuditEventTypes.IPV_IDENTITY_STORED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -48,6 +53,7 @@ public class StoreIdentityHandler implements RequestHandler<ProcessRequest, Map<
     private final SessionCredentialsService sessionCredentialsService;
     private final VerifiableCredentialService verifiableCredentialService;
     private final AuditService auditService;
+    private final EvcsService evcsService;
 
     public StoreIdentityHandler(
             ConfigService configService,
@@ -55,13 +61,15 @@ public class StoreIdentityHandler implements RequestHandler<ProcessRequest, Map<
             IpvSessionService ipvSessionService,
             SessionCredentialsService sessionCredentialsService,
             VerifiableCredentialService verifiableCredentialService,
-            AuditService auditService) {
+            AuditService auditService,
+            EvcsService evcsService) {
         this.configService = configService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
         this.ipvSessionService = ipvSessionService;
         this.sessionCredentialsService = sessionCredentialsService;
         this.verifiableCredentialService = verifiableCredentialService;
         this.auditService = auditService;
+        this.evcsService = evcsService;
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -72,6 +80,7 @@ public class StoreIdentityHandler implements RequestHandler<ProcessRequest, Map<
         this.sessionCredentialsService = new SessionCredentialsService(configService);
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.evcsService = new EvcsService(configService);
     }
 
     @Override
@@ -90,20 +99,30 @@ public class StoreIdentityHandler implements RequestHandler<ProcessRequest, Map<
             LogHelper.attachGovukSigninJourneyIdToLogs(
                     clientOAuthSessionItem.getGovukSigninJourneyId());
 
-            verifiableCredentialService.storeIdentity(
+            String userId = clientOAuthSessionItem.getUserId();
+            List<VerifiableCredential> credentials =
                     sessionCredentialsService.getCredentials(
-                            ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId()),
-                    clientOAuthSessionItem.getUserId());
+                            ipvSessionItem.getIpvSessionId(), userId);
+            verifiableCredentialService.storeIdentity(credentials, userId);
 
+            if (configService.enabled(EVCS_WRITE_ENABLED)) {
+                if (RequestHelper.getIsCompletedIdentity(input)) {
+                    evcsService.storeCompletedIdentity(
+                            userId, credentials, clientOAuthSessionItem.getEvcsAccessToken());
+                } else {
+                    evcsService.storePendingIdentity(
+                            userId, credentials, clientOAuthSessionItem.getEvcsAccessToken());
+                }
+            }
             LOGGER.info(LogHelper.buildLogMessage("Identity successfully stored"));
-            Vot vot = ipvSessionItem.getVot();
 
+            Vot vot = ipvSessionItem.getVot();
             auditService.sendAuditEvent(
                     new AuditEvent(
                             IPV_IDENTITY_STORED,
                             configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
                             new AuditEventUser(
-                                    clientOAuthSessionItem.getUserId(),
+                                    userId,
                                     ipvSessionItem.getIpvSessionId(),
                                     clientOAuthSessionItem.getGovukSigninJourneyId(),
                                     input.getIpAddress()),
@@ -112,7 +131,9 @@ public class StoreIdentityHandler implements RequestHandler<ProcessRequest, Map<
 
             return JOURNEY_IDENTITY_STORED;
 
-        } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
+        } catch (HttpResponseExceptionWithErrorBody
+                | VerifiableCredentialException
+                | EvcsServiceException e) {
             LOGGER.error(LogHelper.buildErrorMessage("Failed to store identity", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())

--- a/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
+++ b/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.storeidentity;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,8 +16,10 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionVot;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
+import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -24,22 +27,30 @@ import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.service.EvcsService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.quality.Strictness.LENIENT;
 import static uk.gov.di.ipv.core.library.auditing.AuditEventTypes.IPV_IDENTITY_STORED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_AT_EVCS_HTTP_REQUEST_SEND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_STORE_IDENTITY;
@@ -64,10 +75,17 @@ class StoreIdentityHandlerTest {
     private static final String SESSION_ID = "session-id";
     private static final String STATUS_CODE = "statusCode";
     private static final String USER_ID = "user-id";
-    private static final ProcessRequest PROCESS_REQUEST =
+    private static final ProcessRequest PROCESS_REQUEST_FOR_COMPLETED_IDENTITY =
             ProcessRequest.processRequestBuilder()
                     .ipvSessionId(SESSION_ID)
                     .ipAddress(IP_ADDRESS)
+                    .lambdaInput(new HashMap<>(Map.of("isCompletedIdentity", true)))
+                    .build();
+    private static final ProcessRequest PROCESS_REQUEST_FOR_PENDING_IDENTITY =
+            ProcessRequest.processRequestBuilder()
+                    .ipvSessionId(SESSION_ID)
+                    .ipAddress(IP_ADDRESS)
+                    .lambdaInput(new HashMap<>(Map.of("isCompletedIdentity", false)))
                     .build();
     private static final List<VerifiableCredential> VCS =
             List.of(
@@ -85,6 +103,7 @@ class StoreIdentityHandlerTest {
     @Mock private SessionCredentialsService mockSessionCredentialService;
     @Mock private VerifiableCredentialService mockVerifiableCredentialService;
     @Mock private AuditService mockAuditService;
+    @Mock private EvcsService mockEvcsService;
     @InjectMocks private StoreIdentityHandler storeIdentityHandler;
 
     @BeforeAll
@@ -92,6 +111,7 @@ class StoreIdentityHandlerTest {
         clientOAuthSessionItem = new ClientOAuthSessionItem();
         clientOAuthSessionItem.setUserId(USER_ID);
         clientOAuthSessionItem.setGovukSigninJourneyId(GOVUK_JOURNEY_ID);
+        clientOAuthSessionItem.setEvcsAccessToken("TEST_EVCS_ACCESS_TOKEN");
     }
 
     @BeforeEach
@@ -111,15 +131,19 @@ class StoreIdentityHandlerTest {
 
     @Test
     void shouldReturnAnIdentityStoredJourney() throws Exception {
-        var response = storeIdentityHandler.handleRequest(PROCESS_REQUEST, mockContext);
+        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
+        var response =
+                storeIdentityHandler.handleRequest(
+                        PROCESS_REQUEST_FOR_COMPLETED_IDENTITY, mockContext);
 
         assertEquals(JOURNEY_IDENTITY_STORED_PATH, response.get(JOURNEY));
         verify(mockVerifiableCredentialService).storeIdentity(VCS, USER_ID);
+        verify(mockEvcsService, times(1)).storeCompletedIdentity(anyString(), any(), any());
     }
 
     @Test
     void shouldSendAuditEventWithVotExtensionWhenIdentityAchieved() throws Exception {
-        storeIdentityHandler.handleRequest(PROCESS_REQUEST, mockContext);
+        storeIdentityHandler.handleRequest(PROCESS_REQUEST_FOR_COMPLETED_IDENTITY, mockContext);
 
         verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
         var auditEvent = auditEventCaptor.getValue();
@@ -130,13 +154,14 @@ class StoreIdentityHandlerTest {
         assertEquals(
                 new AuditEventUser(USER_ID, SESSION_ID, GOVUK_JOURNEY_ID, IP_ADDRESS),
                 auditEvent.getUser());
+        verify(mockEvcsService, times(0)).storeCompletedIdentity(anyString(), any(), any());
     }
 
     @Test
     void shouldSendAuditEventWithVotExtensionWhenIdentityIncomplete() throws Exception {
         ipvSessionItem.setVot(P0);
 
-        storeIdentityHandler.handleRequest(PROCESS_REQUEST, mockContext);
+        storeIdentityHandler.handleRequest(PROCESS_REQUEST_FOR_COMPLETED_IDENTITY, mockContext);
 
         verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
         var auditEvent = auditEventCaptor.getValue();
@@ -169,7 +194,9 @@ class StoreIdentityHandlerTest {
         when(mockSessionCredentialService.getCredentials(SESSION_ID, USER_ID))
                 .thenThrow(new VerifiableCredentialException(418, FAILED_TO_GET_CREDENTIAL));
 
-        var response = storeIdentityHandler.handleRequest(PROCESS_REQUEST, mockContext);
+        var response =
+                storeIdentityHandler.handleRequest(
+                        PROCESS_REQUEST_FOR_COMPLETED_IDENTITY, mockContext);
 
         assertEquals(JOURNEY_ERROR_PATH, response.get(JOURNEY));
         assertEquals(418, response.get(STATUS_CODE));
@@ -184,7 +211,9 @@ class StoreIdentityHandlerTest {
                 .when(mockVerifiableCredentialService)
                 .storeIdentity(any(), any());
 
-        var response = storeIdentityHandler.handleRequest(PROCESS_REQUEST, mockContext);
+        var response =
+                storeIdentityHandler.handleRequest(
+                        PROCESS_REQUEST_FOR_COMPLETED_IDENTITY, mockContext);
 
         assertEquals(JOURNEY_ERROR_PATH, response.get(JOURNEY));
         assertEquals(418, response.get(STATUS_CODE));
@@ -198,11 +227,63 @@ class StoreIdentityHandlerTest {
                 .when(mockAuditService)
                 .sendAuditEvent(any(AuditEvent.class));
 
-        var response = storeIdentityHandler.handleRequest(PROCESS_REQUEST, mockContext);
+        var response =
+                storeIdentityHandler.handleRequest(
+                        PROCESS_REQUEST_FOR_COMPLETED_IDENTITY, mockContext);
 
         assertEquals(JOURNEY_ERROR_PATH, response.get(JOURNEY));
         assertEquals(500, response.get(STATUS_CODE));
         assertEquals(FAILED_TO_SEND_AUDIT_EVENT.getCode(), response.get(CODE));
         assertEquals(FAILED_TO_SEND_AUDIT_EVENT.getMessage(), response.get(MESSAGE));
+    }
+
+    @Test
+    void
+            shouldStoreIdentityInEvcsAndSendAuditEventAndSendIdentityStoredJourney_whenEvcsWriteEnabled_forPendingF2f()
+                    throws Exception {
+        reset(mockIpvSessionService);
+        ipvSessionItem.setJourneyType(IpvJourneyTypes.REPEAT_FRAUD_CHECK);
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
+        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
+
+        var response =
+                storeIdentityHandler.handleRequest(
+                        PROCESS_REQUEST_FOR_PENDING_IDENTITY, mockContext);
+
+        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        var auditEvent = auditEventCaptor.getValue();
+
+        assertEquals(JOURNEY_IDENTITY_STORED_PATH, response.get(JOURNEY));
+        assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
+        assertEquals(P2, ((AuditExtensionVot) auditEvent.getExtensions()).vot());
+        assertEquals(COMPONENT_ID, auditEvent.getComponentId());
+        assertEquals(
+                new AuditEventUser(USER_ID, SESSION_ID, GOVUK_JOURNEY_ID, IP_ADDRESS),
+                auditEvent.getUser());
+        verify(mockEvcsService, times(1))
+                .storePendingIdentity(USER_ID, VCS, clientOAuthSessionItem.getEvcsAccessToken());
+    }
+
+    @Test
+    void
+            shouldReturnAnErrorJourneyIfFailedAtEvcsIdentityStore_whenEvcsWriteEnabled_forPendingF2f() {
+        reset(mockIpvSessionService);
+        ipvSessionItem.setJourneyType(IpvJourneyTypes.REPEAT_FRAUD_CHECK);
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
+        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
+        doThrow(
+                        new EvcsServiceException(
+                                HTTPResponse.SC_SERVER_ERROR, FAILED_AT_EVCS_HTTP_REQUEST_SEND))
+                .when(mockEvcsService)
+                .storePendingIdentity(USER_ID, VCS, clientOAuthSessionItem.getEvcsAccessToken());
+
+        var response =
+                storeIdentityHandler.handleRequest(
+                        PROCESS_REQUEST_FOR_PENDING_IDENTITY, mockContext);
+
+        assertEquals(JOURNEY_ERROR_PATH, response.get(JOURNEY));
+        assertEquals(500, response.get(STATUS_CODE));
+        assertEquals(FAILED_AT_EVCS_HTTP_REQUEST_SEND.getCode(), response.get(CODE));
+        assertEquals(FAILED_AT_EVCS_HTTP_REQUEST_SEND.getMessage(), response.get(MESSAGE));
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -78,7 +78,6 @@ public enum ErrorResponse {
     UNKNOWN_SCORE_TYPE(1060, "Unknown score type in request"),
     FAILED_TO_PARSE_SUCCESSFUL_VC_STORE_ITEMS(1061, "Failed to parse successful VC Store items."),
     FAILED_TO_GENERATE_NINO_CLAIM(1062, "Failed to generate the NINO claim"),
-    MISSING_IS_USER_INITIATED_PARAMETER(1063, "Missing isUserInitiated in request"),
     MISSING_VTR(1064, "The 'vtr' claim is required and was not provided in the request."),
     NO_IPV_FOR_CRI_OAUTH_SESSION(1065, "No ipvSession for existing CriOAuthSession."),
     FAILED_TO_PARSE_CRI_CALLBACK_REQUEST(1066, "Failed to parse cri callback request."),
@@ -97,7 +96,8 @@ public enum ErrorResponse {
     FAILED_TO_PARSE_EVCS_RESPONSE(1079, "Failed to parse EVCS response"),
     FAILED_TO_PARSE_EVCS_REQUEST_BODY(1080, "Failed to parse EVCS request body"),
     FAILED_TO_PARSE_EVCS_VC(1081, "Failed to parse a vc from EVCS"),
-    FAILED_AT_EVCS_HTTP_REQUEST_SEND(1082, "Failed while sending http request to EVCS");
+    FAILED_AT_EVCS_HTTP_REQUEST_SEND(1082, "Failed while sending http request to EVCS"),
+    MISSING_IS_COMPLETED_IDENTITY_PARAMETER(1083, "Missing isCompletedIdentity in request");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VocabConstants.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VocabConstants.java
@@ -13,6 +13,8 @@ public class VocabConstants {
     public static final String IDENTITY_CLAIM_NAME = "https://vocab.account.gov.uk/v1/coreIdentity";
     public static final String INHERITED_IDENTITY_JWT_CLAIM_NAME =
             "https://vocab.account.gov.uk/v1/inheritedIdentityJWT";
+    public static final String EVCS_ACCESS_TOKEN_CLAIM_NAME =
+            "https://vocab.account.gov.uk/v1/storageAccessToken";
     public static final String NINO_CLAIM_NAME =
             "https://vocab.account.gov.uk/v1/socialSecurityRecord";
     public static final String PASSPORT_CLAIM_NAME = "https://vocab.account.gov.uk/v1/passport";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -27,8 +27,8 @@ public class RequestHelper {
     public static final String IP_ADDRESS_HEADER = "ip-address";
     public static final String ENCODED_DEVICE_INFORMATION_HEADER = "txma-audit-encoded";
     public static final String FEATURE_SET_HEADER = "feature-set";
-    public static final String IS_USER_INITIATED = "isUserInitiated";
     public static final String DELETE_ONLY_GPG45_VCS = "deleteOnlyGPG45VCs";
+    public static final String IS_COMPLETED_IDENTITY = "isCompletedIdentity";
     private static final Logger LOGGER = LogManager.getLogger();
 
     private RequestHelper() {}
@@ -145,15 +145,6 @@ public class RequestHelper {
                 request, "scoreThreshold", ErrorResponse.MISSING_SCORE_THRESHOLD);
     }
 
-    public static boolean getIsUserInitiated(ProcessRequest request)
-            throws HttpResponseExceptionWithErrorBody {
-        return Boolean.TRUE.equals(
-                extractValueFromLambdaInput(
-                        request,
-                        IS_USER_INITIATED,
-                        ErrorResponse.MISSING_IS_USER_INITIATED_PARAMETER));
-    }
-
     public static boolean getDeleteOnlyGPG45VCs(ProcessRequest request)
             throws HttpResponseExceptionWithErrorBody {
         return Boolean.TRUE.equals(
@@ -161,6 +152,15 @@ public class RequestHelper {
                         request,
                         DELETE_ONLY_GPG45_VCS,
                         ErrorResponse.MISSING_IS_RESET_DELETE_GPG45_ONLY_PARAMETER));
+    }
+
+    public static boolean getIsCompletedIdentity(ProcessRequest request)
+            throws HttpResponseExceptionWithErrorBody {
+        return Boolean.TRUE.equals(
+                extractValueFromLambdaInput(
+                        request,
+                        IS_COMPLETED_IDENTITY,
+                        ErrorResponse.MISSING_IS_COMPLETED_IDENTITY_PARAMETER));
     }
 
     private static <T> T extractValueFromLambdaInput(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
@@ -28,6 +28,7 @@ public class ClientOAuthSessionItem implements DynamodbItem {
     private Boolean reproveIdentity;
     private List<String> vtr;
     private long ttl;
+    private String evcsAccessToken;
 
     @DynamoDbPartitionKey
     public String getClientOAuthSessionId() {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -37,7 +37,10 @@ public class ClientOAuthSessionDetailsService {
     }
 
     public ClientOAuthSessionItem generateClientSessionDetails(
-            String clientOauthSessionId, JWTClaimsSet claimsSet, String clientId)
+            String clientOauthSessionId,
+            JWTClaimsSet claimsSet,
+            String clientId,
+            String evcsAccessToken)
             throws ParseException {
         ClientOAuthSessionItem clientOAuthSessionItem = new ClientOAuthSessionItem();
 
@@ -58,7 +61,7 @@ public class ClientOAuthSessionDetailsService {
                         : null;
 
         clientOAuthSessionItem.setReproveIdentity(reproveIdentity);
-
+        clientOAuthSessionItem.setEvcsAccessToken(evcsAccessToken);
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);
 
         return clientOAuthSessionItem;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -237,13 +237,12 @@ class RequestHelperTest {
         String ipvSessionId = "a-session-id";
         String ipAddress = "a-ipaddress";
         String featureSet = "a-feature-set";
-        String journey = DCMAW_CRI;
         var event =
                 JourneyRequest.builder()
                         .ipvSessionId(ipvSessionId)
                         .ipAddress(ipAddress)
                         .clientOAuthSessionId(clientSessionId)
-                        .journey(journey)
+                        .journey(DCMAW_CRI)
                         .featureSet(featureSet)
                         .build();
 
@@ -259,12 +258,11 @@ class RequestHelperTest {
         String clientSessionId = "client-session-id";
         String ipAddress = "a-ipaddress";
         String featureSet = "a-feature-set";
-        String journey = DCMAW_CRI;
         var event =
                 JourneyRequest.builder()
                         .ipAddress(ipAddress)
                         .clientOAuthSessionId(clientSessionId)
-                        .journey(journey)
+                        .journey(DCMAW_CRI)
                         .featureSet(featureSet)
                         .build();
 
@@ -419,26 +417,6 @@ class RequestHelperTest {
     }
 
     @Test
-    void getIsUserInitiatedShouldReturnTrue() throws Exception {
-        ProcessRequest request =
-                ProcessRequest.processRequestBuilder()
-                        .lambdaInput(Map.of("isUserInitiated", true))
-                        .build();
-
-        assertTrue(RequestHelper.getIsUserInitiated(request));
-    }
-
-    @Test
-    void getIsUserInitiatedShouldReturnFalse() throws Exception {
-        ProcessRequest request =
-                ProcessRequest.processRequestBuilder()
-                        .lambdaInput(Map.of("isUserInitiated", false))
-                        .build();
-
-        assertFalse(RequestHelper.getIsUserInitiated(request));
-    }
-
-    @Test
     void getDeleteOnlyGPG45VCsShouldReturnTrue() throws Exception {
         ProcessRequest request =
                 ProcessRequest.processRequestBuilder()
@@ -459,17 +437,38 @@ class RequestHelperTest {
     }
 
     @Test
-    void getIsUserInitiatedShouldThrowIfNull() {
+    void getIsCompletedIdentityShouldReturnTrue() throws Exception {
+        ProcessRequest request =
+                ProcessRequest.processRequestBuilder()
+                        .lambdaInput(Map.of("isCompletedIdentity", true))
+                        .build();
+
+        assertTrue(RequestHelper.getIsCompletedIdentity(request));
+    }
+
+    @Test
+    void getIsCompletedIdentityShouldReturnFalse() throws Exception {
+        ProcessRequest request =
+                ProcessRequest.processRequestBuilder()
+                        .lambdaInput(Map.of("isCompletedIdentity", false))
+                        .build();
+
+        assertFalse(RequestHelper.getIsCompletedIdentity(request));
+    }
+
+    @Test
+    void getIsCompletedIdentityShouldThrowIfNull() {
         var lambdaInput = new HashMap<String, Object>();
-        lambdaInput.put("isUserInitiated", null);
+        lambdaInput.put("isCompletedIdentity", null);
         ProcessRequest request =
                 ProcessRequest.processRequestBuilder().lambdaInput(lambdaInput).build();
 
         HttpResponseExceptionWithErrorBody thrown =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> RequestHelper.getIsUserInitiated(request));
+                        () -> RequestHelper.getIsCompletedIdentity(request));
 
-        assertEquals(ErrorResponse.MISSING_IS_USER_INITIATED_PARAMETER, thrown.getErrorResponse());
+        assertEquals(
+                ErrorResponse.MISSING_IS_COMPLETED_IDENTITY_PARAMETER, thrown.getErrorResponse());
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
@@ -83,7 +83,10 @@ class ClientOAuthSessionDetailsServiceTest {
                         .build();
         ClientOAuthSessionItem clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.generateClientSessionDetails(
-                        clientOAuthSessionId, testClaimSet, "test-client");
+                        clientOAuthSessionId,
+                        testClaimSet,
+                        "test-client",
+                        "test-evcs-access-token");
 
         ArgumentCaptor<ClientOAuthSessionItem> clientOAuthSessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(ClientOAuthSessionItem.class);
@@ -105,6 +108,9 @@ class ClientOAuthSessionDetailsServiceTest {
         assertEquals(
                 clientOAuthSessionItem.getUserId(),
                 clientOAuthSessionItemArgumentCaptor.getValue().getUserId());
+        assertEquals(
+                clientOAuthSessionItem.getEvcsAccessToken(),
+                clientOAuthSessionItemArgumentCaptor.getValue().getEvcsAccessToken());
         assertEquals(
                 clientOAuthSessionItem.getGovukSigninJourneyId(),
                 clientOAuthSessionItemArgumentCaptor.getValue().getGovukSigninJourneyId());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
- Store EVCS access token in session (PYIC-6217)
- Update storeIdentity lambda to use EVCSService to store user VCs in EVCS

### What changed
- Storing EVCS access token in session then passing on evcsService to pass in read request as header.
- Updated storeIdentity lambda to use EVCSService to write user VCs to EVCS
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6527](https://govukverify.atlassian.net/browse/PYIC-6527)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-6527]: https://govukverify.atlassian.net/browse/PYIC-6527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ