### PR TITLE
PYIC-6660: Update TxMA audit event when storing identity

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -427,7 +427,7 @@ states:
       type: process
       lambda: store-identity
       lambdaInput:
-        isCompletedIdentity: true
+        identityType: NEW
     events:
       identity-stored:
         targetState: IPV_SUCCESS_PAGE
@@ -440,7 +440,7 @@ states:
       type: process
       lambda: store-identity
       lambdaInput:
-        isCompletedIdentity: false
+        identityType: PENDING
     events:
       identity-stored:
         targetState: RESET_SESSION_BEFORE_F2F_HANDOFF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -149,7 +149,7 @@ states:
       type: process
       lambda: store-identity
       lambdaInput:
-        isCompletedIdentity: true
+        identityType: UPDATE
     events:
       identity-stored:
         targetState: IPV_SUCCESS_PAGE_RFC

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -84,7 +84,7 @@ states:
       type: process
       lambda: store-identity
       lambdaInput:
-        isCompletedIdentity: true
+        identityType: UPDATE
     events:
       identity-stored:
         targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -252,7 +252,7 @@ states:
       type: process
       lambda: store-identity
       lambdaInput:
-        isCompletedIdentity: true
+        identityType: UPDATE
     events:
       identity-stored:
         targetState: IPV_SUCCESS_PAGE_UPDATE_ADDRESS

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionIdentityType.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionIdentityType.java
@@ -1,0 +1,12 @@
+package uk.gov.di.ipv.core.library.auditing.extension;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.enums.IdentityType;
+import uk.gov.di.ipv.core.library.enums.Vot;
+
+@ExcludeFromGeneratedCoverageReport
+public record AuditExtensionIdentityType(
+        @JsonProperty(value = "identity_type", required = true) IdentityType identityType,
+        @JsonProperty(required = false) Vot vot)
+        implements AuditExtensions {}

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionVot.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionVot.java
@@ -1,7 +1,0 @@
-package uk.gov.di.ipv.core.library.auditing.extension;
-
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.enums.Vot;
-
-@ExcludeFromGeneratedCoverageReport
-public record AuditExtensionVot(Vot vot) implements AuditExtensions {}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -97,7 +97,7 @@ public enum ErrorResponse {
     FAILED_TO_PARSE_EVCS_REQUEST_BODY(1080, "Failed to parse EVCS request body"),
     FAILED_TO_PARSE_EVCS_VC(1081, "Failed to parse a vc from EVCS"),
     FAILED_AT_EVCS_HTTP_REQUEST_SEND(1082, "Failed while sending http request to EVCS"),
-    MISSING_IS_COMPLETED_IDENTITY_PARAMETER(1083, "Missing isCompletedIdentity in request");
+    INVALID_IDENTITY_TYPE_PARAMETER(1083, "Invalid or missing identityType in request");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/IdentityType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/IdentityType.java
@@ -1,0 +1,12 @@
+package uk.gov.di.ipv.core.library.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum IdentityType {
+    @JsonProperty("new")
+    NEW,
+    @JsonProperty("update")
+    UPDATE,
+    @JsonProperty("pending")
+    PENDING;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
+import uk.gov.di.ipv.core.library.enums.IdentityType;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import java.util.Arrays;
@@ -28,7 +29,7 @@ public class RequestHelper {
     public static final String ENCODED_DEVICE_INFORMATION_HEADER = "txma-audit-encoded";
     public static final String FEATURE_SET_HEADER = "feature-set";
     public static final String DELETE_ONLY_GPG45_VCS = "deleteOnlyGPG45VCs";
-    public static final String IS_COMPLETED_IDENTITY = "isCompletedIdentity";
+    public static final String IDENTITY_TYPE = "identityType";
     private static final Logger LOGGER = LogManager.getLogger();
 
     private RequestHelper() {}
@@ -154,13 +155,17 @@ public class RequestHelper {
                         ErrorResponse.MISSING_IS_RESET_DELETE_GPG45_ONLY_PARAMETER));
     }
 
-    public static boolean getIsCompletedIdentity(ProcessRequest request)
+    public static IdentityType getIdentityType(ProcessRequest request)
             throws HttpResponseExceptionWithErrorBody {
-        return Boolean.TRUE.equals(
+        String identityType =
                 extractValueFromLambdaInput(
-                        request,
-                        IS_COMPLETED_IDENTITY,
-                        ErrorResponse.MISSING_IS_COMPLETED_IDENTITY_PARAMETER));
+                        request, IDENTITY_TYPE, ErrorResponse.INVALID_IDENTITY_TYPE_PARAMETER);
+        try {
+            return IdentityType.valueOf(identityType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new HttpResponseExceptionWithErrorBody(
+                    SC_BAD_REQUEST, ErrorResponse.INVALID_IDENTITY_TYPE_PARAMETER);
+        }
     }
 
     private static <T> T extractValueFromLambdaInput(

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
+import uk.gov.di.ipv.core.library.enums.IdentityType;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import java.util.Arrays;
@@ -437,38 +438,62 @@ class RequestHelperTest {
     }
 
     @Test
-    void getIsCompletedIdentityShouldReturnTrue() throws Exception {
+    void getIdentityTypeShouldReturnNew() throws Exception {
         ProcessRequest request =
                 ProcessRequest.processRequestBuilder()
-                        .lambdaInput(Map.of("isCompletedIdentity", true))
+                        .lambdaInput(Map.of("identityType", "new"))
                         .build();
 
-        assertTrue(RequestHelper.getIsCompletedIdentity(request));
+        assertEquals(IdentityType.NEW, RequestHelper.getIdentityType(request));
     }
 
     @Test
-    void getIsCompletedIdentityShouldReturnFalse() throws Exception {
+    void getIdentityTypeShouldReturnPending() throws Exception {
         ProcessRequest request =
                 ProcessRequest.processRequestBuilder()
-                        .lambdaInput(Map.of("isCompletedIdentity", false))
+                        .lambdaInput(Map.of("identityType", "pending"))
                         .build();
 
-        assertFalse(RequestHelper.getIsCompletedIdentity(request));
+        assertEquals(IdentityType.PENDING, RequestHelper.getIdentityType(request));
     }
 
     @Test
-    void getIsCompletedIdentityShouldThrowIfNull() {
+    void getIdentityTypeShouldReturnUpdate() throws Exception {
+        ProcessRequest request =
+                ProcessRequest.processRequestBuilder()
+                        .lambdaInput(Map.of("identityType", "UPDATE"))
+                        .build();
+
+        assertEquals(IdentityType.UPDATE, RequestHelper.getIdentityType(request));
+    }
+
+    @Test
+    void getIdentityTypeShouldThrowIfNull() {
         var lambdaInput = new HashMap<String, Object>();
-        lambdaInput.put("isCompletedIdentity", null);
+        lambdaInput.put("identityType", null);
         ProcessRequest request =
                 ProcessRequest.processRequestBuilder().lambdaInput(lambdaInput).build();
 
         HttpResponseExceptionWithErrorBody thrown =
                 assertThrows(
                         HttpResponseExceptionWithErrorBody.class,
-                        () -> RequestHelper.getIsCompletedIdentity(request));
+                        () -> RequestHelper.getIdentityType(request));
 
-        assertEquals(
-                ErrorResponse.MISSING_IS_COMPLETED_IDENTITY_PARAMETER, thrown.getErrorResponse());
+        assertEquals(ErrorResponse.INVALID_IDENTITY_TYPE_PARAMETER, thrown.getErrorResponse());
+    }
+
+    @Test
+    void getIdentityTypeShouldThrowIfInvalid() {
+        var lambdaInput = new HashMap<String, Object>();
+        lambdaInput.put("identityType", "invalid");
+        ProcessRequest request =
+                ProcessRequest.processRequestBuilder().lambdaInput(lambdaInput).build();
+
+        HttpResponseExceptionWithErrorBody thrown =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> RequestHelper.getIdentityType(request));
+
+        assertEquals(ErrorResponse.INVALID_IDENTITY_TYPE_PARAMETER, thrown.getErrorResponse());
     }
 }


### PR DESCRIPTION
## Proposed changes

Update TxMA audit event when storing identity to include the identity type (new, update, pending)

### What changed

- changed `isCompletedIdentity` boolean lambda input to `identityType` string
- added enum for the different identity types
- added identity type to `AuditExtensionVot` and renamed to `AuditExtensionIdentityType`
- changed `RequestHelper` to get the identity type
- updated associated tests

### Why did it change

When an identity is stored we need to add an extra audit field to distinguish between the different event types

### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-6660

## Checklists

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed
