### PR TITLE
PYIC-6868: Fix test API deploy in build

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -188,35 +188,35 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "49edc8e5cce3d7f30610b919b21c6722f4553131",
         "is_verified": false,
-        "line_number": 1073
+        "line_number": 1094
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 1075
+        "line_number": 1096
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
         "is_verified": false,
-        "line_number": 1889
+        "line_number": 1910
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
-        "line_number": 2269
+        "line_number": 2290
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "92746a9d2183099758834bb9262832ec928843df",
         "is_verified": false,
-        "line_number": 2422
+        "line_number": 2443
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -1962,5 +1962,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-20T06:02:24Z"
+  "generated_at": "2024-06-20T09:12:47Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -461,18 +461,27 @@ Resources:
     Condition: IsTestApiEnv
     Properties:
       DomainName: !If
-        - IsDev01
-        - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-        - !If [IsDev02, !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk", !Ref AWS::NoValue]
+        - IsDevelopment
+        - !If
+          - IsDev01
+          - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
+          - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
+        - !Sub "internal-api.identity.${Environment}.account.gov.uk"
       DomainValidationOptions:
         - DomainName: !If
+          - IsDevelopment
+          - !If
             - IsDev01
             - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-            - !If [IsDev02, !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk", !Ref AWS::NoValue]
+            - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
+          - !Sub "internal-api.identity.${Environment}.account.gov.uk"
           HostedZoneId: !If
-            - IsDev01
-            - !ImportValue Dev01IdentityHostedZoneId
-            - !If [IsDev02, !ImportValue Dev02IdentityHostedZoneId, DevIdentityHostedZoneId]
+            - IsDevelopment
+            - !If
+              - IsDev01
+              - !ImportValue Dev01IdentityHostedZoneId
+              - Dev02IdentityHostedZoneId
+            - !ImportValue PublicHostedZoneId
       ValidationMethod: DNS
 
   # api domain entries / mapping
@@ -482,9 +491,12 @@ Resources:
     Condition: IsTestApiEnv
     Properties:
       DomainName: !If
-        - IsDev01
-        - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-        - !If [IsDev02, !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk", !Ref AWS::NoValue]
+        - IsDevelopment
+        - !If
+          - IsDev01
+          - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
+          - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
+        - !Sub "internal-api.identity.${Environment}.account.gov.uk"
       DomainNameConfigurations:
         - CertificateArn: !Ref IPVCoreInternalTestingApiSSLCert
           EndpointType: REGIONAL
@@ -495,9 +507,12 @@ Resources:
     Condition: IsTestApiEnv
     Properties:
       DomainName: !If
-        - IsDev01
-        - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-        - !If [IsDev02, !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk", !Ref AWS::NoValue]
+        - IsDevelopment
+        - !If
+          - IsDev01
+          - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
+          - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
+        - !Sub "internal-api.identity.${Environment}.account.gov.uk"
       ApiId: !Ref IPVCoreInternalTestingApi
       Stage: !Ref IPVCoreInternalTestingApi.Stage
     DependsOn:
@@ -510,13 +525,19 @@ Resources:
     Properties:
       Type: A
       Name: !If
-        - IsDev01
-        - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-        - !If [IsDev02, !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk", !Ref AWS::NoValue]
+        - IsDevelopment
+        - !If
+          - IsDev01
+          - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
+          - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
+        - !Sub "internal-api.identity.${Environment}.account.gov.uk"
       HostedZoneId: !If
-        - IsDev01
-        - !ImportValue Dev01IdentityHostedZoneId
-        - !If [IsDev02, !ImportValue Dev02IdentityHostedZoneId, DevIdentityHostedZoneId]
+        - IsDevelopment
+        - !If
+          - IsDev01
+          - !ImportValue Dev01IdentityHostedZoneId
+          - Dev02IdentityHostedZoneId
+        - !ImportValue PublicHostedZoneId
       AliasTarget:
         DNSName: !GetAtt IPVCoreInternalTestingApiDomain.RegionalDomainName
         HostedZoneId: !GetAtt IPVCoreInternalTestingApiDomain.RegionalHostedZoneId

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -464,17 +464,17 @@ Resources:
         - IsDevelopment
         - !If
           - IsDev01
-          - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-          - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
-        - !Sub "internal-api.identity.${Environment}.account.gov.uk"
+          - !Sub "internal-test-api-${Environment}.01.dev.identity.account.gov.uk"
+          - !Sub "internal-test-api-${Environment}.02.dev.identity.account.gov.uk"
+        - !Sub "internal-test-api.identity.${Environment}.account.gov.uk"
       DomainValidationOptions:
         - DomainName: !If
           - IsDevelopment
           - !If
             - IsDev01
-            - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-            - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
-          - !Sub "internal-api.identity.${Environment}.account.gov.uk"
+            - !Sub "internal-test-api-${Environment}.01.dev.identity.account.gov.uk"
+            - !Sub "internal-test-api-${Environment}.02.dev.identity.account.gov.uk"
+          - !Sub "internal-test-api.identity.${Environment}.account.gov.uk"
           HostedZoneId: !If
             - IsDevelopment
             - !If
@@ -494,9 +494,9 @@ Resources:
         - IsDevelopment
         - !If
           - IsDev01
-          - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-          - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
-        - !Sub "internal-api.identity.${Environment}.account.gov.uk"
+          - !Sub "internal-test-api-${Environment}.01.dev.identity.account.gov.uk"
+          - !Sub "internal-test-api-${Environment}.02.dev.identity.account.gov.uk"
+        - !Sub "internal-test-api.identity.${Environment}.account.gov.uk"
       DomainNameConfigurations:
         - CertificateArn: !Ref IPVCoreInternalTestingApiSSLCert
           EndpointType: REGIONAL
@@ -510,9 +510,9 @@ Resources:
         - IsDevelopment
         - !If
           - IsDev01
-          - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-          - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
-        - !Sub "internal-api.identity.${Environment}.account.gov.uk"
+          - !Sub "internal-test-api-${Environment}.01.dev.identity.account.gov.uk"
+          - !Sub "internal-test-api-${Environment}.02.dev.identity.account.gov.uk"
+        - !Sub "internal-test-api.identity.${Environment}.account.gov.uk"
       ApiId: !Ref IPVCoreInternalTestingApi
       Stage: !Ref IPVCoreInternalTestingApi.Stage
     DependsOn:
@@ -528,9 +528,9 @@ Resources:
         - IsDevelopment
         - !If
           - IsDev01
-          - !Sub "internal-api-${Environment}.01.dev.identity.account.gov.uk"
-          - !Sub "internal-api-${Environment}.02.dev.identity.account.gov.uk"
-        - !Sub "internal-api.identity.${Environment}.account.gov.uk"
+          - !Sub "internal-test-api-${Environment}.01.dev.identity.account.gov.uk"
+          - !Sub "internal-test-api-${Environment}.02.dev.identity.account.gov.uk"
+        - !Sub "internal-test-api.identity.${Environment}.account.gov.uk"
       HostedZoneId: !If
         - IsDevelopment
         - !If


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix test API deploy in build

### Why did it change

[PYIC-6868: Make internal-api urls work for build](https://github.com/govuk-one-login/ipv-core-back/commit/7d49e8af746326df98b05f8ccb82911d7730adc2)

The CF resources for deploying the test API worked in dev but not build.
This change allows the correct URLs to be built, and adds them to the
hosted zone exported from the dns stack.


[PYIC-6868: Update test API URL](https://github.com/govuk-one-login/ipv-core-back/commit/1dcf4d585517b322f7308e462f7af37cee5d2a5e)

This changes the URL of the test api to make it clear that it's a
testing API, to differentiate more clearly for the normal internal API.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6868](https://govukverify.atlassian.net/browse/PYIC-6868)


[PYIC-6868]: https://govukverify.atlassian.net/browse/PYIC-6868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ