### PR TITLE
PYIC-6685: Use `userinfo` claim, not `userInfo`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -299,21 +299,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 118
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 118
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 119
+        "line_number": 118
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1935,5 +1935,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-06T13:24:59Z"
+  "generated_at": "2024-06-06T13:55:23Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -299,21 +299,21 @@
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 119
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 119
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 119
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -1935,5 +1935,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-06T09:36:47Z"
+  "generated_at": "2024-06-06T13:24:59Z"
 }

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -315,7 +315,7 @@ public class InitialiseIpvSessionHandler
             return Optional.ofNullable(
                             OBJECT_MAPPER.convertValue(
                                     claimsSet.getJSONObjectClaim(CLAIMS_CLAIM), JarClaims.class))
-                    .map(JarClaims::userInfo);
+                    .map(JarClaims::userinfo);
         } catch (IllegalArgumentException | ParseException e) {
             throw new RecoverableJarValidationException(
                     OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -193,14 +193,13 @@ public class InitialiseIpvSessionHandler
                     ipvSessionService.generateIpvSession(
                             clientOAuthSessionId, null, emailAddress, isReverification);
 
-            Optional<JarUserInfo> jarUserInfoClaim = getJarUserInfo(claimsSet);
             String evcsAccessToken = null;
-            if ((configService.enabled(EVCS_READ_ENABLED)
-                            || configService.enabled(EVCS_WRITE_ENABLED))
-                    && (jarUserInfoClaim.isPresent())) {
+            if (configService.enabled(EVCS_READ_ENABLED)
+                    || configService.enabled(EVCS_WRITE_ENABLED)) {
                 evcsAccessToken =
                         validateEvcsAccessToken(
-                                jarUserInfoClaim.map(JarUserInfo::evcsAccessToken), claimsSet);
+                                getJarUserInfo(claimsSet).map(JarUserInfo::evcsAccessToken),
+                                claimsSet);
             }
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.generateClientSessionDetails(
@@ -216,10 +215,9 @@ public class InitialiseIpvSessionHandler
                             govukSigninJourneyId,
                             ipAddress);
 
-            if (configService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)
-                    && (jarUserInfoClaim.isPresent())) {
-                Optional<StringListClaim> inheritedIdentityJwtClaim =
-                        jarUserInfoClaim.map(JarUserInfo::inheritedIdentityClaim);
+            if (configService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)) {
+                var inheritedIdentityJwtClaim =
+                        getJarUserInfo(claimsSet).map(JarUserInfo::inheritedIdentityClaim);
                 if (inheritedIdentityJwtClaim.isPresent()) {
                     validateAndStoreHMRCInheritedIdentity(
                             clientOAuthSessionItem.getUserId(),

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -193,10 +193,11 @@ public class InitialiseIpvSessionHandler
                     ipvSessionService.generateIpvSession(
                             clientOAuthSessionId, null, emailAddress, isReverification);
 
+            Optional<JarUserInfo> jarUserInfoClaim = getJarUserInfo(claimsSet);
             String evcsAccessToken = null;
             if ((configService.enabled(EVCS_READ_ENABLED)
-                    || configService.enabled(EVCS_WRITE_ENABLED))) {
-                Optional<JarUserInfo> jarUserInfoClaim = getJarUserInfo(claimsSet);
+                            || configService.enabled(EVCS_WRITE_ENABLED))
+                    && (jarUserInfoClaim.isPresent())) {
                 evcsAccessToken =
                         validateEvcsAccessToken(
                                 jarUserInfoClaim.map(JarUserInfo::evcsAccessToken), claimsSet);
@@ -215,8 +216,8 @@ public class InitialiseIpvSessionHandler
                             govukSigninJourneyId,
                             ipAddress);
 
-            if (configService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)) {
-                Optional<JarUserInfo> jarUserInfoClaim = getJarUserInfo(claimsSet);
+            if (configService.enabled(CoreFeatureFlag.INHERITED_IDENTITY)
+                    && (jarUserInfoClaim.isPresent())) {
                 Optional<StringListClaim> inheritedIdentityJwtClaim =
                         jarUserInfoClaim.map(JarUserInfo::inheritedIdentityClaim);
                 if (inheritedIdentityJwtClaim.isPresent()) {

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/JarClaims.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/domain/JarClaims.java
@@ -1,3 +1,3 @@
 package uk.gov.di.ipv.core.initialiseipvsession.domain;
 
-public record JarClaims(JarUserInfo userInfo) {}
+public record JarClaims(JarUserInfo userinfo) {}

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -93,7 +93,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -970,8 +969,6 @@ class InitialiseIpvSessionHandlerTest {
 
         @Test
         void shouldRecoverIfClaimsClaimCanNotBeConverted() throws Exception {
-            reset(mockConfigService);
-            reset(mockClientOAuthSessionDetailsService);
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -128,7 +128,7 @@ class InitialiseIpvSessionHandlerTest {
     private static final String CLIENT_ID = "client_id";
     private static final String VTR = "vtr";
     private static final String CLAIMS = "claims";
-    private static final String USER_INFO = "userInfo";
+    private static final String USER_INFO = "userinfo";
     private static final String VALUES = "values";
     private static final String SCOPE = "scope";
     private static final String INVALID_INHERITED_IDENTITY = "invalid_inherited_identity";


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use `userinfo` claim, not `userInfo`

### Why did it change

We were extracting the userinfo claim using the wrong claim name. Our orch-stub was sending us the wrong claim name, so this was only detected in staging when running a journey using the real orch.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6685](https://govukverify.atlassian.net/browse/PYIC-6685)


[PYIC-6685]: https://govukverify.atlassian.net/browse/PYIC-6685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ