### PR TITLE
PYIC-6584: POC for async SQS messaging

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ awsSdkKms = { module = "software.amazon.awssdk:kms" }
 awsSdkLambda = { module = "software.amazon.awssdk:lambda" }
 awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
 awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
+awsSdkCrtClient = { module = "software.amazon.awssdk:aws-crt-client" }
 commonsCodec = "commons-codec:commons-codec:1.17.0"
 hamcrest = "org.hamcrest:hamcrest:2.2"
 jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -197,6 +197,8 @@ public class CheckExistingIdentityHandler
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -305,6 +305,8 @@ public class InitialiseIpvSessionHandler
                     LogHelper.buildErrorMessage("Failed to check if stronger vot vc present.", e));
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -169,6 +169,8 @@ public class ProcessJourneyEventHandler
         } catch (SqsException e) {
             return StepFunctionHelpers.generateErrorOutputMap(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkUrlConnectionClient,
+			libs.awsSdkCrtClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditException.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.service;
+
+public class AuditException extends RuntimeException {
+    public AuditException(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -2,48 +2,76 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
-import software.amazon.awssdk.services.sqs.SqsClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import static software.amazon.awssdk.regions.Region.EU_WEST_2;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.SQS_AUDIT_EVENT_QUEUE_URL;
 
 public class AuditService {
-    private final SqsClient sqs;
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final SqsAsyncClient sqs;
     private final String queueUrl;
     private final ObjectMapper objectMapper;
 
-    public AuditService(SqsClient sqs, ConfigService configService) {
+    private List<CompletableFuture<SendMessageResponse>> events = new ArrayList<>();
+
+    public AuditService(SqsAsyncClient sqs, ConfigService configService) {
         this.sqs = sqs;
         this.queueUrl = configService.getEnvironmentVariable(SQS_AUDIT_EVENT_QUEUE_URL);
         this.objectMapper = new ObjectMapper();
     }
 
-    public AuditService(SqsClient sqs, ConfigService configService, ObjectMapper objectMapper) {
+    public AuditService(
+            SqsAsyncClient sqs, ConfigService configService, ObjectMapper objectMapper) {
         this.sqs = sqs;
         this.queueUrl = configService.getEnvironmentVariable(SQS_AUDIT_EVENT_QUEUE_URL);
         this.objectMapper = objectMapper;
     }
 
-    public static SqsClient getSqsClient() {
-        return SqsClient.builder()
+    public static SqsAsyncClient getSqsClient() {
+        return SqsAsyncClient.builder()
                 .region(EU_WEST_2)
-                .httpClientBuilder(UrlConnectionHttpClient.builder())
+                .httpClientBuilder(AwsCrtAsyncHttpClient.builder())
                 .build();
     }
 
     public void sendAuditEvent(AuditEvent auditEvent) throws SqsException {
         try {
-            sqs.sendMessage(
-                    SendMessageRequest.builder()
-                            .queueUrl(queueUrl)
-                            .messageBody(objectMapper.writeValueAsString(auditEvent))
-                            .build());
+            var event =
+                    sqs.sendMessage(
+                            SendMessageRequest.builder()
+                                    .queueUrl(queueUrl)
+                                    .messageBody(objectMapper.writeValueAsString(auditEvent))
+                                    .build());
+            events.add(event);
         } catch (JsonProcessingException e) {
             throw new SqsException(e);
+        }
+    }
+
+    // Await audit events MUST be called before the end of each handler
+    public void awaitAuditEvents() {
+        try {
+            var eventsToAwait = events;
+            events = new ArrayList<>();
+            CompletableFuture.allOf(eventsToAwait.toArray(new CompletableFuture[0])).get();
+        } catch (InterruptedException | ExecutionException e) {
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to send audit event(s)", e));
+            throw new AuditException("Failed to send audit event(s)", e);
         }
     }
 }

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
@@ -46,7 +46,7 @@ class AuditServiceTest {
 
     private AuditService auditService;
 
-    @Mock private SqsClient mockSqs;
+    @Mock private SqsAsyncClient mockSqs;
     @Mock private ConfigService mockConfigService;
 
     @BeforeEach


### PR DESCRIPTION
Try creating an async SQS client, to potentially improve performance by parallelising AWS API calls.

The X-Ray traces show SQS requests running in parallel to others, so this appears to work. It'll be hard to tell without a proper performance test whether it makes an appreciable difference.

Other clients could also be made async, but the value will be reduced - e.g. most DynamoDB and SSM calls need to be synchronous as we have to wait for the result.