### PR TITLE
BAU: Use slim secrets to reduce merge conflicts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -113,99 +113,85 @@
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
-        "is_verified": false,
-        "line_number": 23
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
-        "is_verified": false,
-        "line_number": 29
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
-        "is_verified": false,
-        "line_number": 35
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
-        "is_verified": false,
-        "line_number": 41
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
-        "is_verified": false,
-        "line_number": 47
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
-        "is_verified": false,
-        "line_number": 70
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
-        "is_verified": false,
-        "line_number": 143
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
-        "is_verified": false,
-        "line_number": 198
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "d3053d5db9cc8cb93b26db3c26c76bdfdff06ace",
-        "is_verified": false,
-        "line_number": 393
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
-        "is_verified": false,
-        "line_number": 395
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "49edc8e5cce3d7f30610b919b21c6722f4553131",
-        "is_verified": false,
-        "line_number": 1070
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
-        "is_verified": false,
-        "line_number": 1072
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
-        "is_verified": false,
-        "line_number": 1991
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
-        "is_verified": false,
-        "line_number": 2259
+        "is_verified": false
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -213,22 +199,19 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "85d1e7563098941624848ca8a7c731a6c013235b",
-        "is_verified": false,
-        "line_number": 222
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "69facda46567909882c049ea59985c33000974b3",
-        "is_verified": false,
-        "line_number": 305
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
         "hashed_secret": "1bb4f6b3cf1f8b05e40be98e555120bbac8bb8a8",
-        "is_verified": false,
-        "line_number": 358
+        "is_verified": false
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -236,8 +219,7 @@
         "type": "Secret Keyword",
         "filename": "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false,
-        "line_number": 38
+        "is_verified": false
       }
     ],
     "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java": [
@@ -245,43 +227,37 @@
         "type": "Secret Keyword",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 55
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 58
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 58
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 58
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false,
-        "line_number": 91
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false,
-        "line_number": 91
+        "is_verified": false
       }
     ],
     "lambdas/call-ticf-cri/src/test/resources/dvlaVc/body.json": [
@@ -289,8 +265,7 @@
         "type": "Hex High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/resources/dvlaVc/body.json",
         "hashed_secret": "17bcb421d140ca9041e86d38912a52bc85358e29",
-        "is_verified": false,
-        "line_number": 76
+        "is_verified": false
       }
     ],
     "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java": [
@@ -298,22 +273,19 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false,
-        "line_number": 118
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false,
-        "line_number": 118
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
-        "is_verified": false,
-        "line_number": 118
+        "is_verified": false
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -321,8 +293,7 @@
         "type": "JSON Web Token",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "cf9b62e233417c2da28bd1f5bebe8717ea21e559",
-        "is_verified": false,
-        "line_number": 107
+        "is_verified": false
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java": [
@@ -330,43 +301,37 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "85b64b6097e8bdbbf9c4e2cab9df0c237aae2dca",
-        "is_verified": false,
-        "line_number": 125
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "90972d09acf28b39b53f2ea5a145b3fd5017167e",
-        "is_verified": false,
-        "line_number": 125
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "c1305006857ab69a99734702cf8dbf6c71817857",
-        "is_verified": false,
-        "line_number": 125
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "01c2ef0ba40b5ac6268fb58d724ef0418536e5cb",
-        "is_verified": false,
-        "line_number": 129
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "256c2b82b396574d931fb1fe5977cb470bdc53e8",
-        "is_verified": false,
-        "line_number": 129
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "daa586bb42bc7f31bf51be59b3dda26c8c71f1d9",
-        "is_verified": false,
-        "line_number": 129
+        "is_verified": false
       }
     ],
     "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java": [
@@ -374,78 +339,67 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 1065
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 1065
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 1065
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 1069
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "b60c41d5b4329ce9c2d55917dde2400088c0c597",
-        "is_verified": false,
-        "line_number": 1151
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "d7510adb7c14f50e777873bd360673649c761955",
-        "is_verified": false,
-        "line_number": 1221
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "bbcb51db616d2ac08269c13205d270d351dc5f92",
-        "is_verified": false,
-        "line_number": 1292
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "f2df0f7b44bf5c31fdfd84707fdba8c929cb3697",
-        "is_verified": false,
-        "line_number": 1369
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "2e0ac06f760e19dbdcd067cd0adb1bbc26d01773",
-        "is_verified": false,
-        "line_number": 1446
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "d7bd1cfee500c2d63914aa027406b5454d2f0d60",
-        "is_verified": false,
-        "line_number": 1518
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java",
         "hashed_secret": "24c70bf44c8aa6751dc3b909a880cc5e2b21ccf0",
-        "is_verified": false,
-        "line_number": 1590
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java": [
@@ -453,8 +407,7 @@
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriApiService.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false,
-        "line_number": 52
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java": [
@@ -462,71 +415,61 @@
         "type": "JSON Web Token",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "cd23708f1479f214b2352735ecc20fa95bea75f3",
-        "is_verified": false,
-        "line_number": 85
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "4e88faf50ded9c660c4b0a8cf34e1dedddc451ce",
-        "is_verified": false,
-        "line_number": 123
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 126
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 534
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 542
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 542
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 542
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 546
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "ef7c2d1d3ed0f9e08e42bfae5844e0bd027c5d98",
-        "is_verified": false,
-        "line_number": 611
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "1bb4f6b3cf1f8b05e40be98e555120bbac8bb8a8",
-        "is_verified": false,
-        "line_number": 663
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java": [
@@ -534,85 +477,73 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 430
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 585
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "b412a4293bbe14e7a58e03b9074d481cd9ec91c6",
-        "is_verified": false,
-        "line_number": 588
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "3734b77e44c454060a9c4b80e676db6012bb2d17",
-        "is_verified": false,
-        "line_number": 590
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 598
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 598
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 598
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 602
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "5a8d6b3d3ca71cb72e3e75294fbb727065ea6681",
-        "is_verified": false,
-        "line_number": 607
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "ad302621d832b872af77ecdb58ffb8f0c54395b1",
-        "is_verified": false,
-        "line_number": 610
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "e831b14ed87c4d3302133bba15140f85b9fb98a6",
-        "is_verified": false,
-        "line_number": 682
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "6c5cd64a44043056066a4f565b0b1e59b75cc35f",
-        "is_verified": false,
-        "line_number": 746
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java": [
@@ -620,71 +551,61 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "4e88faf50ded9c660c4b0a8cf34e1dedddc451ce",
-        "is_verified": false,
-        "line_number": 290
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 293
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 455
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "031382d0ec1d3893d92b13dc1d7eff79adc428c2",
-        "is_verified": false,
-        "line_number": 457
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 466
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 466
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 466
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 470
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "f73c12ae0548e17e0f23d2b1d91ff1acde2c75de",
-        "is_verified": false,
-        "line_number": 475
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java",
         "hashed_secret": "67f92963d1235bcf8f2a7771ff99f43c73f5a3ea",
-        "is_verified": false,
-        "line_number": 537
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java": [
@@ -692,155 +613,133 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 134
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 1941
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 1949
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 1949
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 1949
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 1953
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "e3cafe9affd6c2a031d61477f707d91a72dbe887",
-        "is_verified": false,
-        "line_number": 1958
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "0a0dd0abc9e8e65df5692b4d25c140fb2f537249",
-        "is_verified": false,
-        "line_number": 1961
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "1a411d6144fd2cef006179139b2fddd59f2b7135",
-        "is_verified": false,
-        "line_number": 2077
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "4f9ffefbcf5a7b1a979787a4c41706293795b072",
-        "is_verified": false,
-        "line_number": 2175
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "5100dd5705ae273ec4ac9e203ea7204c023f8ae7",
-        "is_verified": false,
-        "line_number": 2280
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "026df3067222e66fa1aaaa8e5d426043b61ebaf6",
-        "is_verified": false,
-        "line_number": 2387
+        "is_verified": false
       },
       {
         "type": "Hex High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "17bcb421d140ca9041e86d38912a52bc85358e29",
-        "is_verified": false,
-        "line_number": 2468
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "3ef9850064c24125c78d88cec84a241564a8181d",
-        "is_verified": false,
-        "line_number": 2493
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "04ed9d4553b5eb1c46a48b742f50c52887eb8a0f",
-        "is_verified": false,
-        "line_number": 2599
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "9eaa91ac7c0e6f0e726b4d63ceca2b0ddc18aaba",
-        "is_verified": false,
-        "line_number": 2685
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "85828b3c99cbc23b0d312f1536e5d4a2fb1d7ad3",
-        "is_verified": false,
-        "line_number": 2771
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "98d89d3d8caa6cf473703d310b586f786ae99489",
-        "is_verified": false,
-        "line_number": 2860
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "5e6586ba159cec01bcd98a6bc6614ae8156ae741",
-        "is_verified": false,
-        "line_number": 2943
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "96932521bfcbf030506b0d04dbd78bb8339e546c",
-        "is_verified": false,
-        "line_number": 3029
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "795e509ed2dc8b3b97abe3580f1eb96fdbe29191",
-        "is_verified": false,
-        "line_number": 3112
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "9de015a7d8d22a2feaa2be0b5f70fab4aa5ac99a",
-        "is_verified": false,
-        "line_number": 3196
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java": [
@@ -848,64 +747,55 @@
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 639
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 647
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 647
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 647
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 651
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "70a72c4229f34fd63cf3ee20ad12f854c0225603",
-        "is_verified": false,
-        "line_number": 739
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "6892628b0a48d937b00d4323004d803caaec48c6",
-        "is_verified": false,
-        "line_number": 819
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "e25414dc7ae18879c7628b1fbeea059bab2d3a61",
-        "is_verified": false,
-        "line_number": 896
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "94eac6536a2191c4ae13ddbe9d0e551643f6c6e1",
-        "is_verified": false,
-        "line_number": 975
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java": [
@@ -913,57 +803,49 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 113
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 244
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 252
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 252
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 252
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 256
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "28dca06207b1c570f7d1b25ae549d37bdeb93353",
-        "is_verified": false,
-        "line_number": 261
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "5a2eb5c8850b9e4c2cd896826d871114652ac2f1",
-        "is_verified": false,
-        "line_number": 264
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java": [
@@ -971,78 +853,67 @@
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 75
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 80
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 80
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 80
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 84
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "f081dac627359c3ed0b5e24b8ad9334a041f57ee",
-        "is_verified": false,
-        "line_number": 90
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "879555570ac2902194da3a60870183fac1afcedb",
-        "is_verified": false,
-        "line_number": 93
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "b7199240a34f5f246bb1c83bc2d3c4706d4a3be7",
-        "is_verified": false,
-        "line_number": 330
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "855c12d79f06fadb653e35b5bdd0d5a27b7035b1",
-        "is_verified": false,
-        "line_number": 333
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "0160253ed9efcc4899692f59c30292c6c1c6f2af",
-        "is_verified": false,
-        "line_number": 336
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 397
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java": [
@@ -1050,64 +921,55 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "4e88faf50ded9c660c4b0a8cf34e1dedddc451ce",
-        "is_verified": false,
-        "line_number": 191
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 194
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 341
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "5c8dfacbdf22729464c6644afd7f347fad2b0f3b",
-        "is_verified": false,
-        "line_number": 344
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 349
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 349
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 349
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 353
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "9030ee3740f6c38494ca83b5382fbe5eabf003e4",
-        "is_verified": false,
-        "line_number": 357
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java": [
@@ -1115,57 +977,49 @@
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 536
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 544
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 544
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 544
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 548
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "e0ec64e65511487ce5e8931c8de7e99ca6fe80a1",
-        "is_verified": false,
-        "line_number": 644
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "3667765e9a5e6e2f3c2ca4027746a953e82cff82",
-        "is_verified": false,
-        "line_number": 731
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "c944a2449092336d1300f2ed4fc7e5fdb1c1cd3b",
-        "is_verified": false,
-        "line_number": 818
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java": [
@@ -1173,57 +1027,49 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 113
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 244
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 252
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 252
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 252
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 256
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "62fd942d39e3d3d1b4d709719df4d7693c0bc290",
-        "is_verified": false,
-        "line_number": 261
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "8a66206e7019a66038e854b4df48a87e5392aa69",
-        "is_verified": false,
-        "line_number": 264
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java": [
@@ -1231,78 +1077,67 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 505
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 665
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 673
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 673
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 673
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 677
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "54035c391c5d4882c4d2b8be780191ab8619f375",
-        "is_verified": false,
-        "line_number": 683
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "ee28fe3a8431e59253a3ad7848bdd09a36b41afd",
-        "is_verified": false,
-        "line_number": 686
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "8462f12287fc396e3eca74ea39176412d2ced12c",
-        "is_verified": false,
-        "line_number": 762
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "778fa73746ab9447b057573728416c7549794715",
-        "is_verified": false,
-        "line_number": 833
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "9dccd448570397c49519a7eb369cd0d309220ba3",
-        "is_verified": false,
-        "line_number": 900
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java": [
@@ -1310,85 +1145,73 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 614
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 771
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 779
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 779
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 779
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 783
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "eec4c2b90b7643f2f658af2656cb9138af9daff7",
-        "is_verified": false,
-        "line_number": 788
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "78d507a2201fe4d687a2ecefb68b6d1371cf9e32",
-        "is_verified": false,
-        "line_number": 791
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "4d02bb0f82cf95ab6a67488068c3a678e6d6783b",
-        "is_verified": false,
-        "line_number": 863
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "dc2ec6f56e5d7085849515561ec0c69dd8d40f63",
-        "is_verified": false,
-        "line_number": 927
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "7f93b33fb3980c5ac56157d3230015f257c1e58b",
-        "is_verified": false,
-        "line_number": 986
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "62be2551e44d504f8cf6c3c442e77913b162d0a9",
-        "is_verified": false,
-        "line_number": 1048
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java": [
@@ -1396,57 +1219,49 @@
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 499
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 508
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 508
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 508
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 512
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java",
         "hashed_secret": "1a6c82b9f48e7d8a33e4676e7963009656ba3151",
-        "is_verified": false,
-        "line_number": 592
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java",
         "hashed_secret": "873fc92771ea721e99a5953c96b9b0430e70c371",
-        "is_verified": false,
-        "line_number": 664
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java",
         "hashed_secret": "66c2a3cc34be0ce5443ad108974aadda0677da62",
-        "is_verified": false,
-        "line_number": 746
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java": [
@@ -1454,57 +1269,49 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false,
-        "line_number": 113
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false,
-        "line_number": 247
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false,
-        "line_number": 256
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false,
-        "line_number": 256
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false,
-        "line_number": 256
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false,
-        "line_number": 260
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "015609fda0bffdcafdbac742e8bb0114cbf5adab",
-        "is_verified": false,
-        "line_number": 265
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "72035fdef6763169e387da573c171bcf1780fc05",
-        "is_verified": false,
-        "line_number": 268
+        "is_verified": false
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriApiServiceTest.java": [
@@ -1512,29 +1319,25 @@
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriApiServiceTest.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false,
-        "line_number": 65
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriApiServiceTest.java",
         "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
-        "is_verified": false,
-        "line_number": 66
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriApiServiceTest.java",
         "hashed_secret": "29cf87d79251ad6757dbaa452e459c733ca0c819",
-        "is_verified": false,
-        "line_number": 68
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriApiServiceTest.java",
         "hashed_secret": "bbd2d902a5f8ca57be23f5280ec809e60b1275f2",
-        "is_verified": false,
-        "line_number": 196
+        "is_verified": false
       }
     ],
     "libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java": [
@@ -1542,8 +1345,7 @@
         "type": "Secret Keyword",
         "filename": "libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java",
         "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
-        "is_verified": false,
-        "line_number": 62
+        "is_verified": false
       }
     ],
     "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java": [
@@ -1551,162 +1353,139 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
-        "is_verified": false,
-        "line_number": 23
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false,
-        "line_number": 25
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false,
-        "line_number": 25
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
-        "is_verified": false,
-        "line_number": 25
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "4a7f246c69142397baf5ba99de29d9e5b8ef9a3e",
-        "is_verified": false,
-        "line_number": 27
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "7d84194f6e1833d9b741aa35f821beb0dd998d2c",
-        "is_verified": false,
-        "line_number": 27
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "856fc17fb4615aeaadd609de3621431d7fe8a35a",
-        "is_verified": false,
-        "line_number": 27
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
-        "is_verified": false,
-        "line_number": 29
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "b6093091a50fd53973e8e12889d4150b09d6b5c9",
-        "is_verified": false,
-        "line_number": 33
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "b62364b7c20e7936b947b9dc756c9916c611ccdf",
-        "is_verified": false,
-        "line_number": 33
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "dc620e25f02856ddf327f15dd9d627b029e6e949",
-        "is_verified": false,
-        "line_number": 36
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "0e3d19bd15948288b40a7efe10519a9b86cd10db",
-        "is_verified": false,
-        "line_number": 39
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "152db88c213515d9aff8c8100865b32e359c20b5",
-        "is_verified": false,
-        "line_number": 42
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "85f12a0b975f7e81b7c8fe188a58bebc4644346f",
-        "is_verified": false,
-        "line_number": 45
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "3b6f59ee0fcb5d8403aadbf6e2a1b4329c0336df",
-        "is_verified": false,
-        "line_number": 47
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "2812ffec9cb7df5645761a20b3ba88a7a4ec0a40",
-        "is_verified": false,
-        "line_number": 50
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "f4c97c25cb92c0261cc22bc5dd2f6f30fdca0d86",
-        "is_verified": false,
-        "line_number": 53
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "fd908b8dfcfeb53c2115698f23b18ec5786c76f1",
-        "is_verified": false,
-        "line_number": 193
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "9a5e8740901c56429f9bb12ee8f5bc26bc9b01ca",
-        "is_verified": false,
-        "line_number": 196
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "a47c19456c2124a5ca042f266cd944c3f2b00792",
-        "is_verified": false,
-        "line_number": 199
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "eb88f12ea98cd5f8fdcab0927de8e88e0e1c3c99",
-        "is_verified": false,
-        "line_number": 202
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "8a6ecebf9408b9a543e7cc91c9c8b4a9daa75d15",
-        "is_verified": false,
-        "line_number": 205
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "dd203d85309179f63c6fc174721a97a05a71c59f",
-        "is_verified": false,
-        "line_number": 208
+        "is_verified": false
       }
     ],
     "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java": [
@@ -1714,8 +1493,7 @@
         "type": "Hex High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java",
         "hashed_secret": "8ee890f6d27197fff7e84647ce06290699d09812",
-        "is_verified": false,
-        "line_number": 967
+        "is_verified": false
       }
     ],
     "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java": [
@@ -1723,8 +1501,7 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java",
         "hashed_secret": "d1d4766fd2a2f73940b46f0d7ccabba3dd98e2cd",
-        "is_verified": false,
-        "line_number": 68
+        "is_verified": false
       }
     ],
     "libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java": [
@@ -1732,8 +1509,7 @@
         "type": "Secret Keyword",
         "filename": "libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false,
-        "line_number": 41
+        "is_verified": false
       }
     ],
     "libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/client/EvcsClientTest.java": [
@@ -1741,15 +1517,13 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/client/EvcsClientTest.java",
         "hashed_secret": "2ba2a3a7ef1cee1e8cf4b0471a0fc29649d9d84a",
-        "is_verified": false,
-        "line_number": 53
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/client/EvcsClientTest.java",
         "hashed_secret": "2ba2a3a7ef1cee1e8cf4b0471a0fc29649d9d84a",
-        "is_verified": false,
-        "line_number": 53
+        "is_verified": false
       }
     ],
     "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java": [
@@ -1757,57 +1531,49 @@
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "3adc0d9c42348beaa39937e9db5d718f9c1b5ec8",
-        "is_verified": false,
-        "line_number": 28
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "67b679abd671132a59ff27ad46431df54c41b07a",
-        "is_verified": false,
-        "line_number": 30
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "4fc22b8c1dd53dcb6dddb51b0fe5942b9e039848",
-        "is_verified": false,
-        "line_number": 32
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "f4ba4459404f2823fc676f2338670516dfe2a545",
-        "is_verified": false,
-        "line_number": 34
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "487f5a28937fc78bb6ad24213e9421792f540f33",
-        "is_verified": false,
-        "line_number": 36
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "23348bb7c49b5dd5d47bef01426b71b3557017d9",
-        "is_verified": false,
-        "line_number": 38
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "556375f7970dae1fdf30f9fa4d6a5db72ec3dc96",
-        "is_verified": false,
-        "line_number": 40
+        "is_verified": false
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "b1d6208ffc7e3ab3edd1de897fb7c172e587ad5d",
-        "is_verified": false,
-        "line_number": 43
+        "is_verified": false
       }
     ],
     "libs/kms-es256-signer/src/test/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerTest.java": [
@@ -1815,8 +1581,7 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/kms-es256-signer/src/test/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerTest.java",
         "hashed_secret": "1b6c8b4ac46cd7d0168c8b99fe2aa923a8f8c628",
-        "is_verified": false,
-        "line_number": 29
+        "is_verified": false
       }
     ],
     "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtBuilderTest.java": [
@@ -1824,8 +1589,7 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtBuilderTest.java",
         "hashed_secret": "a7f906370fbf641726c31b0b2db0dba5f8d7d210",
-        "is_verified": false,
-        "line_number": 32
+        "is_verified": false
       }
     ],
     "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtIgnoreSignatureBodyBuilderTest.java": [
@@ -1833,8 +1597,7 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtIgnoreSignatureBodyBuilderTest.java",
         "hashed_secret": "a7f906370fbf641726c31b0b2db0dba5f8d7d210",
-        "is_verified": false,
-        "line_number": 34
+        "is_verified": false
       }
     ],
     "libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java": [
@@ -1842,22 +1605,19 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java",
         "hashed_secret": "73e89ec90cc182f863d62379f3f3d7f1351eda44",
-        "is_verified": false,
-        "line_number": 59
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java",
         "hashed_secret": "c8e88551c7610fd83231609310e7bf88ef7b44b6",
-        "is_verified": false,
-        "line_number": 59
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java",
         "hashed_secret": "cbc582e2dea39b92355cb9ec190332b272e8f1a7",
-        "is_verified": false,
-        "line_number": 59
+        "is_verified": false
       }
     ],
     "local-running/compose.yaml": [
@@ -1865,43 +1625,37 @@
         "type": "Base64 High Entropy String",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "0994216bb83b6b18ecde427ee2716915c9c64825",
-        "is_verified": false,
-        "line_number": 8
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
-        "is_verified": false,
-        "line_number": 25
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false,
-        "line_number": 36
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false,
-        "line_number": 36
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
-        "is_verified": false,
-        "line_number": 36
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "a622a83e16c56c242e78d8f0b6cfc639005c7e85",
-        "is_verified": false,
-        "line_number": 49
+        "is_verified": false
       }
     ],
     "local-running/setConfigForLocalOrCloudRunning.py": [
@@ -1909,31 +1663,26 @@
         "type": "Base64 High Entropy String",
         "filename": "local-running/setConfigForLocalOrCloudRunning.py",
         "hashed_secret": "941443ade4a41d67343885660bc79ef5f8d29a6f",
-        "is_verified": false,
-        "line_number": 40
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/setConfigForLocalOrCloudRunning.py",
         "hashed_secret": "c6fc0dad9371be54dc77708cad1a8098c363e74b",
-        "is_verified": false,
-        "line_number": 40
+        "is_verified": false
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/setConfigForLocalOrCloudRunning.py",
         "hashed_secret": "cd93cb86a58869ea8f3968e7a8408ca2acf257aa",
-        "is_verified": false,
-        "line_number": 41
+        "is_verified": false
       },
       {
         "type": "Secret Keyword",
         "filename": "local-running/setConfigForLocalOrCloudRunning.py",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
-        "is_verified": false,
-        "line_number": 44
+        "is_verified": false
       }
     ]
-  },
-  "generated_at": "2024-06-06T13:55:23Z"
+  }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Change format of the secrets.baseline to 'slim' mode.

### Why did it change

The slim mode removes line numbers and timestamps from the secret listing, which should significantly reduce noise when refactoring, and merge conflicts in secrets.

This does mean that we cannot 'audit' the secrets file, but we don't do that anyway - it's only used as a mechanism to avoid inadvertently committing new secrets.