### PR TITLE
PYIC-6805: log evcs-tactical vc mismatches

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
+import uk.gov.di.ipv.core.library.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.enums.OperationalProfile;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
@@ -62,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.amazonaws.util.CollectionUtils.isNullOrEmpty;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
@@ -75,6 +77,7 @@ import static uk.gov.di.ipv.core.library.domain.ProfileType.GPG45;
 import static uk.gov.di.ipv.core.library.domain.ProfileType.OPERATIONAL_HMRC;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.VOT_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.enums.EvcsVCState.CURRENT;
+import static uk.gov.di.ipv.core.library.enums.EvcsVCState.PENDING;
 import static uk.gov.di.ipv.core.library.enums.EvcsVCState.PENDING_RETURN;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_VOT;
@@ -331,22 +334,75 @@ public class CheckExistingIdentityHandler
     private VerifiableCredentialBundle getVerifiableCredentials(
             String userId, String evcsAccessToken)
             throws CredentialParseException, EvcsServiceException {
-        if (configService.enabled(EVCS_READ_ENABLED)) {
+
+        var tacticalVcs = verifiableCredentialService.getVcs(userId);
+
+        if (configService.enabled(EVCS_WRITE_ENABLED) || configService.enabled(EVCS_READ_ENABLED)) {
             var vcs =
                     evcsService.getVerifiableCredentialsByState(
-                            userId, evcsAccessToken, CURRENT, PENDING_RETURN);
-            var pendingReturnVcs = vcs.get(PENDING_RETURN);
-            // use pending return vcs to determine identity if available
-            if (!isNullOrEmpty(pendingReturnVcs)) {
-                return new VerifiableCredentialBundle(pendingReturnVcs, true, true);
-            }
-            var currentVcs = vcs.get(CURRENT);
-            if (!isNullOrEmpty(currentVcs)) {
-                return new VerifiableCredentialBundle(currentVcs, true, false);
+                            userId, evcsAccessToken, CURRENT, PENDING_RETURN, PENDING);
+
+            logIdentityMismatches(tacticalVcs, vcs);
+
+            if (configService.enabled(EVCS_READ_ENABLED)) {
+                var pendingReturnVcs = vcs.get(PENDING_RETURN);
+                // use pending return vcs to determine identity if available
+                if (!isNullOrEmpty(pendingReturnVcs)) {
+                    return new VerifiableCredentialBundle(pendingReturnVcs, true, true);
+                }
+                var currentVcs = vcs.get(CURRENT);
+                if (!isNullOrEmpty(currentVcs)) {
+                    return new VerifiableCredentialBundle(currentVcs, true, false);
+                }
             }
         }
-        return new VerifiableCredentialBundle(
-                verifiableCredentialService.getVcs(userId), false, false);
+        return new VerifiableCredentialBundle(tacticalVcs, false, false);
+    }
+
+    @ExcludeFromGeneratedCoverageReport
+    private void logIdentityMismatches(
+            List<VerifiableCredential> tacticalVcs,
+            Map<EvcsVCState, List<VerifiableCredential>> evcsVcs) {
+
+        var migratedTacticalVcStrings =
+                tacticalVcs.stream()
+                        .filter(vc -> vc.getMigrated() != null)
+                        .map(VerifiableCredential::getVcString)
+                        .collect(Collectors.toSet());
+
+        // if we have pending vcs just check those
+        var evcsToCheck =
+                Optional.ofNullable(evcsVcs.get(PENDING_RETURN))
+                        .or(() -> Optional.ofNullable(evcsVcs.get(CURRENT)))
+                        .orElse(List.of());
+
+        var allTacticalVcStrings =
+                tacticalVcs.stream()
+                        .map(VerifiableCredential::getVcString)
+                        .collect(Collectors.toSet());
+
+        var evcsVcStrings =
+                evcsToCheck.stream()
+                        .map(VerifiableCredential::getVcString)
+                        .collect(Collectors.toSet());
+
+        var hasUnmigratedVcs = allTacticalVcStrings.size() > migratedTacticalVcStrings.size();
+
+        // check if we have unmigrated credentials alongside migrated ones
+        if (hasUnmigratedVcs && !migratedTacticalVcStrings.isEmpty()) {
+            LOGGER.warn("Unmigrated tactical credentials found alongside migrated credentials");
+        }
+
+        // check all the tactical vcs are in the selected evcs vcs
+        if (!hasUnmigratedVcs && !evcsVcStrings.containsAll(migratedTacticalVcStrings)) {
+            LOGGER.warn(
+                    "Failed to find corresponding evcs credential for migrated tactical credential");
+        }
+
+        // check all the evcs vcs are in the tactical store
+        if (!hasUnmigratedVcs && !migratedTacticalVcStrings.containsAll(evcsVcStrings)) {
+            LOGGER.warn("Failed to find corresponding tactical credential for evcs credential");
+        }
     }
 
     @Tracing

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -248,10 +248,19 @@ class CheckExistingIdentityHandlerTest {
 
         @Test
         void shouldUseEvcsServiceWhenEnabled() throws Exception {
+            var vc = vcHmrcMigration();
+            vc.setMigrated(Instant.now());
+            when(mockVerifiableCredentialService.getVcs(any())).thenReturn(List.of(vc));
+            when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
             when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
+
             when(mockEvcsService.getVerifiableCredentialsByState(
-                            any(), any(), any(EvcsVCState.class), any(EvcsVCState.class)))
-                    .thenReturn(Map.of(PENDING_RETURN, List.of(gpg45Vc, vcHmrcMigration())));
+                            any(),
+                            any(),
+                            any(EvcsVCState.class),
+                            any(EvcsVCState.class),
+                            any(EvcsVCState.class)))
+                    .thenReturn(Map.of(EvcsVCState.CURRENT, List.of(gpg45Vc)));
 
             checkExistingIdentityHandler.handleRequest(event, context);
 
@@ -261,15 +270,20 @@ class CheckExistingIdentityHandlerTest {
                             TEST_USER_ID,
                             EVCS_TEST_TOKEN,
                             EvcsVCState.CURRENT,
-                            EvcsVCState.PENDING_RETURN);
-            verify(mockVerifiableCredentialService, never()).getVcs(TEST_USER_ID);
+                            EvcsVCState.PENDING_RETURN,
+                            EvcsVCState.PENDING);
         }
 
         @Test
         void shouldUseVcServiceWhenEvcsServiceWhenAndReturnsEmpty() throws Exception {
+            when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
             when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
             when(mockEvcsService.getVerifiableCredentialsByState(
-                            any(), any(), any(EvcsVCState.class), any(EvcsVCState.class)))
+                            any(),
+                            any(),
+                            any(EvcsVCState.class),
+                            any(EvcsVCState.class),
+                            any(EvcsVCState.class)))
                     .thenReturn(new HashMap<EvcsVCState, List<VerifiableCredential>>());
 
             checkExistingIdentityHandler.handleRequest(event, context);
@@ -280,7 +294,8 @@ class CheckExistingIdentityHandlerTest {
                             TEST_USER_ID,
                             EVCS_TEST_TOKEN,
                             EvcsVCState.CURRENT,
-                            EvcsVCState.PENDING_RETURN);
+                            EvcsVCState.PENDING_RETURN,
+                            EvcsVCState.PENDING);
             verify(mockVerifiableCredentialService, times(1)).getVcs(TEST_USER_ID);
         }
 
@@ -331,10 +346,16 @@ class CheckExistingIdentityHandlerTest {
         void shouldReturnJourneyReuseUpdateResponseIfVcIsF2fAndHasPendingReturnInEvcs()
                 throws CredentialParseException, EvcsServiceException,
                         HttpResponseExceptionWithErrorBody, VerifiableCredentialException {
+
+            when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
             when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
 
             when(mockEvcsService.getVerifiableCredentialsByState(
-                            any(), any(), any(EvcsVCState.class), any(EvcsVCState.class)))
+                            any(),
+                            any(),
+                            any(EvcsVCState.class),
+                            any(EvcsVCState.class),
+                            any(EvcsVCState.class)))
                     .thenReturn(Map.of(PENDING_RETURN, List.of(vcF2fM1a())));
 
             when(criResponseService.getFaceToFaceRequest(any())).thenReturn(new CriResponseItem());
@@ -1100,6 +1121,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.checkRequiresAdditionalEvidence(any())).thenReturn(false);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+        when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
         when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
         when(configService.enabled(INHERITED_IDENTITY)).thenReturn(true);
@@ -1145,6 +1167,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(testContraIndicators);
+        when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
         when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
         when(ciMitUtilityService.isBreachingCiThreshold(any())).thenReturn(true);
@@ -1302,6 +1325,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.checkRequiresAdditionalEvidence(any())).thenReturn(false);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+        when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
         when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
         when(configService.enabled(INHERITED_IDENTITY)).thenReturn(false);
@@ -1381,6 +1405,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.checkRequiresAdditionalEvidence(any())).thenReturn(false);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+        when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
         when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
         when(configService.enabled(INHERITED_IDENTITY)).thenReturn(false);


### PR DESCRIPTION
## Proposed changes

Adds some logs to sanity check the EVCS credentials

### What changed

If evcs writes are enabled:
 - get evcs credentials from the store and compare them with the tactical store
 - if there are any evcs credentials that do not exist in the tactical store - log a warning
 - if there are any tactical credentials that do that not exist in the relevant pending/current credentials, then log a warning


https://govukverify.atlassian.net/browse/PYIC-6805

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

