### PR TITLE
IPS-623: Add BE alarms

### DIFF
--- a/deploy-delete-user-data/template.yaml
+++ b/deploy-delete-user-data/template.yaml
@@ -272,7 +272,31 @@ Resources:
       QueueName: DeleteAccountSQSQueue
       RedrivePolicy: !Sub "{ \"deadLetterTargetArn\": \"arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:DeleteAccountSNSDLQ\", \"maxReceiveCount\": \"5\" }"
 
-#Delete Account Queue
+#Delete Account Queue alarm for old messages
+  DeleteAccountSQSMessagesNotConsumedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-DeleteAccountSQSMessagesNotConsumedAlarm"
+      AlarmDescription: "Trigger an alarm when the age of the oldest message in the DeleteAccountSQSQueue is 5 or more minutes"
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt DeleteAccountSQSQueue.QueueName
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 300
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+#IPV Delete Account Queue
   IPVDeleteAccountSQSQueue:
     DependsOn: DeleteAccountSNSDLQ
     Type: AWS::SQS::Queue
@@ -281,6 +305,30 @@ Resources:
       VisibilityTimeout: 60
       QueueName: IPVDeleteAccountSQSQueue
       RedrivePolicy: !Sub "{ \"deadLetterTargetArn\": \"arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:DeleteAccountSNSDLQ\", \"maxReceiveCount\": \"5\" }"
+
+#IPV Delete Account Queue alarm for old messages
+  IPVDeleteAccountSQSMessagesNotConsumedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-IPVDeleteAccountSQSMessagesNotConsumedAlarm"
+      AlarmDescription: "Trigger an alarm when the age of the oldest message in the IPVDeleteAccountSQSQueue is 5 or more minutes"
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt IPVDeleteAccountSQSQueue.QueueName
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 300
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
 
 #DLQ for SNS Subsciption
   DeleteAccountSNSDLQ:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3335,9 +3335,10 @@ Resources:
       MetricName: Duration
       Namespace: AWS/Lambda
       Statistic: Maximum
-      Period: 300 #Evaluated over 300s = 5 minutes
-      EvaluationPeriods: 1
-      Threshold: 300000 #300k milliseconds = 5 minutes
+      Period: 60
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 3
+      Threshold: 30000 #30k milliseconds = 30 seconds
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3184,6 +3184,12 @@ Resources:
               ArnLike:
                 "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
 
+  ####################################################################
+  #                                                                  #
+  # Monitoring & Alerts                                              #
+  #                                                                  #
+  ####################################################################
+
   CoreApiPrivateGw5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Condition: IsNotDevelopment
@@ -3249,6 +3255,91 @@ Resources:
                   Value: !Sub IPV Core External API Gateway ${Environment}
             Period: 300
             Stat: Sum
+
+  LatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-apiGWLatencyAlarm"
+      AlarmDescription: "There has been increased latency on backend api-gateway"
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      InsufficientDataActions: []
+      Dimensions: []
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 2500
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: safeLatency
+          Label: safeLatency
+          ReturnData: true
+          Expression: IF(invocations<10,0,maxLatency)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - Core API"
+            Period: 60
+            Stat: Sum
+        - Id: maxLatency
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Latency
+              Dimensions:
+                - Name: ApiName
+                  Value: !Sub "${AWS::StackName} - Core API"
+            Period: 60
+            Stat: Maximum
+
+  LambdaThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: "Trigger the alarm if any lambda in the account throttles"
+      AlarmName: !Sub "${AWS::StackName}-LambdaThrottleAlarm"
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      InsufficientDataActions: []
+      MetricName: Throttles
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      TreatMissingData: notBreaching
+      Period: 60 # This is the minimum value for the AWS Namespace
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+
+  LambdaDurationAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-LambdaDurationAlarm"
+      AlarmDescription: Alarm for Lambda functions running longer than 5 minutes
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      OKActions:
+        - !ImportValue alarm-alerts-topic
+      MetricName: Duration
+      Namespace: AWS/Lambda
+      Statistic: Maximum
+      Period: 300 #Evaluated over 300s = 5 minutes
+      EvaluationPeriods: 1
+      Threshold: 300000 #300k milliseconds = 5 minutes
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
 
 Outputs:
   IPVCorePrivateAPIGatewayID:


### PR DESCRIPTION
### What changed

Added the following alarms:
- DeleteAccountSQSMessagesNotConsumedAlarm
- IPVDeleteAccountSQSMessagesNotConsumedAlarm
- LatencyAlarm (for APIGW)
- LambdaThrottleAlarm
- LambdaDurationAlarm

The topics and alarms are not yet linked to Pagerduty. They will be monitored in production and tweaked as necessary before this change is made.

### Why did it change

- Improved monitoring and alerts

### Issue tracking
- [IPS-623] (https://govukverify.atlassian.net/browse/IPS-623)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-623]: https://govukverify.atlassian.net/browse/IPS-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ