### PR TITLE
PYIC-6870: Remove coiEnabled flag and redundant contexts

### DIFF
--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -226,7 +226,6 @@ const resolveAllPossibleEventTargets = (eventDefinition) => [
 
 const calcOrphanStates = (journeyMap) => {
     const targetedStates = [
-        ...initialStates,
         ...Object.values(journeyMap).flatMap((stateDefinition) => [
             ...Object.values(stateDefinition.events || {}).flatMap(resolveAllPossibleEventTargets),
             ...Object.values(stateDefinition.exitEvents || {}).flatMap(resolveAllPossibleEventTargets)

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -9,10 +9,7 @@ states:
   START:
     events:
       next:
-        targetState: CONFIRM_NAME_DOB
-        checkFeatureFlag:
-          coiEnabled:
-            targetState: CONFIRM_DETAILS
+        targetState: CONFIRM_DETAILS
 
   # Parent States
 
@@ -181,26 +178,6 @@ states:
       next:
         targetState: FRAUD_CHECK_RFC
 
-  CONFIRM_NAME_DOB:
-    response:
-      type: page
-      pageId: confirm-name-date-birth
-    events:
-      next:
-        targetState: CONFIRM_ADDRESS
-      end:
-        targetState: UPDATE_NAME_DOB
-
-  CONFIRM_ADDRESS:
-    response:
-      type: page
-      pageId: confirm-address
-    events:
-      address-current:
-        targetState: FRAUD_CHECK_RFC
-      next:
-        targetState: ADDRESS_AND_FRAUD_RFC
-
   UPDATE_NAME_DOB:
     response:
       type: page
@@ -208,12 +185,9 @@ states:
       context: repeatFraudCheck
     events:
       end:
-        targetState: CONFIRM_NAME_DOB
-        checkFeatureFlag:
-          coiEnabled:
-            targetState: CONFIRM_DETAILS
-            auditEvents:
-              - IPV_USER_DETAILS_UPDATE_ABORTED
+       targetState: CONFIRM_DETAILS
+       auditEvents:
+         - IPV_USER_DETAILS_UPDATE_ABORTED
 
   FRAUD_CHECK_RFC:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -15,8 +15,6 @@ states:
             targetState: CRI_TICF_BEFORE_REUSE
           deleteDetailsEnabled:
             targetState: IDENTITY_REUSE_PAGE_TEST
-          coiEnabled:
-            targetState: IDENTITY_REUSE_PAGE_COI
 
   UPDATE_DETAILS_START:
     events:
@@ -35,8 +33,6 @@ states:
         checkFeatureFlag:
           deleteDetailsEnabled:
             targetState: IDENTITY_REUSE_PAGE_TEST
-          coiEnabled:
-            targetState: IDENTITY_REUSE_PAGE_COI
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
@@ -60,15 +56,6 @@ states:
     events:
       next:
         targetState: RETURN_TO_RP
-
-  IDENTITY_REUSE_PAGE_COI:
-    response:
-      type: page
-      pageId: page-ipv-reuse
-      context: coi
-    events:
-      next:
-        targetState: RETURN_TO_RP
       update-details:
         targetState: UPDATE_DETAILS_PAGE
         auditEvents:
@@ -81,6 +68,9 @@ states:
     events:
       next:
         targetState: NEW_DETAILS_PAGE
+      update-details:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   NEW_DETAILS_PAGE:
     response:
@@ -91,9 +81,6 @@ states:
         targetState: CONFIRM_DELETE_DETAILS_PAGE
       end:
         targetState: IDENTITY_REUSE_PAGE
-        checkFeatureFlag:
-          coiEnabled:
-            targetState: IDENTITY_REUSE_PAGE_COI
 
   RESET_SESSION_IDENTITY:
     response:
@@ -114,9 +101,6 @@ states:
         targetState: RESET_SESSION_IDENTITY
       end:
         targetState: IDENTITY_REUSE_PAGE
-        checkFeatureFlag:
-          coiEnabled:
-            targetState: IDENTITY_REUSE_PAGE_COI
 
   UPDATE_DETAILS_PAGE:
     response:
@@ -238,7 +222,7 @@ states:
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
       back:
-        targetState: IDENTITY_REUSE_PAGE_COI
+        targetState: IDENTITY_REUSE_PAGE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
 
@@ -255,7 +239,6 @@ states:
     response:
       type: page
       pageId: update-name-date-birth
-      context: coi
     events:
       end:
         targetState: UPDATE_DETAILS_PAGE


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove coiEnabled flag and redundant contexts

### Why did it change

This removes the use of the coiEnabled feature flag in the journey maps. We've been able to drop a couple of states because of this.

There are also some now unneccessary contexts which can also be removed.

There will be a fronend-change which should be merged before this.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6870](https://govukverify.atlassian.net/browse/PYIC-6870)


[PYIC-6870]: https://govukverify.atlassian.net/browse/PYIC-6870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ