### PR TITLE
PYIC-6579: Remove COI check from address only journeys

### DIFF
--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -104,7 +104,11 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
                                 .areFamilyNameAndDobCorrelatedForCoiCheck(credentials);
                         case FAMILY_NAME_ONLY, FAMILY_NAME_AND_ADDRESS -> userIdentityService
                                 .areGivenNamesAndDobCorrelated(credentials);
-                        case ADDRESS_ONLY -> userIdentityService.areVcsCorrelated(credentials);
+                        case ADDRESS_ONLY -> {
+                            LOGGER.warn(
+                                    LogHelper.buildLogMessage("Address only COI check requested"));
+                            yield true;
+                        }
                     };
 
             if (!successfulCheck) {

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -119,10 +119,7 @@ class CheckCoiHandlerTest {
             }
 
             @Test
-            void shouldReturnPassedForSuccessfulAddressOnlyCheck() throws Exception {
-                when(mockUserIdentityService.areVcsCorrelated(
-                                List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
-                        .thenReturn(true);
+            void shouldReturnPassedForAddressOnlyCheck() {
                 when(mockIpvSessionItem.getCoiSubjourneyType()).thenReturn(ADDRESS_ONLY);
 
                 var request =
@@ -166,21 +163,6 @@ class CheckCoiHandlerTest {
                                 List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                         .thenReturn(false);
                 when(mockIpvSessionItem.getCoiSubjourneyType()).thenReturn(coiSubjourneyType);
-
-                var request =
-                        ProcessRequest.processRequestBuilder().ipvSessionId(IPV_SESSION_ID).build();
-
-                var responseMap = checkCoiHandler.handleRequest(request, mockContext);
-
-                assertEquals(JOURNEY_COI_CHECK_FAILED_PATH, responseMap.get("journey"));
-            }
-
-            @Test
-            void shouldReturnFailedForFailedAddressOnlyCheck() throws Exception {
-                when(mockUserIdentityService.areVcsCorrelated(
-                                List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
-                        .thenReturn(false);
-                when(mockIpvSessionItem.getCoiSubjourneyType()).thenReturn(ADDRESS_ONLY);
 
                 var request =
                         ProcessRequest.processRequestBuilder().ipvSessionId(IPV_SESSION_ID).build();
@@ -251,24 +233,6 @@ class CheckCoiHandlerTest {
             assertEquals(FAILED_NAME_CORRELATION.getMessage(), responseMap.get("message"));
         }
 
-        @Test
-        void shouldReturnErrorIfFullCorrelationCheckThrowsHttpResponseException() throws Exception {
-            when(mockUserIdentityService.areVcsCorrelated(
-                            List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
-                    .thenThrow(
-                            new HttpResponseExceptionWithErrorBody(
-                                    SC_SERVER_ERROR, FAILED_NAME_CORRELATION));
-            when(mockIpvSessionItem.getCoiSubjourneyType()).thenReturn(ADDRESS_ONLY);
-
-            var request =
-                    ProcessRequest.processRequestBuilder().ipvSessionId(IPV_SESSION_ID).build();
-
-            var responseMap = checkCoiHandler.handleRequest(request, mockContext);
-
-            assertEquals(JOURNEY_ERROR_PATH, responseMap.get("journey"));
-            assertEquals(FAILED_NAME_CORRELATION.getMessage(), responseMap.get("message"));
-        }
-
         @ParameterizedTest
         @EnumSource(
                 value = CoiSubjourneyType.class,
@@ -300,23 +264,6 @@ class CheckCoiHandlerTest {
                             List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                     .thenThrow(new CredentialParseException("oops"));
             when(mockIpvSessionItem.getCoiSubjourneyType()).thenReturn(coiSubjourneyType);
-
-            var request =
-                    ProcessRequest.processRequestBuilder().ipvSessionId(IPV_SESSION_ID).build();
-
-            var responseMap = checkCoiHandler.handleRequest(request, mockContext);
-
-            assertEquals(JOURNEY_ERROR_PATH, responseMap.get("journey"));
-            assertEquals(
-                    FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(), responseMap.get("message"));
-        }
-
-        @Test
-        void shouldReturnErrorIfFullCorrelationCheckThrowsCredParseException() throws Exception {
-            when(mockUserIdentityService.areVcsCorrelated(
-                            List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
-                    .thenThrow(new CredentialParseException("oops"));
-            when(mockIpvSessionItem.getCoiSubjourneyType()).thenReturn(ADDRESS_ONLY);
 
             var request =
                     ProcessRequest.processRequestBuilder().ipvSessionId(IPV_SESSION_ID).build();

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -57,24 +57,10 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CHECK_COI_UPDATE_ADDRESS
+        targetState: EVALUATE_GPG45_SCORES_UPDATE_ADDRESS
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
-
-  CHECK_COI_UPDATE_ADDRESS:
-    response:
-      type: process
-      lambda: check-coi
-    events:
-      coi-check-passed:
-        targetState: EVALUATE_GPG45_SCORES_UPDATE_ADDRESS
-      coi-check-failed:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
 
   EVALUATE_GPG45_SCORES_UPDATE_ADDRESS:
     response:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove COI check from address only journeys

### Why did it change

If a user is updating just their address then there is no need to run a COI check. Their name and DOB won't have changed.

This also removes the actual check from the lambda and replaces it with some logging. We should never see that log.

This leaves the ADDRESS_ONLY enum in place - it's used by the reset session lambda to remove the correct VCs. This will probably get addressed in an upcoming ticket to use contexts instead of a value in session.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6579](https://govukverify.atlassian.net/browse/PYIC-6579)


[PYIC-6579]: https://govukverify.atlassian.net/browse/PYIC-6579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ