### PR TITLE
PYIC-6676: Update COI TxMA event to include old and new user details

### DIFF
--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -12,14 +12,15 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCoiCheck;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedCheckCoi;
+import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
+import uk.gov.di.ipv.core.library.auditing.restricted.DeviceInformation;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
-import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
-import uk.gov.di.ipv.core.library.domain.Name;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
 import uk.gov.di.ipv.core.library.domain.ScopeConstants;
+import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.CoiCheckType;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -103,6 +104,7 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
 
         try {
             var ipAddress = request.getIpAddress();
+            var deviceInformation = request.getDeviceInformation();
             var ipvSession =
                     ipvSessionService.getIpvSession(RequestHelper.getIpvSessionId(request));
             var ipvSessionId = ipvSession.getIpvSessionId();
@@ -115,30 +117,30 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
             var checkType = RequestHelper.getCoiCheckType(request);
+            var auditEventUser =
+                    new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
             sendAuditEvent(
                     AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
                     checkType,
                     null,
-                    userId,
-                    ipvSessionId,
-                    govukSigninJourneyId,
-                    ipAddress);
+                    auditEventUser,
+                    null,
+                    null,
+                    deviceInformation);
 
-            var credentials =
-                    Stream.concat(
-                                    verifiableCredentialService.getVcs(userId).stream(),
-                                    sessionCredentialsService
-                                            .getCredentials(ipvSessionId, userId)
-                                            .stream())
-                            .toList();
+            var oldVcs = verifiableCredentialService.getVcs(userId);
+            var sessionVcs = sessionCredentialsService.getCredentials(ipvSessionId, userId);
+
+            var combinedCredentials = Stream.concat(oldVcs.stream(), sessionVcs.stream()).toList();
 
             var successfulCheck =
                     switch (checkType) {
                         case GIVEN_NAMES_AND_DOB -> userIdentityService
-                                .areGivenNamesAndDobCorrelated(credentials);
+                                .areGivenNamesAndDobCorrelated(combinedCredentials);
                         case FAMILY_NAME_AND_DOB -> userIdentityService
-                                .areFamilyNameAndDobCorrelatedForCoiCheck(credentials);
-                        case FULL_NAME_AND_DOB -> userIdentityService.areVcsCorrelated(credentials);
+                                .areFamilyNameAndDobCorrelatedForCoiCheck(combinedCredentials);
+                        case FULL_NAME_AND_DOB -> userIdentityService.areVcsCorrelated(
+                                combinedCredentials);
                     };
 
             var scopeClaims = clientOAuthSession.getScopeClaims();
@@ -148,10 +150,10 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
                     AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END,
                     checkType,
                     successfulCheck,
-                    userId,
-                    ipvSessionId,
-                    govukSigninJourneyId,
-                    ipAddress);
+                    auditEventUser,
+                    oldVcs,
+                    sessionVcs,
+                    deviceInformation);
 
             if (isReverification) {
                 setIpvSessionReverificationStatus(
@@ -212,19 +214,17 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
             AuditEventTypes auditEventType,
             CoiCheckType coiCheckType,
             Boolean coiCheckSuccess,
-            String userId,
-            String ipvSessionId,
-            String govukSigninJourneyId,
-            String ipAddress)
+            AuditEventUser auditEventUser,
+            List<VerifiableCredential> oldVcs,
+            List<VerifiableCredential> sessionsVcs,
+            String deviceInformation)
             throws SqsException, HttpResponseExceptionWithErrorBody, CredentialParseException,
                     VerifiableCredentialException {
-        var auditEventUser =
-                new AuditEventUser(userId, ipvSessionId, govukSigninJourneyId, ipAddress);
 
         var restrictedData =
                 auditEventType == AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END
-                        ? getRestrictedAuditDataforCheckCoi(userId, ipvSessionId)
-                        : null;
+                        ? getRestrictedCheckCoiAuditData(oldVcs, sessionsVcs, deviceInformation)
+                        : new AuditRestrictedDeviceInformation(deviceInformation);
 
         auditService.sendAuditEvent(
                 new AuditEvent(
@@ -235,26 +235,25 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
                         restrictedData));
     }
 
-    private AuditRestrictedCheckCoi getRestrictedAuditDataforCheckCoi(
-            String userId, String ipvSessionId)
-            throws HttpResponseExceptionWithErrorBody, CredentialParseException,
-                    VerifiableCredentialException {
-        var oldVcs = verifiableCredentialService.getVcs(userId);
-        var sessionVcs = sessionCredentialsService.getCredentials(ipvSessionId, userId);
-
+    private AuditRestrictedCheckCoi getRestrictedCheckCoiAuditData(
+            List<VerifiableCredential> oldVcs,
+            List<VerifiableCredential> sessionVcs,
+            String deviceInformation)
+            throws HttpResponseExceptionWithErrorBody, CredentialParseException {
         var oldIdentityClaim = userIdentityService.findIdentityClaim(oldVcs);
         var sessionIdentityClaim = userIdentityService.findIdentityClaim(sessionVcs);
 
         if (oldIdentityClaim.isEmpty() || sessionIdentityClaim.isEmpty()) {
-            LOGGER.error(LogHelper.buildLogMessage("Failed to generate identity claim"));
-            throw new HttpResponseExceptionWithErrorBody(
-                    500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
+            LOGGER.error(LogHelper.buildLogMessage("Failed to get identity claim."));
+            return new AuditRestrictedCheckCoi(
+                    null, null, null, null, new DeviceInformation(deviceInformation));
         }
 
         return new AuditRestrictedCheckCoi(
-                List.of(new Name(oldIdentityClaim.get().getNameParts())),
-                List.of(new Name(sessionIdentityClaim.get().getNameParts())),
+                oldIdentityClaim.get().getName(),
+                sessionIdentityClaim.get().getName(),
                 oldIdentityClaim.get().getBirthDate(),
-                sessionIdentityClaim.get().getBirthDate());
+                sessionIdentityClaim.get().getBirthDate(),
+                new DeviceInformation(deviceInformation));
     }
 }

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedCheckCoi;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
 import uk.gov.di.ipv.core.library.auditing.restricted.DeviceInformation;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
@@ -242,17 +243,11 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
         var oldIdentityClaim = userIdentityService.findIdentityClaim(oldVcs);
         var sessionIdentityClaim = userIdentityService.findIdentityClaim(sessionVcs);
 
-        if (oldIdentityClaim.isEmpty() || sessionIdentityClaim.isEmpty()) {
-            LOGGER.error(LogHelper.buildLogMessage("Failed to get identity claim."));
-            return new AuditRestrictedCheckCoi(
-                    null, null, null, null, new DeviceInformation(deviceInformation));
-        }
-
         return new AuditRestrictedCheckCoi(
-                oldIdentityClaim.get().getName(),
-                sessionIdentityClaim.get().getName(),
-                oldIdentityClaim.get().getBirthDate(),
-                sessionIdentityClaim.get().getBirthDate(),
+                oldIdentityClaim.map(IdentityClaim::getName).orElse(null),
+                sessionIdentityClaim.map(IdentityClaim::getName).orElse(null),
+                oldIdentityClaim.map(IdentityClaim::getBirthDate).orElse(null),
+                sessionIdentityClaim.map(IdentityClaim::getBirthDate).orElse(null),
                 new DeviceInformation(deviceInformation));
     }
 }

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -218,8 +218,7 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
             List<VerifiableCredential> oldVcs,
             List<VerifiableCredential> sessionsVcs,
             String deviceInformation)
-            throws SqsException, HttpResponseExceptionWithErrorBody, CredentialParseException,
-                    VerifiableCredentialException {
+            throws SqsException, HttpResponseExceptionWithErrorBody, CredentialParseException {
 
         var restrictedData =
                 auditEventType == AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -108,11 +108,6 @@ class CheckCoiHandlerTest {
 
         @BeforeEach
         void setup() throws Exception {
-            when(mockUserIdentityService.getSuccessfulVcs(List.of(M1A_ADDRESS_VC)))
-                    .thenReturn(List.of(M1A_ADDRESS_VC));
-            when(mockUserIdentityService.getSuccessfulVcs(List.of(M1A_EXPERIAN_FRAUD_VC)))
-                    .thenReturn(List.of(M1A_EXPERIAN_FRAUD_VC));
-
             when(mockUserIdentityService.findIdentityClaim(any()))
                     .thenReturn(getMockIdentityClaim());
         }
@@ -679,10 +674,6 @@ class CheckCoiHandlerTest {
             when(mockUserIdentityService.areGivenNamesAndDobCorrelated(
                             List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                     .thenReturn(true);
-            when(mockUserIdentityService.getSuccessfulVcs(List.of(M1A_ADDRESS_VC)))
-                    .thenReturn(List.of(M1A_ADDRESS_VC));
-            when(mockUserIdentityService.getSuccessfulVcs(List.of(M1A_EXPERIAN_FRAUD_VC)))
-                    .thenReturn(List.of(M1A_EXPERIAN_FRAUD_VC));
             when(mockUserIdentityService.findIdentityClaim(any()))
                     .thenThrow(
                             new HttpResponseExceptionWithErrorBody(
@@ -706,10 +697,6 @@ class CheckCoiHandlerTest {
             when(mockUserIdentityService.areGivenNamesAndDobCorrelated(
                             List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                     .thenReturn(true);
-            when(mockUserIdentityService.getSuccessfulVcs(List.of(M1A_ADDRESS_VC)))
-                    .thenReturn(List.of(M1A_ADDRESS_VC));
-            when(mockUserIdentityService.getSuccessfulVcs(List.of(M1A_EXPERIAN_FRAUD_VC)))
-                    .thenReturn(List.of(M1A_EXPERIAN_FRAUD_VC));
             when(mockUserIdentityService.findIdentityClaim(any())).thenReturn(Optional.empty());
 
             var request =

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -15,6 +15,10 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCoiCheck;
+import uk.gov.di.ipv.core.library.domain.BirthDate;
+import uk.gov.di.ipv.core.library.domain.IdentityClaim;
+import uk.gov.di.ipv.core.library.domain.Name;
+import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
 import uk.gov.di.ipv.core.library.domain.ScopeConstants;
@@ -35,6 +39,7 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredent
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -94,6 +99,16 @@ class CheckCoiHandlerTest {
 
     @Nested
     class SuccessAndFailChecks {
+        @BeforeEach
+        void setup() throws Exception {
+            when(mockUserIdentityService.getSuccessfulVcs(List.of(M1A_ADDRESS_VC)))
+                    .thenReturn(List.of(M1A_ADDRESS_VC));
+            when(mockUserIdentityService.getSuccessfulVcs(List.of(M1A_EXPERIAN_FRAUD_VC)))
+                    .thenReturn(List.of(M1A_EXPERIAN_FRAUD_VC));
+            when(mockUserIdentityService.findIdentityClaim(any()))
+                    .thenReturn(getMockIdentityClaim());
+        }
+
         @Nested
         @DisplayName("Successful checks")
         class SuccessfulChecks {
@@ -564,5 +579,13 @@ class CheckCoiHandlerTest {
             assertEquals(JOURNEY_ERROR_PATH, responseMap.get("journey"));
             assertEquals(UNKNOWN_CHECK_TYPE.getMessage(), responseMap.get("message"));
         }
+    }
+
+    private Optional<IdentityClaim> getMockIdentityClaim() {
+        var mockName =
+                List.of(new Name(List.of(new NameParts("Kenneth Decerqueira", "full-name"))));
+        var mockBirthDate = List.of(new BirthDate("1965-07-08"));
+
+        return Optional.of(new IdentityClaim(mockName, mockBirthDate));
     }
 }

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -374,7 +374,7 @@ class CheckCoiHandlerTest {
                 assertEquals(
                         new AuditExtensionCoiCheck(GIVEN_NAMES_AND_DOB, false),
                         auditEventsCaptured.get(1).getExtensions());
-                var restrictedData = auditEventsCaptured.get(1).getRestricted();
+
                 var restrictedAuditData =
                         getRestrictedAuditDataNodeFromEvent(auditEventsCaptured.get(1));
                 assertTrue(restrictedAuditData.has("newName"));

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.core.library.auditing.restricted;
+
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.BirthDate;
+import uk.gov.di.ipv.core.library.domain.Name;
+
+import java.util.List;
+
+@ExcludeFromGeneratedCoverageReport
+public record AuditRestrictedCheckCoi(
+        List<Name> oldName,
+        List<Name> newName,
+        List<BirthDate> oldBirthDate,
+        List<BirthDate> newBirthDate)
+        implements AuditRestricted {}

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.core.library.auditing.restricted;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.Name;
@@ -8,8 +10,10 @@ import java.util.List;
 
 @ExcludeFromGeneratedCoverageReport
 public record AuditRestrictedCheckCoi(
-        List<Name> oldName,
-        List<Name> newName,
-        List<BirthDate> oldBirthDate,
-        List<BirthDate> newBirthDate)
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<Name> oldName,
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<Name> newName,
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<BirthDate> oldBirthDate,
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<BirthDate> newBirthDate,
+        @JsonProperty(value = "device_information", required = true)
+                DeviceInformation deviceInformation)
         implements AuditRestricted {}

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -284,7 +284,7 @@ public class UserIdentityService {
         return true;
     }
 
-    public List<VerifiableCredential> getSuccessfulVcs(List<VerifiableCredential> vcs)
+    private List<VerifiableCredential> getSuccessfulVcs(List<VerifiableCredential> vcs)
             throws CredentialParseException {
         var successfulVcs = new ArrayList<VerifiableCredential>();
         for (var vc : VcHelper.filterVCBasedOnProfileType(vcs, ProfileType.GPG45)) {

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -186,12 +186,8 @@ public class UserIdentityService {
 
     public boolean areVcsCorrelated(List<VerifiableCredential> vcs)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
-        var successfulVcs = new ArrayList<VerifiableCredential>();
-        for (var vc : VcHelper.filterVCBasedOnProfileType(vcs, ProfileType.GPG45)) {
-            if (VcHelper.isSuccessfulVc(vc)) {
-                successfulVcs.add(vc);
-            }
-        }
+        var successfulVcs = getSuccessfulVcs(vcs);
+
         if (!checkNameAndFamilyNameCorrelationInCredentials(successfulVcs)) {
             LOGGER.error(
                     new StringMapMessage()
@@ -222,12 +218,8 @@ public class UserIdentityService {
 
     public boolean areGivenNamesAndDobCorrelated(List<VerifiableCredential> vcs)
             throws CredentialParseException, HttpResponseExceptionWithErrorBody {
-        var successfulVcs = new ArrayList<VerifiableCredential>();
-        for (var vc : VcHelper.filterVCBasedOnProfileType(vcs, ProfileType.GPG45)) {
-            if (VcHelper.isSuccessfulVc(vc)) {
-                successfulVcs.add(vc);
-            }
-        }
+        var successfulVcs = getSuccessfulVcs(vcs);
+
         if (!checkNamesForCorrelation(
                 getNameProperty(
                         getIdentityClaimsForNameCorrelation(successfulVcs),
@@ -261,12 +253,8 @@ public class UserIdentityService {
 
     public boolean areFamilyNameAndDobCorrelatedForCoiCheck(List<VerifiableCredential> vcs)
             throws CredentialParseException, HttpResponseExceptionWithErrorBody {
-        var successfulVcs = new ArrayList<VerifiableCredential>();
-        for (var vc : VcHelper.filterVCBasedOnProfileType(vcs, ProfileType.GPG45)) {
-            if (VcHelper.isSuccessfulVc(vc)) {
-                successfulVcs.add(vc);
-            }
-        }
+        var successfulVcs = getSuccessfulVcs(vcs);
+
         if (!checkNamesForCorrelation(
                 getFamilyNameForCoiCheck(getIdentityClaimsForNameCorrelation(successfulVcs)))) {
             LOGGER.error(
@@ -294,6 +282,17 @@ public class UserIdentityService {
             return false;
         }
         return true;
+    }
+
+    public List<VerifiableCredential> getSuccessfulVcs(List<VerifiableCredential> vcs)
+            throws CredentialParseException {
+        var successfulVcs = new ArrayList<VerifiableCredential>();
+        for (var vc : VcHelper.filterVCBasedOnProfileType(vcs, ProfileType.GPG45)) {
+            if (VcHelper.isSuccessfulVc(vc)) {
+                successfulVcs.add(vc);
+            }
+        }
+        return successfulVcs;
     }
 
     private void buildUserIdentityBasedOnProfileType(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- `IPV_CONTINUITY_OF_IDENTITY_CHECK_END` event now includes restricted data containing old and new names and birthDate of user
- deviceInformation sent in both START and END events

### Why did it change
To track the requests to update user details, and the outcome of those changes.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6676](https://govukverify.atlassian.net/browse/PYIC-6676)

| Successful Family Name + DOB check (user updated given name) | Unsuccessful Full Name + DOB check | Successful Full Name + DOB check | COI_CHECK_START with device information |
| ----- | -------| ------ | -- |
| <img width="405" alt="Screenshot 2024-06-14 at 11 58 47" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/8cd706e9-c449-4e25-9fa8-f99c67f3a9ec"> | <img width="407" alt="Screenshot 2024-06-14 at 12 01 12" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/937581cf-d71d-4cdf-a663-eaf538aaac35"> | <img width="407" alt="Screenshot 2024-06-14 at 12 00 12" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/51d4c70c-ea2b-4c88-9e9f-ce3b0a14a47b"> |  <img width="412" alt="Screenshot 2024-06-14 at 11 59 57" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/3a8fde2d-6dc6-4bb0-838e-83be1dbc4315"> |

[PYIC-6676]: https://govukverify.atlassian.net/browse/PYIC-6676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ