### PR TITLE
PYIC-6710 exclude secrets from lambdas

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,7 +115,8 @@
       "pattern": [
         "(?i)dummyapikey",
         "(?i)test-secret",
-        "^x-api-key$"
+        "^x-api-key$",
+        "^1f9d73167e2166b707c6$"
       ]
     }
   ],
@@ -225,31 +226,6 @@
         "hashed_secret": "92746a9d2183099758834bb9262832ec928843df",
         "is_verified": false,
         "line_number": 2447
-      }
-    ],
-    "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
-        "hashed_secret": "85d1e7563098941624848ca8a7c731a6c013235b",
-        "is_verified": false,
-        "line_number": 223
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java",
-        "hashed_secret": "69facda46567909882c049ea59985c33000974b3",
-        "is_verified": false,
-        "line_number": 306
-      }
-    ],
-    "lambdas/call-ticf-cri/src/test/resources/dvlaVc/body.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "lambdas/call-ticf-cri/src/test/resources/dvlaVc/body.json",
-        "hashed_secret": "17bcb421d140ca9041e86d38912a52bc85358e29",
-        "is_verified": false,
-        "line_number": 76
       }
     ],
     "lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java": [
@@ -379,13 +355,6 @@
         "hashed_secret": "026df3067222e66fa1aaaa8e5d426043b61ebaf6",
         "is_verified": false,
         "line_number": 2375
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java",
-        "hashed_secret": "17bcb421d140ca9041e86d38912a52bc85358e29",
-        "is_verified": false,
-        "line_number": 2456
       },
       {
         "type": "Base64 High Entropy String",
@@ -863,5 +832,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-20T13:57:04Z"
+  "generated_at": "2024-06-20T15:37:18Z"
 }

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
@@ -220,7 +220,7 @@ class BuildUserIdentityHandlerTest {
             """;
 
     private final String CIMIT_VC_NO_CIS_SIGNATURE =
-            "q9bLcKWe9K13QJoJL-f8Lz4UdhUGfzQgXPtsmu5TK5W2mP4mr7oXJjqKBAUPypnZdWza1zdKZiQpAmmVy1BW3A";
+            "q9bLcKWe9K13QJoJL-f8Lz4UdhUGfzQgXPtsmu5TK5W2mP4mr7oXJjqKBAUPypnZdWza1zdKZiQpAmmVy1BW3A"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-3079-AC1
@@ -303,7 +303,7 @@ class BuildUserIdentityHandlerTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_UK_PASSPORT_VC_SIGNATURE =
-            "dnXc3avCGKj6XdKpGnNTgjH3lpRZotBSyzx4ttFksnaheiHExklxqGHc8ZNRdIJu0cpFyP-Dw6Bl5xO46nZCVA";
+            "dnXc3avCGKj6XdKpGnNTgjH3lpRZotBSyzx4ttFksnaheiHExklxqGHc8ZNRdIJu0cpFyP-Dw6Bl5xO46nZCVA"; // pragma: allowlist secret
 
     private static final String VALID_ADDRESS_VC_BODY =
             """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- exclude secrets from build-user-identity and call-ticf-cri lambdas

### Why did it change

The .secrets.baseline file was being updated with new secrets every time a "secret" was detected. Instead, we should use rules to avoid false positives being added to the baseline. This means we'll have less conflicts as the only changes made to the baseline should be if the filters are updated.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6710](https://govukverify.atlassian.net/browse/PYIC-6710)


[PYIC-6710]: https://govukverify.atlassian.net/browse/PYIC-6710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ