### PR TITLE
PYIC-6052: Store async VCs in EVCS

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -196,16 +196,16 @@
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
+        "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
         "is_verified": false,
-        "line_number": 2288
+        "line_number": 2022
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
+        "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
-        "line_number": 2756
+        "line_number": 2290
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -1935,5 +1935,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-05T13:17:18Z"
+  "generated_at": "2024-06-05T13:25:00Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2018,6 +2018,8 @@ Resources:
             QueueName: !ImportValue AuditEventQueueName
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ci-config-*
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/evcs/api-key-*
         - Statement:
             - Sid: kmsSigningKeyPermission
               Effect: Allow

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
@@ -120,10 +120,10 @@ class BuildUserIdentityHandlerTest {
         List<SessionCredentialItem> sessionCredentials = new ArrayList<>();
         var passportCredential =
                 new SessionCredentialItem(
-                        IPV_SESSION_ID, DCMAW_CRI, passportVcBuilder.buildSignedJwt(), true);
+                        IPV_SESSION_ID, DCMAW_CRI, passportVcBuilder.buildSignedJwt(), true, null);
         var addressCredential =
                 new SessionCredentialItem(
-                        IPV_SESSION_ID, ADDRESS_CRI, addressVcBuilder.buildSignedJwt(), true);
+                        IPV_SESSION_ID, ADDRESS_CRI, addressVcBuilder.buildSignedJwt(), true, null);
         sessionCredentials.add(passportCredential);
         sessionCredentials.add(addressCredential);
 

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -11,10 +11,11 @@ repositories {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
-			project(":libs:common-services"),
-			project(":libs:cimit-service"),
-			project(":libs:cri-response-service"),
 			project(":libs:audit-service"),
+			project(":libs:cimit-service"),
+			project(":libs:common-services"),
+			project(":libs:cri-response-service"),
+			project(":libs:evcs-service"),
 			project(":libs:verifiable-credentials")
 
 	compileOnly	libs.lombok

--- a/lambdas/restore-vcs/src/test/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandlerTest.java
+++ b/lambdas/restore-vcs/src/test/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandlerTest.java
@@ -44,6 +44,7 @@ class RestoreVcsHandlerTest {
                         "kbv",
                         PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
                         Instant.now(),
+                        Instant.now(),
                         Instant.now());
         when(mockVcDataStore.getItem(TEST_USER_ID, "kbv")).thenReturn(testKbvVc);
 

--- a/lambdas/revoke-vcs/src/test/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandlerTest.java
+++ b/lambdas/revoke-vcs/src/test/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandlerTest.java
@@ -52,6 +52,7 @@ class RevokeVcsHandlerTest {
                         "kbv",
                         PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
                         Instant.now(),
+                        Instant.now(),
                         Instant.now());
         when(mockDataStore.getItem(TEST_USER_ID, "kbv")).thenReturn(testKbvVcStoreItem);
 
@@ -99,6 +100,7 @@ class RevokeVcsHandlerTest {
                         TEST_USER_ID,
                         "kbv",
                         PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
+                        Instant.now(),
                         Instant.now(),
                         Instant.now());
         when(mockDataStore.getItem(TEST_USER_ID, "kbv")).thenReturn(testKbvVcStoreItem);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItem.java
@@ -9,6 +9,8 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+import java.time.Instant;
+
 @ExcludeFromGeneratedCoverageReport
 @DynamoDbBean
 @Data
@@ -21,17 +23,20 @@ public class SessionCredentialItem implements DynamodbItem {
     private String sortKey;
     private String credential;
     private boolean receivedThisSession;
+    private Instant migrated;
     private long ttl;
 
     public SessionCredentialItem(
             String ipvSessionId,
             String criId,
             SignedJWT signedCredJwt,
-            boolean receivedThisSession) {
+            boolean receivedThisSession,
+            Instant migrated) {
         this.ipvSessionId = ipvSessionId;
         this.sortKey = String.format(SORT_KEY_TEMPLATE, criId, signedCredJwt.getSignature());
         this.credential = signedCredJwt.serialize();
         this.receivedThisSession = receivedThisSession;
+        this.migrated = migrated;
     }
 
     @DynamoDbPartitionKey

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/VcStoreItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/VcStoreItem.java
@@ -24,6 +24,7 @@ public class VcStoreItem implements DynamodbItem {
     private String credential;
     private Instant dateCreated;
     private Instant expirationTime;
+    private Instant migrated;
 
     @DynamoDbPartitionKey
     public String getUserId() {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistance/item/SessionCredentialItemTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistance/item/SessionCredentialItemTest.java
@@ -9,6 +9,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
 
+import java.time.Instant;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -21,9 +23,10 @@ class SessionCredentialItemTest {
     private SessionCredentialItem sessionCredentialItem;
 
     @BeforeEach
-    private void setUp() {
+    public void setUp() {
         when(mockJwt.getSignature()).thenReturn(Base64URL.encode(SIGNATURE));
-        sessionCredentialItem = new SessionCredentialItem(SESSION_ID, CRI_ID, mockJwt, true);
+        sessionCredentialItem =
+                new SessionCredentialItem(SESSION_ID, CRI_ID, mockJwt, true, Instant.now());
     }
 
     @Test

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/DataStoreTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/DataStoreTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.library.persistance;
+package uk.gov.di.ipv.core.library.persistence;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +18,6 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.conditional.BeginsWithC
 import software.amazon.awssdk.enhanced.dynamodb.model.*;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.TableDescription;
-import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItemTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItemTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.library.persistance.item;
+package uk.gov.di.ipv.core.library.persistence.item;
 
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.SignedJWT;
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
 
 import java.time.Instant;
 

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
@@ -20,13 +20,13 @@ import static uk.gov.di.ipv.core.library.enums.EvcsVCState.PENDING_RETURN;
 public class EvcsService {
     private final EvcsClient evcsClient;
 
+    public EvcsService(EvcsClient evcsClient) {
+        this.evcsClient = evcsClient;
+    }
+
     @ExcludeFromGeneratedCoverageReport
     public EvcsService(ConfigService configService) {
         this.evcsClient = new EvcsClient(configService);
-    }
-
-    public EvcsService(EvcsClient evcsClient) {
-        this.evcsClient = evcsClient;
     }
 
     @Tracing
@@ -51,6 +51,15 @@ public class EvcsService {
                         .vcs();
 
         persistEvcsUserVCs(userId, credentials, existingEvcsUserVCs, true);
+    }
+
+    @Tracing
+    public void storePendingVc(VerifiableCredential credential) {
+        evcsClient.storeUserVCs(
+                credential.getUserId(),
+                List.of(
+                        new EvcsCreateUserVCsDto(
+                                credential.getVcString(), PENDING_RETURN, null, null)));
     }
 
     @Tracing

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -100,15 +101,20 @@ class SessionCredentialsServiceTest {
     class Reads {
         @Test
         void getCredentialsShouldReturnAListOfVerifiableCredentials() throws Exception {
+            var now = Instant.now();
             var item1 =
                     new SessionCredentialItem(
-                            SESSION_ID, CRI_ID_1, CREDENTIAL_1.getSignedJwt(), false);
+                            SESSION_ID, CRI_ID_1, CREDENTIAL_1.getSignedJwt(), false, now);
             var item2 =
                     new SessionCredentialItem(
-                            SESSION_ID, CRI_ID_2, CREDENTIAL_2.getSignedJwt(), false);
+                            SESSION_ID,
+                            CRI_ID_2,
+                            CREDENTIAL_2.getSignedJwt(),
+                            false,
+                            now.plusSeconds(10));
             var item3 =
                     new SessionCredentialItem(
-                            SESSION_ID, CRI_ID_3, CREDENTIAL_3.getSignedJwt(), true);
+                            SESSION_ID, CRI_ID_3, CREDENTIAL_3.getSignedJwt(), true, null);
 
             when(mockDataStore.getItems(SESSION_ID)).thenReturn(List.of(item1, item2, item3));
 
@@ -129,7 +135,7 @@ class SessionCredentialsServiceTest {
         void getCredentialsShouldAllowFilteringByReceivedThisSession() throws Exception {
             var item1 =
                     new SessionCredentialItem(
-                            SESSION_ID, CRI_ID_1, CREDENTIAL_1.getSignedJwt(), false);
+                            SESSION_ID, CRI_ID_1, CREDENTIAL_1.getSignedJwt(), false, null);
 
             when(mockDataStore.getItemsWithBooleanAttribute(
                             SESSION_ID, "receivedThisSession", true))
@@ -149,7 +155,7 @@ class SessionCredentialsServiceTest {
             when(mockSignedJwt.serialize()).thenReturn("🫠");
 
             var sessionCredentialItem =
-                    new SessionCredentialItem(SESSION_ID, CRI_ID_1, mockSignedJwt, false);
+                    new SessionCredentialItem(SESSION_ID, CRI_ID_1, mockSignedJwt, false, null);
             when(mockDataStore.getItems(SESSION_ID)).thenReturn(List.of(sessionCredentialItem));
 
             var caughtException =


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Store async VCs in EVCS

### Why did it change

Stores f2f VCs received by the process-async-cri-credential lambda in evcs, behind a feature flag.

This also adds a `migrated` timestamp to VCs stored in the tactical store, as well as fields on the SessionCredential and VerifiableCredential classes. This is neccessary to ensure that the `migrated` timestamp isn't lost.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6052](https://govukverify.atlassian.net/browse/PYIC-6052)


[PYIC-6052]: https://govukverify.atlassian.net/browse/PYIC-6052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ