### PR TITLE
BAU: Run spotless in pre-commit with local hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,11 @@ repos:
         verbose: true
         args: [--soft-fail]
 
-  - repo: https://github.com/Wynndow/spotless-pre-commit.git
-    rev: 'v0.2.0'
+  - repo: local
     hooks:
       - id: spotlessCheck
+        name: Run spotless check
+        entry: ./gradlew spotlessCheck
+        language: system
+        pass_filenames: false
+        files: \.(java|gradle)


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Run spotless in pre-commit with local hook

### Why did it change

Rather than using a remote plugin, we can just run it locally and remove that dependance on a personal repo. Should have done it this way the first time around.
