### PR TITLE
PYIC-6868: Deploy test-api to build with perms boundary for role

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,63 +160,63 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 199
+        "line_number": 201
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "d3053d5db9cc8cb93b26db3c26c76bdfdff06ace",
         "is_verified": false,
-        "line_number": 394
+        "line_number": 396
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 396
+        "line_number": 398
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "49edc8e5cce3d7f30610b919b21c6722f4553131",
         "is_verified": false,
-        "line_number": 1092
+        "line_number": 1098
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "2f4012d62ceff52b17fe028aeb7a5efa6e6e23cf",
         "is_verified": false,
-        "line_number": 1094
+        "line_number": 1100
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "38450ffe4ff65a68053ea5083d47521010709df2",
         "is_verified": false,
-        "line_number": 1908
+        "line_number": 1914
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "6afab4c634af2dd2b9c344a98f96667277c56df0",
         "is_verified": false,
-        "line_number": 2288
+        "line_number": 2294
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "92746a9d2183099758834bb9262832ec928843df",
         "is_verified": false,
-        "line_number": 2441
+        "line_number": 2447
       }
     ],
     "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
@@ -1962,5 +1962,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-20T10:38:03Z"
+  "generated_at": "2024-06-20T11:49:30Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -122,7 +122,9 @@ Conditions:
   UseIndividualCiMitStubs: !And
     - !Condition IsDevelopment
     - !Equals [ !Ref IndividualCiMitStubs, "True"]
-  IsTestApiEnv: !Condition IsDevelopment
+  IsTestApiEnv: !Or
+    - !Condition IsDevelopment
+    - !Equals [ !Ref Environment, build ]
 
 # The AWS Account Id is used in the following mapping section because we have
 # multiple developer environments and it is undesirable to have to keep this
@@ -452,6 +454,10 @@ Resources:
                 - "repo:govuk-one-login/ipv-core-back:*"
       ManagedPolicyArns:
         - !Ref IPVCoreInternalTestingApiTokenFetchPolicy
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
 
   # ssl cert
   IPVCoreInternalTestingApiSSLCert:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Deploy test-api to build with perms boundary for role

### Why did it change

This is another attempt at deploying the test API gateway in build. Previously the role was failing to deploy and adding the perms boundary is a suggested fix. This is how we deploy all other roles in the template, so this makes sense.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6868](https://govukverify.atlassian.net/browse/PYIC-6868)


[PYIC-6868]: https://govukverify.atlassian.net/browse/PYIC-6868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ