### PR TITLE
IPS-620: Upgrade devplatform-upload-action to v3.5 with explicit path for SAM

### DIFF
--- a/.github/workflows/secure-post-merge-delete-account.yml
+++ b/.github/workflows/secure-post-merge-delete-account.yml
@@ -58,25 +58,17 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_DELETE_ACCOUNT_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./deploy-delete-user-data/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM validate
-        working-directory: ./deploy-delete-user-data
-        run: sam validate --region ${{ env.AWS_REGION }}
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy-delete-user-data/template.yaml
 
-      - name: SAM build and test
-        working-directory: ./deploy-delete-user-data
-        run: sam build
+      - name: SAM build
+        run: |
+          mkdir build
+          sam build -t deploy-delete-user-data/template.yaml -b out
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.5
         with:
             artifact-bucket-name: ${{ secrets.DELETE_ACCOUNT_ARTIFACT_BUCKET_NAME }}
             signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-            working-directory: ./deploy-delete-user-data
-            template-file: template.yaml
+            working-directory: ./out

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -61,25 +61,17 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./deploy/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM validate
-        working-directory: ./deploy
-        run: sam validate --region ${{ env.AWS_REGION }}
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
 
-      - name: SAM build and test
-        working-directory: ./deploy
-        run: sam build
+      - name: SAM build
+        run: |
+          mkdir build
+          sam build -t deploy/template.yaml -b out
 
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3
+        uses: govuk-one-login/devplatform-upload-action@v3.5
         with:
             artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
             signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-            working-directory: ./deploy
-            template-file: template.yaml
+            working-directory: ./out


### PR DESCRIPTION
### What changed

- Removed rusty actions
- Upgraded devplatform-upload-action to v3.5 with explicit path for SAM with `-b out`
- Example from [ipv-cri-dl-api](https://github.com/govuk-one-login/ipv-cri-dl-api/blob/b145bdcaf4c30e774e6a909616bcf5d826940de5/.github/workflows/post-merge-package-for-build.yml)

### Why did it change

- Upgrade to v3.5
- Path specified to prevent empty zips being packaged

### Issue tracking
- [IPS-620](https://govukverify.atlassian.net/browse/IPS-620)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-620]: https://govukverify.atlassian.net/browse/IPS-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ