### PR TITLE
PYIC-6424: Set VOT to P0 in reset-session-identity lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2568,7 +2568,7 @@ Resources:
             QueueName: !ImportValue AuditEventQueueName
         - DynamoDBCrudPolicy:
             TableName: !Ref SessionCredentialsTable
-        - DynamoDBReadPolicy:
+        - DynamoDBCrudPolicy:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredential
 
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
@@ -72,6 +73,9 @@ public class ResetSessionIdentityHandler
                             ipvSessionItem.getClientOAuthSessionId());
             String govukSigninJourneyId = clientOAuthSessionItem.getGovukSigninJourneyId();
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
+
+            ipvSessionItem.setVot(P0);
+            ipvSessionService.updateIpvSession(ipvSessionItem);
 
             sessionCredentialsService.deleteSessionCredentialsForSubjourneyType(
                     ipvSessionId, ipvSessionItem.getCoiSubjourneyType());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set VOT to P0 in reset-session-identity lambda

### Why did it change

This sets the users VOT to P0 at the point we reset some or all of the VCs in the session credential store.

This is to reflect the fact that the VCs in the store no longer form a valid P2 identity.

This is especially important for COI journeys where a user has an existing valid identity they're reusing. Their VOT will have already been set to P2. If they choose to update their details, but the fall out of COI journey either by abandoning a CRI or a fail-with-no-ci, we need to make sure that the VCs they are returned to the service with match the VOT in their session.

There is probably more work to do around content, or potentially sending the user back to the check-existing-identity lambda to have another go, but this is an MVP solution.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6424](https://govukverify.atlassian.net/browse/PYIC-6424)


[PYIC-6424]: https://govukverify.atlassian.net/browse/PYIC-6424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ