### PR TITLE
PYIC-5097: Fix invalid-request

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -56,9 +56,6 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED
-      invalid-request:
-        targetJourney: FAILED
-        targetState: FAILED
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

invalid-request is causing the passport stub when submitted with no data to go to no-match instead of technical error

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5097](https://govukverify.atlassian.net/browse/PYIC-5097)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-5097]: https://govukverify.atlassian.net/browse/PYIC-5097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ