### PR TITLE
BAU: Remove redundant logger config

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/resources/log4j2.json
+++ b/lambdas/build-client-oauth-response/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/build-cri-oauth-request/src/main/resources/log4j2.json
+++ b/lambdas/build-cri-oauth-request/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/build-proven-user-identity-details/src/main/resources/log4j2.json
+++ b/lambdas/build-proven-user-identity-details/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/build-user-identity/src/main/resources/log4j2.json
+++ b/lambdas/build-user-identity/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/call-ticf-cri/src/main/resources/log4j2.json
+++ b/lambdas/call-ticf-cri/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/check-coi/src/main/resources/log4j2.json
+++ b/lambdas/check-coi/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/check-existing-identity/src/main/resources/log4j2.json
+++ b/lambdas/check-existing-identity/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/check-gpg45-score/src/main/resources/log4j2.json
+++ b/lambdas/check-gpg45-score/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/evaluate-gpg45-scores/src/main/resources/log4j2.json
+++ b/lambdas/evaluate-gpg45-scores/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/initialise-ipv-session/src/main/resources/log4j2.json
+++ b/lambdas/initialise-ipv-session/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/issue-client-access-token/src/main/resources/log4j2.json
+++ b/lambdas/issue-client-access-token/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/process-async-cri-credential/src/main/resources/log4j2.json
+++ b/lambdas/process-async-cri-credential/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/process-cri-callback/src/main/resources/log4j2.json
+++ b/lambdas/process-cri-callback/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/process-journey-event/src/main/resources/log4j2.json
+++ b/lambdas/process-journey-event/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/replay-cimit-vcs/src/main/resources/log4j2.json
+++ b/lambdas/replay-cimit-vcs/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/reset-session-identity/src/main/resources/log4j2.json
+++ b/lambdas/reset-session-identity/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/restore-vcs/src/main/resources/log4j2.json
+++ b/lambdas/restore-vcs/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/revoke-vcs/src/main/resources/log4j2.json
+++ b/lambdas/revoke-vcs/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {

--- a/lambdas/store-identity/src/main/resources/log4j2.json
+++ b/lambdas/store-identity/src/main/resources/log4j2.json
@@ -11,16 +11,6 @@
       }
     },
     "Loggers": {
-      "logger": [
-        {
-          "name": "JsonLogger",
-          "level": "info",
-          "additivity": false,
-          "AppenderRef": {
-            "ref": "JsonAppender"
-          }
-        }
-      ],
       "Root": {
         "level": "info",
         "AppenderRef": {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove redundant logger config

### Why did it change

We were defining an extra logger, but it had exactly the same config as the root logger.

I've deployed this to my dev env and I'm still getting JSON logs into cloudwatch.
