### PR TITLE
Pyic 6711 audit event journey event

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -70,7 +70,7 @@ public class ProcessJourneyEventHandler
     private static final String NEXT_EVENT = "next";
     private static final String END_SESSION_EVENT = "build-client-oauth-response";
     private static final StepResponse END_SESSION_RESPONSE =
-            new ProcessStepResponse(END_SESSION_EVENT, null, null, null);
+            new ProcessStepResponse(END_SESSION_EVENT, null);
     private final IpvSessionService ipvSessionService;
     private final AuditService auditService;
     private final ConfigService configService;
@@ -163,11 +163,6 @@ public class ProcessJourneyEventHandler
             }
 
             ipvSessionService.updateIpvSession(ipvSessionItem);
-
-            if (stepResponse.getMitigationStart() != null) {
-                sendMitigationStartAuditEvent(
-                        auditEventUser, stepResponse.getMitigationStart(), deviceInformation);
-            }
 
             return stepResponse.value();
         } catch (HttpResponseExceptionWithErrorBody e) {
@@ -369,19 +364,6 @@ public class ProcessJourneyEventHandler
                             new StateMachineInitializer(journeyType, stateMachineInitializerMode)));
         }
         return stateMachinesMap;
-    }
-
-    private void sendMitigationStartAuditEvent(
-            AuditEventUser auditEventUser, String mitigationType, String deviceInformation)
-            throws SqsException {
-
-        auditService.sendAuditEvent(
-                new AuditEvent(
-                        AuditEventTypes.IPV_MITIGATION_START,
-                        configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
-                        auditEventUser,
-                        new AuditExtensionMitigationType(mitigationType),
-                        new AuditRestrictedDeviceInformation(deviceInformation)));
     }
 
     private void sendJourneyAuditEvent(

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/TransitionResult.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/TransitionResult.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.core.processjourneyevent.statemachine;
+
+import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
+
+import java.util.List;
+import java.util.Map;
+
+public record TransitionResult(
+        State state, List<AuditEventTypes> auditEvents, Map<String, String> auditContext) {
+    public TransitionResult(State state) {
+        this(state, null, null);
+    }
+}

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEvent.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEvent.java
@@ -3,13 +3,16 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.events;
 import lombok.Data;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.JourneyChangeState;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -22,8 +25,10 @@ public class BasicEvent implements Event {
     private State targetStateObj;
     private LinkedHashMap<String, Event> checkIfDisabled;
     private LinkedHashMap<String, Event> checkFeatureFlag;
+    private List<AuditEventTypes> auditEvents;
+    private LinkedHashMap<String, String> auditContext;
 
-    public State resolve(JourneyContext journeyContext) throws UnknownEventException {
+    public TransitionResult resolve(JourneyContext journeyContext) throws UnknownEventException {
         if (checkIfDisabled != null) {
             Optional<String> firstDisabledCri =
                     checkIfDisabled.keySet().stream()
@@ -50,7 +55,7 @@ public class BasicEvent implements Event {
                 return checkFeatureFlag.get(featureFlagValue).resolve(journeyContext);
             }
         }
-        return targetStateObj;
+        return new TransitionResult(targetStateObj, auditEvents, auditContext);
     }
 
     @Override

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/Event.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/Event.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.events;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
@@ -14,7 +15,7 @@ import java.util.Map;
     @JsonSubTypes.Type(value = ExitNestedJourneyEvent.class)
 })
 public interface Event {
-    State resolve(JourneyContext journeyContext) throws UnknownEventException;
+    TransitionResult resolve(JourneyContext journeyContext) throws UnknownEventException;
 
     void initialize(String name, Map<String, State> states);
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEvent.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEvent.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.processjourneyevent.statemachine.events;
 
 import lombok.Data;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
@@ -14,7 +15,7 @@ public class ExitNestedJourneyEvent implements Event {
     private Map<String, Event> nestedJourneyExitEvents;
 
     @Override
-    public State resolve(JourneyContext journeyContext) throws UnknownEventException {
+    public TransitionResult resolve(JourneyContext journeyContext) throws UnknownEventException {
         Event event = nestedJourneyExitEvents.get(exitEventToEmit);
         if (event == null) {
             throw new UnknownEventException("Event '%s' not found in nested journey's exit events");

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicState.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicState.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.events.Event;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
@@ -19,7 +20,6 @@ import java.util.Optional;
 @AllArgsConstructor
 public class BasicState implements State {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final String ATTEMPT_RECOVERY_EVENT = "attempt-recovery";
     private String name;
     private String parent;
     private BasicState parentObj;
@@ -27,12 +27,9 @@ public class BasicState implements State {
     private Map<String, Event> events = new HashMap<>();
 
     @Override
-    public State transition(String eventName, String startState, JourneyContext journeyContext)
+    public TransitionResult transition(
+            String eventName, String startState, JourneyContext journeyContext)
             throws UnknownEventException {
-        if (ATTEMPT_RECOVERY_EVENT.equals(eventName)) {
-            return this;
-        }
-
         return getEvent(eventName)
                 .orElseThrow(
                         () ->

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/JourneyChangeState.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/JourneyChangeState.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.states;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownStateException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
@@ -14,7 +15,8 @@ public class JourneyChangeState implements State {
     private String initialState;
 
     @Override
-    public State transition(String eventName, String startState, JourneyContext journeyContext)
+    public TransitionResult transition(
+            String eventName, String startState, JourneyContext journeyContext)
             throws UnknownEventException, UnknownStateException {
         throw new IllegalStateException("Cannot transition from JourneyChangeState");
     }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/State.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/State.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.states;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownStateException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
@@ -12,6 +13,6 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.Journey
     @JsonSubTypes.Type(value = NestedJourneyInvokeState.class),
 })
 public interface State {
-    State transition(String eventName, String startState, JourneyContext journeyContext)
+    TransitionResult transition(String eventName, String startState, JourneyContext journeyContext)
             throws UnknownEventException, UnknownStateException;
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -33,7 +33,6 @@ public class CriStepResponse implements StepResponse {
     private String criId;
     private String context;
     private EvidenceRequest evidenceRequest;
-    private String mitigationStart;
 
     public Map<String, Object> value() {
         try {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponse.java
@@ -34,7 +34,6 @@ public class CriStepResponse implements StepResponse {
     private String context;
     private EvidenceRequest evidenceRequest;
     private String mitigationStart;
-    private String auditEvent;
 
     public Map<String, Object> value() {
         try {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponse.java
@@ -13,8 +13,6 @@ public class ErrorStepResponse implements StepResponse {
     private static final String ERROR = "error";
     private String pageId;
     private String statusCode;
-    private String mitigationStart;
-    private String auditEvent;
 
     public Map<String, Object> value() {
         return Map.of("type", ERROR, "page", pageId, "statusCode", Integer.parseInt(statusCode));

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
@@ -14,8 +14,6 @@ public class PageStepResponse implements StepResponse {
 
     private String pageId;
     private String context;
-    private String mitigationStart;
-    private String auditEvent;
 
     public Map<String, Object> value() {
         Map<String, Object> response = new HashMap<>();

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponse.java
@@ -16,8 +16,6 @@ public class ProcessStepResponse implements StepResponse {
     private static final String JOURNEY_TEMPLATE = "/journey/%s";
     private String lambda;
     private Map<String, Object> lambdaInput;
-    private String mitigationStart;
-    private String auditEvent;
 
     @Override
     public Map<String, Object> value() {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
@@ -14,6 +14,4 @@ import java.util.Map;
 })
 public interface StepResponse {
     Map<String, Object> value();
-
-    String getMitigationStart();
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/StepResponse.java
@@ -16,6 +16,4 @@ public interface StepResponse {
     Map<String, Object> value();
 
     String getMitigationStart();
-
-    String getAuditEvent();
 }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -15,6 +15,10 @@ states:
     events:
       next:
         targetState: MITIGATION_01_IDENTITY_START_PAGE
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
 
   ALTERNATE_DOC_PASSPORT:
     events:
@@ -517,9 +521,17 @@ states:
         targetState: EVALUATE_GPG45_SCORES
       enhanced-verification:
         targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
 
   # DCMAW journey (J1)
   POST_DCMAW_SUCCESS_PAGE:
@@ -555,6 +567,10 @@ states:
             targetState: MULTIPLE_DOC_CHECK_PAGE
       alternate-doc-invalid-passport:
         targetState: MITIGATION_05_OPTIONS
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-passport
 
   PROVE_ANOTHER_WAY_J2:
     response:
@@ -600,6 +616,10 @@ states:
             targetState: MULTIPLE_DOC_CHECK_PAGE
       alternate-doc-invalid-dl:
         targetState: MITIGATION_03_OPTIONS
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-dl
 
   PROVE_ANOTHER_WAY_J3:
     response:
@@ -690,9 +710,17 @@ states:
         targetState: EVALUATE_GPG45_SCORES
       enhanced-verification:
         targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
 
   CRI_HMRC_KBV_M2B:
     response:
@@ -706,9 +734,17 @@ states:
         targetState: EVALUATE_GPG45_SCORES
       enhanced-verification:
         targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
 
   # No photo id journey (M2B)
   CRI_CLAIMED_IDENTITY_M2B:
@@ -794,10 +830,17 @@ states:
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
 
   MITIGATION_KBV_FAIL_M2B:
     response:
-      mitigationStart: enhanced-verification
       type: page
       pageId: no-photo-id-security-questions-find-another-way
     events:
@@ -927,7 +970,6 @@ states:
     response:
       type: page
       pageId: page-ipv-identity-document-start
-      mitigationStart: enhanced-verification
     events:
       appTriage:
         targetState: MITIGATION_01_CRI_DCMAW
@@ -1054,7 +1096,6 @@ states:
     response:
       type: page
       pageId: pyi-suggest-other-options-no-f2f
-      mitigationStart: enhanced-verification
     events:
       appTriage:
         targetState: CRI_DCMAW_PYI_ESCAPE
@@ -1152,7 +1193,6 @@ states:
     response:
       type: page
       pageId: pyi-suggest-other-options
-      mitigationStart: enhanced-verification
     events:
       f2f:
         targetState: CRI_F2F
@@ -1201,7 +1241,6 @@ states:
       type: page
       pageId: pyi-suggest-other-options
       context: no-photo-id
-      mitigationStart: enhanced-verification
     events:
       f2f:
         targetState: CRI_F2F
@@ -1246,7 +1285,6 @@ states:
     response:
       type: page
       pageId: pyi-driving-licence-no-match-another-way
-      mitigationStart: invalid-dl
     events:
       next:
         targetState: MITIGATION_PP_CRI_UK_PASSPORT
@@ -1262,12 +1300,15 @@ states:
     events:
       next:
         targetState: MITIGATION_04_IDENTITY_START_PAGE
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-dl
 
   MITIGATION_04_IDENTITY_START_PAGE:
     response:
       type: page
       pageId: pyi-continue-with-passport
-      mitigationStart: invalid-dl
     events:
       next:
         targetState: MITIGATION_PP_CRI_UK_PASSPORT
@@ -1317,7 +1358,6 @@ states:
     response:
       type: page
       pageId: pyi-passport-no-match-another-way
-      mitigationStart: invalid-passport
     events:
       next:
         targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
@@ -1333,12 +1373,15 @@ states:
     events:
       next:
         targetState: MITIGATION_06_IDENTITY_START_PAGE
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-passport
 
   MITIGATION_06_IDENTITY_START_PAGE:
     response:
       type: page
       pageId: pyi-continue-with-driving-licence
-      mitigationStart: invalid-passport
     events:
       next:
         targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
@@ -1451,5 +1494,9 @@ states:
     events:
       next:
         targetState: MITIGATION_01_IDENTITY_START_PAGE
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
       end:
         targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -207,6 +207,8 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_M2B
+        auditEvents:
+          - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_M2B
 
@@ -713,7 +715,6 @@ states:
     response:
       type: cri
       criId: claimedIdentity
-      auditEvent: IPV_NO_PHOTO_ID_JOURNEY_START
       context: bank_account
     parent: CRI_STATE
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -36,9 +36,16 @@ states:
       testWithMitigationStart:
         targetState: PAGE_STATE_AT_START_OF_MITIGATION
       testWithAuditEvent:
-        targetState: PAGE_STATE_AT_START_OF_NO_PHOTO_ID
-      testWithWrongAuditEvent:
-        targetState: WRONG_AUDIT_EVENT_STATE
+        targetState: ERROR_STATE
+        auditEvents:
+          - IPV_NO_PHOTO_ID_JOURNEY_START
+      testWithAuditEventContext:
+        targetState: ERROR_STATE
+        auditEvents:
+          - IPV_NO_PHOTO_ID_JOURNEY_START
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: test-mitigation
       testJourneyStep:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -88,16 +95,6 @@ states:
     response:
       type: page
       pageId: page-id-for-some-page
-      auditEvent: IPV_NO_PHOTO_ID_JOURNEY_START
-    events:
-      enterNestedJourneyAtStateOne:
-        targetState: NESTED_JOURNEY_INVOKE_STATE
-
-  WRONG_AUDIT_EVENT_STATE:
-    response:
-      type: page
-      pageId: page-id-for-some-page
-      auditEvent: WRONG_AUDIT_EVENT_TYPE
     events:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -33,8 +33,6 @@ states:
         targetState: CRI_STATE_WITH_EVIDENCE_REQUEST
       testWithContextAndEvidenceRequest:
         targetState: CRI_STATE_WITH_CONTEXT_AND_EVIDENCE_REQUEST
-      testWithMitigationStart:
-        targetState: PAGE_STATE_AT_START_OF_MITIGATION
       testWithAuditEvent:
         targetState: ERROR_STATE
         auditEvents:
@@ -78,15 +76,6 @@ states:
       evidenceRequest:
         scoringPolicy: gpg45
         strengthScore: 2
-    events:
-      enterNestedJourneyAtStateOne:
-        targetState: NESTED_JOURNEY_INVOKE_STATE
-
-  PAGE_STATE_AT_START_OF_MITIGATION:
-    response:
-      type: page
-      pageId: page-id-for-some-page
-      mitigationStart: a-mitigation-type
     events:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -466,32 +466,6 @@ class ProcessJourneyEventHandlerTest {
     }
 
     @Test
-    void shouldSendAuditEventForMitigationStart() throws Exception {
-        var input =
-                JourneyRequest.builder()
-                        .ipAddress(TEST_IP)
-                        .journey("testWithMitigationStart")
-                        .ipvSessionId(TEST_IP)
-                        .build();
-        mockIpvSessionItemAndTimeout("CRI_STATE");
-
-        getProcessJourneyStepHandler(StateMachineInitializerMode.TEST)
-                .handleRequest(input, mockContext);
-
-        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
-        AuditEvent capturedAuditEvent = auditEventCaptor.getValue();
-
-        assertEquals(AuditEventTypes.IPV_MITIGATION_START, capturedAuditEvent.getEventName());
-        assertEquals("core", capturedAuditEvent.getComponentId());
-        assertEquals("testuserid", capturedAuditEvent.getUser().getUserId());
-        assertEquals("testjourneyid", capturedAuditEvent.getUser().getGovukSigninJourneyId());
-        assertEquals(
-                "a-mitigation-type",
-                ((AuditExtensionMitigationType) capturedAuditEvent.getExtensions())
-                        .mitigationType());
-    }
-
-    @Test
     void shouldSendAuditEventWhenThereIsAuditEventInJourneyMap() throws Exception {
         var input =
                 JourneyRequest.builder()

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -503,7 +503,7 @@ class ProcessJourneyEventHandlerTest {
 
         verify(mockAuditService, times(2)).sendAuditEvent(auditEventCaptor.capture());
         var capturedAuditEvents = auditEventCaptor.getAllValues();
-        assertEquals(capturedAuditEvents.size(), 2);
+        assertEquals(2, capturedAuditEvents.size());
 
         var firstEvent = capturedAuditEvents.get(0);
         assertEquals(AuditEventTypes.IPV_NO_PHOTO_ID_JOURNEY_START, firstEvent.getEventName());

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEventTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEventTest.java
@@ -7,8 +7,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
-import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
 
 import java.util.LinkedHashMap;
@@ -24,11 +24,11 @@ class BasicEventTest {
 
     @Test
     void resolveShouldReturnAState() throws Exception {
-        BasicState targetState = new BasicState();
+        var expectedResult = new TransitionResult(new BasicState());
         BasicEvent basicEvent = new BasicEvent();
-        basicEvent.setTargetStateObj(targetState);
+        basicEvent.setTargetStateObj(expectedResult.state());
 
-        assertEquals(targetState, basicEvent.resolve(journeyContext));
+        assertEquals(expectedResult, basicEvent.resolve(journeyContext));
     }
 
     @Test
@@ -47,9 +47,9 @@ class BasicEventTest {
         checkIfDisabled.put("aDisabledCri", alternativeEvent);
         basicEventWithCheckIfDisabledConfigured.setCheckIfDisabled(checkIfDisabled);
 
-        State resolve = basicEventWithCheckIfDisabledConfigured.resolve(journeyContext);
+        var result = basicEventWithCheckIfDisabledConfigured.resolve(journeyContext);
 
-        assertEquals(alternativeTargetState, resolve);
+        assertEquals(alternativeTargetState, result.state());
     }
 
     @Test
@@ -66,9 +66,9 @@ class BasicEventTest {
                 CoreFeatureFlag.UNUSED_PLACEHOLDER.getName(), eventWithCheckFeatureFlagConfigured);
         defaultEvent.setCheckFeatureFlag(checkFeatureFlag);
 
-        State resolve = defaultEvent.resolve(journeyContext);
+        var result = defaultEvent.resolve(journeyContext);
 
-        assertEquals(featureFlagTargetState, resolve);
+        assertEquals(featureFlagTargetState, result.state());
     }
 
     @Test

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEventTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEventTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.events;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
@@ -21,16 +22,16 @@ class ExitNestedJourneyEventTest {
 
     @Test
     void resolveShouldResolveEventFromNestedJourneyExitEvents() throws UnknownEventException {
-        BasicState expectedState = new BasicState();
+        var expectedResult = new TransitionResult(new BasicState());
         BasicEvent nestedJourneyExitEvent = mock(BasicEvent.class);
-        when(nestedJourneyExitEvent.resolve(any(JourneyContext.class))).thenReturn(expectedState);
+        when(nestedJourneyExitEvent.resolve(any(JourneyContext.class))).thenReturn(expectedResult);
 
         ExitNestedJourneyEvent exitNestedJourneyEvent = new ExitNestedJourneyEvent();
         exitNestedJourneyEvent.setExitEventToEmit("exiting");
         exitNestedJourneyEvent.setNestedJourneyExitEvents(
                 Map.of("exiting", nestedJourneyExitEvent));
 
-        assertEquals(expectedState, exitNestedJourneyEvent.resolve(JOURNEY_CONTEXT));
+        assertEquals(expectedResult, exitNestedJourneyEvent.resolve(JOURNEY_CONTEXT));
     }
 
     @Test

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
@@ -24,7 +24,7 @@ class BasicStateTest {
     @Test
     void transitionShouldReturnAStateWithAResponse() throws Exception {
         BasicState targetState = new BasicState();
-        PageStepResponse stepResponse = new PageStepResponse("stepId", "context", null, null);
+        PageStepResponse stepResponse = new PageStepResponse("stepId", "context");
         targetState.setResponse(stepResponse);
 
         BasicState currentState = new BasicState();

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageSte
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,11 +32,9 @@ class BasicStateTest {
         currentToTargetEvent.setTargetStateObj(targetState);
         currentState.setEvents(Map.of("next", currentToTargetEvent));
 
-        BasicState transitionedState =
-                (BasicState) currentState.transition("next", "startState", journeyContext);
+        var result = currentState.transition("next", "startState", journeyContext);
 
-        assertEquals(targetState, transitionedState);
-        assertEquals(stepResponse, transitionedState.getResponse());
+        assertEquals(targetState, result.state());
     }
 
     @Test
@@ -52,17 +49,9 @@ class BasicStateTest {
         BasicState currentState = new BasicState();
         currentState.setParentObj(parentState);
 
-        State transitionedState =
-                currentState.transition("parent-event", "startState", journeyContext);
+        var result = currentState.transition("parent-event", "startState", journeyContext);
 
-        assertEquals(parentEventTargetState, transitionedState);
-    }
-
-    @Test
-    void transitionShouldReturnThisIfAttemptRecoveryEventReceived() throws Exception {
-        State state = new BasicState();
-
-        assertSame(state, state.transition("attempt-recovery", "startState", journeyContext));
+        assertEquals(parentEventTargetState, result.state());
     }
 
     @Test

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeStateTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeStateTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.states;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.events.BasicEvent;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownStateException;
@@ -22,9 +23,9 @@ class NestedJourneyInvokeStateTest {
 
     @Test
     void transitionShouldUseEntryEventsWhenStartStateHasOnePart() throws Exception {
-        BasicState expectedEndState = new BasicState();
+        var expectedResult = new TransitionResult(new BasicState());
         BasicEvent basicEvent = mock(BasicEvent.class);
-        when(basicEvent.resolve(any(JourneyContext.class))).thenReturn(expectedEndState);
+        when(basicEvent.resolve(any(JourneyContext.class))).thenReturn(expectedResult);
 
         NestedJourneyDefinition nestedJourneyDefinition = new NestedJourneyDefinition();
         nestedJourneyDefinition.setEntryEvents(Map.of("next", basicEvent));
@@ -32,10 +33,10 @@ class NestedJourneyInvokeStateTest {
         NestedJourneyInvokeState nestedJourneyInvokeState = new NestedJourneyInvokeState();
         nestedJourneyInvokeState.setNestedJourneyDefinition(nestedJourneyDefinition);
 
-        State transitionedToState =
+        var actualResult =
                 nestedJourneyInvokeState.transition("next", "INVOKE_STATE", JOURNEY_CONTEXT);
 
-        assertEquals(expectedEndState, transitionedToState);
+        assertEquals(expectedResult, actualResult);
     }
 
     @Test
@@ -45,19 +46,19 @@ class NestedJourneyInvokeStateTest {
         BasicState currentNestedState = mock(BasicState.class);
         nestedJourneyDefinition.setNestedJourneyStates(Map.of("NESTED_STATE", currentNestedState));
 
-        BasicState expectedEndState = new BasicState();
+        var expectedResult = new TransitionResult(new BasicState());
         when(currentNestedState.transition(
                         eq("next"), eq("NESTED_STATE"), any(JourneyContext.class)))
-                .thenReturn(expectedEndState);
+                .thenReturn(expectedResult);
 
         NestedJourneyInvokeState nestedJourneyInvokeState = new NestedJourneyInvokeState();
         nestedJourneyInvokeState.setNestedJourneyDefinition(nestedJourneyDefinition);
 
-        State transitionedToState =
+        var actualResult =
                 nestedJourneyInvokeState.transition(
                         "next", "INVOKE_STATE/NESTED_STATE", JOURNEY_CONTEXT);
 
-        assertEquals(expectedEndState, transitionedToState);
+        assertEquals(expectedResult, actualResult);
     }
 
     @Test
@@ -71,19 +72,19 @@ class NestedJourneyInvokeStateTest {
 
         NestedJourneyInvokeState nestedNestedJourneyInvokeState =
                 mock(NestedJourneyInvokeState.class);
-        BasicState expectedEndState = new BasicState();
+        var expectedResult = new TransitionResult(new BasicState());
         when(nestedNestedJourneyInvokeState.transition(
                         eq("next"), eq("NESTED_STATE"), any(JourneyContext.class)))
-                .thenReturn(expectedEndState);
+                .thenReturn(expectedResult);
         when(currentNestedState.transition(
                         eq("next"), eq("NESTED_STATE"), any(JourneyContext.class)))
-                .thenReturn(nestedNestedJourneyInvokeState);
+                .thenReturn(new TransitionResult(nestedNestedJourneyInvokeState));
 
-        State transitionedToState =
+        var actualResult =
                 nestedJourneyInvokeState.transition(
                         "next", "INVOKE_STATE/NESTED_STATE", JOURNEY_CONTEXT);
 
-        assertEquals(expectedEndState, transitionedToState);
+        assertEquals(expectedResult, actualResult);
     }
 
     @Test

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -16,7 +16,7 @@ class CriStepResponseTest {
     @MethodSource("journeyUriParameters")
     void valueReturnsExpectedJourneyResponse(
             String criId, String context, EvidenceRequest evidenceRequest, String expectedJourney) {
-        CriStepResponse response = new CriStepResponse(criId, context, evidenceRequest, null);
+        CriStepResponse response = new CriStepResponse(criId, context, evidenceRequest);
         assertEquals(
                 Map.of("journey", expectedJourney),
                 response.value(),

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -16,7 +16,7 @@ class CriStepResponseTest {
     @MethodSource("journeyUriParameters")
     void valueReturnsExpectedJourneyResponse(
             String criId, String context, EvidenceRequest evidenceRequest, String expectedJourney) {
-        CriStepResponse response = new CriStepResponse(criId, context, evidenceRequest, null, null);
+        CriStepResponse response = new CriStepResponse(criId, context, evidenceRequest, null);
         assertEquals(
                 Map.of("journey", expectedJourney),
                 response.value(),

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ErrorStepResponseTest.java
@@ -8,8 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ErrorStepResponseTest {
 
-    public static final ErrorStepResponse ERROR_RESPONSE =
-            new ErrorStepResponse("aPageId", "500", null, null);
+    public static final ErrorStepResponse ERROR_RESPONSE = new ErrorStepResponse("aPageId", "500");
 
     @Test
     void valueReturnsCorrectResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PageStepResponseTest {
 
     public static final PageStepResponse PAGE_RESPONSE =
-            new PageStepResponse("aPageId", "testContext", "mitigationType", "startNoPhotoId");
+            new PageStepResponse("aPageId", "testContext");
 
     @Test
     void valueReturnsCorrectPageResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/ProcessStepResponseTest.java
@@ -12,10 +12,7 @@ class ProcessStepResponseTest {
     void valueReturnsCorrectJourneyResponse() {
         ProcessStepResponse processStepResponse =
                 new ProcessStepResponse(
-                        "a-process-lambda",
-                        Map.of("input1", "Windom Earle", "input2", 315),
-                        "mitigationType",
-                        null);
+                        "a-process-lambda", Map.of("input1", "Windom Earle", "input2", 315));
 
         Map<String, Object> expectedValue =
                 Map.of(


### PR DESCRIPTION
## Proposed changes

### What changed

Added a new mechanism to trigger audit events upon specific journey events, e.g. in the journey event definition:
```
  SOME_JOURNEY_STATE:
    response:
      type: page
      pageId: some-page-id
    events:
      next:
        targetState: SOME_OTHER_STATE
        auditEvents:
          - IPV_SOME_AUDIT_EVENT
        auditContext:
          foo: bar
```

### Why did it change

We are getting an increasing number of audit event requirements, which are tied to specific journeys. Having a mechanism like this should make it easier to define 

### Issue tracking

- [PYIC-6711](https://govukverify.atlassian.net/browse/PYIC-6711)

[PYIC-6711]: https://govukverify.atlassian.net/browse/PYIC-6711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ