### PR TITLE
Pyic 5759 vc validator

### DIFF
--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -11,7 +11,6 @@ import uk.gov.di.ipv.core.callticfcri.exception.TicfCriServiceException;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.RestCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -119,7 +118,6 @@ public class TicfCriService {
                     clientOAuthSessionItem.getUserId(),
                     TICF.getId(),
                     ticfCriResponse.credentials(),
-                    VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                     ticfCriConfig.getSigningKey(),
                     ticfCriConfig.getComponentId());
         } catch (VerifiableCredentialException | JsonProcessingException e) {

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriServiceTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriServiceTest.java
@@ -119,8 +119,7 @@ class TicfCriServiceTest {
                 .thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatus.SC_OK);
         when(mockHttpResponse.body()).thenReturn(OBJECT_MAPPER.writeValueAsString(ticfCriResponse));
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        any(), any(), any(), any(), any(), any()))
+        when(mockVerifiableCredentialValidator.parseAndValidate(any(), any(), any(), any(), any()))
                 .thenReturn(List.of(VC_ADDRESS));
 
         try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
@@ -247,7 +246,7 @@ class TicfCriServiceTest {
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatus.SC_OK);
         when(mockHttpResponse.body()).thenReturn(OBJECT_MAPPER.writeValueAsString(ticfResponse));
         when(mockVerifiableCredentialValidator.parseAndValidate(
-                        any(), any(), eq(List.of(someCredential)), any(), any(), any()))
+                        any(), any(), eq(List.of(someCredential)), any(), any()))
                 .thenThrow(
                         new VerifiableCredentialException(
                                 500, ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS));

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -37,7 +37,6 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -427,7 +426,6 @@ public class InitialiseIpvSessionHandler
                         userId,
                         HMRC_MIGRATION.getId(),
                         inheritedIdentityJwtList.get(0),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                         inheritedIdentityCriConfig.getSigningKey(),
                         inheritedIdentityCriConfig.getComponentId(),
                         true);

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -99,7 +99,6 @@ import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABL
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.Cri.HMRC_MIGRATION;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.REVERIFICATION;
-import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.ADDRESS_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.CORE_IDENTITY_JWT_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.EVCS_ACCESS_TOKEN_CLAIM_NAME;
@@ -579,7 +578,6 @@ class InitialiseIpvSessionHandlerTest {
                             TEST_USER_ID,
                             HMRC_MIGRATION.getId(),
                             PCL250_MIGRATION_VC.getVcString(),
-                            IDENTITY_CHECK_CREDENTIAL_TYPE,
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
                             true))
@@ -599,7 +597,6 @@ class InitialiseIpvSessionHandlerTest {
                             eq(TEST_USER_ID),
                             eq(HMRC_MIGRATION.getId()),
                             stringArgumentCaptor.capture(),
-                            eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
                             eq(TEST_SIGNING_KEY),
                             eq(TEST_COMPONENT_ID),
                             eq(true));
@@ -643,7 +640,6 @@ class InitialiseIpvSessionHandlerTest {
                             TEST_USER_ID,
                             HMRC_MIGRATION.getId(),
                             PCL200_MIGRATION_VC.getVcString(),
-                            IDENTITY_CHECK_CREDENTIAL_TYPE,
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
                             true))
@@ -660,7 +656,6 @@ class InitialiseIpvSessionHandlerTest {
                             eq(TEST_USER_ID),
                             eq(HMRC_MIGRATION.getId()),
                             stringArgumentCaptor.capture(),
-                            eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
                             eq(TEST_SIGNING_KEY),
                             eq(TEST_COMPONENT_ID),
                             eq(true));
@@ -704,7 +699,6 @@ class InitialiseIpvSessionHandlerTest {
                             TEST_USER_ID,
                             HMRC_MIGRATION.getId(),
                             PCL200_MIGRATION_VC.getVcString(),
-                            IDENTITY_CHECK_CREDENTIAL_TYPE,
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
                             true))
@@ -780,7 +774,6 @@ class InitialiseIpvSessionHandlerTest {
                             TEST_USER_ID,
                             HMRC_MIGRATION.getId(),
                             PCL200_MIGRATION_VC.getVcString(),
-                            IDENTITY_CHECK_CREDENTIAL_TYPE,
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
                             true))
@@ -800,7 +793,6 @@ class InitialiseIpvSessionHandlerTest {
                             eq(TEST_USER_ID),
                             eq(HMRC_MIGRATION.getId()),
                             stringArgumentCaptor.capture(),
-                            eq(IDENTITY_CHECK_CREDENTIAL_TYPE),
                             eq(TEST_SIGNING_KEY),
                             eq(TEST_COMPONENT_ID),
                             eq(true));
@@ -847,7 +839,6 @@ class InitialiseIpvSessionHandlerTest {
                             TEST_USER_ID,
                             HMRC_MIGRATION.getId(),
                             PCL200_MIGRATION_VC.getVcString(),
-                            IDENTITY_CHECK_CREDENTIAL_TYPE,
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
                             true))
@@ -1085,7 +1076,6 @@ class InitialiseIpvSessionHandlerTest {
                             TEST_USER_ID,
                             HMRC_MIGRATION.getId(),
                             "🌭",
-                            IDENTITY_CHECK_CREDENTIAL_TYPE,
                             TEST_CRI_CONFIG.getSigningKey(),
                             TEST_CRI_CONFIG.getComponentId(),
                             true))
@@ -1155,7 +1145,6 @@ class InitialiseIpvSessionHandlerTest {
                             TEST_USER_ID,
                             HMRC_MIGRATION.getId(),
                             PCL200_MIGRATION_VC.getVcString(),
-                            IDENTITY_CHECK_CREDENTIAL_TYPE,
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
                             true))

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -20,7 +20,6 @@ import uk.gov.di.ipv.core.library.cimit.exception.CiPostMitigationsException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiPutException;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
@@ -185,7 +184,6 @@ public class ProcessAsyncCriCredentialHandler
                         successAsyncCriResponse.getUserId(),
                         successAsyncCriResponse.getCredentialIssuer(),
                         successAsyncCriResponse.getVerifiableCredentialJWTs(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                         oauthCriConfig.getSigningKey(),
                         oauthCriConfig.getComponentId());
 

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -113,12 +113,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE);
 
         when(verifiableCredentialValidator.parseAndValidate(
-                        eq(TEST_USER_ID),
-                        eq(TEST_CREDENTIAL_ISSUER_ID),
-                        anyList(),
-                        any(),
-                        any(),
-                        any()))
+                        eq(TEST_USER_ID), eq(TEST_CREDENTIAL_ISSUER_ID), anyList(), any(), any()))
                 .thenReturn(List.of(F2F_VC));
         when(criResponseService.getCriResponseItem(TEST_USER_ID, TEST_COMPONENT_ID))
                 .thenReturn(TEST_CRI_RESPONSE_ITEM);
@@ -194,7 +189,7 @@ class ProcessAsyncCriCredentialHandlerTest {
                 .thenReturn(TEST_CREDENTIAL_ISSUER_CONFIG);
         doThrow(VerifiableCredentialException.class)
                 .when(verifiableCredentialValidator)
-                .parseAndValidate(any(), any(), anyList(), any(), any(), any());
+                .parseAndValidate(any(), any(), anyList(), any(), any());
 
         final SQSBatchResponse batchResponse = handler.handleRequest(testEvent, null);
 
@@ -208,12 +203,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE);
 
         when(verifiableCredentialValidator.parseAndValidate(
-                        eq(TEST_USER_ID),
-                        eq(TEST_CREDENTIAL_ISSUER_ID),
-                        anyList(),
-                        any(),
-                        any(),
-                        any()))
+                        eq(TEST_USER_ID), eq(TEST_CREDENTIAL_ISSUER_ID), anyList(), any(), any()))
                 .thenReturn(List.of(F2F_VC));
         when(criResponseService.getCriResponseItem(TEST_USER_ID, TEST_COMPONENT_ID))
                 .thenReturn(TEST_CRI_RESPONSE_ITEM);
@@ -244,12 +234,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE);
 
         when(verifiableCredentialValidator.parseAndValidate(
-                        eq(TEST_USER_ID),
-                        eq(TEST_CREDENTIAL_ISSUER_ID),
-                        anyList(),
-                        any(),
-                        any(),
-                        any()))
+                        eq(TEST_USER_ID), eq(TEST_CREDENTIAL_ISSUER_ID), anyList(), any(), any()))
                 .thenReturn(List.of(F2F_VC));
         when(criResponseService.getCriResponseItem(TEST_USER_ID, TEST_COMPONENT_ID))
                 .thenReturn(TEST_CRI_RESPONSE_ITEM);
@@ -307,7 +292,7 @@ class ProcessAsyncCriCredentialHandlerTest {
 
     private void verifyVerifiableCredentialJwtValidator() throws Exception {
         verify(verifiableCredentialValidator)
-                .parseAndValidate(any(), any(), anyList(), any(), any(), any());
+                .parseAndValidate(any(), any(), anyList(), any(), any());
     }
 
     private void verifyAuditService() throws SqsException {

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.FixedTimeJWTClaimsVerifier;
@@ -129,7 +128,6 @@ public class ContractTest {
                                 TEST_USER,
                                 F2F.getId(),
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
-                                VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                 criConfig.getSigningKey(),
                                 criConfig.getComponentId())
                         .forEach(
@@ -257,7 +255,6 @@ public class ContractTest {
                                 TEST_USER,
                                 F2F.getId(),
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
-                                VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
                         .forEach(
@@ -403,7 +400,6 @@ public class ContractTest {
                                 TEST_USER,
                                 F2F.getId(),
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
-                                VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
                         .forEach(
@@ -548,7 +544,6 @@ public class ContractTest {
                                 TEST_USER,
                                 F2F.getId(),
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
-                                VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
                         .forEach(
@@ -690,7 +685,6 @@ public class ContractTest {
                                 TEST_USER,
                                 F2F.getId(),
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
-                                VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
                         .forEach(
@@ -827,7 +821,6 @@ public class ContractTest {
                                 TEST_USER,
                                 F2F.getId(),
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
-                                VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
                         .forEach(
@@ -956,7 +949,6 @@ public class ContractTest {
                                 TEST_USER,
                                 F2F.getId(),
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
-                                VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
                         .forEach(

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -23,7 +23,6 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
@@ -324,7 +323,6 @@ public class ProcessCriCallbackHandler
                             clientOAuthSessionItem.getUserId(),
                             callbackRequest.getCredentialIssuerId(),
                             vcResponse.getVerifiableCredentials(),
-                            VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                             criConfig.getSigningKey(),
                             criConfig.getComponentId());
 

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
@@ -91,8 +91,7 @@ class ProcessCriCallbackHandlerTest {
         when(mockCriApiService.fetchVerifiableCredential(
                         bearerToken, TEST_CRI_ID, criOAuthSessionItem))
                 .thenReturn(vcResponse);
-        when(mockVerifiableCredentialValidator.parseAndValidate(
-                        any(), any(), any(), any(), any(), any()))
+        when(mockVerifiableCredentialValidator.parseAndValidate(any(), any(), any(), any(), any()))
                 .thenReturn(vcs);
         when(mockCriCheckingService.checkVcResponse(
                         any(),

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java
@@ -26,7 +26,6 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -287,8 +286,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 ADDRESS.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -397,8 +394,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 ADDRESS.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java
@@ -546,7 +546,7 @@ class ContractTest {
                   "vc": {
                      "type": [
                        "VerifiableCredential",
-                       "IdentityCheckCredential"
+                       "AddressCredential"
                      ],
                      "credentialSubject": {
                        "name": [
@@ -588,7 +588,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_EXPERIAN_SIGNATURE =
-            "MY-0HSHHDSVZWFwzJrtCalS-jO8tFNwx1Oso6rbcfwQI69N7vRi_GEm4lQu-Da7Wn4bxkAMzxKM3R7PLu8yH_Q"; // pragma: allowlist secret
+            "JYSqzC1Ga54CmBAQtdLMA3-RBeiXBjF5I_LjozTuiIfD9gal7htp_HB1ErNEKI_zAZesFHBVhuOB1Klxta1uPg"; // pragma: allowlist secret
 
     private static final String VALID_ADDRESS_BODY =
             """
@@ -600,7 +600,7 @@ class ContractTest {
                   "vc": {
                      "type": [
                        "VerifiableCredential",
-                       "IdentityCheckCredential"
+                       "AddressCredential"
                      ],
                      "credentialSubject": {
                        "name": [
@@ -640,5 +640,5 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_ADDRESS_SIGNATURE =
-            "EFfq4iMeJ9ekCYJDZS8MTqxK0semEH7HRMac9Tc69zILtxzlVmJxnrhsVSgjpMNi3osCBUhWlz3Zh-jEUB4izw"; // pragma: allowlist secret
+            "WyJwkhYzdfqGddOSEhFGuQdL_FWUj9A63TRsc8kTL0gHtt4HwuyMFAdwNW6AFmVYOVSCEi_gUEZcFUkrzll_ig"; // pragma: allowlist secret
 }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
@@ -29,7 +29,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -163,8 +162,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 BAV.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -281,8 +278,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 BAV.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java
@@ -29,7 +29,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -153,8 +152,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 CLAIMED_IDENTITY.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -31,7 +31,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -294,8 +293,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -418,8 +415,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -539,8 +534,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -663,8 +656,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -788,8 +779,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -915,8 +904,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -1039,8 +1026,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -1156,8 +1141,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -1273,8 +1256,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -1392,8 +1373,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -1506,8 +1485,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -1623,8 +1600,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -1744,8 +1719,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 DCMAW.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java
@@ -23,7 +23,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.FixedTimeJWTClaimsVerifier;
@@ -132,8 +131,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 DRIVING_LICENCE.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -241,8 +238,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 DRIVING_LICENCE.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -355,8 +350,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 DRIVING_LICENCE.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -464,8 +457,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 DRIVING_LICENCE.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java
@@ -28,7 +28,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -556,8 +555,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 EXPERIAN_KBV.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -694,8 +691,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 EXPERIAN_KBV.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -877,8 +872,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 EXPERIAN_KBV.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java
@@ -22,7 +22,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.FixedTimeJWTClaimsVerifier;
@@ -135,8 +134,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 EXPERIAN_FRAUD.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -251,8 +248,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 EXPERIAN_FRAUD.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -364,8 +359,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 EXPERIAN_FRAUD.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java
@@ -28,7 +28,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -139,8 +138,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 HMRC_MIGRATION.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -234,8 +231,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 HMRC_MIGRATION.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -399,8 +394,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 HMRC_MIGRATION.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java
@@ -28,7 +28,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -143,8 +142,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 NINO.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -255,8 +252,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 NINO.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -362,8 +357,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 NINO.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -461,8 +454,6 @@ class ContractTest {
                                                 TEST_USER,
                                                 NINO.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java
@@ -23,7 +23,6 @@ import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.FixedTimeJWTClaimsVerifier;
@@ -125,8 +124,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 PASSPORT.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -219,8 +216,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 PASSPORT.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);
@@ -321,8 +316,6 @@ class CredentialTests {
                                                 TEST_USER,
                                                 PASSPORT.getId(),
                                                 credential,
-                                                VerifiableCredentialConstants
-                                                        .IDENTITY_CHECK_CREDENTIAL_TYPE,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
                                                 false);

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -23,7 +23,6 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.domain.cimitvc.CiMitJwt;
 import uk.gov.di.ipv.core.library.domain.cimitvc.CiMitVc;
 import uk.gov.di.ipv.core.library.domain.cimitvc.EvidenceItem;
@@ -222,13 +221,7 @@ public class CiMitService {
                     LogHelper.buildLogMessage(
                             "Validating ContraIndicators Verifiable Credential."));
             return verifiableCredentialValidator.parseAndValidate(
-                    userId,
-                    null,
-                    contraIndicatorsVC,
-                    VerifiableCredentialConstants.SECURITY_CHECK_CREDENTIAL_TYPE,
-                    cimitSigningKey,
-                    cimitComponentId,
-                    false);
+                    userId, null, contraIndicatorsVC, cimitSigningKey, cimitComponentId, false);
         } catch (VerifiableCredentialException vcEx) {
             LOGGER.error(LogHelper.buildLogMessage(vcEx.getErrorResponse().getMessage()));
             throw new CiRetrievalException(vcEx.getErrorResponse().getMessage());

--- a/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CiMitServiceTest.java
+++ b/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CiMitServiceTest.java
@@ -24,7 +24,6 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialValidator;
@@ -186,7 +185,6 @@ class CiMitServiceTest {
                         eq(TEST_USER_ID),
                         eq(null),
                         eq(SIGNED_CONTRA_INDICATOR_VC),
-                        eq(VerifiableCredentialConstants.SECURITY_CHECK_CREDENTIAL_TYPE),
                         any(),
                         eq(CIMIT_COMPONENT_ID),
                         eq(false)))
@@ -253,7 +251,7 @@ class CiMitServiceTest {
         when(configService.getSsmParameter(ConfigurationVariable.CIMIT_SIGNING_KEY))
                 .thenReturn(TEST_EC_PUBLIC_JWK);
         when(verifiableCredentialValidator.parseAndValidate(
-                        any(), any(), any(), any(), any(), any(), eq(false)))
+                        any(), any(), any(), any(), any(), eq(false)))
                 .thenThrow(
                         new VerifiableCredentialException(
                                 500, ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL));
@@ -305,7 +303,7 @@ class CiMitServiceTest {
                                 HTTPResponse.SC_SERVER_ERROR,
                                 ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL))
                 .when(verifiableCredentialValidator)
-                .parseAndValidate(any(), any(), any(), any(), any(), any(), anyBoolean());
+                .parseAndValidate(any(), any(), any(), any(), any(), anyBoolean());
 
         assertThrows(
                 CiRetrievalException.class,
@@ -323,7 +321,7 @@ class CiMitServiceTest {
         when(configService.getSsmParameter(ConfigurationVariable.CIMIT_SIGNING_KEY))
                 .thenReturn(TEST_EC_PUBLIC_JWK);
         when(verifiableCredentialValidator.parseAndValidate(
-                        any(), any(), any(), any(), any(), any(), anyBoolean()))
+                        any(), any(), any(), any(), any(), anyBoolean()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
@@ -370,7 +368,7 @@ class CiMitServiceTest {
         when(configService.getSsmParameter(ConfigurationVariable.CIMIT_SIGNING_KEY))
                 .thenReturn(TEST_EC_PUBLIC_JWK);
         when(verifiableCredentialValidator.parseAndValidate(
-                        any(), any(), any(), any(), any(), any(), anyBoolean()))
+                        any(), any(), any(), any(), any(), anyBoolean()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
@@ -406,7 +404,6 @@ class CiMitServiceTest {
                         eq(TEST_USER_ID),
                         eq(null),
                         eq(SIGNED_CONTRA_INDICATOR_VC),
-                        eq(VerifiableCredentialConstants.SECURITY_CHECK_CREDENTIAL_TYPE),
                         any(),
                         eq(CIMIT_COMPONENT_ID),
                         eq(false)))
@@ -454,7 +451,6 @@ class CiMitServiceTest {
                         TEST_USER_ID,
                         null,
                         SIGNED_CONTRA_INDICATOR_VC,
-                        VerifiableCredentialConstants.SECURITY_CHECK_CREDENTIAL_TYPE,
                         "INVALID_CIMIT_KEY",
                         CIMIT_COMPONENT_ID,
                         false))
@@ -489,7 +485,7 @@ class CiMitServiceTest {
                                 HTTPResponse.SC_SERVER_ERROR,
                                 ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL))
                 .when(verifiableCredentialValidator)
-                .parseAndValidate(any(), any(), any(), any(), any(), any(), anyBoolean());
+                .parseAndValidate(any(), any(), any(), any(), any(), anyBoolean());
 
         assertThrows(
                 CiRetrievalException.class,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredential.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredential.java
@@ -4,11 +4,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
-import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.VerifiableCredentialParser;
 import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
@@ -20,8 +16,6 @@ import java.util.Date;
 @Data
 @EqualsAndHashCode(exclude = "signedJwt")
 public class VerifiableCredential {
-    private static final Logger LOGGER = LogManager.getLogger();
-
     private final String userId;
     private final String criId;
     private final String vcString;
@@ -39,25 +33,10 @@ public class VerifiableCredential {
             this.claimsSet = signedJwt.getJWTClaimsSet();
             this.signedJwt = signedJwt;
             this.migrated = migrated;
-            this.credential = parseCredential(this.claimsSet);
+            this.credential = VerifiableCredentialParser.parseCredential(this.claimsSet);
         } catch (ParseException e) {
             throw new CredentialParseException(
                     "Failed to get jwt claims to construct verifiable credential", e);
-        }
-    }
-
-    private static uk.gov.di.model.VerifiableCredential parseCredential(JWTClaimsSet claimsSet)
-            throws CredentialParseException {
-        try {
-            return VerifiableCredentialParser.parseCredential(claimsSet);
-        } catch (CredentialParseException e) {
-            if ("production".equals(System.getenv(EnvironmentVariable.ENVIRONMENT.name()))) {
-                // Just warn for now in production - will be an error in future
-                LOGGER.warn(
-                        LogHelper.buildErrorMessage("Failed to parse verifiable credential", e));
-                return null;
-            }
-            throw e;
         }
     }
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialTest.java
@@ -3,21 +3,15 @@ package uk.gov.di.ipv.core.library.domain;
 import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
-import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.helpers.VerifiableCredentialParser;
 import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
-import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
-import uk.org.webcompere.systemstubs.jupiter.SystemStub;
-import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.text.ParseException;
 import java.time.Instant;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,14 +20,11 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
 
-@ExtendWith(SystemStubsExtension.class)
 class VerifiableCredentialTest {
     private static final String USER_ID = "a-user-id";
     private static final String CRI_ID = "cri-id";
     private static final String SESSION_ID = "a-session-id";
     private VerifiableCredential vcFixture;
-
-    @SystemStub private EnvironmentVariables environmentVariables;
 
     @BeforeEach
     void setUp() {
@@ -58,23 +49,6 @@ class VerifiableCredentialTest {
                     .thenThrow(new CredentialParseException("Failed to parse VC"));
             assertThrows(
                     CredentialParseException.class,
-                    () ->
-                            VerifiableCredential.fromValidJwt(
-                                    vcFixture.getUserId(),
-                                    vcFixture.getCriId(),
-                                    vcFixture.getSignedJwt()));
-        }
-    }
-
-    @Test
-    void fromValidJwtShouldIgnoreVCParserExceptionsInProduction() {
-        environmentVariables.set(EnvironmentVariable.ENVIRONMENT, "production");
-        try (MockedStatic<VerifiableCredentialParser> mockVcParser =
-                mockStatic(VerifiableCredentialParser.class)) {
-            mockVcParser
-                    .when(() -> VerifiableCredentialParser.parseCredential(any()))
-                    .thenThrow(new CredentialParseException("Failed to parse VC"));
-            assertDoesNotThrow(
                     () ->
                             VerifiableCredential.fromValidJwt(
                                     vcFixture.getUserId(),

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -791,6 +791,29 @@ public interface VcFixtures {
                 Instant.ofEpochSecond(1704822570));
     }
 
+    static VerifiableCredential vcTicfWithCi() {
+        return generateVerifiableCredential(
+                TEST_SUBJECT,
+                TICF.getId(),
+                TestVc.builder()
+                        .credentialSubject(null)
+                        .evidence(
+                                List.of(
+                                        TestVc.TestEvidence.builder()
+                                                .type(RISK_ASSESSMENT_EVIDENCE_TYPE)
+                                                .txn("963deeb5-a52c-4030-a69a-3184f77a4f18")
+                                                .checkDetails(null)
+                                                .ci(List.of("test"))
+                                                .build()))
+                        .type(
+                                new String[] {
+                                    VERIFIABLE_CREDENTIAL_TYPE, RISK_ASSESSMENT_CREDENTIAL_TYPE
+                                })
+                        .build(),
+                "https://ticf.stubs.account.gov.uk",
+                Instant.ofEpochSecond(1704822570));
+    }
+
     static VerifiableCredential vcVerificationM1a() {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder()

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidator.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidator.java
@@ -1,8 +1,5 @@
 package uk.gov.di.ipv.core.library.verifiablecredential.validator;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.CollectionType;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
@@ -24,12 +21,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
-import uk.gov.di.ipv.core.library.gpg45.domain.CredentialEvidenceItem;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.model.IdentityCheckCredential;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -41,16 +37,9 @@ import static com.nimbusds.jose.JWSAlgorithm.ES256;
 import static com.nimbusds.jose.jwk.KeyType.EC;
 import static com.nimbusds.jose.jwk.KeyType.RSA;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
 
 public class VerifiableCredentialValidator {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final CollectionType CREDENTIAL_EVIDENCE_ITEM_LIST_TYPE =
-            OBJECT_MAPPER
-                    .getTypeFactory()
-                    .constructCollectionType(List.class, CredentialEvidenceItem.class);
-    private static final String VC_CLAIM_NAME = "vc";
     private final ConfigService configService;
 
     public interface IClaimsVerifierFactory {
@@ -72,17 +61,11 @@ public class VerifiableCredentialValidator {
     }
 
     public List<VerifiableCredential> parseAndValidate(
-            String userId,
-            String criId,
-            List<String> vcs,
-            String vcType,
-            String signingKey,
-            String componentId)
+            String userId, String criId, List<String> vcs, String signingKey, String componentId)
             throws VerifiableCredentialException {
         var validVcs = new ArrayList<VerifiableCredential>();
         for (String vc : vcs) {
-            validVcs.add(
-                    parseAndValidate(userId, criId, vc, vcType, signingKey, componentId, false));
+            validVcs.add(parseAndValidate(userId, criId, vc, signingKey, componentId, false));
         }
         return validVcs;
     }
@@ -92,7 +75,6 @@ public class VerifiableCredentialValidator {
             String userId,
             String criId,
             String vcString,
-            String vcType,
             String signingKey,
             String componentId,
             boolean skipSubjectCheck)
@@ -104,8 +86,8 @@ public class VerifiableCredentialValidator {
 
             var vc = VerifiableCredential.fromValidJwt(userId, criId, vcJwt);
 
-            if (VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE.equals(vcType)) {
-                validateCiCodes(vc);
+            if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
+                validateCiCodes(identityCheckCredential);
             }
 
             LOGGER.info(LogHelper.buildLogMessage("Verifiable Credential validated."));
@@ -204,7 +186,7 @@ public class VerifiableCredentialValidator {
         if (!skipSubjectCheck) {
             exactMatchClaimsBuilder.subject(userId);
         }
-        var requiredClaims = new HashSet<>(Arrays.asList(JWTClaimNames.NOT_BEFORE, VC_CLAIM_NAME));
+        var requiredClaims = new HashSet<>(Arrays.asList(JWTClaimNames.NOT_BEFORE, VC_CLAIM));
 
         DefaultJWTClaimsVerifier<SimpleSecurityContext> verifier =
                 claimsVerifierFactory.createVerifier(
@@ -221,34 +203,13 @@ public class VerifiableCredentialValidator {
         }
     }
 
-    private void validateCiCodes(VerifiableCredential vc) throws VerifiableCredentialException {
-        try {
-            var evidenceArray =
-                    OBJECT_MAPPER
-                            .valueToTree(vc.getClaimsSet().getClaim(VC_CLAIM))
-                            .path(VC_EVIDENCE);
-            if (evidenceArray.isArray()) {
-                List<CredentialEvidenceItem> credentialEvidenceList =
-                        OBJECT_MAPPER.treeToValue(
-                                evidenceArray, CREDENTIAL_EVIDENCE_ITEM_LIST_TYPE);
-                boolean anyUnrecognisedCiCodes = false;
-                for (CredentialEvidenceItem evidenceItem : credentialEvidenceList) {
-                    List<String> cis = evidenceItem.getCi();
-                    if (cis != null) {
-                        anyUnrecognisedCiCodes =
-                                cis.stream()
-                                        .anyMatch(
-                                                ciCode ->
-                                                        !configService
-                                                                .getContraIndicatorConfigMap()
-                                                                .containsKey(ciCode));
-                        if (anyUnrecognisedCiCodes) {
-                            break;
-                        }
-                    }
-                }
+    private void validateCiCodes(IdentityCheckCredential identityCheckCredential)
+            throws VerifiableCredentialException {
+        var ciConfig = configService.getContraIndicatorConfigMap();
 
-                if (anyUnrecognisedCiCodes) {
+        for (var evidence : identityCheckCredential.getEvidence()) {
+            for (var ci : evidence.getCi()) {
+                if (!ciConfig.containsKey(ci)) {
                     LOGGER.error(
                             LogHelper.buildLogMessage(
                                     "Verifiable credential contains unrecognised CI codes"));
@@ -257,13 +218,6 @@ public class VerifiableCredentialValidator {
                             ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
                 }
             }
-        } catch (VerifiableCredentialException | JsonProcessingException e) {
-            LOGGER.error(
-                    LogHelper.buildErrorMessage(
-                            "Failed to parse verifiable credential claims set", e));
-            throw new VerifiableCredentialException(
-                    HTTPResponse.SC_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);
         }
     }
 }

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.FixedTimeJWTClaimsVerifier;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -73,7 +72,6 @@ class VerifiableCredentialValidatorTest {
                         TEST_USER,
                         PASSPORT.getId(),
                         PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         false);
@@ -90,7 +88,6 @@ class VerifiableCredentialValidatorTest {
                         TEST_USER,
                         Cri.PASSPORT.getId(),
                         PASSPORT_NON_DCMAW_SUCCESSFUL_RSA_SIGNED_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                         VALID_RSA_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         false);
@@ -110,7 +107,6 @@ class VerifiableCredentialValidatorTest {
                         TEST_USER,
                         PASSPORT.getId(),
                         vcString,
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         false);
@@ -127,7 +123,6 @@ class VerifiableCredentialValidatorTest {
                         TEST_USER,
                         PASSPORT.getId(),
                         List.of(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString()),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID);
 
@@ -144,7 +139,6 @@ class VerifiableCredentialValidatorTest {
                         "not the user",
                         PASSPORT.getId(),
                         PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         true);
@@ -163,7 +157,6 @@ class VerifiableCredentialValidatorTest {
                                     "not the user",
                                     PASSPORT.getId(),
                                     PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
-                                    VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
                                     false);
@@ -184,7 +177,6 @@ class VerifiableCredentialValidatorTest {
                                     TEST_USER,
                                     PASSPORT.getId(),
                                     PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
-                                    VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                     VALID_EC_SIGNING_KEY,
                                     "not the component id",
                                     false);
@@ -205,7 +197,6 @@ class VerifiableCredentialValidatorTest {
                                     TEST_USER,
                                     PASSPORT.getId(),
                                     PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
-                                    VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                     INVALID_EC_SIGNING_KEY, // intentionally not valid
                                     TEST_COMPONENT_ID,
                                     false);
@@ -232,7 +223,6 @@ class VerifiableCredentialValidatorTest {
                         TEST_USER,
                         PASSPORT.getId(),
                         verifiableCredentialsWithDerSignature.serialize(),
-                        VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         false);
@@ -262,7 +252,6 @@ class VerifiableCredentialValidatorTest {
                                     TEST_USER,
                                     PASSPORT.getId(),
                                     verifiableCredentialsWithDerSignature.serialize(),
-                                    VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
                                     false);
@@ -286,7 +275,6 @@ class VerifiableCredentialValidatorTest {
                                     TEST_USER,
                                     PASSPORT.getId(),
                                     vcPassportM1aWithCI().getVcString(),
-                                    VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
                                     false);
@@ -296,24 +284,6 @@ class VerifiableCredentialValidatorTest {
         assertEquals(
                 ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
                 exception.getErrorResponse());
-    }
-
-    @Test
-    void validateDoesNotCheckCiCodesWhenSecurityCheckVc() throws VerifiableCredentialException {
-        var vcString = vcPassportM1aWithCI().getVcString();
-        var vc =
-                vcJwtValidator.parseAndValidate(
-                        TEST_USER,
-                        PASSPORT.getId(),
-                        vcString,
-                        VerifiableCredentialConstants.SECURITY_CHECK_CREDENTIAL_TYPE,
-                        VALID_EC_SIGNING_KEY,
-                        TEST_COMPONENT_ID,
-                        false);
-
-        assertEquals(TEST_USER, vc.getUserId());
-        assertEquals(PASSPORT.getId(), vc.getCriId());
-        assertEquals(vcString, vc.getVcString());
     }
 
     @Test
@@ -335,7 +305,6 @@ class VerifiableCredentialValidatorTest {
                                     TEST_USER,
                                     PASSPORT.getId(),
                                     vcPassportM1aWithCI().getVcString(),
-                                    VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
                                     false);
@@ -357,7 +326,6 @@ class VerifiableCredentialValidatorTest {
                                     TEST_USER,
                                     Cri.PASSPORT.getId(),
                                     vcPassportM1aWithCI().getVcString(),
-                                    VerifiableCredentialConstants.IDENTITY_CHECK_CREDENTIAL_TYPE,
                                     "not a valid signing key",
                                     TEST_COMPONENT_ID,
                                     false);

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java
@@ -30,11 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.domain.Cri.PASSPORT;
+import static uk.gov.di.ipv.core.library.domain.Cri.TICF;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_SIGNING_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.TEST_EC_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_SUCCESSFUL_RSA_SIGNED_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_SUCCESSFUL_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcPassportM1aWithCI;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcTicfWithCi;
 
 @ExtendWith(MockitoExtension.class)
 class VerifiableCredentialValidatorTest {
@@ -263,7 +265,7 @@ class VerifiableCredentialValidatorTest {
     }
 
     @Test
-    void throwsVerifiableCredentialExceptionWhenCiCodesAreNotRecognised() {
+    void throwsVerifiableCredentialExceptionWhenIdentityCheckCiCodesAreNotRecognised() {
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(Map.of("NO", new ContraIndicatorConfig()));
 
@@ -277,6 +279,30 @@ class VerifiableCredentialValidatorTest {
                                     vcPassportM1aWithCI().getVcString(),
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
+                                    false);
+                        });
+
+        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getResponseCode());
+        assertEquals(
+                ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL,
+                exception.getErrorResponse());
+    }
+
+    @Test
+    void throwsVerifiableCredentialExceptionWhenRiskAssessmentCiCodesAreNotRecognised() {
+        when(mockConfigService.getContraIndicatorConfigMap())
+                .thenReturn(Map.of("NO", new ContraIndicatorConfig()));
+
+        var exception =
+                assertThrows(
+                        VerifiableCredentialException.class,
+                        () -> {
+                            vcJwtValidator.parseAndValidate(
+                                    TEST_USER,
+                                    TICF.getId(),
+                                    vcTicfWithCi().getVcString(),
+                                    VALID_EC_SIGNING_KEY,
+                                    "https://ticf.stubs.account.gov.uk",
                                     false);
                         });
 


### PR DESCRIPTION
*Not to be merged until credential parsing is confirmed to be working as expected in production*

## Proposed changes

### What changed

Use the new parsed credential in the VerifiableCredentialValidator

### Why did it change

Clearer and safer than using JSON parsing

### Issue tracking

- [PYIC-5759](https://govukverify.atlassian.net/browse/PYIC-5759)

[PYIC-5759]: https://govukverify.atlassian.net/browse/PYIC-5759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ