### PR TITLE
PYIC-6818: Add PITR and Deletion Protection to CRI responses

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3123,6 +3123,15 @@ Resources:
       # checkov:skip=CKV_AWS_28: Point in time recovery is not necessary for this table.
       TableName: !Sub "cri-response-${Environment}"
       BillingMode: "PAY_PER_REQUEST"
+      DeletionProtectionEnabled: !If
+        - IsProduction
+        - true
+        - false
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: !If
+          - IsProduction
+          - true
+          - false
       AttributeDefinitions:
         - AttributeName: "userId"
           AttributeType: "S"


### PR DESCRIPTION
## Proposed changes

Add PITR and Deletion Protection to CRI responses

### What changed

Dynamo db configuraiton for the CRI responses table

### Why did it change

The table contains F2F pending journeys, so it will be useful to be able to recover them if necessary

### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-6818

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
