### PR TITLE
BAU: Revert change to DCMAW VC success criteria

### DIFF
--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45DcmawValidator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45DcmawValidator.java
@@ -14,8 +14,7 @@ public class Gpg45DcmawValidator {
             return false;
         }
 
-        return item.getValidityScore() != 0
-                && item.getVerificationScore() > 0
-                && item.getStrengthScore() > 0;
+        // PYIC-3907 This should also check strength and verification scores
+        return item.getValidityScore() != 0;
     }
 }

--- a/libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45DcmawValidatorTest.java
+++ b/libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45DcmawValidatorTest.java
@@ -5,7 +5,6 @@ import uk.gov.di.ipv.core.library.gpg45.domain.CheckDetail;
 import uk.gov.di.ipv.core.library.gpg45.domain.CredentialEvidenceItem;
 
 import java.util.Collections;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,20 +27,6 @@ class Gpg45DcmawValidatorTest {
                         Collections.emptyList());
 
         assertTrue(Gpg45DcmawValidator.isSuccessful(credentialEvidenceItem));
-    }
-
-    @Test
-    void isSuccessfulShouldReturnFalseOnInvalidCredentialWithNoBiometricVerificationProcessLevel() {
-        CredentialEvidenceItem credentialEvidenceItem =
-                CredentialEvidenceItem.builder()
-                        .strengthScore(3)
-                        .validityScore(2)
-                        .activityHistoryScore(1)
-                        .checkDetails(List.of(new CheckDetail()))
-                        .failedCheckDetails(null)
-                        .build();
-
-        assertFalse(Gpg45DcmawValidator.isSuccessful(credentialEvidenceItem));
     }
 
     @Test


### PR DESCRIPTION
In build, the DL VCs are incorrectly being identified as 'DCMAW' VCs, and these are failing the stricter success criteria added in https://github.com/govuk-one-login/ipv-core-back/pull/1985

We need to fully examine the matching and success criteria as part of PYIC-3907, but for now we want to revert the change.