### PR TITLE
fix: targetState for REUSE_WITH_STORE_IDENTITY.next

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -26,7 +26,7 @@ states:
   REUSE_WITH_STORE_IDENTITY:
     events:
       next:
-        targetState: UPDATE_IDENTITY_BEFORE_IDENTITY_REUSE_PAGE
+        targetState: STORE_NEW_IDENTITY
 
   # Journey states
 


### PR DESCRIPTION
## Proposed changes
Fix REUSE_WITH_STORE_IDENTITY.next.targetState 
### What changed

It currently points to a non-existant state but should be STORE_NEW_IDENTITY as introduced in https://github.com/govuk-one-login/ipv-core-back/pull/2033/files

### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-6066

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

