### PR TITLE
PYIC-5875: Namespace dev env test API key

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -421,7 +421,12 @@ Resources:
     Condition: IsTestApiEnv
     Properties:
       Enabled: true
-      Value: '{{resolve:secretsmanager:CoreBackInternalTestingApiKey:SecretString}}' # pragma: allowlist secret
+      Value: !Sub
+        - "{{resolve:secretsmanager:CoreBackInternalTestingApiKey:SecretString}}${env}" # pragma: allowlist secret
+        - env: !If
+            - IsDevelopment
+            - !Sub "-${Environment}"
+            - ""
 
   IPVCoreInternalTestingApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Namespace dev env test API key

### Why did it change

You can't have two API keys in API Gateway that have the same value. This means the approaching of using the same secret for all dev env API keys doesn't work as they'll clash.

This namespaces the API key in the dev accounts with the environment which should prevent a clash.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5875](https://govukverify.atlassian.net/browse/PYIC-5875)


[PYIC-5875]: https://govukverify.atlassian.net/browse/PYIC-5875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ