### PR TITLE
BAU: Accept missing IdentityCheck evidence

### DIFF
--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidator.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidator.java
@@ -210,7 +210,8 @@ public class VerifiableCredentialValidator {
     private void validateCiCodes(VerifiableCredential credential)
             throws VerifiableCredentialException {
         Stream<String> ciCodes;
-        if (credential.getCredential() instanceof IdentityCheckCredential icc) {
+        if (credential.getCredential() instanceof IdentityCheckCredential icc
+                && icc.getEvidence() != null) {
             ciCodes =
                     icc.getEvidence().stream()
                             .map(IdentityCheck::getCi)


### PR DESCRIPTION
The stub address CRI produces credentials with the wrong type (`IdentityCheckCredential`), this needs a separate fix to the stub, but in the meantime we should make this check more permissive.