### PR TITLE
PYIC-6819: new txma events

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -183,8 +183,7 @@ public class BuildClientOauthResponseHandler
                             new AuditRestrictedDeviceInformation(input.getDeviceInformation())));
 
             var isReproveIdentity = clientOAuthSessionItem.getReproveIdentity();
-            if (Boolean.TRUE.equals(isReproveIdentity)
-                    && List.of(Vot.P0, Vot.P2).contains(ipvSessionItem.getVot())) {
+            if (Boolean.TRUE.equals(isReproveIdentity)) {
                 auditService.sendAuditEvent(
                         AuditEvent.createWithoutDeviceInformation(
                                 AuditEventTypes.IPV_ACCOUNT_INTERVENTION_END,

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -21,11 +21,13 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
+import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionAccountIntervention;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
+import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -179,6 +181,19 @@ public class BuildClientOauthResponseHandler
                             configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
                             auditEventUser,
                             new AuditRestrictedDeviceInformation(input.getDeviceInformation())));
+
+            var isReproveIdentity = clientOAuthSessionItem.getReproveIdentity();
+            if (Boolean.TRUE.equals(isReproveIdentity)
+                    && List.of(Vot.P0, Vot.P2).contains(ipvSessionItem.getVot())) {
+                auditService.sendAuditEvent(
+                        AuditEvent.createWithoutDeviceInformation(
+                                AuditEventTypes.IPV_ACCOUNT_INTERVENTION_END,
+                                configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
+                                auditEventUser,
+                                AuditExtensionAccountIntervention.newReproveIdentity(
+                                        ipvSessionItem.getErrorCode() == null
+                                                && Vot.P2.equals(ipvSessionItem.getVot()))));
+            }
 
             var message =
                     new StringMapMessage()

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -31,6 +31,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
+import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionAccountIntervention;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsIpvJourneyStart;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
@@ -229,8 +230,9 @@ public class InitialiseIpvSessionHandler
                 }
             }
 
+            var isReproveIdentity = isReproveIdentity(claimsSet);
             AuditExtensionsIpvJourneyStart extensionsIpvJourneyStart =
-                    new AuditExtensionsIpvJourneyStart(isReproveIdentity(claimsSet), vtr);
+                    new AuditExtensionsIpvJourneyStart(isReproveIdentity, vtr);
 
             AuditEvent auditEvent =
                     AuditEvent.createWithDeviceInformation(
@@ -241,6 +243,15 @@ public class InitialiseIpvSessionHandler
                             new AuditRestrictedDeviceInformation(deviceInformation));
 
             auditService.sendAuditEvent(auditEvent);
+
+            if (Boolean.TRUE.equals(isReproveIdentity)) {
+                auditService.sendAuditEvent(
+                        AuditEvent.createWithoutDeviceInformation(
+                                AuditEventTypes.IPV_ACCOUNT_INTERVENTION_START,
+                                configService.getSsmParameter(ConfigurationVariable.COMPONENT_ID),
+                                auditEventUser,
+                                AuditExtensionAccountIntervention.newReproveIdentity()));
+            }
 
             Map<String, String> response =
                     Map.of(IPV_SESSION_ID_KEY, ipvSessionItem.getIpvSessionId());

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventTypes.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventTypes.java
@@ -4,6 +4,8 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 
 @ExcludeFromGeneratedCoverageReport
 public enum AuditEventTypes {
+    IPV_ACCOUNT_INTERVENTION_END,
+    IPV_ACCOUNT_INTERVENTION_START,
     IPV_CONTINUITY_OF_IDENTITY_CHECK_END,
     IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
     IPV_CORE_CRI_RESOURCE_RETRIEVED,

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionAccountIntervention.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionAccountIntervention.java
@@ -1,0 +1,30 @@
+package uk.gov.di.ipv.core.library.auditing.extension;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuditExtensionAccountIntervention implements AuditExtensions {
+
+    private static final String REPROVE_IDENTITY_TYPE = "reprove_identity";
+
+    @JsonProperty private Boolean success;
+    @JsonProperty private final String type;
+
+    private AuditExtensionAccountIntervention(String type, Boolean success) {
+        this.type = type;
+        this.success = success;
+    }
+
+    public static AuditExtensionAccountIntervention newReproveIdentity() {
+        return new AuditExtensionAccountIntervention(REPROVE_IDENTITY_TYPE, null);
+    }
+
+    public static AuditExtensionAccountIntervention newReproveIdentity(boolean success) {
+        return new AuditExtensionAccountIntervention(REPROVE_IDENTITY_TYPE, success);
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
New audit events for account intervention

### What changed

Two new events added:
 - IPV_ACCOUNT_INTERVENTION_START when a user has been identified as needing to reprove their identity and starts to do so
 - IPV_ACCOUNT_INTERVENTION_END on failed or successful completion of a user reproving their identity 

### Why did it change
So we can start tracking account interventions

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
https://govukverify.atlassian.net/browse/PYIC-6819

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

