### PR TITLE
PYIC-6724: Implement inbuilt back navigation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -116,92 +112,107 @@
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "49edc8e5cce3d7f30610b919b21c6722f4553131",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
-        "is_verified": false
+        "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
+        "is_verified": false,
+        "line_number": 23
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 29
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
-        "is_verified": false
+        "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
+        "is_verified": false,
+        "line_number": 35
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
-        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "92746a9d2183099758834bb9262832ec928843df",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/template.yaml",
-        "hashed_secret": "d3053d5db9cc8cb93b26db3c26c76bdfdff06ace",
-        "is_verified": false
+        "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
+        "is_verified": false,
+        "line_number": 41
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
+        "is_verified": false,
+        "line_number": 198
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "d3053d5db9cc8cb93b26db3c26c76bdfdff06ace",
+        "is_verified": false,
+        "line_number": 393
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 395
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "49edc8e5cce3d7f30610b919b21c6722f4553131",
+        "is_verified": false,
+        "line_number": 1070
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
+        "is_verified": false,
+        "line_number": 1072
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
+        "is_verified": false,
+        "line_number": 1886
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
+        "is_verified": false,
+        "line_number": 2266
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/template.yaml",
+        "hashed_secret": "92746a9d2183099758834bb9262832ec928843df",
+        "is_verified": false,
+        "line_number": 2419
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -232,7 +243,8 @@
         "type": "Secret Keyword",
         "filename": "lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 33
       }
     ],
     "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java": [
@@ -240,45 +252,52 @@
         "type": "Secret Keyword",
         "filename": "lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 38
       }
     ],
     "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java": [
       {
-        "type": "Base64 High Entropy String",
+        "type": "Secret Keyword",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
-        "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false
+        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
+        "is_verified": false,
+        "line_number": 55
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
-        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
-        "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 58
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 58
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 58
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
+        "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java",
+        "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
+        "is_verified": false,
+        "line_number": 91
       }
     ],
     "lambdas/call-ticf-cri/src/test/resources/dvlaVc/body.json": [
@@ -286,7 +305,8 @@
         "type": "Hex High Entropy String",
         "filename": "lambdas/call-ticf-cri/src/test/resources/dvlaVc/body.json",
         "hashed_secret": "17bcb421d140ca9041e86d38912a52bc85358e29",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 76
       }
     ],
     "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java": [
@@ -294,19 +314,22 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 117
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 117
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 117
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java": [
@@ -314,45 +337,52 @@
         "type": "JSON Web Token",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "cf9b62e233417c2da28bd1f5bebe8717ea21e559",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 107
       }
     ],
     "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java": [
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
-        "hashed_secret": "01c2ef0ba40b5ac6268fb58d724ef0418536e5cb",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
-        "hashed_secret": "256c2b82b396574d931fb1fe5977cb470bdc53e8",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "85b64b6097e8bdbbf9c4e2cab9df0c237aae2dca",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 125
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "90972d09acf28b39b53f2ea5a145b3fd5017167e",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 125
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "c1305006857ab69a99734702cf8dbf6c71817857",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
+        "hashed_secret": "01c2ef0ba40b5ac6268fb58d724ef0418536e5cb",
+        "is_verified": false,
+        "line_number": 129
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
+        "hashed_secret": "256c2b82b396574d931fb1fe5977cb470bdc53e8",
+        "is_verified": false,
+        "line_number": 129
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java",
         "hashed_secret": "daa586bb42bc7f31bf51be59b3dda26c8c71f1d9",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 129
       }
     ],
     "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java": [
@@ -436,22 +466,25 @@
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java": [
       {
+        "type": "JSON Web Token",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
+        "hashed_secret": "cd23708f1479f214b2352735ecc20fa95bea75f3",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "4e88faf50ded9c660c4b0a8cf34e1dedddc451ce",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 123
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java",
-        "hashed_secret": "cd23708f1479f214b2352735ecc20fa95bea75f3",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 126
       },
       {
         "type": "Secret Keyword",
@@ -505,76 +538,88 @@
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java": [
       {
-        "type": "JSON Web Token",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
-        "hashed_secret": "3734b77e44c454060a9c4b80e676db6012bb2d17",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
-        "hashed_secret": "5a8d6b3d3ca71cb72e3e75294fbb727065ea6681",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
-        "hashed_secret": "6c5cd64a44043056066a4f565b0b1e59b75cc35f",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 431
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
-        "hashed_secret": "ad302621d832b872af77ecdb58ffb8f0c54395b1",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 583
       },
       {
         "type": "JSON Web Token",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "b412a4293bbe14e7a58e03b9074d481cd9ec91c6",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 586
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "3734b77e44c454060a9c4b80e676db6012bb2d17",
+        "is_verified": false,
+        "line_number": 588
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 596
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
-        "hashed_secret": "e831b14ed87c4d3302133bba15140f85b9fb98a6",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 596
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 596
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 600
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "5a8d6b3d3ca71cb72e3e75294fbb727065ea6681",
+        "is_verified": false,
+        "line_number": 605
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "ad302621d832b872af77ecdb58ffb8f0c54395b1",
+        "is_verified": false,
+        "line_number": 608
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "e831b14ed87c4d3302133bba15140f85b9fb98a6",
+        "is_verified": false,
+        "line_number": 680
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java",
+        "hashed_secret": "6c5cd64a44043056066a4f565b0b1e59b75cc35f",
+        "is_verified": false,
+        "line_number": 744
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java": [
@@ -653,308 +698,358 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "026df3067222e66fa1aaaa8e5d426043b61ebaf6",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "04ed9d4553b5eb1c46a48b742f50c52887eb8a0f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "0a0dd0abc9e8e65df5692b4d25c140fb2f537249",
-        "is_verified": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "17bcb421d140ca9041e86d38912a52bc85358e29",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "1a411d6144fd2cef006179139b2fddd59f2b7135",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "3ef9850064c24125c78d88cec84a241564a8181d",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "4f9ffefbcf5a7b1a979787a4c41706293795b072",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "5100dd5705ae273ec4ac9e203ea7204c023f8ae7",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "5e6586ba159cec01bcd98a6bc6614ae8156ae741",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 1936
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "795e509ed2dc8b3b97abe3580f1eb96fdbe29191",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "85828b3c99cbc23b0d312f1536e5d4a2fb1d7ad3",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "96932521bfcbf030506b0d04dbd78bb8339e546c",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "98d89d3d8caa6cf473703d310b586f786ae99489",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "9de015a7d8d22a2feaa2be0b5f70fab4aa5ac99a",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "9eaa91ac7c0e6f0e726b4d63ceca2b0ddc18aaba",
-        "is_verified": false
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 1944
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 1944
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
+        "is_verified": false,
+        "line_number": 1944
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 1948
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
         "hashed_secret": "e3cafe9affd6c2a031d61477f707d91a72dbe887",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 1953
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "hashed_secret": "0a0dd0abc9e8e65df5692b4d25c140fb2f537249",
+        "is_verified": false,
+        "line_number": 1956
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "1a411d6144fd2cef006179139b2fddd59f2b7135",
+        "is_verified": false,
+        "line_number": 2072
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "4f9ffefbcf5a7b1a979787a4c41706293795b072",
+        "is_verified": false,
+        "line_number": 2170
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "5100dd5705ae273ec4ac9e203ea7204c023f8ae7",
+        "is_verified": false,
+        "line_number": 2275
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "026df3067222e66fa1aaaa8e5d426043b61ebaf6",
+        "is_verified": false,
+        "line_number": 2382
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "17bcb421d140ca9041e86d38912a52bc85358e29",
+        "is_verified": false,
+        "line_number": 2463
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "3ef9850064c24125c78d88cec84a241564a8181d",
+        "is_verified": false,
+        "line_number": 2488
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "04ed9d4553b5eb1c46a48b742f50c52887eb8a0f",
+        "is_verified": false,
+        "line_number": 2594
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "9eaa91ac7c0e6f0e726b4d63ceca2b0ddc18aaba",
+        "is_verified": false,
+        "line_number": 2680
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "85828b3c99cbc23b0d312f1536e5d4a2fb1d7ad3",
+        "is_verified": false,
+        "line_number": 2766
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "98d89d3d8caa6cf473703d310b586f786ae99489",
+        "is_verified": false,
+        "line_number": 2855
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "5e6586ba159cec01bcd98a6bc6614ae8156ae741",
+        "is_verified": false,
+        "line_number": 2938
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "96932521bfcbf030506b0d04dbd78bb8339e546c",
+        "is_verified": false,
+        "line_number": 3024
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "795e509ed2dc8b3b97abe3580f1eb96fdbe29191",
+        "is_verified": false,
+        "line_number": 3107
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
+        "hashed_secret": "9de015a7d8d22a2feaa2be0b5f70fab4aa5ac99a",
+        "is_verified": false,
+        "line_number": 3191
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java": [
       {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
-        "hashed_secret": "6892628b0a48d937b00d4323004d803caaec48c6",
-        "is_verified": false
-      },
-      {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 625
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
-        "hashed_secret": "70a72c4229f34fd63cf3ee20ad12f854c0225603",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
-        "hashed_secret": "94eac6536a2191c4ae13ddbe9d0e551643f6c6e1",
-        "is_verified": false
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 633
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
-        "hashed_secret": "e25414dc7ae18879c7628b1fbeea059bab2d3a61",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 633
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 633
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 637
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "70a72c4229f34fd63cf3ee20ad12f854c0225603",
+        "is_verified": false,
+        "line_number": 725
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "6892628b0a48d937b00d4323004d803caaec48c6",
+        "is_verified": false,
+        "line_number": 805
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "e25414dc7ae18879c7628b1fbeea059bab2d3a61",
+        "is_verified": false,
+        "line_number": 882
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java",
+        "hashed_secret": "94eac6536a2191c4ae13ddbe9d0e551643f6c6e1",
+        "is_verified": false,
+        "line_number": 961
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java": [
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
-        "hashed_secret": "28dca06207b1c570f7d1b25ae549d37bdeb93353",
-        "is_verified": false
+        "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
+        "is_verified": false,
+        "line_number": 114
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
+        "is_verified": false,
+        "line_number": 242
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 250
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
+        "is_verified": false,
+        "line_number": 250
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
+        "is_verified": false,
+        "line_number": 250
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
+        "hashed_secret": "28dca06207b1c570f7d1b25ae549d37bdeb93353",
+        "is_verified": false,
+        "line_number": 259
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
         "hashed_secret": "5a2eb5c8850b9e4c2cd896826d871114652ac2f1",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
-        "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
-        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
-        "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java",
-        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 262
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java": [
       {
-        "type": "Base64 High Entropy String",
+        "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
-        "hashed_secret": "0160253ed9efcc4899692f59c30292c6c1c6f2af",
-        "is_verified": false
+        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
+        "is_verified": false,
+        "line_number": 75
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
-        "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
-        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
-        "hashed_secret": "855c12d79f06fadb653e35b5bdd0d5a27b7035b1",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
-        "hashed_secret": "879555570ac2902194da3a60870183fac1afcedb",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
-        "hashed_secret": "b7199240a34f5f246bb1c83bc2d3c4706d4a3be7",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 80
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 80
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 84
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
         "hashed_secret": "f081dac627359c3ed0b5e24b8ad9334a041f57ee",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
+        "hashed_secret": "879555570ac2902194da3a60870183fac1afcedb",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
+        "hashed_secret": "b7199240a34f5f246bb1c83bc2d3c4706d4a3be7",
+        "is_verified": false,
+        "line_number": 330
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
+        "hashed_secret": "855c12d79f06fadb653e35b5bdd0d5a27b7035b1",
+        "is_verified": false,
+        "line_number": 333
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
+        "hashed_secret": "0160253ed9efcc4899692f59c30292c6c1c6f2af",
+        "is_verified": false,
+        "line_number": 336
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java",
+        "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
+        "is_verified": false,
+        "line_number": 397
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java": [
@@ -962,297 +1057,345 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "4e88faf50ded9c660c4b0a8cf34e1dedddc451ce",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
-        "hashed_secret": "5c8dfacbdf22729464c6644afd7f347fad2b0f3b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 183
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 333
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
+        "hashed_secret": "5c8dfacbdf22729464c6644afd7f347fad2b0f3b",
+        "is_verified": false,
+        "line_number": 336
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 341
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
+        "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
+        "is_verified": false,
+        "line_number": 341
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
+        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
+        "is_verified": false,
+        "line_number": 341
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 345
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
         "hashed_secret": "9030ee3740f6c38494ca83b5382fbe5eabf003e4",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
-        "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java",
-        "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 349
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java": [
       {
-        "type": "Base64 High Entropy String",
+        "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
-        "hashed_secret": "3667765e9a5e6e2f3c2ca4027746a953e82cff82",
-        "is_verified": false
+        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
+        "is_verified": false,
+        "line_number": 521
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
-        "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 529
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
-        "hashed_secret": "c944a2449092336d1300f2ed4fc7e5fdb1c1cd3b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
-        "hashed_secret": "e0ec64e65511487ce5e8931c8de7e99ca6fe80a1",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 529
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 529
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 533
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
+        "hashed_secret": "e0ec64e65511487ce5e8931c8de7e99ca6fe80a1",
+        "is_verified": false,
+        "line_number": 629
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
+        "hashed_secret": "3667765e9a5e6e2f3c2ca4027746a953e82cff82",
+        "is_verified": false,
+        "line_number": 716
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java",
+        "hashed_secret": "c944a2449092336d1300f2ed4fc7e5fdb1c1cd3b",
+        "is_verified": false,
+        "line_number": 803
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java": [
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
-        "hashed_secret": "62fd942d39e3d3d1b4d709719df4d7693c0bc290",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 114
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 242
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
-        "hashed_secret": "8a66206e7019a66038e854b4df48a87e5392aa69",
-        "is_verified": false
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 250
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 250
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 250
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
+        "hashed_secret": "62fd942d39e3d3d1b4d709719df4d7693c0bc290",
+        "is_verified": false,
+        "line_number": 259
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java",
+        "hashed_secret": "8a66206e7019a66038e854b4df48a87e5392aa69",
+        "is_verified": false,
+        "line_number": 262
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java": [
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
-        "hashed_secret": "54035c391c5d4882c4d2b8be780191ab8619f375",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 666
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
-        "hashed_secret": "778fa73746ab9447b057573728416c7549794715",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
-        "hashed_secret": "8462f12287fc396e3eca74ea39176412d2ced12c",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
-        "hashed_secret": "9dccd448570397c49519a7eb369cd0d309220ba3",
-        "is_verified": false
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 674
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 674
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 674
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 678
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
+        "hashed_secret": "54035c391c5d4882c4d2b8be780191ab8619f375",
+        "is_verified": false,
+        "line_number": 684
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
         "hashed_secret": "ee28fe3a8431e59253a3ad7848bdd09a36b41afd",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 687
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
+        "hashed_secret": "8462f12287fc396e3eca74ea39176412d2ced12c",
+        "is_verified": false,
+        "line_number": 763
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
+        "hashed_secret": "778fa73746ab9447b057573728416c7549794715",
+        "is_verified": false,
+        "line_number": 834
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java",
+        "hashed_secret": "9dccd448570397c49519a7eb369cd0d309220ba3",
+        "is_verified": false,
+        "line_number": 901
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java": [
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
-        "hashed_secret": "4d02bb0f82cf95ab6a67488068c3a678e6d6783b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
-        "hashed_secret": "62be2551e44d504f8cf6c3c442e77913b162d0a9",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 617
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 771
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
-        "hashed_secret": "78d507a2201fe4d687a2ecefb68b6d1371cf9e32",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
-        "hashed_secret": "7f93b33fb3980c5ac56157d3230015f257c1e58b",
-        "is_verified": false
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 779
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
-        "hashed_secret": "dc2ec6f56e5d7085849515561ec0c69dd8d40f63",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 779
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 779
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 783
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
         "hashed_secret": "eec4c2b90b7643f2f658af2656cb9138af9daff7",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 788
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
+        "hashed_secret": "78d507a2201fe4d687a2ecefb68b6d1371cf9e32",
+        "is_verified": false,
+        "line_number": 791
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
+        "hashed_secret": "4d02bb0f82cf95ab6a67488068c3a678e6d6783b",
+        "is_verified": false,
+        "line_number": 863
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
+        "hashed_secret": "dc2ec6f56e5d7085849515561ec0c69dd8d40f63",
+        "is_verified": false,
+        "line_number": 927
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
+        "hashed_secret": "7f93b33fb3980c5ac56157d3230015f257c1e58b",
+        "is_verified": false,
+        "line_number": 986
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java",
+        "hashed_secret": "62be2551e44d504f8cf6c3c442e77913b162d0a9",
+        "is_verified": false,
+        "line_number": 1048
       }
     ],
     "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java": [
@@ -1317,50 +1460,58 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
-        "hashed_secret": "015609fda0bffdcafdbac742e8bb0114cbf5adab",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
-        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
-        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "6a306e57e40da3db20acfd887b1a6111a2e7b7ce",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 114
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "706f9a779d4f10497eb54c0c1a2d3212b54fdb0c",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 245
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
-        "hashed_secret": "72035fdef6763169e387da573c171bcf1780fc05",
-        "is_verified": false
+        "hashed_secret": "4fe0cb4b0c3ce482cb6a43c1931c54502e95ca6f",
+        "is_verified": false,
+        "line_number": 254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "c5752e536a022e8e8c02798c9d785b795ff6983b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
         "hashed_secret": "eada7a0758b629fd871b680e59ca482986eb835b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
+        "hashed_secret": "646b4a06350332d91a8ce04fd49101bb4e274f04",
+        "is_verified": false,
+        "line_number": 258
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
+        "hashed_secret": "015609fda0bffdcafdbac742e8bb0114cbf5adab",
+        "is_verified": false,
+        "line_number": 263
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java",
+        "hashed_secret": "72035fdef6763169e387da573c171bcf1780fc05",
+        "is_verified": false,
+        "line_number": 266
       }
     ],
     "libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java": [
@@ -1368,147 +1519,171 @@
         "type": "Secret Keyword",
         "filename": "libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java",
         "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 65
       }
     ],
     "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java": [
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "0e3d19bd15948288b40a7efe10519a9b86cd10db",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "152db88c213515d9aff8c8100865b32e359c20b5",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "2812ffec9cb7df5645761a20b3ba88a7a4ec0a40",
-        "is_verified": false
+        "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
+        "is_verified": false,
+        "line_number": 23
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "3b6f59ee0fcb5d8403aadbf6e2a1b4329c0336df",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "4a7f246c69142397baf5ba99de29d9e5b8ef9a3e",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "7d84194f6e1833d9b741aa35f821beb0dd998d2c",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "856fc17fb4615aeaadd609de3621431d7fe8a35a",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "85f12a0b975f7e81b7c8fe188a58bebc4644346f",
-        "is_verified": false
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "8a6ecebf9408b9a543e7cc91c9c8b4a9daa75d15",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "9a5e8740901c56429f9bb12ee8f5bc26bc9b01ca",
-        "is_verified": false
+        "hashed_secret": "4a7f246c69142397baf5ba99de29d9e5b8ef9a3e",
+        "is_verified": false,
+        "line_number": 27
       },
       {
-        "type": "JSON Web Token",
+        "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "a47c19456c2124a5ca042f266cd944c3f2b00792",
-        "is_verified": false
+        "hashed_secret": "7d84194f6e1833d9b741aa35f821beb0dd998d2c",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "856fc17fb4615aeaadd609de3621431d7fe8a35a",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
+        "is_verified": false,
+        "line_number": 29
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "b6093091a50fd53973e8e12889d4150b09d6b5c9",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 33
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "b62364b7c20e7936b947b9dc756c9916c611ccdf",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 33
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "dc620e25f02856ddf327f15dd9d627b029e6e949",
-        "is_verified": false
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "dd203d85309179f63c6fc174721a97a05a71c59f",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 36
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
-        "is_verified": false
+        "hashed_secret": "0e3d19bd15948288b40a7efe10519a9b86cd10db",
+        "is_verified": false,
+        "line_number": 39
       },
       {
-        "type": "JSON Web Token",
+        "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
-        "hashed_secret": "eb88f12ea98cd5f8fdcab0927de8e88e0e1c3c99",
-        "is_verified": false
+        "hashed_secret": "152db88c213515d9aff8c8100865b32e359c20b5",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "85f12a0b975f7e81b7c8fe188a58bebc4644346f",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "3b6f59ee0fcb5d8403aadbf6e2a1b4329c0336df",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "2812ffec9cb7df5645761a20b3ba88a7a4ec0a40",
+        "is_verified": false,
+        "line_number": 50
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "f4c97c25cb92c0261cc22bc5dd2f6f30fdca0d86",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 53
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
         "hashed_secret": "fd908b8dfcfeb53c2115698f23b18ec5786c76f1",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 193
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "9a5e8740901c56429f9bb12ee8f5bc26bc9b01ca",
+        "is_verified": false,
+        "line_number": 196
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "a47c19456c2124a5ca042f266cd944c3f2b00792",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "eb88f12ea98cd5f8fdcab0927de8e88e0e1c3c99",
+        "is_verified": false,
+        "line_number": 202
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "8a6ecebf9408b9a543e7cc91c9c8b4a9daa75d15",
+        "is_verified": false,
+        "line_number": 205
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java",
+        "hashed_secret": "dd203d85309179f63c6fc174721a97a05a71c59f",
+        "is_verified": false,
+        "line_number": 208
       }
     ],
     "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java": [
@@ -1516,7 +1691,8 @@
         "type": "Hex High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java",
         "hashed_secret": "8ee890f6d27197fff7e84647ce06290699d09812",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 975
       }
     ],
     "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java": [
@@ -1524,7 +1700,8 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java",
         "hashed_secret": "d1d4766fd2a2f73940b46f0d7ccabba3dd98e2cd",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 75
       }
     ],
     "libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java": [
@@ -1532,39 +1709,45 @@
         "type": "Secret Keyword",
         "filename": "libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 58
       }
     ],
     "libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java": [
       {
         "type": "Secret Keyword",
         "filename": "libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java",
-        "hashed_secret": "1798199421ee968b83165215e4ad5c7165fb8aff",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java",
-        "hashed_secret": "29cf87d79251ad6757dbaa452e459c733ca0c819",
-        "is_verified": false
+        "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
+        "is_verified": false,
+        "line_number": 68
       },
       {
         "type": "Secret Keyword",
         "filename": "libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java",
         "hashed_secret": "767ef7376d44bb6e52b390ddcd12c1cb1b3902a4",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java",
-        "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false
+        "hashed_secret": "1798199421ee968b83165215e4ad5c7165fb8aff",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java",
+        "hashed_secret": "29cf87d79251ad6757dbaa452e459c733ca0c819",
+        "is_verified": false,
+        "line_number": 73
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java",
         "hashed_secret": "bbd2d902a5f8ca57be23f5280ec809e60b1275f2",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 201
       }
     ],
     "libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java": [
@@ -1572,7 +1755,8 @@
         "type": "Secret Keyword",
         "filename": "libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java",
         "hashed_secret": "b894b81be94cf8fa8d7536475aaec876addf05c8",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 45
       }
     ],
     "libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/client/EvcsClientTest.java": [
@@ -1580,63 +1764,73 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/client/EvcsClientTest.java",
         "hashed_secret": "2ba2a3a7ef1cee1e8cf4b0471a0fc29649d9d84a",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 58
       },
       {
         "type": "Secret Keyword",
         "filename": "libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/client/EvcsClientTest.java",
         "hashed_secret": "2ba2a3a7ef1cee1e8cf4b0471a0fc29649d9d84a",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 58
       }
     ],
     "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java": [
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
-        "hashed_secret": "23348bb7c49b5dd5d47bef01426b71b3557017d9",
-        "is_verified": false
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "3adc0d9c42348beaa39937e9db5d718f9c1b5ec8",
-        "is_verified": false
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
-        "hashed_secret": "487f5a28937fc78bb6ad24213e9421792f540f33",
-        "is_verified": false
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
-        "hashed_secret": "4fc22b8c1dd53dcb6dddb51b0fe5942b9e039848",
-        "is_verified": false
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
-        "hashed_secret": "556375f7970dae1fdf30f9fa4d6a5db72ec3dc96",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 28
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "67b679abd671132a59ff27ad46431df54c41b07a",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 30
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
-        "hashed_secret": "b1d6208ffc7e3ab3edd1de897fb7c172e587ad5d",
-        "is_verified": false
+        "hashed_secret": "4fc22b8c1dd53dcb6dddb51b0fe5942b9e039848",
+        "is_verified": false,
+        "line_number": 32
       },
       {
         "type": "JSON Web Token",
         "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
         "hashed_secret": "f4ba4459404f2823fc676f2338670516dfe2a545",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
+        "hashed_secret": "487f5a28937fc78bb6ad24213e9421792f540f33",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
+        "hashed_secret": "23348bb7c49b5dd5d47bef01426b71b3557017d9",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
+        "hashed_secret": "556375f7970dae1fdf30f9fa4d6a5db72ec3dc96",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "libs/gpg45-evaluator/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluatorTest.java",
+        "hashed_secret": "b1d6208ffc7e3ab3edd1de897fb7c172e587ad5d",
+        "is_verified": false,
+        "line_number": 43
       }
     ],
     "libs/kms-es256-signer/src/test/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerTest.java": [
@@ -1644,7 +1838,8 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/kms-es256-signer/src/test/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerTest.java",
         "hashed_secret": "1b6c8b4ac46cd7d0168c8b99fe2aa923a8f8c628",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 29
       }
     ],
     "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtBuilderTest.java": [
@@ -1652,7 +1847,8 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtBuilderTest.java",
         "hashed_secret": "a7f906370fbf641726c31b0b2db0dba5f8d7d210",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 32
       }
     ],
     "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtIgnoreSignatureBodyBuilderTest.java": [
@@ -1660,7 +1856,8 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/pact-test-helpers/src/test/java/uk/gov/di/ipv/core/library/pacttesthelpers/PactJwtIgnoreSignatureBodyBuilderTest.java",
         "hashed_secret": "a7f906370fbf641726c31b0b2db0dba5f8d7d210",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 34
       }
     ],
     "libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java": [
@@ -1668,19 +1865,22 @@
         "type": "Base64 High Entropy String",
         "filename": "libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java",
         "hashed_secret": "73e89ec90cc182f863d62379f3f3d7f1351eda44",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 59
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java",
         "hashed_secret": "c8e88551c7610fd83231609310e7bf88ef7b44b6",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 59
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java",
         "hashed_secret": "cbc582e2dea39b92355cb9ec190332b272e8f1a7",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 59
       }
     ],
     "local-running/compose.yaml": [
@@ -1688,65 +1888,75 @@
         "type": "Base64 High Entropy String",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "0994216bb83b6b18ecde427ee2716915c9c64825",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "local-running/compose.yaml",
-        "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "local-running/compose.yaml",
-        "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "local-running/compose.yaml",
-        "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "local-running/compose.yaml",
-        "hashed_secret": "a622a83e16c56c242e78d8f0b6cfc639005c7e85",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 8
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/compose.yaml",
         "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "local-running/compose.yaml",
+        "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "local-running/compose.yaml",
+        "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "local-running/compose.yaml",
+        "hashed_secret": "904f06efe10138ecd43c7cf5ca8dacbc91cb8119",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "local-running/compose.yaml",
+        "hashed_secret": "a622a83e16c56c242e78d8f0b6cfc639005c7e85",
+        "is_verified": false,
+        "line_number": 49
       }
     ],
     "local-running/setConfigForLocalOrCloudRunning.py": [
       {
-        "type": "Secret Keyword",
-        "filename": "local-running/setConfigForLocalOrCloudRunning.py",
-        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
-        "is_verified": false
-      },
-      {
         "type": "Base64 High Entropy String",
         "filename": "local-running/setConfigForLocalOrCloudRunning.py",
         "hashed_secret": "941443ade4a41d67343885660bc79ef5f8d29a6f",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 41
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/setConfigForLocalOrCloudRunning.py",
         "hashed_secret": "c6fc0dad9371be54dc77708cad1a8098c363e74b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 41
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "local-running/setConfigForLocalOrCloudRunning.py",
         "hashed_secret": "cd93cb86a58869ea8f3968e7a8408ca2acf257aa",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "local-running/setConfigForLocalOrCloudRunning.py",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 45
       }
     ]
   },
-  "generated_at": "2024-06-18T10:26:48Z"
+  "generated_at": "2024-06-19T15:22:03Z"
 }

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 
 @ExtendWith(MockitoExtension.class)
 class BuildClientOauthResponseHandlerTest {
@@ -58,7 +59,7 @@ class BuildClientOauthResponseHandlerTest {
     private static final String TEST_CLIENT_OAUTH_SESSION_ID =
             SecureTokenHelper.getInstance().generate();
     public static final String TEST_FEATURE_SET = "fs-001";
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Mock private Context context;
     @Mock private IpvSessionService mockSessionService;
@@ -346,7 +347,7 @@ class BuildClientOauthResponseHandlerTest {
                         .addParameter("state", "test-state")
                         .build();
 
-        ClientResponse responseBody = objectMapper.convertValue(response, ClientResponse.class);
+        ClientResponse responseBody = OBJECT_MAPPER.convertValue(response, ClientResponse.class);
         URI actualRedirectUrl = new URI(responseBody.getClient().getRedirectUrl());
         List<NameValuePair> params =
                 URLEncodedUtils.parse(actualRedirectUrl, StandardCharsets.UTF_8);
@@ -358,7 +359,7 @@ class BuildClientOauthResponseHandlerTest {
     private IpvSessionItem generateIpvSessionItem() {
         IpvSessionItem item = new IpvSessionItem();
         item.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        item.setUserState("test-state");
+        item.pushState(INITIAL_JOURNEY_SELECTION, "test-state");
         item.setCreationDateTime(new Date().toString());
         return item;
     }
@@ -376,6 +377,6 @@ class BuildClientOauthResponseHandlerTest {
     }
 
     private <T> T toResponseClass(Map<String, Object> handlerOutput, Class<T> responseClass) {
-        return objectMapper.convertValue(handlerOutput, responseClass);
+        return OBJECT_MAPPER.convertValue(handlerOutput, responseClass);
     }
 }

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
+import uk.gov.di.ipv.core.library.domain.JourneyState;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -359,7 +360,7 @@ class BuildClientOauthResponseHandlerTest {
     private IpvSessionItem generateIpvSessionItem() {
         IpvSessionItem item = new IpvSessionItem();
         item.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        item.pushState(INITIAL_JOURNEY_SELECTION, "test-state");
+        item.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"));
         item.setCreationDateTime(new Date().toString());
         return item;
     }

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -75,6 +75,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.TICF_CRI_BETA;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.ADDRESS_JSON_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.DRIVING_PERMIT_JSON_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.NINO_JSON_1;
@@ -164,7 +165,7 @@ class BuildUserIdentityHandlerTest {
 
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
-        ipvSessionItem.setUserState("test-state");
+        ipvSessionItem.pushState(INITIAL_JOURNEY_SELECTION, "test-state");
         ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setAccessToken(TEST_ACCESS_TOKEN);
         ipvSessionItem.setAccessTokenMetadata(new AccessTokenMetadata());

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -29,6 +29,7 @@ import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
+import uk.gov.di.ipv.core.library.domain.JourneyState;
 import uk.gov.di.ipv.core.library.domain.Name;
 import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.domain.ReturnCode;
@@ -165,7 +166,7 @@ class BuildUserIdentityHandlerTest {
 
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
-        ipvSessionItem.pushState(INITIAL_JOURNEY_SELECTION, "test-state");
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"));
         ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setAccessToken(TEST_ACCESS_TOKEN);
         ipvSessionItem.setAccessTokenMetadata(new AccessTokenMetadata());

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -46,7 +46,6 @@ import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsVcEvidence;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedInheritedIdentity;
 import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.CriConfig;
 import uk.gov.di.ipv.core.library.enums.Vot;
@@ -180,7 +179,6 @@ class InitialiseIpvSessionHandlerTest {
     @BeforeEach
     void setUp() {
         ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setJourneyType(IpvJourneyTypes.INITIAL_JOURNEY_SELECTION);
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setClientOAuthSessionId(CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setCreationDateTime(Instant.now().toString());

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -442,9 +442,8 @@ public class ProcessJourneyEventHandler
     }
 
     private boolean isBackEventDefinedOnState(JourneyState journeyState) {
-        return ((BasicState)
-                        stateMachines.get(journeyState.subJourney()).getState(journeyState.state()))
-                .getEvents()
-                .containsKey(BACK_EVENT);
+        return stateMachines.get(journeyState.subJourney()).getState(journeyState.state())
+                        instanceof BasicState basicState
+                && basicState.getEvents().containsKey(BACK_EVENT);
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -306,7 +306,8 @@ public class ProcessJourneyEventHandler
         }
 
         if (result.state() instanceof BasicState basicState) {
-            ipvSessionItem.pushState(basicState.getJourneyType(), basicState.getName());
+            ipvSessionItem.pushState(
+                    new JourneyState(basicState.getJourneyType(), basicState.getName()));
         }
 
         return result.state();
@@ -342,7 +343,7 @@ public class ProcessJourneyEventHandler
 
         ipvSessionItem.setErrorCode(OAuth2Error.ACCESS_DENIED.getCode());
         ipvSessionItem.setErrorDescription(OAuth2Error.ACCESS_DENIED.getDescription());
-        ipvSessionItem.pushState(SESSION_TIMEOUT, CORE_SESSION_TIMEOUT_STATE);
+        ipvSessionItem.pushState(new JourneyState(SESSION_TIMEOUT, CORE_SESSION_TIMEOUT_STATE));
 
         logStateChange(oldJourneyState, "timeout", ipvSessionItem);
         sendSubJourneyStartAuditEvent(auditEventUser, SESSION_TIMEOUT, deviceInformation);
@@ -431,9 +432,8 @@ public class ProcessJourneyEventHandler
         return stateMachine.isPageState(journeyState);
     }
 
-    private BasicState journeyStateToBasicState(JourneyState journeyState) {
-        return (BasicState)
-                stateMachines.get(journeyState.subJourney()).getState(journeyState.state());
+    private State journeyStateToBasicState(JourneyState journeyState) {
+        return stateMachines.get(journeyState.subJourney()).getState(journeyState.state());
     }
 
     private JourneyState journeyStateFrom(JourneyChangeState journeyChangeState) {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -220,14 +220,11 @@ public class ProcessJourneyEventHandler
                                 deviceInformation);
             }
 
-            var basicState = (BasicState) newState;
-            ipvSessionItem.pushState(basicState.getJourneyType(), basicState.getName());
-
             logStateChange(currentJourneyState, journeyEvent, ipvSessionItem);
 
             clearOauthSessionIfExists(ipvSessionItem);
 
-            return basicState.getResponse();
+            return ((BasicState) newState).getResponse();
         } catch (UnknownStateException e) {
             LOGGER.error(
                     LogHelper.buildErrorMessage(
@@ -285,7 +282,7 @@ public class ProcessJourneyEventHandler
             var previousJourneyState = ipvSessionItem.getPreviousState();
 
             if (isPageState(initialJourneyState) && isPageState(previousJourneyState)) {
-                ipvSessionItem.pushState(previousJourneyState);
+                ipvSessionItem.popState();
                 return journeyStateToBasicState(previousJourneyState);
             }
 
@@ -306,6 +303,10 @@ public class ProcessJourneyEventHandler
                 sendJourneyAuditEvent(
                         auditEventType, result.auditContext(), auditEventUser, deviceInformation);
             }
+        }
+
+        if (result.state() instanceof BasicState basicState) {
+            ipvSessionItem.pushState(basicState.getJourneyType(), basicState.getName());
         }
 
         return result.state();

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
@@ -54,6 +54,14 @@ public class StateMachine {
         return result;
     }
 
+    public Map<String, State> getStates() {
+        return states;
+    }
+
+    public State getState(String state) {
+        return states.get(state);
+    }
+
     private boolean isPageOrCriStateAndOutOfSync(BasicState basicState, String currentPage) {
         return basicState.getResponse() instanceof PageStepResponse pageStepResponse
                         && !pageStepResponse.getPageId().equals(currentPage)

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
@@ -76,6 +76,7 @@ public class StateMachineInitializer {
             Map<String, State> eventTargetsStatesMap,
             Map<String, Event> nestedJourneyExitEvents) {
         state.setName(stateName);
+        state.setJourneyType(journeyType);
         linkBasicStateParents(state, journeyStates);
         initializeBasicStateEvents(state, eventTargetsStatesMap, nestedJourneyExitEvents);
     }
@@ -110,6 +111,7 @@ public class StateMachineInitializer {
     void initializeNestedJourneyInvokeState(
             NestedJourneyInvokeState state, String stateName, Map<String, State> journeyStates) {
         state.setName(stateName);
+        state.setJourneyType(journeyType);
         NestedJourneyDefinition nestedJourneyDefinition =
                 nestedJourneyDefinitions.get(state.getNestedJourney());
         NestedJourneyDefinition nestedJourneyDefinitionCopy =

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicState.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicState.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.events.Event;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
@@ -27,6 +28,7 @@ public class BasicState implements State {
     private BasicState parentObj;
     private StepResponse response;
     private Map<String, Event> events = new HashMap<>();
+    private IpvJourneyTypes journeyType;
 
     @Override
     public TransitionResult transition(

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeState.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeState.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.events.Event;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
@@ -26,6 +27,7 @@ public class NestedJourneyInvokeState implements State {
     private NestedJourneyDefinition nestedJourneyDefinition;
     private Map<String, Event> exitEvents;
     private String name;
+    private IpvJourneyTypes journeyType;
 
     @Override
     public TransitionResult transition(

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeState.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeState.java
@@ -17,12 +17,13 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 
+import static uk.gov.di.ipv.core.library.domain.JourneyState.JOURNEY_STATE_DELIMITER;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class NestedJourneyInvokeState implements State {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final String DELIMITER = "/";
     private String nestedJourney;
     private NestedJourneyDefinition nestedJourneyDefinition;
     private Map<String, Event> exitEvents;
@@ -57,19 +58,24 @@ public class NestedJourneyInvokeState implements State {
             }
             result =
                     currentNestedState.transition(
-                            eventName, String.join(DELIMITER, stateNameParts), journeyContext);
+                            eventName,
+                            String.join(JOURNEY_STATE_DELIMITER, stateNameParts),
+                            journeyContext);
         }
 
         if (result.state() instanceof NestedJourneyInvokeState) {
             return result.state()
-                    .transition(eventName, String.join(DELIMITER, stateNameParts), journeyContext);
+                    .transition(
+                            eventName,
+                            String.join(JOURNEY_STATE_DELIMITER, stateNameParts),
+                            journeyContext);
         }
 
         return result;
     }
 
     private Queue<String> getStateNameParts(String stateName) {
-        return new LinkedList<>(Arrays.asList(stateName.split(DELIMITER)));
+        return new LinkedList<>(Arrays.asList(stateName.split(JOURNEY_STATE_DELIMITER)));
     }
 
     @Override

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/State.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/State.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.processjourneyevent.statemachine.states;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownStateException;
@@ -15,4 +16,6 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.Journey
 public interface State {
     TransitionResult transition(String eventName, String startState, JourneyContext journeyContext)
             throws UnknownEventException, UnknownStateException;
+
+    IpvJourneyTypes getJourneyType();
 }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -200,8 +200,6 @@ states:
         targetState: FRAUD_CHECK_RFC
       next:
         targetState: ADDRESS_AND_FRAUD_RFC
-      back:
-        targetState: CONFIRM_NAME_DOB
 
   UPDATE_NAME_DOB:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -94,9 +94,6 @@ states:
         targetState: RETURN_TO_RP
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
-      back:
-        targetJourney: REUSE_EXISTING_IDENTITY
-        targetState: UPDATE_DETAILS_START
 
   GIVEN_ONLY_AFTER_RFC:
     response:
@@ -127,9 +124,6 @@ states:
         targetState: RETURN_TO_RP
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
-      back:
-        targetJourney: REUSE_EXISTING_IDENTITY
-        targetState: UPDATE_DETAILS_START
 
   FAMILY_ONLY_AFTER_RFC:
     response:
@@ -266,9 +260,6 @@ states:
         targetState: RETURN_TO_RP
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
-      back:
-        targetJourney: REUSE_EXISTING_IDENTITY
-        targetState: UPDATE_DETAILS_START
 
   GIVEN_WITH_ADDRESS_AFTER_RFC:
     response:
@@ -299,9 +290,6 @@ states:
         targetState: RETURN_TO_RP
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
-      back:
-        targetJourney: REUSE_EXISTING_IDENTITY
-        targetState: UPDATE_DETAILS_START
 
   FAMILY_WITH_ADDRESS_AFTER_RFC:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -8,7 +8,7 @@ states:
   PAGE_STATE:
     response:
       type: page
-      pageId: page-id-for-some-page
+      pageId: page-id-for-page-state
       context: test
     parent: PARENT_STATE
     events:
@@ -19,6 +19,11 @@ states:
         checkIfDisabled:
           aCriId:
             targetState: ERROR_STATE
+      eventThree:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      eventFour:
+        targetState: PAGE_STATE_AT_START_OF_NO_PHOTO_ID
 
   CRI_STATE:
     response:
@@ -88,7 +93,7 @@ states:
   PAGE_STATE_AT_START_OF_NO_PHOTO_ID:
     response:
       type: page
-      pageId: page-id-for-some-page
+      pageId: page-id-for-page-state-at-start-of-no-photo-id
     events:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -24,6 +24,8 @@ states:
         targetState: ERROR
       eventFour:
         targetState: PAGE_STATE_AT_START_OF_NO_PHOTO_ID
+      eventFive:
+        targetState: PAGE_STATE_WITH_BACK_EVENT
 
   CRI_STATE:
     response:
@@ -97,6 +99,14 @@ states:
     events:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE
+
+  PAGE_STATE_WITH_BACK_EVENT:
+    response:
+      type: page
+      pageId: page-id-for-page-state-with-back-event
+    events:
+      back:
+        targetState: PROCESS_STATE
 
   ERROR_STATE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -13,7 +13,7 @@ states:
     parent: PARENT_STATE
     events:
       eventOne:
-        targetState: JOURNEY_STATE
+        targetState: ANOTHER_PAGE_STATE
       eventTwo:
         targetState: CRI_STATE
         checkIfDisabled:
@@ -99,6 +99,8 @@ states:
     events:
       enterNestedJourneyAtStateOne:
         targetState: NESTED_JOURNEY_INVOKE_STATE
+      anotherPageState:
+        targetState: ANOTHER_PAGE_STATE
 
   PAGE_STATE_WITH_BACK_EVENT:
     response:
@@ -135,11 +137,11 @@ states:
     nestedJourney: NESTED_JOURNEY_DEFINITION
     exitEvents:
       exitEventFromNestedStateTwo:
-        targetState: JOURNEY_STATE
+        targetState: ANOTHER_PAGE_STATE
       exitEventFromDoublyNestedInvokeState:
         targetState: ERROR_STATE
 
-  JOURNEY_STATE:
+  ANOTHER_PAGE_STATE:
     response:
       type: page
-      pageId: page-id-for-some-page
+      pageId: page-id-for-another-page-state

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -207,6 +207,9 @@ class JourneyMapTest {
                     }
 
                     var pageEvents = new HashSet<>(basicState.getEvents().keySet());
+                    pageEvents.remove(
+                            "back"); // the back event is a special case that may or may not be
+                    // defined
                     if (basicState.getParent() != null) {
                         pageEvents.addAll(
                                 ((BasicState) stateMachine.get(basicState.getParent()))

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -365,7 +365,7 @@ class ProcessJourneyEventHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.pushState(SESSION_TIMEOUT, TIMEOUT_UNRECOVERABLE_STATE);
+        ipvSessionItem.pushState(new JourneyState(SESSION_TIMEOUT, TIMEOUT_UNRECOVERABLE_STATE));
 
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
@@ -635,14 +635,17 @@ class ProcessJourneyEventHandlerTest {
 
         processJourneyEventHandler.handleRequest(firstTransitionInput, mockContext);
         inOrder.verify(ipvSessionItem)
-                .pushState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID");
+                .pushState(
+                        new JourneyState(
+                                INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"));
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
         assertEquals(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"),
                 ipvSessionItem.getState());
 
         processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
-        inOrder.verify(ipvSessionItem).pushState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE");
+        inOrder.verify(ipvSessionItem)
+                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"));
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
         assertEquals(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
@@ -798,8 +801,8 @@ class ProcessJourneyEventHandlerTest {
 
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
-        ipvSession.pushState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE");
-        ipvSession.pushState(INITIAL_JOURNEY_SELECTION, "CRI_STATE");
+        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
+        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"));
 
         ProcessJourneyEventHandler processJourneyEventHandler =
                 new ProcessJourneyEventHandler(
@@ -828,8 +831,8 @@ class ProcessJourneyEventHandlerTest {
 
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
-        ipvSession.pushState(INITIAL_JOURNEY_SELECTION, "CRI_STATE");
-        ipvSession.pushState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE");
+        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"));
+        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
 
         ProcessJourneyEventHandler processJourneyEventHandler =
                 new ProcessJourneyEventHandler(
@@ -858,8 +861,8 @@ class ProcessJourneyEventHandlerTest {
 
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
-        ipvSession.pushState(TECHNICAL_ERROR, "CRI_STATE");
-        ipvSession.pushState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE");
+        ipvSession.pushState(new JourneyState(TECHNICAL_ERROR, "CRI_STATE"));
+        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
 
         ProcessJourneyEventHandler processJourneyEventHandler =
                 new ProcessJourneyEventHandler(
@@ -881,7 +884,7 @@ class ProcessJourneyEventHandlerTest {
         IpvSessionItem ipvSessionItem = spy(IpvSessionItem.class);
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.pushState(INITIAL_JOURNEY_SELECTION, userState);
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, userState));
         ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
 
         when(mockConfigService.getSsmParameter(COMPONENT_ID)).thenReturn("core");

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 
 class StateMachineInitializerTest {
 
@@ -36,7 +37,7 @@ class StateMachineInitializerTest {
         StateMachineInitializerMode modeMock = mock(StateMachineInitializerMode.class);
         when(modeMock.getPathPart()).thenReturn("some-rubbish");
         StateMachineInitializer initializer =
-                new StateMachineInitializer(IpvJourneyTypes.INITIAL_JOURNEY_SELECTION, modeMock);
+                new StateMachineInitializer(INITIAL_JOURNEY_SELECTION, modeMock);
         assertThrows(JourneyMapDeserializationException.class, initializer::initialize);
     }
 
@@ -59,8 +60,7 @@ class StateMachineInitializerTest {
     void stateMachineInitializerShouldCorrectlyDeserializeJourneyMaps() throws IOException {
         Map<String, State> journeyMap =
                 new StateMachineInitializer(
-                                IpvJourneyTypes.INITIAL_JOURNEY_SELECTION,
-                                StateMachineInitializerMode.TEST)
+                                INITIAL_JOURNEY_SELECTION, StateMachineInitializerMode.TEST)
                         .initialize();
 
         State parentState = journeyMap.get("PARENT_STATE");
@@ -78,8 +78,9 @@ class StateMachineInitializerTest {
                 (NestedJourneyInvokeState) journeyMap.get("NESTED_JOURNEY_INVOKE_STATE");
 
         // page state assertions
-        assertEquals("page-id-for-some-page", pageState.getResponse().value().get("page"));
+        assertEquals("page-id-for-page-state", pageState.getResponse().value().get("page"));
         assertEquals(parentState, pageState.getParentObj());
+        assertEquals(INITIAL_JOURNEY_SELECTION, pageState.getJourneyType());
         assertEquals(
                 journeyState,
                 ((BasicEvent) pageState.getEvents().get("eventOne")).getTargetStateObj());
@@ -141,6 +142,7 @@ class StateMachineInitializerTest {
                 ((BasicEvent) processState.getEvents().get("unmet")).getTargetStateObj());
 
         // nested journey invoke state assertions
+        assertEquals(INITIAL_JOURNEY_SELECTION, pageState.getJourneyType());
         assertEquals(
                 journeyState,
                 ((BasicEvent)

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -65,7 +65,7 @@ class StateMachineInitializerTest {
 
         State parentState = journeyMap.get("PARENT_STATE");
         BasicState pageState = (BasicState) journeyMap.get("PAGE_STATE");
-        BasicState journeyState = (BasicState) journeyMap.get("JOURNEY_STATE");
+        BasicState anotherPageState = (BasicState) journeyMap.get("ANOTHER_PAGE_STATE");
         BasicState criState = (BasicState) journeyMap.get("CRI_STATE");
         BasicState criWithContextState = (BasicState) journeyMap.get("CRI_STATE_WITH_CONTEXT");
         BasicState criWithEvidenceRequest =
@@ -82,7 +82,7 @@ class StateMachineInitializerTest {
         assertEquals(parentState, pageState.getParentObj());
         assertEquals(INITIAL_JOURNEY_SELECTION, pageState.getJourneyType());
         assertEquals(
-                journeyState,
+                anotherPageState,
                 ((BasicEvent) pageState.getEvents().get("eventOne")).getTargetStateObj());
         assertEquals(
                 criState, ((BasicEvent) pageState.getEvents().get("eventTwo")).getTargetStateObj());
@@ -144,7 +144,7 @@ class StateMachineInitializerTest {
         // nested journey invoke state assertions
         assertEquals(INITIAL_JOURNEY_SELECTION, pageState.getJourneyType());
         assertEquals(
-                journeyState,
+                anotherPageState,
                 ((BasicEvent)
                                 nestedJourneyInvokeState
                                         .getExitEvents()

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineTest.java
@@ -1,19 +1,26 @@
 package uk.gov.di.ipv.core.processjourneyevent.statemachine;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.domain.JourneyState;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownStateException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.NestedJourneyDefinition;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.NestedJourneyInvokeState;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageStepResponse;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.ProcessStepResponse;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 
 class StateMachineTest {
     private static final JourneyContext JOURNEY_CONTEXT =
@@ -92,5 +99,182 @@ class StateMachineTest {
                         "START_STATE/NESTED_JOURNEY", "event", JOURNEY_CONTEXT, null);
 
         assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    void getStateShouldReturnState() throws Exception {
+        State stateOne = mock(BasicState.class);
+        State stateTwo = mock(BasicState.class);
+        State stateThree = mock(BasicState.class);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(
+                        Map.of(
+                                "STATE_ONE",
+                                stateOne,
+                                "STATE_TWO",
+                                stateTwo,
+                                "STATE_THREE",
+                                stateThree));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertEquals(stateTwo, stateMachine.getState("STATE_TWO"));
+    }
+
+    @Test
+    void getStateShouldGetNestedState() throws Exception {
+        State stateOne = mock(BasicState.class);
+        NestedJourneyInvokeState stateTwo = new NestedJourneyInvokeState();
+        State stateThree = mock(BasicState.class);
+
+        State nestedStateOne = mock(BasicState.class);
+        State nestedStateTwo = mock(BasicState.class);
+        State nestedStateThree = mock(BasicState.class);
+
+        var nestedJourneyDefinition = new NestedJourneyDefinition();
+        nestedJourneyDefinition.setNestedJourneyStates(
+                Map.of(
+                        "NESTED_ONE",
+                        nestedStateOne,
+                        "NESTED_TWO",
+                        nestedStateTwo,
+                        "NESTED_THREE",
+                        nestedStateThree));
+        stateTwo.setNestedJourneyDefinition(nestedJourneyDefinition);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(
+                        Map.of(
+                                "STATE_ONE",
+                                stateOne,
+                                "STATE_TWO_NESTED_INVOKE_STATE",
+                                stateTwo,
+                                "STATE_THREE",
+                                stateThree));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertEquals(
+                nestedStateThree,
+                stateMachine.getState("STATE_TWO_NESTED_INVOKE_STATE/NESTED_THREE"));
+    }
+
+    @Test
+    void getStateShouldGetDoublyNestedState() throws Exception {
+        State stateOne = mock(BasicState.class);
+        NestedJourneyInvokeState stateTwo = new NestedJourneyInvokeState();
+        State stateThree = mock(BasicState.class);
+
+        State nestedStateOne = mock(BasicState.class);
+        State nestedStateTwo = mock(BasicState.class);
+        NestedJourneyInvokeState nestedStateThree = new NestedJourneyInvokeState();
+
+        State doublyNestedStateOne = mock(BasicState.class);
+        State doublyNestedStateTwo = mock(BasicState.class);
+        State doublyNestedStateThree = mock(BasicState.class);
+
+        var nestedJourneyDefinition = new NestedJourneyDefinition();
+        nestedJourneyDefinition.setNestedJourneyStates(
+                Map.of(
+                        "NESTED_ONE",
+                        nestedStateOne,
+                        "NESTED_TWO",
+                        nestedStateTwo,
+                        "NESTED_THREE_NESTED_INVOKE_STATE",
+                        nestedStateThree));
+        stateTwo.setNestedJourneyDefinition(nestedJourneyDefinition);
+
+        var doublyNestedJourneyDefinition = new NestedJourneyDefinition();
+        doublyNestedJourneyDefinition.setNestedJourneyStates(
+                Map.of(
+                        "DOUBLE_NESTED_ONE",
+                        doublyNestedStateOne,
+                        "DOUBLE_NESTED_TWO",
+                        doublyNestedStateTwo,
+                        "DOUBLE_NESTED_THREE",
+                        doublyNestedStateThree));
+        nestedStateThree.setNestedJourneyDefinition(doublyNestedJourneyDefinition);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(
+                        Map.of(
+                                "STATE_ONE",
+                                stateOne,
+                                "STATE_TWO_NESTED_INVOKE_STATE",
+                                stateTwo,
+                                "STATE_THREE",
+                                stateThree));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertEquals(
+                doublyNestedStateTwo,
+                stateMachine.getState(
+                        "STATE_TWO_NESTED_INVOKE_STATE/NESTED_THREE_NESTED_INVOKE_STATE/DOUBLE_NESTED_TWO"));
+    }
+
+    @Test
+    void isPageStateShouldReturnTrue() throws Exception {
+        var stateWithPageResponse = mock(BasicState.class);
+        when(stateWithPageResponse.getResponse()).thenReturn(new PageStepResponse());
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("STATE_ONE", stateWithPageResponse));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertTrue(
+                stateMachine.isPageState(new JourneyState(INITIAL_JOURNEY_SELECTION, "STATE_ONE")));
+    }
+
+    @Test
+    void isPageStateShouldReturnFalseIfNotPageResponse() throws Exception {
+        var stateWithProcessResponse = mock(BasicState.class);
+        when(stateWithProcessResponse.getResponse()).thenReturn(new ProcessStepResponse());
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("STATE_ONE", stateWithProcessResponse));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertFalse(
+                stateMachine.isPageState(new JourneyState(INITIAL_JOURNEY_SELECTION, "STATE_ONE")));
+    }
+
+    @Test
+    void isPageStateShouldReturnFalseIfNotBasicState() throws Exception {
+        var nestedJourneyInvokeState = mock(NestedJourneyInvokeState.class);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("STATE_ONE", nestedJourneyInvokeState));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertFalse(
+                stateMachine.isPageState(new JourneyState(INITIAL_JOURNEY_SELECTION, "STATE_ONE")));
+    }
+
+    @Test
+    void isPageStateShouldThrowIfNoStateFound() throws Exception {
+        var nestedJourneyInvokeState = mock(NestedJourneyInvokeState.class);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("STATE_ONE", nestedJourneyInvokeState));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        assertThrows(
+                UnknownStateException.class,
+                () ->
+                        stateMachine.isPageState(
+                                new JourneyState(INITIAL_JOURNEY_SELECTION, "NO_STATE")));
     }
 }

--- a/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
+++ b/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
@@ -16,7 +16,6 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionIdentityType;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
-import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.IdentityType;
@@ -354,7 +353,6 @@ class StoreIdentityHandlerTest {
             shouldStoreIdentityInEvcsAndSendAuditEventAndSendIdentityStoredJourney_whenEvcsWriteEnabled_forPendingF2f()
                     throws Exception {
         reset(mockIpvSessionService);
-        ipvSessionItem.setJourneyType(IpvJourneyTypes.REPEAT_FRAUD_CHECK);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
 
@@ -383,7 +381,6 @@ class StoreIdentityHandlerTest {
     void shouldReturnAnErrorJourneyIfFailedAtEvcsIdentityStore_whenEvcsWriteEnabled_forPendingF2f()
             throws Exception {
         reset(mockIpvSessionService);
-        ipvSessionItem.setJourneyType(IpvJourneyTypes.REPEAT_FRAUD_CHECK);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
         doThrow(

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandlerTest.java
@@ -69,7 +69,6 @@ class UserReverificationHandlerTest {
     void setUp() {
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
-        ipvSessionItem.setUserState("test-state");
         ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setAccessToken(TEST_ACCESS_TOKEN);
         ipvSessionItem.setAccessTokenMetadata(new AccessTokenMetadata());

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyState.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyState.java
@@ -1,3 +1,5 @@
 package uk.gov.di.ipv.core.library.domain;
 
-public record JourneyState(IpvJourneyTypes subJourney, String state) {}
+public record JourneyState(IpvJourneyTypes subJourney, String state) {
+    public static final String JOURNEY_STATE_DELIMITER = "/";
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyState.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyState.java
@@ -2,4 +2,18 @@ package uk.gov.di.ipv.core.library.domain;
 
 public record JourneyState(IpvJourneyTypes subJourney, String state) {
     public static final String JOURNEY_STATE_DELIMITER = "/";
+
+    public JourneyState(String sessionItemString) {
+        this(
+                IpvJourneyTypes.valueOf(splitSessionItemString(sessionItemString)[0]),
+                splitSessionItemString(sessionItemString)[1]);
+    }
+
+    public String toSessionItemString() {
+        return String.format("%s%s%s", subJourney, JOURNEY_STATE_DELIMITER, state);
+    }
+
+    private static String[] splitSessionItemString(String sessionItemString) {
+        return sessionItemString.split(JOURNEY_STATE_DELIMITER, 2);
+    }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyState.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyState.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.core.library.domain;
+
+public record JourneyState(IpvJourneyTypes subJourney, String state) {}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/NoCurrentStateException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/NoCurrentStateException.java
@@ -1,6 +1,0 @@
-package uk.gov.di.ipv.core.library.exceptions;
-
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-
-@ExcludeFromGeneratedCoverageReport
-public class NoCurrentStateException extends Exception {}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -74,35 +74,23 @@ public class IpvSessionItem implements DynamodbItem {
         stateStack.add(String.format("%s/%s", journeyType.name(), state));
     }
 
-    public void pushState(String state) {
-        if (stateStack.isEmpty()) {
-            throw new IllegalStateException();
-        }
-        var currentJourney =
-                IpvJourneyTypes.valueOf(
-                        stateStack.get(stateStack.size() - 1).split(JOURNEY_STATE_DELIMITER, 2)[0]);
-        pushState(currentJourney, state);
+    public void pushState(JourneyState journeyState) {
+        pushState(journeyState.subJourney(), journeyState.state());
     }
 
     public JourneyState getState() {
         if (stateStack.isEmpty()) {
             throw new IllegalStateException();
         }
-
-        var currentJourneyState =
-                stateStack.get(stateStack.size() - 1).split(JOURNEY_STATE_DELIMITER, 2);
-        return new JourneyState(
-                IpvJourneyTypes.valueOf(currentJourneyState[0]), currentJourneyState[1]);
+        var journeyState = stateStack.get(stateStack.size() - 1).split(JOURNEY_STATE_DELIMITER, 2);
+        return new JourneyState(IpvJourneyTypes.valueOf(journeyState[0]), journeyState[1]);
     }
 
-    public JourneyState popState() {
-        if (stateStack.isEmpty()) {
+    public JourneyState getPreviousState() {
+        if (stateStack.size() < 2) {
             throw new IllegalStateException();
         }
-
-        var currentJourneyState =
-                stateStack.remove(stateStack.size() - 1).split(JOURNEY_STATE_DELIMITER, 2);
-        return new JourneyState(
-                IpvJourneyTypes.valueOf(currentJourneyState[0]), currentJourneyState[1]);
+        var journeyState = stateStack.get(stateStack.size() - 2).split(JOURNEY_STATE_DELIMITER, 2);
+        return new JourneyState(IpvJourneyTypes.valueOf(journeyState[0]), journeyState[1]);
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -17,11 +17,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static uk.gov.di.ipv.core.library.domain.JourneyState.JOURNEY_STATE_DELIMITER;
+
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
 @Data
 public class IpvSessionItem implements DynamodbItem {
-    public static final String JOURNEY_STATE_DELIMITER = "/";
     private String ipvSessionId;
     private String clientOAuthSessionId;
     private String criOAuthSessionId;
@@ -71,7 +72,7 @@ public class IpvSessionItem implements DynamodbItem {
     }
 
     public void pushState(IpvJourneyTypes journeyType, String state) {
-        stateStack.add(String.format("%s/%s", journeyType.name(), state));
+        stateStack.add(String.format("%s%s%s", journeyType.name(), JOURNEY_STATE_DELIMITER, state));
     }
 
     public void pushState(JourneyState journeyState) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -79,6 +79,10 @@ public class IpvSessionItem implements DynamodbItem {
         pushState(journeyState.subJourney(), journeyState.state());
     }
 
+    public void popState() {
+        stateStack.remove(stateStack.size() - 1);
+    }
+
     public JourneyState getState() {
         if (stateStack.isEmpty()) {
             throw new IllegalStateException();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -7,7 +7,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
+import uk.gov.di.ipv.core.library.domain.JourneyState;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
 import uk.gov.di.ipv.core.library.enums.Vot;
@@ -21,6 +21,9 @@ import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.IPV_SESSIONS_TABLE_NAME;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.REVERIFICATION;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.TECHNICAL_ERROR;
 
 public class IpvSessionService {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -102,12 +105,12 @@ public class IpvSessionService {
 
         if (errorObject == null) {
             if (isReverification) {
-                ipvSessionItem.pushState(IpvJourneyTypes.REVERIFICATION, START_STATE);
+                ipvSessionItem.pushState(new JourneyState(REVERIFICATION, START_STATE));
             } else {
-                ipvSessionItem.pushState(IpvJourneyTypes.INITIAL_JOURNEY_SELECTION, START_STATE);
+                ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
             }
         } else {
-            ipvSessionItem.pushState(IpvJourneyTypes.TECHNICAL_ERROR, ERROR_STATE);
+            ipvSessionItem.pushState(new JourneyState(TECHNICAL_ERROR, ERROR_STATE));
             ipvSessionItem.setErrorCode(errorObject.getCode());
             ipvSessionItem.setErrorDescription(errorObject.getDescription());
         }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -102,16 +102,11 @@ public class IpvSessionService {
 
         if (errorObject == null) {
             if (isReverification) {
-                ipvSessionItem.setJourneyType(IpvJourneyTypes.REVERIFICATION);
                 ipvSessionItem.pushState(IpvJourneyTypes.REVERIFICATION, START_STATE);
             } else {
-                ipvSessionItem.setJourneyType(IpvJourneyTypes.INITIAL_JOURNEY_SELECTION);
                 ipvSessionItem.pushState(IpvJourneyTypes.INITIAL_JOURNEY_SELECTION, START_STATE);
             }
-            ipvSessionItem.setUserState(START_STATE);
         } else {
-            ipvSessionItem.setJourneyType(IpvJourneyTypes.TECHNICAL_ERROR);
-            ipvSessionItem.setUserState(ERROR_STATE);
             ipvSessionItem.pushState(IpvJourneyTypes.TECHNICAL_ERROR, ERROR_STATE);
             ipvSessionItem.setErrorCode(errorObject.getCode());
             ipvSessionItem.setErrorDescription(errorObject.getDescription());

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -46,7 +46,7 @@ class IpvSessionServiceTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
-        ipvSessionItem.pushState(INITIAL_JOURNEY_SELECTION, START_STATE);
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         when(mockDataStore.getItem(ipvSessionID)).thenReturn(ipvSessionItem);
@@ -183,7 +183,7 @@ class IpvSessionServiceTest {
     void shouldUpdateSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.pushState(INITIAL_JOURNEY_SELECTION, START_STATE);
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         ipvSessionService.updateIpvSession(ipvSessionItem);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.JourneyState;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
@@ -24,6 +25,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.REVERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.TECHNICAL_ERROR;
 
@@ -31,7 +33,8 @@ import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.TECHNICAL_ERROR;
 class IpvSessionServiceTest {
     private static final String START_STATE = "START";
     private static final String ERROR_STATE = "ERROR";
-    private static final String IPV_SUCCESS_PAGE_STATE = "IPV_SUCCESS_PAGE";
+    private static final JourneyState INITIAL_START_JOURNEY_STATE =
+            new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE);
 
     @Captor private ArgumentCaptor<IpvSessionItem> ipvSessionItemArgumentCaptor;
     @Mock private DataStore<IpvSessionItem> mockDataStore;
@@ -43,7 +46,7 @@ class IpvSessionServiceTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
-        ipvSessionItem.setUserState(START_STATE);
+        ipvSessionItem.pushState(INITIAL_JOURNEY_SELECTION, START_STATE);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         when(mockDataStore.getItem(ipvSessionID)).thenReturn(ipvSessionItem);
@@ -54,7 +57,7 @@ class IpvSessionServiceTest {
         verify(mockDataStore).getItem(ipvSessionIDArgumentCaptor.capture());
         assertEquals(ipvSessionID, ipvSessionIDArgumentCaptor.getValue());
         assertEquals(ipvSessionItem.getIpvSessionId(), result.getIpvSessionId());
-        assertEquals(ipvSessionItem.getUserState(), result.getUserState());
+        assertEquals(ipvSessionItem.getState(), result.getState());
         assertEquals(ipvSessionItem.getCreationDateTime(), result.getCreationDateTime());
     }
 
@@ -122,8 +125,7 @@ class IpvSessionServiceTest {
         assertNotNull(capturedSessionItem.getCreationDateTime());
 
         assertEquals(ipvSessionItem.getIpvSessionId(), capturedSessionItem.getIpvSessionId());
-        assertEquals(START_STATE, capturedSessionItem.getUserState());
-        assertEquals("INITIAL_JOURNEY_SELECTION/START", capturedSessionItem.getStateStack().get(0));
+        assertEquals(INITIAL_START_JOURNEY_STATE, capturedSessionItem.getState());
     }
 
     @Test
@@ -139,7 +141,7 @@ class IpvSessionServiceTest {
         assertNotNull(capturedSessionItem.getCreationDateTime());
 
         assertEquals(capturedSessionItem.getIpvSessionId(), ipvSessionItem.getIpvSessionId());
-        assertEquals(START_STATE, capturedSessionItem.getUserState());
+        assertEquals(INITIAL_START_JOURNEY_STATE, capturedSessionItem.getState());
         assertEquals("test@test.com", capturedSessionItem.getEmailAddress());
     }
 
@@ -156,11 +158,10 @@ class IpvSessionServiceTest {
         assertNotNull(capturedSessionItem.getIpvSessionId());
         assertNotNull(capturedSessionItem.getCreationDateTime());
         assertEquals(capturedSessionItem.getIpvSessionId(), ipvSessionItem.getIpvSessionId());
-        assertEquals(TECHNICAL_ERROR, capturedSessionItem.getJourneyType());
-        assertEquals(ERROR_STATE, capturedSessionItem.getUserState());
         assertEquals(testErrorObject.getCode(), capturedSessionItem.getErrorCode());
         assertEquals(testErrorObject.getDescription(), capturedSessionItem.getErrorDescription());
-        assertEquals("TECHNICAL_ERROR/ERROR", capturedSessionItem.getStateStack().get(0));
+        assertEquals(
+                new JourneyState(TECHNICAL_ERROR, ERROR_STATE), capturedSessionItem.getState());
     }
 
     @Test
@@ -175,15 +176,14 @@ class IpvSessionServiceTest {
         assertNotNull(capturedSessionItem.getIpvSessionId());
         assertNotNull(capturedSessionItem.getCreationDateTime());
         assertEquals(ipvSessionItem.getIpvSessionId(), capturedSessionItem.getIpvSessionId());
-        assertEquals(REVERIFICATION, capturedSessionItem.getJourneyType());
-        assertEquals("REVERIFICATION/START", capturedSessionItem.getStateStack().get(0));
+        assertEquals(new JourneyState(REVERIFICATION, START_STATE), capturedSessionItem.getState());
     }
 
     @Test
     void shouldUpdateSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.setUserState(START_STATE);
+        ipvSessionItem.pushState(INITIAL_JOURNEY_SELECTION, START_STATE);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         ipvSessionService.updateIpvSession(ipvSessionItem);
@@ -196,7 +196,6 @@ class IpvSessionServiceTest {
         AuthorizationCode testCode = new AuthorizationCode();
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.setUserState(IPV_SUCCESS_PAGE_STATE);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         ipvSessionService.setAuthorizationCode(
@@ -212,7 +211,6 @@ class IpvSessionServiceTest {
         BearerAccessToken accessToken = new BearerAccessToken("test-access-token");
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.setUserState(IPV_SUCCESS_PAGE_STATE);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         ipvSessionService.setAccessToken(ipvSessionItem, accessToken);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Implement inbuilt back navigation

### Why did it change

[PYIC-6724: Start reading user state from stack](https://github.com/govuk-one-login/ipv-core-back/commit/200ee830e3446da80e3d49e7d63677d89e0eee50)

This switches core-back to start using the users state and subjourney
type from the stack, rather than the individual fields in their session.
It removes those fields entirely.
This also updates the exception thrown if the stack is empty to a
runtime exception. Keeping it as checked would have made the
process-journey-event lambda excessivley verbose. And this is an
exception that shouldn't ever happen in reality.

[PYIC-6724: Implement back functionality in journey-engine](https://github.com/govuk-one-login/ipv-core-back/commit/39b7631d772da8030b491fa3d98d1ddea11ecd28)

This adds functionality to the journey engine to detect a back event,
and find a legitimate previous state for them from the stack.

Initially we will only support back where the current state and the
previous state are page states.

This change needs to take account of jumps between subjourneys, as well
as nested journeys.

This change removes the addition of JourneyChangeStates to the stack -
they make the logic a lot more complicated and add little of value.

This change also adds a new field to the states object - journeyType.
This in populated when the state machine is initialized, and makes
writing states to the stack a lot simpler, particularly when moving
between subjourneys.

When a user does go "back", this change actually adds the previous state
on top of the stack, rather than just popping off the top one. This will
give us a fuller picture of the users journey should we need it.

[PYIC-6724: Default to back event on state](https://github.com/govuk-one-login/ipv-core-back/commit/b4b00bf368f70b1068f39b94ba432b4d984e5745)

If a state has a back event explicitly defined we should use it rather
than the inbuilt mechanism. The motivation for this is that we currently
have back events defined that emit audit events defined in the journey
map. If we just use the inbuilt functionality we'd lose the audit
events.

This will also allow us to configure a back event that does something
other than go back to the user previous state, or to a non page state.
Such as in the passport mitigation journey.

[PYIC-6724: Remove back events from journey map](https://github.com/govuk-one-login/ipv-core-back/commit/e8d4a599b1fb79699abf9b32cbb30c4f3d92be2b)

This removes all the back events that the new functionality can replace,
leaving only those with audit events and those that go back to a
non-page state (CRI states).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6724](https://govukverify.atlassian.net/browse/PYIC-6724)


[PYIC-6724]: https://govukverify.atlassian.net/browse/PYIC-6724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ