### PR TITLE
BAU: Disable provider-side tests in dependabot PRs as they cannot acc…

### DIFF
--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -24,7 +24,7 @@ on:
       - synchronize
 
 jobs:
-  contract-testing:
+  contract-testing-consumer:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -38,24 +38,27 @@ jobs:
       - name: Run consumer contract tests
         run: ./gradlew --parallel pactConsumerTests
       - name: Upload pacts to broker with gradle
+        # Dependabot PRs do not have access to secrets, so cannot access the pacts broker
         if: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
         run: ./gradlew pactPublish
       # The initial call to the pact broker starts a 30 second timer where calls will succeed. As uploading the pacts and
       # verifying the pacts together takes over 30s we need to wait for the timer to expire so that the pact verification
       # call starts its own timer.
       - name: Sleep for 30 seconds
+        if: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
         run: sleep 30s
         shell: bash
       - name: Verify pacts
+        if: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
         run: ./gradlew pactProviderTests
       - name: Upload build-user-identity provider pact test report
-        if: '!cancelled()'
+        if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
         uses: actions/upload-artifact@v4
         with:
           name: build-user-identity provider pact test report
           path: /home/runner/work/ipv-core-back/ipv-core-back/lambdas/build-user-identity/build/reports/tests/pactProviderTests/
       - name: Upload issue-client-access-token provider pact test report
-        if: '!cancelled()'
+        if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
         uses: actions/upload-artifact@v4
         with:
           name: issue-client-access-token provider pact test report


### PR DESCRIPTION
Dependabot PRs cannot access secrets (to avoid revealing secrets via a malicious package update).

This means they cannot access the pact broker, so only consumer-side tests can run (and we cannot upload the pacts for them either).