### PR TITLE
BAU: Move attempt-recovery back into basic state

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 public class StateMachine {
     public static final String DELIMITER = "/";
-    private static final String ATTEMPT_RECOVERY_EVENT = "attempt-recovery";
 
     private final Map<String, State> states;
 
@@ -43,11 +42,6 @@ public class StateMachine {
                                 "Unexpected page event (%s) from page (%s) received in process state (%s)",
                                 event, currentPage, startState));
             }
-        }
-
-        // Special recovery event
-        if (ATTEMPT_RECOVERY_EVENT.equals(event)) {
-            return new TransitionResult(state);
         }
 
         var result = state.transition(event, startState, journeyContext);

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicState.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicState.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 @AllArgsConstructor
 public class BasicState implements State {
     private static final Logger LOGGER = LogManager.getLogger();
+    private static final String ATTEMPT_RECOVERY_EVENT = "attempt-recovery";
+
     private String name;
     private String parent;
     private BasicState parentObj;
@@ -30,6 +32,11 @@ public class BasicState implements State {
     public TransitionResult transition(
             String eventName, String startState, JourneyContext journeyContext)
             throws UnknownEventException {
+        // Special recovery event
+        if (ATTEMPT_RECOVERY_EVENT.equals(eventName)) {
+            return new TransitionResult(this);
+        }
+
         return getEvent(eventName)
                 .orElseThrow(
                         () ->

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineTest.java
@@ -93,20 +93,4 @@ class StateMachineTest {
 
         assertEquals(expectedResult, actualResult);
     }
-
-    @Test
-    void transitionShouldReturnSameStateIfAttemptedRecovery() throws Exception {
-        State startingState = mock(BasicState.class);
-
-        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
-        when(mockStateMachineInitializer.initialize())
-                .thenReturn(Map.of("START_STATE", startingState));
-
-        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
-
-        var actualResult =
-                stateMachine.transition("START_STATE", "attempt-recovery", JOURNEY_CONTEXT, null);
-
-        assertEquals(startingState, actualResult.state());
-    }
 }

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
@@ -55,6 +55,14 @@ class BasicStateTest {
     }
 
     @Test
+    void transitionShouldReturnThisIfAttemptRecoveryEventReceived() throws Exception {
+        var state = new BasicState();
+
+        assertEquals(
+                state, state.transition("attempt-recovery", "startState", journeyContext).state());
+    }
+
+    @Test
     void transitionShouldThrowIfEventNotFound() {
         assertThrows(
                 UnknownEventException.class,


### PR DESCRIPTION
attempt-recovery needs to be inside the basic state transition so that it fully resolves a nested state before trying to return it