### PR TITLE
PYIC-6053 Migration tweaks

### DIFF
--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -333,8 +333,7 @@ class CheckExistingIdentityHandlerTest {
             inOrder.verify(ipvSessionItem, never()).setVot(any());
             assertEquals(P2, ipvSessionItem.getVot());
             verify(mockEvcsMigrationService)
-                    .migrateExistingIdentity(
-                            TEST_USER_ID, List.of(gpg45Vc, hmrcMigrationVC), EVCS_TEST_TOKEN);
+                    .migrateExistingIdentity(TEST_USER_ID, List.of(gpg45Vc, hmrcMigrationVC));
         }
 
         @Test
@@ -361,7 +360,7 @@ class CheckExistingIdentityHandlerTest {
 
             assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
             // pending vcs should not be migrated
-            verify(mockEvcsMigrationService, never()).migrateExistingIdentity(any(), any(), any());
+            verify(mockEvcsMigrationService, never()).migrateExistingIdentity(any(), any());
             assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
         }
 
@@ -1067,7 +1066,7 @@ class CheckExistingIdentityHandlerTest {
         inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
         inOrder.verify(ipvSessionItem, never()).setVot(any());
         assertEquals(P2, ipvSessionItem.getVot());
-        verify(mockEvcsMigrationService, times(0)).migrateExistingIdentity(any(), any(), any());
+        verify(mockEvcsMigrationService, times(0)).migrateExistingIdentity(any(), any());
     }
 
     @Test
@@ -1337,7 +1336,7 @@ class CheckExistingIdentityHandlerTest {
 
         verify(ipvSessionItem, never()).setVot(any());
         verify(ipvSessionService, never()).updateIpvSession(any());
-        verify(mockEvcsMigrationService, times(0)).migrateExistingIdentity(any(), any(), any());
+        verify(mockEvcsMigrationService, times(0)).migrateExistingIdentity(any(), any());
     }
 
     @Test
@@ -1386,8 +1385,7 @@ class CheckExistingIdentityHandlerTest {
                 vcs.stream().filter(vc -> vc != EXPIRED_M1A_EXPERIAN_FRAUD_VC).toList();
         verify(mockSessionCredentialService)
                 .persistCredentials(expectedStoredVc, ipvSessionItem.getIpvSessionId(), false);
-        verify(mockEvcsMigrationService)
-                .migrateExistingIdentity(TEST_USER_ID, vcs, EVCS_TEST_TOKEN);
+        verify(mockEvcsMigrationService).migrateExistingIdentity(TEST_USER_ID, vcs);
     }
 
     @Test

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -275,7 +275,6 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldUseVcServiceWhenEvcsServiceEnabledAndReturnsEmpty() throws Exception {
             when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
-            when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
             when(mockEvcsService.getVerifiableCredentialsByState(
                             any(), any(), any(EvcsVCState.class), any(EvcsVCState.class)))
                     .thenReturn(new HashMap<EvcsVCState, List<VerifiableCredential>>());
@@ -1366,7 +1365,6 @@ class CheckExistingIdentityHandlerTest {
         when(configService.enabled(INHERITED_IDENTITY)).thenReturn(false);
         when(configService.enabled(REPEAT_FRAUD_CHECK)).thenReturn(true);
         when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
-        when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn("http://ipv/");
         when(configService.getSsmParameter(FRAUD_CHECK_EXPIRY_PERIOD_HOURS)).thenReturn("1");
 

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsMigrationService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsMigrationService.java
@@ -32,11 +32,10 @@ public class EvcsMigrationService {
     }
 
     @Tracing
-    public void migrateExistingIdentity(
-            String userId, List<VerifiableCredential> credentials, String evcsAccessToken)
+    public void migrateExistingIdentity(String userId, List<VerifiableCredential> credentials)
             throws EvcsServiceException, VerifiableCredentialException {
         LOGGER.info(LogHelper.buildLogMessage("Migrating existing user VCs to Evcs."));
-        evcsService.storeCompletedIdentity(userId, credentials, evcsAccessToken);
+        evcsService.storeMigratedIdentity(userId, credentials);
         credentials.forEach(credential -> credential.setMigrated(Instant.now()));
         verifiableCredentialService.updateIdentity(credentials);
         LOGGER.info(LogHelper.buildLogMessage("Migrated existing user VCs to Evcs."));

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
@@ -62,6 +62,17 @@ public class EvcsService {
     }
 
     @Tracing
+    public void storeMigratedIdentity(String userId, List<VerifiableCredential> credentials)
+            throws EvcsServiceException {
+        // If we are migrating, assume that there is no existing identity to mark as historic
+        evcsClient.storeUserVCs(
+                userId,
+                credentials.stream()
+                        .map(vc -> new EvcsCreateUserVCsDto(vc.getVcString(), CURRENT, null, null))
+                        .toList());
+    }
+
+    @Tracing
     public List<VerifiableCredential> getVerifiableCredentials(
             String userId, String evcsAccessToken, EvcsVCState... states)
             throws CredentialParseException, EvcsServiceException {

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsMigrationServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsMigrationServiceTest.java
@@ -22,7 +22,6 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
 @ExtendWith(MockitoExtension.class)
 class EvcsMigrationServiceTest {
     private static final String TEST_USER_ID = "a-user-id";
-    private static final String EVCS_TEST_TOKEN = "evcsTestToken";
     private static final List<VerifiableCredential> VCS =
             List.of(vcDrivingPermit(), VC_ADDRESS, M1A_EXPERIAN_FRAUD_VC);
 
@@ -43,9 +42,9 @@ class EvcsMigrationServiceTest {
         ArgumentCaptor<List<VerifiableCredential>> vcsToUpdateCaptor =
                 ArgumentCaptor.forClass(List.class);
 
-        evcsMigrationService.migrateExistingIdentity(TEST_USER_ID, VCS, EVCS_TEST_TOKEN);
+        evcsMigrationService.migrateExistingIdentity(TEST_USER_ID, VCS);
 
-        verify(mockEvcsService).storeCompletedIdentity(TEST_USER_ID, VCS, EVCS_TEST_TOKEN);
+        verify(mockEvcsService).storeMigratedIdentity(TEST_USER_ID, VCS);
         verify(mockVerifiableCredentialService).updateIdentity(vcsToUpdateCaptor.capture());
         vcsToUpdateCaptor.getValue().forEach(vc -> assertNotNull(vc.getMigrated()));
     }

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsServiceTest.java
@@ -305,6 +305,20 @@ class EvcsServiceTest {
     }
 
     @Test
+    void storeMigratedIdentityShouldStoreVcsWithCurrentState() throws EvcsServiceException {
+        evcsService.storeMigratedIdentity(TEST_USER_ID, List.of(VC_ADDRESS_TEST));
+
+        verify(mockEvcsClient)
+                .storeUserVCs(
+                        stringArgumentCaptor.capture(), evcsCreateUserVCsDtosCaptor.capture());
+
+        assertEquals(TEST_USER_ID, stringArgumentCaptor.getValue());
+        assertEquals(
+                VC_ADDRESS_TEST.getVcString(), evcsCreateUserVCsDtosCaptor.getValue().get(0).vc());
+        assertEquals(CURRENT, evcsCreateUserVCsDtosCaptor.getValue().get(0).state());
+    }
+
+    @Test
     void storeAsyncVcShouldStoreVcWithPendingReturnState() throws EvcsServiceException {
         evcsService.storePendingVc(VC_ADDRESS_TEST);
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Decision to migrate is based on whether the user already has an identity in EVCS, even when EVCS_READS is off
- When migrating, we don't need to check the store again, as we already know that it must be empty (from the change above)

### Why did it change

Avoids unnecessary calls to EVCS and misleading migration audit events