### PR TITLE
PYIC-6088: Fix scope validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -278,21 +282,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 111
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 111
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 111
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1889,5 +1893,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-28T15:43:36Z"
+  "generated_at": "2024-05-29T15:23:33Z"
 }

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -70,6 +70,7 @@ import static uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsIpvJo
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAudit;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForInheritedIdentity;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JAR_KMS_ENCRYPTION_KEY_ID;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.CriConstants.HMRC_MIGRATION_CRI;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 
@@ -172,7 +173,9 @@ public class InitialiseIpvSessionHandler
             List<String> vtr = claimsSet.getStringListClaim(REQUEST_VTR_KEY);
 
             var isReverification =
-                    Scope.parse(claimsSet.getStringClaim(SCOPE)).contains(REVERIFICATION);
+                    configService.enabled(MFA_RESET)
+                            && Scope.parse(claimsSet.getStringClaim(SCOPE))
+                                    .contains(REVERIFICATION);
             if (!isReverification && isListEmpty(vtr)) {
                 LOGGER.error(LogHelper.buildLogMessage(ErrorResponse.MISSING_VTR.getMessage()));
                 return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
@@ -234,14 +234,15 @@ public class JarValidator {
                                 JWTClaimNames.EXPIRATION_TIME,
                                 JWTClaimNames.NOT_BEFORE,
                                 JWTClaimNames.ISSUED_AT,
-                                JWTClaimNames.SUBJECT));
+                                JWTClaimNames.SUBJECT,
+                                SCOPE));
 
         try {
             JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
             verifier.verify(claimsSet, null);
 
             validateMaxAllowedJarTtl(claimsSet);
-            //            validateScope(clientId, claimsSet);
+            validateScope(clientId, claimsSet);
 
             return claimsSet;
         } catch (BadJWTException | ParseException e) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -8,7 +8,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
     TICF_CRI_BETA("ticfCriBeta"),
     EVCS_WRITE_ENABLED("evcsWriteEnabled"),
-    EVCS_READ_ENABLED("evcsReadEnabled");
+    EVCS_READ_ENABLED("evcsReadEnabled"),
+    MFA_RESET("mfaResetEnabled");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -29,6 +29,7 @@ public class LogHelper {
         LOG_CONNECTION("connection"),
         LOG_CONTEXT("context"),
         LOG_COI_SUBJOURNEY_TYPE("coiSubjourneyType"),
+        LOG_COUNT("count"),
         LOG_CRI_ID("criId"),
         LOG_CRI_ISSUER("criIssuer"),
         LOG_CRI_OAUTH_SESSION_ID("criOAuthSessionId"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixes the scope validation issues that previously caused a P1 incident, and moves reverification logic behind a feature flag.

### Why did it change

[Revert "BAU: Remove scope checks"](https://github.com/govuk-one-login/ipv-core-back/commit/78b6b871de9dfefcbe418b6052a838fa0a6f147d)

This reverts commit https://github.com/govuk-one-login/ipv-core-back/commit/52abdbef5d3eb80d012deadb768e370c5e909b7a.
This was the fix to end the P1 incident. Bringing the changes back in so we can modify them.

[PYIC-6088: Fix scope validation](https://github.com/govuk-one-login/ipv-core-back/commit/85cc7ae9c0d6a2f26dd7a6948a4325292dbfa65e)

We were validating that all scopes provided were defined in config for a
given client. This was too strict. Orch gives us more than just
`openid`, which is the only scope we care about for them.

This updates the logic to ensure that only clients configured for openid
can use it, and only clients configured for reverification can use it.
If the client doesn't give us either of these we log it and allow an IPV
journey. This is due to the values in the scope being passed on to us
from them by orch, and we don't want to block unneccessarily. If we see
logs showing neither provided we can address this.

[PYIC-6088: Hide scope validation behind flag](https://github.com/govuk-one-login/ipv-core-back/commit/b118487d0b987b9828c8e3834a7df9c404b9cbf9)

This moves all the scope checking and validation behind the mfa reset
feature flag, so that we're only running the new code paths when we
want to.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6088](https://govukverify.atlassian.net/browse/PYIC-6088)


[PYIC-6088]: https://govukverify.atlassian.net/browse/PYIC-6088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ