### PR TITLE
PYIC-6057: Remove references to f2fVolumes feature flag with assumption it was always true

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -545,13 +545,7 @@ states:
       next:
         targetState: ADDRESS_AND_FRAUD_J2
       access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-        checkFeatureFlag:
-          f2fVolumesJourneyEnabled:
-            targetState: PROVE_ANOTHER_WAY_J2
+        targetState: PROVE_ANOTHER_WAY_J2
       alternate-doc-invalid-passport:
         targetState: MITIGATION_05_OPTIONS
 
@@ -593,13 +587,7 @@ states:
       next:
         targetState: ADDRESS_AND_FRAUD_J3
       access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-        checkFeatureFlag:
-          f2fVolumesJourneyEnabled:
-            targetState: PROVE_ANOTHER_WAY_J3
+        targetState: PROVE_ANOTHER_WAY_J3
       alternate-doc-invalid-dl:
         targetState: MITIGATION_03_OPTIONS
 
@@ -1287,11 +1275,7 @@ states:
       next:
         targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
       access-denied:
-        targetJourney: FAILED
-        targetState: FAILED
-        checkFeatureFlag:
-          f2fVolumesJourneyEnabled:
-            targetState: MITIGATION_PP_PROVE_ANOTHER_WAY
+        targetState: MITIGATION_PP_PROVE_ANOTHER_WAY
 
   MITIGATION_PP_PROVE_ANOTHER_WAY:
     response:
@@ -1361,11 +1345,7 @@ states:
       next:
         targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
       access-denied:
-        targetJourney: FAILED
-        targetState: FAILED
-        checkFeatureFlag:
-          f2fVolumesJourneyEnabled:
-            targetState: MITIGATION_DL_PROVE_ANOTHER_WAY
+        targetState: MITIGATION_DL_PROVE_ANOTHER_WAY
 
   MITIGATION_DL_PROVE_ANOTHER_WAY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -546,6 +546,9 @@ states:
         targetState: ADDRESS_AND_FRAUD_J2
       access-denied:
         targetState: PROVE_ANOTHER_WAY_J2
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
       alternate-doc-invalid-passport:
         targetState: MITIGATION_05_OPTIONS
 
@@ -588,6 +591,9 @@ states:
         targetState: ADDRESS_AND_FRAUD_J3
       access-denied:
         targetState: PROVE_ANOTHER_WAY_J3
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
       alternate-doc-invalid-dl:
         targetState: MITIGATION_03_OPTIONS
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove references to a feature flag to clean it up

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6057](https://govukverify.atlassian.net/browse/PYIC-6057)


### Merging order

This must follow this change to turn the feature flag on everywhere:
https://github.com/govuk-one-login/ipv-core-common-infra/pull/952

[PYIC-6057]: https://govukverify.atlassian.net/browse/PYIC-6057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ