### PR TITLE
PYIC-6903: Store the evcs access token regardless if EVCS read/writes are enabled

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -376,7 +376,6 @@ public class InitialiseIpvSessionHandler
                     || configService.enabled(EVCS_READ_ENABLED)) {
                 throw e;
             } else {
-                LOGGER.warn("Failed to get evcs access token");
                 return null;
             }
         }

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -194,12 +194,18 @@ public class InitialiseIpvSessionHandler
                             clientOAuthSessionId, null, emailAddress, isReverification);
 
             String evcsAccessToken = null;
-            if (configService.enabled(EVCS_READ_ENABLED)
-                    || configService.enabled(EVCS_WRITE_ENABLED)) {
+            try {
                 evcsAccessToken =
                         validateEvcsAccessToken(
                                 getJarUserInfo(claimsSet).map(JarUserInfo::evcsAccessToken),
                                 claimsSet);
+            } catch (RecoverableJarValidationException | ParseException e) {
+                if (configService.enabled(EVCS_WRITE_ENABLED)
+                        || configService.enabled(EVCS_READ_ENABLED)) {
+                    throw e;
+                } else {
+                    LOGGER.warn("Failed to get evcs access token");
+                }
             }
             ClientOAuthSessionItem clientOAuthSessionItem =
                     clientOAuthSessionService.generateClientSessionDetails(

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -69,6 +69,7 @@ import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForInheritedIdentity;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JAR_KMS_ENCRYPTION_KEY_ID;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_TOKEN_READ_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.Cri.HMRC_MIGRATION;
@@ -368,12 +369,17 @@ public class InitialiseIpvSessionHandler
     @Tracing
     private String getEvcsAccessToken(JWTClaimsSet claimsSet)
             throws RecoverableJarValidationException, ParseException {
+
+        var writeEnabled = configService.enabled(EVCS_WRITE_ENABLED);
+        var readEnabled = configService.enabled(EVCS_READ_ENABLED);
+        if (!configService.enabled(EVCS_TOKEN_READ_ENABLED) && !writeEnabled && !readEnabled) {
+            return null;
+        }
         try {
             return validateEvcsAccessToken(
                     getJarUserInfo(claimsSet).map(JarUserInfo::evcsAccessToken), claimsSet);
         } catch (RecoverableJarValidationException | ParseException e) {
-            if (configService.enabled(EVCS_WRITE_ENABLED)
-                    || configService.enabled(EVCS_READ_ENABLED)) {
+            if (writeEnabled || readEnabled) {
                 throw e;
             } else {
                 return null;

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -98,6 +98,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsIpvJourneyStart.REPROVE_IDENTITY_KEY;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_TOKEN_READ_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.REPROVE_IDENTITY_ENABLED;
@@ -281,6 +282,8 @@ class InitialiseIpvSessionHandlerTest {
                 .thenReturn(ipvSessionItem);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
+        when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
+        when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
 
@@ -333,6 +336,9 @@ class InitialiseIpvSessionHandlerTest {
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(getValidClaimsBuilder().claim(CLAIMS, evcsAccessTokenClaims).build());
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+        when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+        when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
 
         // Act
         APIGatewayProxyResponseEvent response =
@@ -645,6 +651,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -704,6 +711,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -760,6 +768,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -832,6 +841,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -921,6 +931,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
 
             // Act
             APIGatewayProxyResponseEvent response;
@@ -961,6 +972,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
 
             // Act
             APIGatewayProxyResponseEvent response =
@@ -985,6 +997,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1027,6 +1040,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1082,6 +1096,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1131,6 +1146,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1193,6 +1209,7 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -278,6 +278,15 @@ class InitialiseIpvSessionHandlerTest {
     void shouldReturnIpvSessionIdWhenProvidedValidRequest_andSaveEvcsAccessToken()
             throws JsonProcessingException, JarValidationException, ParseException, SqsException {
         ArgumentCaptor<String> evcsAccessTokenCaptor = ArgumentCaptor.forClass(String.class);
+
+        var evcsAccessTokenClaims =
+                Map.of(
+                        USER_INFO,
+                        Map.of(
+                                INHERITED_IDENTITY_JWT_CLAIM_NAME,
+                                Map.of(VALUES, List.of(PCL200_MIGRATION_VC.getVcString())),
+                                EVCS_ACCESS_TOKEN_CLAIM_NAME,
+                                Map.of(VALUES, List.of(TEST_EVCS_ACCESS_TOKEN))));
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                 .thenReturn(ipvSessionItem);
@@ -285,9 +294,8 @@ class InitialiseIpvSessionHandlerTest {
                         any(), any(), any(), any()))
                 .thenReturn(clientOAuthSessionItem);
         when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(signedJWT.getJWTClaimsSet());
+                .thenReturn(getValidClaimsBuilder().claim(CLAIMS, evcsAccessTokenClaims).build());
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
-        when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
 
         // Act
         APIGatewayProxyResponseEvent response =
@@ -311,7 +319,7 @@ class InitialiseIpvSessionHandlerTest {
 
     @ParameterizedTest
     @MethodSource("getEvcsAccessTokenClaimValuesAndMsg")
-    void shouldRecoverIfEvcsIsEnabled_butClaimsHasMultipleTokenValues(
+    void shouldRecoverIfEvcsAccessClaimsHasMultipleTokenValues(
             Map<String, Map<String, Map<String, List<String>>>> evcsAccessTokenClaims,
             String expectedMessage)
             throws Exception {
@@ -319,7 +327,7 @@ class InitialiseIpvSessionHandlerTest {
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                 .thenReturn(ipvSessionItem);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
-        when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
+        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(getValidClaimsBuilder().claim(CLAIMS, evcsAccessTokenClaims).build());
 
@@ -586,8 +594,6 @@ class InitialiseIpvSessionHandlerTest {
         void setUp() throws Exception {
             when(mockConfigService.enabled(CoreFeatureFlag.INHERITED_IDENTITY))
                     .thenReturn(true); // Mock enabled inherited identity feature flag
-            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                     .thenReturn(ipvSessionItem);
             when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(
@@ -600,6 +606,8 @@ class InitialiseIpvSessionHandlerTest {
                 throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -613,12 +621,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                     VALUES,
                                                                     List.of(
                                                                             PCL250_MIGRATION_VC
-                                                                                    .getVcString())),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                                                    .getVcString())))))
                                     .build());
             when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
                     .thenReturn(TEST_CRI_CONFIG);
@@ -662,6 +665,8 @@ class InitialiseIpvSessionHandlerTest {
         void shouldValidateAndStoreAnyInheritedIdentityWhenNoExistingIdentity() throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -675,12 +680,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                     VALUES,
                                                                     List.of(
                                                                             PCL200_MIGRATION_VC
-                                                                                    .getVcString())),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                                                    .getVcString())))))
                                     .build());
             when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
                     .thenReturn(TEST_CRI_CONFIG);
@@ -721,6 +721,8 @@ class InitialiseIpvSessionHandlerTest {
         void shouldSendAuditEventForIpvInheritedIdentityVcReceived() throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -734,12 +736,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                     VALUES,
                                                                     List.of(
                                                                             PCL200_MIGRATION_VC
-                                                                                    .getVcString())),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                                                    .getVcString())))))
                                     .build());
             when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
                     .thenReturn(TEST_CRI_CONFIG);
@@ -796,6 +793,8 @@ class InitialiseIpvSessionHandlerTest {
         void shouldNotStoreInheritedIdentityWhenVotWeakerThanExisting() throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -809,12 +808,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                     VALUES,
                                                                     List.of(
                                                                             PCL200_MIGRATION_VC
-                                                                                    .getVcString())),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                                                    .getVcString())))))
                                     .build());
             when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
                     .thenReturn(TEST_CRI_CONFIG);
@@ -874,13 +868,9 @@ class InitialiseIpvSessionHandlerTest {
                                                                     VALUES,
                                                                     List.of(
                                                                             PCL200_MIGRATION_VC
-                                                                                    .getVcString())),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                                                    .getVcString())))))
                                     .build());
+
             when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
                     .thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
@@ -892,6 +882,8 @@ class InitialiseIpvSessionHandlerTest {
                             true))
                     .thenReturn(PCL200_MIGRATION_VC);
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
 
             // Act
             APIGatewayProxyResponseEvent response;
@@ -930,6 +922,8 @@ class InitialiseIpvSessionHandlerTest {
                                     .claim(CLAIMS, Map.of(USER_INFO, Map.of()))
                                     .build());
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
 
             // Act
             APIGatewayProxyResponseEvent response =
@@ -952,6 +946,8 @@ class InitialiseIpvSessionHandlerTest {
         void shouldRecoverIfClaimsClaimCanNotBeConverted() throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -992,6 +988,8 @@ class InitialiseIpvSessionHandlerTest {
         void shouldRecoverIfInheritedIdentityJwtHasMultipleValues() throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1007,12 +1005,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                             PCL200_MIGRATION_VC
                                                                                     .getVcString(),
                                                                             PCL200_MIGRATION_VC
-                                                                                    .getVcString())),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                                                    .getVcString())))))
                                     .build());
 
             // Act
@@ -1050,6 +1043,8 @@ class InitialiseIpvSessionHandlerTest {
         void shouldRecoverIfInheritedIdentityJwtHasNullValue() throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1059,12 +1054,7 @@ class InitialiseIpvSessionHandlerTest {
                                                     USER_INFO,
                                                     Map.of(
                                                             INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                            Map.of(),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                            Map.of())))
                                     .build());
 
             // Act
@@ -1102,6 +1092,8 @@ class InitialiseIpvSessionHandlerTest {
         void shouldRecoverIfInheritedIdentityJwtFailsToParseAndValidate() throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1111,12 +1103,7 @@ class InitialiseIpvSessionHandlerTest {
                                                     USER_INFO,
                                                     Map.of(
                                                             INHERITED_IDENTITY_JWT_CLAIM_NAME,
-                                                            Map.of(VALUES, List.of("🌭")),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                            Map.of(VALUES, List.of("🌭")))))
                                     .build());
             when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
                     .thenReturn(TEST_CRI_CONFIG);
@@ -1167,6 +1154,8 @@ class InitialiseIpvSessionHandlerTest {
         void shouldRecoverIfInheritedIdentityJwtFailsToPersist() throws Exception {
             // Arrange
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+            when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1180,12 +1169,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                     VALUES,
                                                                     List.of(
                                                                             PCL200_MIGRATION_VC
-                                                                                    .getVcString())),
-                                                            EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                                            Map.of(
-                                                                    VALUES,
-                                                                    List.of(
-                                                                            TEST_EVCS_ACCESS_TOKEN)))))
+                                                                                    .getVcString())))))
                                     .build());
             when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
                     .thenReturn(TEST_CRI_CONFIG);
@@ -1277,8 +1261,6 @@ class InitialiseIpvSessionHandlerTest {
                                         new Essential(true),
                                         INHERITED_IDENTITY_JWT_CLAIM_NAME,
                                         Map.of(VALUES, List.of()),
-                                        EVCS_ACCESS_TOKEN_CLAIM_NAME,
-                                        Map.of(VALUES, List.of(TEST_EVCS_ACCESS_TOKEN)),
                                         PASSPORT_CLAIM_NAME,
                                         new Essential(true))));
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -9,6 +9,7 @@ public enum CoreFeatureFlag implements FeatureFlag {
     TICF_CRI_BETA("ticfCriBeta"),
     EVCS_WRITE_ENABLED("evcsWriteEnabled"),
     EVCS_READ_ENABLED("evcsReadEnabled"),
+    EVCS_TOKEN_READ_ENABLED("evcsTokenReadEnabled"),
     MFA_RESET("mfaResetEnabled");
 
     private final String name;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -10,7 +10,7 @@ public enum CoreFeatureFlag implements FeatureFlag {
     EVCS_WRITE_ENABLED("evcsWriteEnabled"),
     EVCS_READ_ENABLED("evcsReadEnabled"),
     EVCS_TOKEN_READ_ENABLED("evcsTokenReadEnabled"),
-    MFA_RESET("mfaResetEnabled");
+    MFA_RESET("mfaResetEnabled"),
     P1_JOURNEYS_ENABLED("p1JourneysEnabled");
 
     private final String name;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Store the evcs access token regardless if EVCS read/writes are enabled

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
We currently only store the EVCS access token if one of the read/write feature flags is set, however we need to start storing it ahead of time as well, to cover the case where evcs is disabled at the start of the journey but enabled at the end of the journey

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-6903

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

