### PR TITLE
BAU: Move setting of COI journey type in session

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -131,12 +131,6 @@ public class ProcessJourneyEventHandler
                         HttpStatus.SC_BAD_REQUEST, ErrorResponse.INVALID_SESSION_ID);
             }
 
-            if (isCoiSubjourneyEvent(journeyEvent)) {
-                CoiSubjourneyType coiJourneyType = CoiSubjourneyType.fromString(journeyEvent);
-
-                ipvSessionItem.setCoiSubjourneyType(coiJourneyType);
-            }
-
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.getClientOAuthSession(
                             ipvSessionItem.getClientOAuthSessionId());
@@ -159,6 +153,14 @@ public class ProcessJourneyEventHandler
                             auditEventUser,
                             deviceInformation,
                             currentPage);
+
+            if (isCoiSubjourneyEvent(journeyEvent)) {
+                CoiSubjourneyType coiJourneyType = CoiSubjourneyType.fromString(journeyEvent);
+
+                ipvSessionItem.setCoiSubjourneyType(coiJourneyType);
+            }
+
+            ipvSessionService.updateIpvSession(ipvSessionItem);
 
             if (stepResponse.getMitigationStart() != null) {
                 sendMitigationStartAuditEvent(
@@ -223,8 +225,6 @@ public class ProcessJourneyEventHandler
                     ipvSessionItem);
 
             clearOauthSessionIfExists(ipvSessionItem);
-
-            ipvSessionService.updateIpvSession(ipvSessionItem);
 
             return basicState.getResponse();
         } catch (UnknownStateException e) {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Move setting of COI journey type in session

### Why did it change

@MikeCollingwood highlighted this as a potential issue.

The COI journey type was being set on the users session before we'd validated that the event was legitimate for the users current state.

The implication of this was that a user could potentially update there COI journey type by sending a new request in to the journey engine via the frontend.

The only thing preventing this from happening was that we were not saving the users session before throwing an error for an invalid event.

This feels a little risky - future updates could move the point at which we store the users sessiona and introduce a issue with the COI journey type.
