### PR TITLE
PYIC-6796: Add unsupported COI events to journey map

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -106,6 +106,86 @@ states:
         auditContext:
           updateFields: full-name-or-dob
           updateSupported: false
+      dob:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: dob
+          updateSupported: false
+      dob-given:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: dob,given-names
+          updateSupported: false
+      dob-family:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: dob,family-name
+          updateSupported: false
+      address-dob:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,dob
+          updateSupported: false
+      dob-family-given:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: dob,family-name,given-names
+          updateSupported: false
+      address-dob-given:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,dob,given-names
+          updateSupported: false
+      address-dob-family:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,dob,family-name
+          updateSupported: false
+      address-dob-family-given:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,dob,family-name,given-names
+          updateSupported: false
+      family-given:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: family-name,given-names
+          updateSupported: false
+      address-family-given:
+        targetState: UPDATE_NAME_DOB
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_START
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,family-name,given-names
+          updateSupported: false
       next:
         targetState: FRAUD_CHECK_RFC
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -170,6 +170,76 @@ states:
         auditContext:
           updateFields: full-name-or-dob
           updateSupported: false
+      dob:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: dob
+          updateSupported: false
+      dob-given:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: dob,given-names
+          updateSupported: false
+      dob-family:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: dob,family-name
+          updateSupported: false
+      address-dob:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,dob
+          updateSupported: false
+      dob-family-given:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: dob,family-name,given-names
+          updateSupported: false
+      address-dob-given:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,dob,given-names
+          updateSupported: false
+      address-dob-family:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,dob,family-name
+          updateSupported: false
+      address-dob-family-given:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,dob,family-name,given-names
+          updateSupported: false
+      family-given:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: family-name,given-names
+          updateSupported: false
+      address-family-given:
+        targetState: UPDATE_NAME_DOB_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_SELECTED
+        auditContext:
+          updateFields: address,family-name,given-names
+          updateSupported: false
       cancel:
         targetState: RETURN_TO_RP
         auditEvents:


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add unsupported COI events to journey map

### Why did it change

Fraud are interested in the different combinations of attributes that are unsupported that a user may try to change. This change handles new events from core-front that give us that info for the audit events.

This leaves in place the names-dob event which will become deprectated once core-front starts sending these new events, and will be removed after that. Even though these are all behind a feature flag, it'd be nice to not break things.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6796](https://govukverify.atlassian.net/browse/PYIC-6796)


[PYIC-6796]: https://govukverify.atlassian.net/browse/PYIC-6796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ