### PR TITLE
BAU: added test to catch invalid target state in journey config

### DIFF
--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -143,10 +143,15 @@ class JourneyMapTest {
                             var basicEventStateMachineKeys = basicEventStateMachine.keySet();
                             assertTrue(
                                     basicEventStateMachineKeys.contains(
-                                            basicEvent.getTargetState()));
+                                            basicEvent.getTargetState()),
+                                    "Unknown target state %s"
+                                            .formatted(basicEvent.getTargetState()));
 
                         } else if (basicEvent.getTargetState() != null) {
-                            assertTrue(stateMachineKeys.contains(basicEvent.getTargetState()));
+                            assertTrue(
+                                    stateMachineKeys.contains(basicEvent.getTargetState()),
+                                    "Unknown target state %s"
+                                            .formatted(basicEvent.getTargetState()));
                         }
                     }
                 }

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -124,6 +124,38 @@ class JourneyMapTest {
 
     @ParameterizedTest
     @EnumSource
+    void basicEventTargetStatesShouldExist(IpvJourneyTypes journeyType) throws IOException {
+        var stateMachine = new StateMachineInitializer(journeyType).initialize();
+        var stateMachineKeys = stateMachine.keySet();
+
+        for (var targetKey : stateMachineKeys) {
+            var targetState = stateMachine.get(targetKey);
+            if (targetState instanceof BasicState basicState) {
+                var events = basicState.getEvents();
+                for (var event : events.values()) {
+                    if (event instanceof BasicEvent basicEvent) {
+                        if (basicEvent.getTargetJourney() != null) {
+                            var basicEventStateMachine =
+                                    new StateMachineInitializer(
+                                                    IpvJourneyTypes.valueOf(
+                                                            basicEvent.getTargetJourney()))
+                                            .initialize();
+                            var basicEventStateMachineKeys = basicEventStateMachine.keySet();
+                            assertTrue(
+                                    basicEventStateMachineKeys.contains(
+                                            basicEvent.getTargetState()));
+
+                        } else if (basicEvent.getTargetState() != null) {
+                            assertTrue(stateMachineKeys.contains(basicEvent.getTargetState()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource
     void shouldMatchNestedJourneyExitEvents(IpvJourneyTypes journeyType) throws IOException {
         var stateMachineInitialiser = new StateMachineInitializer(journeyType);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Adds a test to catch invalid journey map configurations where the target journey or target state do not exist

### Why did it change

To improve confidence when updating journey maps and prevent broken configurations in production environment

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
