### PR TITLE
PYIC-6588: send audit event when no photo id journey starts

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -48,6 +48,7 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.StepRes
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,7 @@ public class ProcessJourneyEventHandler
     private static final String NEXT_EVENT = "next";
     private static final String END_SESSION_EVENT = "build-client-oauth-response";
     private static final StepResponse END_SESSION_RESPONSE =
-            new ProcessStepResponse("build-client-oauth-response", null, null);
+            new ProcessStepResponse("build-client-oauth-response", null, null, null);
     private final IpvSessionService ipvSessionService;
     private final AuditService auditService;
     private final ConfigService configService;
@@ -165,6 +166,22 @@ public class ProcessJourneyEventHandler
             if (stepResponse.getMitigationStart() != null) {
                 sendMitigationStartAuditEvent(
                         auditEventUser, stepResponse.getMitigationStart(), deviceInformation);
+            }
+
+            String journeyAuditEvent = stepResponse.getAuditEvent();
+            if (journeyAuditEvent != null) {
+                boolean eventTypeExists =
+                        Arrays.stream(AuditEventTypes.values())
+                                .anyMatch(eventType -> eventType.name().equals(journeyAuditEvent));
+                if (!eventTypeExists) {
+                    LOGGER.error(
+                            LogHelper.buildLogMessage("Invalid audit event type provided")
+                                    .with(LOG_JOURNEY_EVENT.getFieldName(), journeyAuditEvent));
+                    throw new JourneyEngineException(
+                            "Invalid audit event type provided, failed to execute journey engine step.");
+                }
+                AuditEventTypes auditEventType = AuditEventTypes.valueOf(journeyAuditEvent);
+                sendJourneyAuditEvent(auditEventType, auditEventUser, deviceInformation);
             }
 
             return stepResponse.value();
@@ -350,6 +367,18 @@ public class ProcessJourneyEventHandler
                         configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
                         auditEventUser,
                         new AuditExtensionMitigationType(mitigationType),
+                        new AuditRestrictedDeviceInformation(deviceInformation)));
+    }
+
+    private void sendJourneyAuditEvent(
+            AuditEventTypes auditEventType, AuditEventUser auditEventUser, String deviceInformation)
+            throws SqsException {
+
+        auditService.sendAuditEvent(
+                new AuditEvent(
+                        auditEventType,
+                        configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
+                        auditEventUser,
                         new AuditRestrictedDeviceInformation(deviceInformation)));
     }
 

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -69,7 +69,7 @@ public class ProcessJourneyEventHandler
     private static final String NEXT_EVENT = "next";
     private static final String END_SESSION_EVENT = "build-client-oauth-response";
     private static final StepResponse END_SESSION_RESPONSE =
-            new ProcessStepResponse("build-client-oauth-response", null, null, null);
+            new ProcessStepResponse(END_SESSION_EVENT, null, null, null);
     private final IpvSessionService ipvSessionService;
     private final AuditService auditService;
     private final ConfigService configService;

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -34,6 +34,7 @@ public class CriStepResponse implements StepResponse {
     private String context;
     private EvidenceRequest evidenceRequest;
     private String mitigationStart;
+    private String auditEvent;
 
     public Map<String, Object> value() {
         try {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponse.java
@@ -14,6 +14,7 @@ public class ErrorStepResponse implements StepResponse {
     private String pageId;
     private String statusCode;
     private String mitigationStart;
+    private String auditEvent;
 
     public Map<String, Object> value() {
         return Map.of("type", ERROR, "page", pageId, "statusCode", Integer.parseInt(statusCode));

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
@@ -15,6 +15,7 @@ public class PageStepResponse implements StepResponse {
     private String pageId;
     private String context;
     private String mitigationStart;
+    private String auditEvent;
 
     public Map<String, Object> value() {
         Map<String, Object> response = new HashMap<>();

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponse.java
@@ -17,6 +17,7 @@ public class ProcessStepResponse implements StepResponse {
     private String lambda;
     private Map<String, Object> lambdaInput;
     private String mitigationStart;
+    private String auditEvent;
 
     @Override
     public Map<String, Object> value() {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
@@ -16,4 +16,6 @@ public interface StepResponse {
     Map<String, Object> value();
 
     String getMitigationStart();
+
+    String getAuditEvent();
 }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -717,6 +717,7 @@ states:
     response:
       type: cri
       criId: claimedIdentity
+      auditEvent: IPV_NO_PHOTO_ID_JOURNEY_START
       context: bank_account
     parent: CRI_STATE
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -35,6 +35,8 @@ states:
         targetState: CRI_STATE_WITH_CONTEXT_AND_EVIDENCE_REQUEST
       testWithMitigationStart:
         targetState: PAGE_STATE_AT_START_OF_MITIGATION
+      testWithAuditEvent:
+        targetState: PAGE_STATE_AT_START_OF_NO_PHOTO_ID
       testJourneyStep:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -76,6 +78,15 @@ states:
       type: page
       pageId: page-id-for-some-page
       mitigationStart: a-mitigation-type
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
+
+  PAGE_STATE_AT_START_OF_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: page-id-for-some-page
+      auditEvent: IPV_NO_PHOTO_ID_JOURNEY_START
     events:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -37,6 +37,8 @@ states:
         targetState: PAGE_STATE_AT_START_OF_MITIGATION
       testWithAuditEvent:
         targetState: PAGE_STATE_AT_START_OF_NO_PHOTO_ID
+      testWithWrongAuditEvent:
+        targetState: WRONG_AUDIT_EVENT_STATE
       testJourneyStep:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -87,6 +89,15 @@ states:
       type: page
       pageId: page-id-for-some-page
       auditEvent: IPV_NO_PHOTO_ID_JOURNEY_START
+    events:
+      enterNestedJourneyAtStateOne:
+        targetState: NESTED_JOURNEY_INVOKE_STATE
+
+  WRONG_AUDIT_EVENT_STATE:
+    response:
+      type: page
+      pageId: page-id-for-some-page
+      auditEvent: WRONG_AUDIT_EVENT_TYPE
     events:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -513,6 +513,24 @@ class ProcessJourneyEventHandlerTest {
         assertEquals("testjourneyid", capturedAuditEvent.getUser().getGovukSigninJourneyId());
     }
 
+    @Test
+    void shouldReturnErrorWhenWrongAuditEvenTypeProvidedInJourneyMap() throws Exception {
+        var input =
+                JourneyRequest.builder()
+                        .ipAddress(TEST_IP)
+                        .journey("testWithWrongAuditEvent")
+                        .ipvSessionId(TEST_IP)
+                        .build();
+        mockIpvSessionItemAndTimeout("CRI_STATE");
+
+        Map<String, Object> output =
+                getProcessJourneyStepHandler().handleRequest(input, mockContext);
+
+        assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, output.get(STATUS_CODE));
+        assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getCode(), output.get(CODE));
+        assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), output.get(MESSAGE));
+    }
+
     private void mockIpvSessionItemAndTimeout(String userState) {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -490,6 +490,29 @@ class ProcessJourneyEventHandlerTest {
                         .mitigationType());
     }
 
+    @Test
+    void shouldSendAuditEventWhenThereIsAuditEventInJourneyMap() throws Exception {
+        var input =
+                JourneyRequest.builder()
+                        .ipAddress(TEST_IP)
+                        .journey("testWithAuditEvent")
+                        .ipvSessionId(TEST_IP)
+                        .build();
+        mockIpvSessionItemAndTimeout("CRI_STATE");
+
+        getProcessJourneyStepHandler(StateMachineInitializerMode.TEST)
+                .handleRequest(input, mockContext);
+
+        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        AuditEvent capturedAuditEvent = auditEventCaptor.getValue();
+
+        assertEquals(
+                AuditEventTypes.IPV_NO_PHOTO_ID_JOURNEY_START, capturedAuditEvent.getEventName());
+        assertEquals("core", capturedAuditEvent.getComponentId());
+        assertEquals("testuserid", capturedAuditEvent.getUser().getUserId());
+        assertEquals("testjourneyid", capturedAuditEvent.getUser().getGovukSigninJourneyId());
+    }
+
     private void mockIpvSessionItemAndTimeout(String userState) {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
@@ -25,7 +25,7 @@ class BasicStateTest {
     @Test
     void transitionShouldReturnAStateWithAResponse() throws Exception {
         BasicState targetState = new BasicState();
-        PageStepResponse stepResponse = new PageStepResponse("stepId", "context", null);
+        PageStepResponse stepResponse = new PageStepResponse("stepId", "context", null, null);
         targetState.setResponse(stepResponse);
 
         BasicState currentState = new BasicState();

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -16,7 +16,7 @@ class CriStepResponseTest {
     @MethodSource("journeyUriParameters")
     void valueReturnsExpectedJourneyResponse(
             String criId, String context, EvidenceRequest evidenceRequest, String expectedJourney) {
-        CriStepResponse response = new CriStepResponse(criId, context, evidenceRequest, null);
+        CriStepResponse response = new CriStepResponse(criId, context, evidenceRequest, null, null);
         assertEquals(
                 Map.of("journey", expectedJourney),
                 response.value(),

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponseTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ErrorStepResponseTest {
 
     public static final ErrorStepResponse ERROR_RESPONSE =
-            new ErrorStepResponse("aPageId", "500", null);
+            new ErrorStepResponse("aPageId", "500", null, null);
 
     @Test
     void valueReturnsCorrectResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PageStepResponseTest {
 
     public static final PageStepResponse PAGE_RESPONSE =
-            new PageStepResponse("aPageId", "testContext", "mitigationType");
+            new PageStepResponse("aPageId", "testContext", "mitigationType", "startNoPhotoId");
 
     @Test
     void valueReturnsCorrectPageResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponseTest.java
@@ -14,7 +14,8 @@ class ProcessStepResponseTest {
                 new ProcessStepResponse(
                         "a-process-lambda",
                         Map.of("input1", "Windom Earle", "input2", 315),
-                        "mitigationType");
+                        "mitigationType",
+                        null);
 
         Map<String, Object> expectedValue =
                 Map.of(

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventTypes.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventTypes.java
@@ -28,4 +28,5 @@ public enum AuditEventTypes {
     IPV_VC_RESTORED,
     IPV_VC_REVOKED,
     IPV_VC_REVOKED_FAILURE,
+    IPV_NO_PHOTO_ID_JOURNEY_START,
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

-  send audit event when no photo id journey starts

### What changed

- Sending new audit event for the photo id journey.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To allow analytics team to track no photo id journey.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6588](https://govukverify.atlassian.net/browse/PYIC-6588)

![Screenshot 2024-06-04 at 13 28 20](https://github.com/govuk-one-login/ipv-core-back/assets/3963744/461e6afd-c1d8-4cdd-9454-77c31d0cc60c)


[PYIC-6588]: https://govukverify.atlassian.net/browse/PYIC-6588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ