### PR TITLE
Pyic 6583 fix nested journeys

### DIFF
--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -52,6 +52,7 @@ const expandParents = (journeyMap) => {
 
 // Expand out nested states
 const expandNestedJourneys = (journeyMap, subjourneys) => {
+    console.log('expanding nested');
     Object.entries(journeyMap).forEach(([state, definition]) => {
         if (definition.nestedJourney && subjourneys[definition.nestedJourney]) {
             delete journeyMap[state];
@@ -240,7 +241,7 @@ export const render = (journeyMap, nestedJourneys, formData = new FormData()) =>
     const journeyMapCopy = JSON.parse(JSON.stringify(journeyMap));
 
     if (formData.has('expandNestedJourneys')) {
-        expandNestedJourneys(journeyMapCopy, nestedJourneys);
+        expandNestedJourneys(journeyMapCopy.states, nestedJourneys);
     }
 
     expandParents(journeyMapCopy.states);


### PR DESCRIPTION
Nested journey expansion was not working, because of the additional structure in the journey map to provide descriptions.

Also, nested journey expansion did not support a couple of use-cases from strategic app:
- Terminal states in a nested journey (i.e. without any events)
- Nested journeys routed behind a feature flag/disabled flag