### PR TITLE
Revert "BAU: Use AWS CRT Client"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ awsSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
 awsSdkKms = { module = "software.amazon.awssdk:kms" }
 awsSdkLambda = { module = "software.amazon.awssdk:lambda" }
 awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
-awsSdkCrtClient = { module = "software.amazon.awssdk:aws-crt-client" }
+awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
 commonsCodec = "commons-codec:commons-codec:1.17.0"
 diVocab = "uk.gov.di.model:di-data-model-jackson:v1.7.1"
 hamcrest = "org.hamcrest:hamcrest:2.2"

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -8,7 +8,6 @@ plugins {
 dependencies {
 
 	implementation libs.bundles.awsLambda,
-			libs.awsSdkCrtClient,
 			libs.awsSdkKms,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -10,7 +10,7 @@ import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
 import com.nimbusds.jose.jca.JWEJCAContext;
 import com.nimbusds.jose.util.Base64URL;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -38,7 +38,7 @@ public class KmsRsaDecrypter implements JWEDecrypter {
         this.kmsClient =
                 KmsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(AwsCrtHttpClient.builder())
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build();
     }
 

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsSdkCrtClient,
+			libs.awsSdkUrlConnectionClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -2,7 +2,7 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -31,7 +31,7 @@ public class AuditService {
     public static SqsClient getSqsClient() {
         return SqsClient.builder()
                 .region(EU_WEST_2)
-                .httpClientBuilder(AwsCrtHttpClient.builder())
+                .httpClientBuilder(UrlConnectionHttpClient.builder())
                 .build();
     }
 

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -8,7 +8,7 @@ plugins {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkLambda,
-			libs.awsSdkCrtClient,
+			libs.awsSdkUrlConnectionClient,
 			libs.jacksonDatabind,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
@@ -59,7 +59,7 @@ public class CiMitService {
         this.lambdaClient =
                 LambdaClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(AwsCrtHttpClient.builder())
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build();
         this.configService = configService;
         this.verifiableCredentialValidator = new VerifiableCredentialValidator(configService);

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 	api libs.nimbusdsOauth2OidcSdk
 	implementation platform(libs.awsSdkBom),
 			libs.awsLambdaJavaEvents,
-			libs.awsSdkCrtClient,
 			libs.awsSdkDynamodb,
 			libs.awsSdkDynamodbEnhanced,
 			libs.awsSdkLambda,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
@@ -48,7 +48,7 @@ public class DataStore<T extends DynamodbItem> {
         var client =
                 DynamoDbClient.builder()
                         .region(EU_WEST_2)
-                        .httpClient(AwsCrtHttpClient.create())
+                        .httpClient(UrlConnectionHttpClient.create())
                         .build();
 
         return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
 import software.amazon.awssdk.services.secretsmanager.model.InternalServiceErrorException;
@@ -91,13 +91,15 @@ public class ConfigService {
 
         this.ssmProvider =
                 ParamManager.getSsmProvider(
-                                SsmClient.builder().httpClient(AwsCrtHttpClient.create()).build())
+                                SsmClient.builder()
+                                        .httpClient(UrlConnectionHttpClient.create())
+                                        .build())
                         .defaultMaxAge(cacheDuration, MINUTES);
 
         this.secretsProvider =
                 ParamManager.getSecretsProvider(
                                 SecretsManagerClient.builder()
-                                        .httpClient(AwsCrtHttpClient.create())
+                                        .httpClient(UrlConnectionHttpClient.create())
                                         .build())
                         .defaultMaxAge(cacheDuration, MINUTES);
     }

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsLambdaJavaEvents,
 			libs.awsSdkKms,
-			libs.awsSdkCrtClient,
+			libs.awsSdkUrlConnectionClient,
 			libs.commonsCodec,
 			libs.jacksonDatabind,
 			libs.powertoolsLogging,

--- a/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerFactory.java
+++ b/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256SignerFactory.java
@@ -1,7 +1,7 @@
 package uk.gov.di.ipv.core.library.kmses256signer;
 
 import com.nimbusds.jose.JWSSigner;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
@@ -16,7 +16,7 @@ public class KmsEs256SignerFactory {
         this.kmsClient =
                 KmsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(AwsCrtHttpClient.builder())
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build();
     }
 

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -7,7 +7,7 @@ plugins {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkSqs,
-			libs.awsSdkCrtClient,
+			libs.awsSdkUrlConnectionClient,
 			libs.bundles.awsLambda,
 			libs.bundles.log4j,
 			libs.jacksonDatabind,

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsReader.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/sqs/SqsReader.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
@@ -27,7 +27,7 @@ public class SqsReader implements Runnable {
         this.sqs =
                 SqsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(AwsCrtHttpClient.builder())
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build();
         this.queueUrl =
                 String.format(


### PR DESCRIPTION
Since merging this change we've seen a large number of segfaults during the initialisation phase of lambdas.

We haven't been able to confirm this as the source of the issue, but reverting the change to see if it improves.