### PR TITLE
PYIC-6816: replace String cri in Verifiable credential with Cri enum

### DIFF
--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -101,7 +101,6 @@ import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.v
 class BuildCriOauthRequestHandlerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final String ADDRESS_CRI = ADDRESS.getId();
     private static final String CLAIMED_IDENTITY_CRI = CLAIMED_IDENTITY.getId();
     private static final String DCMAW_CRI = DCMAW.getId();
     private static final String F2F_CRI = F2F.getId();
@@ -321,7 +320,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -329,12 +328,12 @@ class BuildCriOauthRequestHandlerTest {
                 List.of(
                         generateVerifiableCredential(
                                 TEST_USER_ID,
-                                ADDRESS_CRI,
+                                ADDRESS,
                                 vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                 IPV_ISSUER),
                         generateVerifiableCredential(
                                 TEST_USER_ID,
-                                ADDRESS_CRI,
+                                ADDRESS,
                                 vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                 IPV_ISSUER));
         when(mockSessionCredentialService.getCredentials(SESSION_ID, TEST_USER_ID)).thenReturn(vcs);
@@ -412,12 +411,12 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER)));
 
@@ -488,7 +487,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -497,12 +496,12 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -571,7 +570,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -580,12 +579,12 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -653,7 +652,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(dcmawOauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -662,12 +661,12 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -825,7 +824,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -834,12 +833,12 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -891,7 +890,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -900,12 +899,12 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3),
                                         IPV_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -955,7 +954,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -964,12 +963,12 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_4),
                                         IPV_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -1038,7 +1037,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -1047,17 +1046,17 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3),
                                         ADDRESS_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -1109,7 +1108,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, false);
@@ -1118,12 +1117,12 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         ADDRESS_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -1178,7 +1177,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn("name,birthDate,address,emailAddress");
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         ipvSessionItem.setEmailAddress(null);
@@ -1188,17 +1187,17 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3),
                                         ADDRESS_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -1250,7 +1249,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(f2FOauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(configService.getAllowedSharedAttributes(F2F_CRI))
                 .thenReturn("name,birthDate,address,emailAddress");
@@ -1261,17 +1260,17 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3),
                                         ADDRESS_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -1325,7 +1324,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(hmrcKbvOauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS_CRI))
+        when(configService.getComponentId(ADDRESS.getId()))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(configService.getAllowedSharedAttributes(HMRC_KBV_CRI))
                 .thenReturn("name,birthDate,address,socialSecurityRecord");
@@ -1336,17 +1335,17 @@ class BuildCriOauthRequestHandlerTest {
                         List.of(
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_1),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_2),
                                         IPV_ISSUER),
                                 generateVerifiableCredential(
                                         TEST_USER_ID,
-                                        ADDRESS_CRI,
+                                        ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3),
                                         ADDRESS_ISSUER)));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -185,9 +185,9 @@ public class BuildProvenUserIdentityDetailsHandler
             throws ParseException, JsonProcessingException, ProvenUserIdentityDetailsException,
                     NoVcStatusForIssuerException {
         for (var vc : vcs) {
-            if (vc.getCriId().equals(ADDRESS.getId())
+            if (vc.getCri().equals(ADDRESS)
                     && userIdentityService.isVcSuccessful(
-                            currentVcStatuses, configService.getComponentId(vc.getCriId()))) {
+                            currentVcStatuses, configService.getComponentId(vc.getCri().getId()))) {
                 JsonNode addressNode =
                         mapper.readTree(SignedJWT.parse(vc.getVcString()).getPayload().toString())
                                 .path(VC_CLAIM)

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -75,6 +75,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.TICF_CRI_BETA;
+import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.ADDRESS_JSON_1;
@@ -189,7 +190,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
-                                "test-cri-id",
+                                ADDRESS,
                                 SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
@@ -258,7 +259,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
-                                "test-cri-id",
+                                ADDRESS,
                                 SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
@@ -341,7 +342,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
-                                "test-cri-id",
+                                ADDRESS,
                                 SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         // Act
         APIGatewayProxyResponseEvent response =
@@ -420,7 +421,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
-                                "test-cri-id",
+                                ADDRESS,
                                 SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(true);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
@@ -498,7 +499,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
-                                "test-cri-id",
+                                ADDRESS,
                                 SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(true);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
@@ -677,7 +678,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
-                                "test-cri-id",
+                                ADDRESS,
                                 SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
@@ -914,13 +915,13 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
-                                "test-cri-id",
+                                ADDRESS,
                                 SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID,
-                                "test-cri-id",
+                                ADDRESS,
                                 SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -75,7 +75,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.TICF_CRI_BETA;
-import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
+import static uk.gov.di.ipv.core.library.domain.Cri.CIMIT;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.ADDRESS_JSON_1;
@@ -189,9 +189,7 @@ class BuildUserIdentityHandlerTest {
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                ADDRESS,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
+                                TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
         when(mockContraIndicators.hasMitigations()).thenReturn(true);
@@ -258,9 +256,7 @@ class BuildUserIdentityHandlerTest {
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                ADDRESS,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
+                                TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
         when(mockContraIndicators.hasMitigations()).thenReturn(true);
@@ -341,9 +337,7 @@ class BuildUserIdentityHandlerTest {
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                ADDRESS,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
+                                TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         // Act
         APIGatewayProxyResponseEvent response =
                 buildUserIdentityHandler.handleRequest(testEvent, mockContext);
@@ -420,9 +414,7 @@ class BuildUserIdentityHandlerTest {
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                ADDRESS,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
+                                TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(true);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         // Act
@@ -498,9 +490,7 @@ class BuildUserIdentityHandlerTest {
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                ADDRESS,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
+                                TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(true);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         // Act
@@ -677,9 +667,7 @@ class BuildUserIdentityHandlerTest {
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                ADDRESS,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
+                                TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
 
@@ -914,15 +902,7 @@ class BuildUserIdentityHandlerTest {
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                ADDRESS,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
-        when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
-                .thenReturn(
-                        VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                ADDRESS,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
+                                TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
         when(mockContraIndicators.hasMitigations()).thenReturn(true);

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -116,7 +116,7 @@ public class TicfCriService {
 
             return jwtValidator.parseAndValidate(
                     clientOAuthSessionItem.getUserId(),
-                    TICF.getId(),
+                    TICF,
                     ticfCriResponse.credentials(),
                     ticfCriConfig.getSigningKey(),
                     ticfCriConfig.getComponentId());

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -417,7 +417,7 @@ public class CheckExistingIdentityHandler
                     tacticalVcs.stream()
                             .filter(
                                     credential ->
-                                            F2F.getId().equals(credential.getCriId())
+                                            F2F.equals(credential.getCri())
                                                     && evcsVcs.stream()
                                                             .noneMatch(
                                                                     evcsVC ->

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -198,7 +198,7 @@ public class CheckExistingIdentityHandler
             boolean hasEvcsIdentity,
             boolean isPendingEvcsIdentity) {
         private boolean isF2fIdentity() {
-            return credentials.stream().anyMatch(vc -> vc.getCriId().equals(F2F.getId()));
+            return credentials.stream().anyMatch(vc -> vc.getCri().equals(F2F));
         }
     }
 
@@ -589,7 +589,7 @@ public class CheckExistingIdentityHandler
     }
 
     private List<VerifiableCredential> allVcsExceptFraud(List<VerifiableCredential> vcs) {
-        return vcs.stream().filter(vc -> !EXPERIAN_FRAUD.getId().equals(vc.getCriId())).toList();
+        return vcs.stream().filter(vc -> !EXPERIAN_FRAUD.equals(vc.getCri())).toList();
     }
 
     private boolean hasCurrentFraudVc(List<VerifiableCredential> vcs) {

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1479,7 +1479,7 @@ class CheckExistingIdentityHandlerTest {
                                 .build());
         jwt.sign(jwtSigner);
         return VerifiableCredential.fromValidJwt(
-                TEST_USER_ID, HMRC_MIGRATION.getId(), SignedJWT.parse(jwt.serialize()));
+                TEST_USER_ID, HMRC_MIGRATION, SignedJWT.parse(jwt.serialize()));
     }
 
     private static ECDSASigner createJwtSigner() throws Exception {

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -435,7 +435,7 @@ public class InitialiseIpvSessionHandler
         var inheritedIdentityVc =
                 verifiableCredentialValidator.parseAndValidate(
                         userId,
-                        HMRC_MIGRATION.getId(),
+                        HMRC_MIGRATION,
                         inheritedIdentityJwtList.get(0),
                         inheritedIdentityCriConfig.getSigningKey(),
                         inheritedIdentityCriConfig.getComponentId(),

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -624,7 +624,7 @@ class InitialiseIpvSessionHandlerTest {
                     .thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
-                            HMRC_MIGRATION.getId(),
+                            HMRC_MIGRATION,
                             PCL250_MIGRATION_VC.getVcString(),
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
@@ -643,7 +643,7 @@ class InitialiseIpvSessionHandlerTest {
             verify(mockVerifiableCredentialValidator, times(1))
                     .parseAndValidate(
                             eq(TEST_USER_ID),
-                            eq(HMRC_MIGRATION.getId()),
+                            eq(HMRC_MIGRATION),
                             stringArgumentCaptor.capture(),
                             eq(TEST_SIGNING_KEY),
                             eq(TEST_COMPONENT_ID),
@@ -686,7 +686,7 @@ class InitialiseIpvSessionHandlerTest {
                     .thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
-                            HMRC_MIGRATION.getId(),
+                            HMRC_MIGRATION,
                             PCL200_MIGRATION_VC.getVcString(),
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
@@ -702,7 +702,7 @@ class InitialiseIpvSessionHandlerTest {
             verify(mockVerifiableCredentialValidator, times(1))
                     .parseAndValidate(
                             eq(TEST_USER_ID),
-                            eq(HMRC_MIGRATION.getId()),
+                            eq(HMRC_MIGRATION),
                             stringArgumentCaptor.capture(),
                             eq(TEST_SIGNING_KEY),
                             eq(TEST_COMPONENT_ID),
@@ -745,7 +745,7 @@ class InitialiseIpvSessionHandlerTest {
                     .thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
-                            HMRC_MIGRATION.getId(),
+                            HMRC_MIGRATION,
                             PCL200_MIGRATION_VC.getVcString(),
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
@@ -820,7 +820,7 @@ class InitialiseIpvSessionHandlerTest {
                     .thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
-                            HMRC_MIGRATION.getId(),
+                            HMRC_MIGRATION,
                             PCL200_MIGRATION_VC.getVcString(),
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
@@ -839,7 +839,7 @@ class InitialiseIpvSessionHandlerTest {
             verify(mockVerifiableCredentialValidator, times(1))
                     .parseAndValidate(
                             eq(TEST_USER_ID),
-                            eq(HMRC_MIGRATION.getId()),
+                            eq(HMRC_MIGRATION),
                             stringArgumentCaptor.capture(),
                             eq(TEST_SIGNING_KEY),
                             eq(TEST_COMPONENT_ID),
@@ -885,7 +885,7 @@ class InitialiseIpvSessionHandlerTest {
                     .thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
-                            HMRC_MIGRATION.getId(),
+                            HMRC_MIGRATION,
                             PCL200_MIGRATION_VC.getVcString(),
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,
@@ -1122,7 +1122,7 @@ class InitialiseIpvSessionHandlerTest {
                     .thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
-                            HMRC_MIGRATION.getId(),
+                            HMRC_MIGRATION,
                             "🌭",
                             TEST_CRI_CONFIG.getSigningKey(),
                             TEST_CRI_CONFIG.getComponentId(),
@@ -1191,7 +1191,7 @@ class InitialiseIpvSessionHandlerTest {
                     .thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
-                            HMRC_MIGRATION.getId(),
+                            HMRC_MIGRATION,
                             PCL200_MIGRATION_VC.getVcString(),
                             TEST_SIGNING_KEY,
                             TEST_COMPONENT_ID,

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionErrorParams;
 import uk.gov.di.ipv.core.library.cimit.exception.CiPostMitigationsException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiPutException;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
@@ -182,7 +183,7 @@ public class ProcessAsyncCriCredentialHandler
         var vcs =
                 verifiableCredentialValidator.parseAndValidate(
                         successAsyncCriResponse.getUserId(),
-                        successAsyncCriResponse.getCredentialIssuer(),
+                        Cri.fromId(successAsyncCriResponse.getCredentialIssuer()),
                         successAsyncCriResponse.getVerifiableCredentialJWTs(),
                         oauthCriConfig.getSigningKey(),
                         oauthCriConfig.getComponentId());

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -113,7 +113,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE);
 
         when(verifiableCredentialValidator.parseAndValidate(
-                        eq(TEST_USER_ID), eq(TEST_CREDENTIAL_ISSUER_ID), anyList(), any(), any()))
+                        eq(TEST_USER_ID), eq(F2F), anyList(), any(), any()))
                 .thenReturn(List.of(F2F_VC));
         when(criResponseService.getCriResponseItem(TEST_USER_ID, TEST_COMPONENT_ID))
                 .thenReturn(TEST_CRI_RESPONSE_ITEM);
@@ -203,7 +203,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE);
 
         when(verifiableCredentialValidator.parseAndValidate(
-                        eq(TEST_USER_ID), eq(TEST_CREDENTIAL_ISSUER_ID), anyList(), any(), any()))
+                        eq(TEST_USER_ID), eq(F2F), anyList(), any(), any()))
                 .thenReturn(List.of(F2F_VC));
         when(criResponseService.getCriResponseItem(TEST_USER_ID, TEST_COMPONENT_ID))
                 .thenReturn(TEST_CRI_RESPONSE_ITEM);
@@ -234,7 +234,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE);
 
         when(verifiableCredentialValidator.parseAndValidate(
-                        eq(TEST_USER_ID), eq(TEST_CREDENTIAL_ISSUER_ID), anyList(), any(), any()))
+                        eq(TEST_USER_ID), eq(F2F), anyList(), any(), any()))
                 .thenReturn(List.of(F2F_VC));
         when(criResponseService.getCriResponseItem(TEST_USER_ID, TEST_COMPONENT_ID))
                 .thenReturn(TEST_CRI_RESPONSE_ITEM);

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/pact/f2fCri/ContractTest.java
@@ -126,7 +126,7 @@ public class ContractTest {
                 verifiableCredentialValidator
                         .parseAndValidate(
                                 TEST_USER,
-                                F2F.getId(),
+                                F2F,
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
                                 criConfig.getSigningKey(),
                                 criConfig.getComponentId())
@@ -253,7 +253,7 @@ public class ContractTest {
                 verifiableCredentialValidator
                         .parseAndValidate(
                                 TEST_USER,
-                                F2F.getId(),
+                                F2F,
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
@@ -398,7 +398,7 @@ public class ContractTest {
                 verifiableCredentialValidator
                         .parseAndValidate(
                                 TEST_USER,
-                                F2F.getId(),
+                                F2F,
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
@@ -542,7 +542,7 @@ public class ContractTest {
                 verifiableCredentialValidator
                         .parseAndValidate(
                                 TEST_USER,
-                                F2F.getId(),
+                                F2F,
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
@@ -683,7 +683,7 @@ public class ContractTest {
                 verifiableCredentialValidator
                         .parseAndValidate(
                                 TEST_USER,
-                                F2F.getId(),
+                                F2F,
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
@@ -819,7 +819,7 @@ public class ContractTest {
                 verifiableCredentialValidator
                         .parseAndValidate(
                                 TEST_USER,
-                                F2F.getId(),
+                                F2F,
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())
@@ -947,7 +947,7 @@ public class ContractTest {
                 verifiableCredentialValidator
                         .parseAndValidate(
                                 TEST_USER,
-                                F2F.getId(),
+                                F2F,
                                 asyncCriResponse.getVerifiableCredentialJWTs(),
                                 credentialIssuerConfig.getSigningKey(),
                                 credentialIssuerConfig.getComponentId())

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.cristoringservice.CriStoringService;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
@@ -321,7 +322,7 @@ public class ProcessCriCallbackHandler
             var vcs =
                     verifiableCredentialValidator.parseAndValidate(
                             clientOAuthSessionItem.getUserId(),
-                            callbackRequest.getCredentialIssuerId(),
+                            Cri.fromId(callbackRequest.getCredentialIssuerId()),
                             vcResponse.getVerifiableCredentials(),
                             criConfig.getSigningKey(),
                             criConfig.getComponentId());

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
@@ -39,13 +39,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_SUCCESSFUL_VC;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
 
 @ExtendWith(MockitoExtension.class)
 class ProcessCriCallbackHandlerTest {
-    private static final String TEST_CRI_ID = "test_cri_id";
+    private static final String TEST_CRI_ID = ADDRESS.getId();
     private static final String TEST_AUTHORISATION_CODE = "test_authorisation_code";
     private static final String TEST_ERROR = "test_error";
     private static final String TEST_IPV_SESSION_ID = "test_ipv_session_id";

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/ContractTest.java
@@ -284,7 +284,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                ADDRESS.getId(),
+                                                ADDRESS,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -392,7 +392,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                ADDRESS.getId(),
+                                                ADDRESS,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
@@ -160,7 +160,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                BAV.getId(),
+                                                BAV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -276,7 +276,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                BAV.getId(),
+                                                BAV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java
@@ -150,7 +150,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                CLAIMED_IDENTITY.getId(),
+                                                CLAIMED_IDENTITY,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -291,7 +291,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -413,7 +413,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -532,7 +532,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -654,7 +654,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -777,7 +777,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -902,7 +902,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -1024,7 +1024,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -1139,7 +1139,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -1254,7 +1254,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -1371,7 +1371,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -1483,7 +1483,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -1598,7 +1598,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -1717,7 +1717,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DCMAW.getId(),
+                                                DCMAW,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java
@@ -129,7 +129,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DRIVING_LICENCE.getId(),
+                                                DRIVING_LICENCE,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -236,7 +236,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DRIVING_LICENCE.getId(),
+                                                DRIVING_LICENCE,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -348,7 +348,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DRIVING_LICENCE.getId(),
+                                                DRIVING_LICENCE,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -455,7 +455,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                DRIVING_LICENCE.getId(),
+                                                DRIVING_LICENCE,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/ContractTest.java
@@ -553,7 +553,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_KBV.getId(),
+                                                EXPERIAN_KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -689,7 +689,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_KBV.getId(),
+                                                EXPERIAN_KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -870,7 +870,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_KBV.getId(),
+                                                EXPERIAN_KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java
@@ -132,7 +132,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_FRAUD.getId(),
+                                                EXPERIAN_FRAUD,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -246,7 +246,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_FRAUD.getId(),
+                                                EXPERIAN_FRAUD,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -357,7 +357,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_FRAUD.getId(),
+                                                EXPERIAN_FRAUD,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/hmrcKbvCri/ContractTest.java
@@ -136,7 +136,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                HMRC_MIGRATION.getId(),
+                                                HMRC_MIGRATION,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -229,7 +229,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                HMRC_MIGRATION.getId(),
+                                                HMRC_MIGRATION,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -392,7 +392,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                HMRC_MIGRATION.getId(),
+                                                HMRC_MIGRATION,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/ContractTest.java
@@ -140,7 +140,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                NINO.getId(),
+                                                NINO,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -250,7 +250,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                NINO.getId(),
+                                                NINO,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -355,7 +355,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                NINO.getId(),
+                                                NINO,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -452,7 +452,7 @@ class ContractTest {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                NINO.getId(),
+                                                NINO,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java
@@ -122,7 +122,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                PASSPORT.getId(),
+                                                PASSPORT,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -214,7 +214,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                PASSPORT.getId(),
+                                                PASSPORT,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -314,7 +314,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                PASSPORT.getId(),
+                                                PASSPORT,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,

--- a/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
+++ b/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
@@ -138,7 +138,7 @@ class StoreIdentityHandlerTest {
         reset(mockSessionCredentialService);
         VCS.forEach(
                 credential -> {
-                    if (credential.getCriId().equals(EXPERIAN_FRAUD.getId())) {
+                    if (credential.getCri().equals(EXPERIAN_FRAUD)) {
                         credential.setMigrated(null);
                     } else {
                         credential.setMigrated(Instant.now());
@@ -164,7 +164,7 @@ class StoreIdentityHandlerTest {
         VCS.stream()
                 .map(
                         credential -> {
-                            if (credential.getCriId().equals(EXPERIAN_FRAUD.getId())) {
+                            if (credential.getCri().equals(EXPERIAN_FRAUD)) {
                                 credential.setMigrated(null);
                             } else {
                                 credential.setMigrated(Instant.now());
@@ -194,7 +194,7 @@ class StoreIdentityHandlerTest {
                 .getValue()
                 .forEach(
                         vc -> {
-                            if (vc.getCriId().equals(EXPERIAN_FRAUD.getId())) {
+                            if (vc.getCri().equals(EXPERIAN_FRAUD)) {
                                 assertNull(vc.getMigrated());
                             } else {
                                 assertNotNull(vc.getMigrated());

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
@@ -22,7 +22,8 @@ public enum Cri {
     TICF("ticf"),
     HMRC_MIGRATION("hmrcMigration", true, false),
     HMRC_KBV("hmrcKbv"),
-    BAV("bav");
+    BAV("bav"),
+    CIMIT("cimit");
 
     private final String id;
     private final boolean isOperationalCri;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
@@ -38,6 +38,15 @@ public enum Cri {
         this.isNonEvidenceCri = isNonEvidence;
     }
 
+    public static Cri fromId(String id) {
+        for (var cri : values()) {
+            if (cri.getId().equals(id)) {
+                return cri;
+            }
+        }
+        throw new IllegalArgumentException("no cri found with ID " + id);
+    }
+
     public static final List<String> getOperationalCriIds() {
         return Arrays.stream(Cri.values())
                 .filter(criId -> criId.isOperationalCri())

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredential.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredential.java
@@ -17,18 +17,18 @@ import java.util.Date;
 @EqualsAndHashCode(exclude = "signedJwt")
 public class VerifiableCredential {
     private final String userId;
-    private final String criId;
+    private final Cri cri;
     private final String vcString;
     private final JWTClaimsSet claimsSet;
     private final SignedJWT signedJwt;
     private Instant migrated;
     private final uk.gov.di.model.VerifiableCredential credential;
 
-    private VerifiableCredential(String userId, String criId, SignedJWT signedJwt, Instant migrated)
+    private VerifiableCredential(String userId, Cri cri, SignedJWT signedJwt, Instant migrated)
             throws CredentialParseException {
         try {
             this.userId = userId;
-            this.criId = criId;
+            this.cri = cri;
             this.vcString = signedJwt.serialize();
             this.claimsSet = signedJwt.getJWTClaimsSet();
             this.signedJwt = signedJwt;
@@ -40,9 +40,9 @@ public class VerifiableCredential {
         }
     }
 
-    public static VerifiableCredential fromValidJwt(String userId, String criId, SignedJWT jwt)
+    public static VerifiableCredential fromValidJwt(String userId, Cri cri, SignedJWT jwt)
             throws CredentialParseException {
-        return new VerifiableCredential(userId, criId, jwt, null);
+        return new VerifiableCredential(userId, cri, jwt, null);
     }
 
     public static VerifiableCredential fromVcStoreItem(VcStoreItem vcStoreItem)
@@ -56,7 +56,7 @@ public class VerifiableCredential {
             var jwt = SignedJWT.parse(vcStoreItem.getCredential());
             return new VerifiableCredential(
                     vcStoreItem.getUserId(),
-                    vcStoreItem.getCredentialIssuer(),
+                    Cri.fromId(vcStoreItem.getCredentialIssuer()),
                     jwt,
                     vcStoreItem.getMigrated());
         } catch (ParseException e) {
@@ -68,7 +68,7 @@ public class VerifiableCredential {
         VcStoreItem vcStoreItem =
                 VcStoreItem.builder()
                         .userId(userId)
-                        .credentialIssuer(criId)
+                        .credentialIssuer(cri.getId())
                         .dateCreated(Instant.now())
                         .credential(vcString)
                         .migrated(migrated)
@@ -87,7 +87,7 @@ public class VerifiableCredential {
         try {
             return new VerifiableCredential(
                     userId,
-                    sessionCredentialItem.getCriId(),
+                    Cri.fromId(sessionCredentialItem.getCriId()),
                     SignedJWT.parse(sessionCredentialItem.getCredential()),
                     sessionCredentialItem.getMigrated());
         } catch (ParseException e) {
@@ -99,6 +99,6 @@ public class VerifiableCredential {
     public SessionCredentialItem toSessionCredentialItem(
             String ipvSessionId, boolean receivedThisSession) {
         return new SessionCredentialItem(
-                ipvSessionId, criId, signedJwt, receivedThisSession, migrated);
+                ipvSessionId, cri.getId(), signedJwt, receivedThisSession, migrated);
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialTest.java
@@ -21,8 +21,9 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
 
 class VerifiableCredentialTest {
+    private static final Cri CRI = Cri.ADDRESS;
     private static final String USER_ID = "a-user-id";
-    private static final String CRI_ID = "cri-id";
+    private static final String CRI_ID = CRI.getId();
     private static final String SESSION_ID = "a-session-id";
     private VerifiableCredential vcFixture;
 
@@ -35,7 +36,7 @@ class VerifiableCredentialTest {
     void fromValidJwtShouldCreateVerifiableCredential() throws Exception {
         var verifiableCredential =
                 VerifiableCredential.fromValidJwt(
-                        vcFixture.getUserId(), vcFixture.getCriId(), vcFixture.getSignedJwt());
+                        vcFixture.getUserId(), vcFixture.getCri(), vcFixture.getSignedJwt());
 
         assertEquals(vcFixture, verifiableCredential);
     }
@@ -52,7 +53,7 @@ class VerifiableCredentialTest {
                     () ->
                             VerifiableCredential.fromValidJwt(
                                     vcFixture.getUserId(),
-                                    vcFixture.getCriId(),
+                                    vcFixture.getCri(),
                                     vcFixture.getSignedJwt()));
         }
     }
@@ -64,7 +65,7 @@ class VerifiableCredentialTest {
 
         assertThrows(
                 CredentialParseException.class,
-                () -> VerifiableCredential.fromValidJwt(USER_ID, CRI_ID, mockJwt));
+                () -> VerifiableCredential.fromValidJwt(USER_ID, CRI, mockJwt));
     }
 
     @Test
@@ -82,7 +83,7 @@ class VerifiableCredentialTest {
         var verifiableCredential = VerifiableCredential.fromVcStoreItem(vcStoreItem);
 
         assertEquals(USER_ID, verifiableCredential.getUserId());
-        assertEquals(CRI_ID, verifiableCredential.getCriId());
+        assertEquals(CRI, verifiableCredential.getCri());
         assertEquals(vcFixture.getVcString(), verifiableCredential.getVcString());
         assertEquals(vcFixture.getClaimsSet(), verifiableCredential.getClaimsSet());
         assertEquals(
@@ -138,7 +139,7 @@ class VerifiableCredentialTest {
         var expectedVcStoreItem =
                 VcStoreItem.builder()
                         .userId(vcFixture.getUserId())
-                        .credentialIssuer(vcFixture.getCriId())
+                        .credentialIssuer(vcFixture.getCri().getId())
                         .credential(vcFixture.getVcString())
                         .dateCreated(vcStoreItem.getDateCreated())
                         .expirationTime(null)
@@ -157,7 +158,7 @@ class VerifiableCredentialTest {
                 VerifiableCredential.fromSessionCredentialItem(sessionCredentialItem, USER_ID);
 
         assertEquals(USER_ID, generatedVc.getUserId());
-        assertEquals(CRI_ID, generatedVc.getCriId());
+        assertEquals(Cri.ADDRESS, generatedVc.getCri());
         assertEquals(vcFixture.getVcString(), generatedVc.getVcString());
         assertEquals(vcFixture.getClaimsSet(), generatedVc.getClaimsSet());
         assertEquals(vcFixture.getSignedJwt().serialize(), generatedVc.getSignedJwt().serialize());

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -314,7 +314,7 @@ public interface VcFixtures {
     VerifiableCredential PASSPORT_NON_DCMAW_SUCCESSFUL_VC =
             generateVerifiableCredential(
                     TEST_SUBJECT,
-                    Cri.PASSPORT.getId(),
+                    Cri.PASSPORT,
                     TestVc.builder()
                             .credentialSubject(
                                     TestVc.TestCredentialSubject.builder()
@@ -327,7 +327,7 @@ public interface VcFixtures {
     VerifiableCredential PASSPORT_NON_DCMAW_SUCCESSFUL_RSA_SIGNED_VC =
             generateVerifiableCredential(
                     TEST_SUBJECT,
-                    Cri.PASSPORT.getId(),
+                    Cri.PASSPORT,
                     TestVc.builder()
                             .credentialSubject(
                                     TestVc.TestCredentialSubject.builder()
@@ -343,7 +343,7 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder().passport(PASSPORT_DETAILS).build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.PASSPORT.getId(),
+                Cri.PASSPORT,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(UNSUCCESSFUL_EVIDENCE)
@@ -356,7 +356,7 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder().passport(PASSPORT_DETAILS).build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.PASSPORT.getId(),
+                Cri.PASSPORT,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(TEST_CI_EVIDENCE)
@@ -369,7 +369,7 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder().passport(PASSPORT_DETAILS).build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.PASSPORT.getId(),
+                Cri.PASSPORT,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(Collections.emptyList())
@@ -385,7 +385,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.PASSPORT.getId(),
+                Cri.PASSPORT,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(SUCCESSFUL_EVIDENCE)
@@ -400,7 +400,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.PASSPORT.getId(),
+                Cri.PASSPORT,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(SUCCESSFUL_EVIDENCE)
@@ -415,7 +415,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.PASSPORT.getId(),
+                Cri.PASSPORT,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(SUCCESSFUL_EVIDENCE)
@@ -427,7 +427,7 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder().passport(Collections.emptyList()).build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.PASSPORT.getId(),
+                Cri.PASSPORT,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(SUCCESSFUL_EVIDENCE)
@@ -437,7 +437,7 @@ public interface VcFixtures {
     VerifiableCredential VC_ADDRESS =
             generateVerifiableCredential(
                     TEST_SUBJECT,
-                    Cri.ADDRESS.getId(),
+                    Cri.ADDRESS,
                     TestVc.builder()
                             .credentialSubject(
                                     TestVc.TestCredentialSubject.builder()
@@ -453,14 +453,14 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.ADDRESS.getId(),
+                Cri.ADDRESS,
                 TestVc.builder().credentialSubject(credentialSubject).build());
     }
 
     VerifiableCredential M1A_ADDRESS_VC =
             generateVerifiableCredential(
                     TEST_SUBJECT,
-                    Cri.ADDRESS.getId(),
+                    Cri.ADDRESS,
                     TestVc.builder()
                             .credentialSubject(
                                     TestVc.TestCredentialSubject.builder()
@@ -480,7 +480,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.ADDRESS.getId(),
+                Cri.ADDRESS,
                 TestVc.builder().credentialSubject(credentialSubject).evidence(null).build(),
                 TEST_ISSUER_INTEGRATION,
                 Instant.ofEpochSecond(1658829720));
@@ -494,7 +494,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.ADDRESS.getId(),
+                Cri.ADDRESS,
                 TestVc.builder().credentialSubject(credentialSubject).evidence(null).build(),
                 TEST_ISSUER_INTEGRATION,
                 Instant.ofEpochSecond(1658829720));
@@ -503,7 +503,7 @@ public interface VcFixtures {
     VerifiableCredential M1A_EXPERIAN_FRAUD_VC =
             generateVerifiableCredential(
                     TEST_SUBJECT,
-                    Cri.EXPERIAN_FRAUD.getId(),
+                    Cri.EXPERIAN_FRAUD,
                     TestVc.builder()
                             .evidence(FRAUD_EVIDENCE_NO_CHECK_DETAILS)
                             .credentialSubject(
@@ -518,7 +518,7 @@ public interface VcFixtures {
     VerifiableCredential EXPIRED_M1A_EXPERIAN_FRAUD_VC =
             generateVerifiableCredential(
                     TEST_SUBJECT,
-                    Cri.EXPERIAN_FRAUD.getId(),
+                    Cri.EXPERIAN_FRAUD,
                     TestVc.builder()
                             .evidence(FRAUD_EVIDENCE_NO_CHECK_DETAILS)
                             .credentialSubject(
@@ -538,7 +538,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.EXPERIAN_KBV.getId(),
+                Cri.EXPERIAN_KBV,
                 TestVc.builder()
                         .evidence(FRAUD_FAILED_EVIDENCE)
                         .credentialSubject(credentialSubject)
@@ -552,7 +552,7 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder().address(List.of(ADDRESS_3)).build();
         return generateVerifiableCredential(
                 "urn:uuid:7fadacac-0d61-4786-aca3-8ef7934cb092",
-                Cri.EXPERIAN_KBV.getId(),
+                Cri.EXPERIAN_KBV,
                 TestVc.builder()
                         .evidence(FRAUD_EVIDENCE_WITH_CHECK_DETAILS)
                         .credentialSubject(credentialSubject)
@@ -569,7 +569,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                EXPERIAN_KBV.getId(),
+                EXPERIAN_KBV,
                 TestVc.builder()
                         .evidence(FRAUD_EVIDENCE_NO_CHECK_DETAILS)
                         .credentialSubject(credentialSubject)
@@ -589,7 +589,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.EXPERIAN_KBV.getId(),
+                Cri.EXPERIAN_KBV,
                 TestVc.builder()
                         .evidence(FRAUD_EVIDENCE_NO_CHECK_DETAILS)
                         .credentialSubject(credentialSubject)
@@ -611,7 +611,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "user-id",
-                Cri.EXPERIAN_KBV.getId(),
+                Cri.EXPERIAN_KBV,
                 TestVc.builder()
                         .evidence(FRAUD_EVIDENCE_CRI_STUB_CHECK)
                         .credentialSubject(credentialSubject)
@@ -628,7 +628,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:7fadacac-0d61-4786-aca3-8ef7934cb092",
-                Cri.EXPERIAN_KBV.getId(),
+                Cri.EXPERIAN_KBV,
                 TestVc.builder()
                         .evidence(FRAUD_EVIDENCE_CRI_STUB_CHECK)
                         .credentialSubject(credentialSubject)
@@ -645,7 +645,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
-                DRIVING_LICENCE.getId(),
+                DRIVING_LICENCE,
                 TestVc.builder()
                         .evidence(DCMAW_EVIDENCE_VRI_CHECK)
                         .credentialSubject(credentialSubject)
@@ -658,7 +658,7 @@ public interface VcFixtures {
                 TestVc.TestCredentialSubject.builder().address(List.of(ADDRESS_4)).build();
         return generateVerifiableCredential(
                 "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
-                DRIVING_LICENCE.getId(),
+                DRIVING_LICENCE,
                 TestVc.builder()
                         .evidence(DCMAW_EVIDENCE_VRI_CHECK)
                         .credentialSubject(credentialSubject)
@@ -674,7 +674,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
-                DRIVING_LICENCE.getId(),
+                DRIVING_LICENCE,
                 TestVc.builder()
                         .evidence(DCMAW_FAILED_EVIDENCE)
                         .credentialSubject(credentialSubject)
@@ -692,7 +692,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
-                DRIVING_LICENCE.getId(),
+                DRIVING_LICENCE,
                 TestVc.builder()
                         .evidence(DCMAW_EVIDENCE_DATA_CHECK)
                         .credentialSubject(credentialSubject)
@@ -711,7 +711,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:51dfa9ac-8624-4b93-aa8f-99ed772ff0ec",
-                NINO.getId(),
+                NINO,
                 TestVc.builder()
                         .evidence(
                                 List.of(
@@ -736,7 +736,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:51dfa9ac-8624-4b93-aa8f-99ed772ff0ec",
-                NINO.getId(),
+                NINO,
                 TestVc.builder()
                         .evidence(
                                 List.of(
@@ -760,7 +760,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:51dfa9ac-8624-4b93-aa8f-99ed772ff0ec",
-                NINO.getId(),
+                NINO,
                 TestVc.builder()
                         .evidence(
                                 List.of(
@@ -778,7 +778,7 @@ public interface VcFixtures {
     static VerifiableCredential vcTicf() {
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                TICF.getId(),
+                TICF,
                 TestVc.builder()
                         .credentialSubject(null)
                         .evidence(TICF_EVIDENCE)
@@ -794,7 +794,7 @@ public interface VcFixtures {
     static VerifiableCredential vcTicfWithCi() {
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                TICF.getId(),
+                TICF,
                 TestVc.builder()
                         .credentialSubject(null)
                         .evidence(
@@ -823,7 +823,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                Cri.EXPERIAN_KBV.getId(),
+                Cri.EXPERIAN_KBV,
                 TestVc.builder()
                         .evidence(
                                 List.of(
@@ -840,7 +840,7 @@ public interface VcFixtures {
     VerifiableCredential M1B_DCMAW_VC =
             generateVerifiableCredential(
                     "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                    DCMAW.getId(),
+                    DCMAW,
                     TestVc.builder()
                             .evidence(
                                     List.of(
@@ -887,7 +887,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                F2F.getId(),
+                F2F,
                 TestVc.builder()
                         .evidence(
                                 List.of(
@@ -941,7 +941,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                F2F.getId(),
+                F2F,
                 TestVc.builder()
                         .evidence(
                                 List.of(
@@ -977,7 +977,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                F2F.getId(),
+                F2F,
                 TestVc.builder()
                         .evidence(
                                 List.of(
@@ -993,14 +993,14 @@ public interface VcFixtures {
     static VerifiableCredential vcMissingCredentialSubject() {
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                Cri.ADDRESS.getId(),
+                Cri.ADDRESS,
                 TestVc.builder().credentialSubject(null).build());
     }
 
     static VerifiableCredential vcEmptyEvidence() {
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                Cri.ADDRESS.getId(),
+                Cri.ADDRESS,
                 TestVc.builder().evidence(Collections.emptyList()).build());
     }
 
@@ -1023,7 +1023,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                HMRC_MIGRATION.getId(),
+                HMRC_MIGRATION,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(List.of(evidence))
@@ -1045,7 +1045,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                HMRC_MIGRATION.getId(),
+                HMRC_MIGRATION,
                 TestVc.builder().evidence(null).credentialSubject(credentialSubject).build(),
                 "https://orch.stubs.account.gov.uk/migration/v1",
                 Vot.PCL250.toString(),
@@ -1073,7 +1073,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                HMRC_MIGRATION.getId(),
+                HMRC_MIGRATION,
                 TestVc.builder()
                         .credentialSubject(credentialSubject)
                         .evidence(List.of(evidence))
@@ -1096,7 +1096,7 @@ public interface VcFixtures {
                         .build();
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                HMRC_MIGRATION.getId(),
+                HMRC_MIGRATION,
                 TestVc.builder()
                         .evidence(Collections.emptyList())
                         .credentialSubject(credentialSubject)

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
@@ -9,6 +9,7 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 
 import java.security.KeyFactory;
@@ -44,26 +45,25 @@ public class VerifiableCredentialGenerator {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public static VerifiableCredential generateVerifiableCredential(
-            String userId, String criId, Map<String, Object> vcClaim) throws Exception {
-        return generateVerifiableCredential(userId, criId, vcClaim, KeyType.EC);
+            String userId, Cri cri, Map<String, Object> vcClaim) throws Exception {
+        return generateVerifiableCredential(userId, cri, vcClaim, KeyType.EC);
     }
 
     public static VerifiableCredential generateVerifiableCredential(
-            String userId, String criId, Map<String, Object> vcClaim, KeyType signingKeyType)
+            String userId, Cri cri, Map<String, Object> vcClaim, KeyType signingKeyType)
             throws Exception {
         return generateVerifiableCredential(
-                userId, criId, vcClaim, "https://subject.example.com", signingKeyType);
+                userId, cri, vcClaim, "https://subject.example.com", signingKeyType);
     }
 
     public static VerifiableCredential generateVerifiableCredential(
-            String userId, String criId, Map<String, Object> vcClaim, String issuer)
-            throws Exception {
-        return generateVerifiableCredential(userId, criId, vcClaim, issuer, KeyType.EC);
+            String userId, Cri cri, Map<String, Object> vcClaim, String issuer) throws Exception {
+        return generateVerifiableCredential(userId, cri, vcClaim, issuer, KeyType.EC);
     }
 
     public static VerifiableCredential generateVerifiableCredential(
             String userId,
-            String criId,
+            Cri cri,
             Map<String, Object> vcClaim,
             String issuer,
             KeyType signingKeyType)
@@ -76,17 +76,17 @@ public class VerifiableCredentialGenerator {
                         .claim(NOT_BEFORE, now.getEpochSecond())
                         .claim(VC_CLAIM, OBJECT_MAPPER.convertValue(vcClaim, Map.class))
                         .build();
-        return signTestVc(userId, criId, claimsSet, signingKeyType);
+        return signTestVc(userId, cri, claimsSet, signingKeyType);
     }
 
     public static VerifiableCredential generateVerifiableCredential(
-            String userId, String criId, TestVc vcClaim, String issuer, Instant nbf) {
-        return generateVerifiableCredential(userId, criId, vcClaim, issuer, nbf, KeyType.EC);
+            String userId, Cri cri, TestVc vcClaim, String issuer, Instant nbf) {
+        return generateVerifiableCredential(userId, cri, vcClaim, issuer, nbf, KeyType.EC);
     }
 
     public static VerifiableCredential generateVerifiableCredential(
             String userId,
-            String criId,
+            Cri cri,
             TestVc vcClaim,
             String issuer,
             Instant nbf,
@@ -99,22 +99,22 @@ public class VerifiableCredentialGenerator {
                             .claim(NOT_BEFORE, nbf.getEpochSecond())
                             .claim(VC_CLAIM, OBJECT_MAPPER.convertValue(vcClaim, Map.class))
                             .build();
-            return signTestVc(userId, criId, claimsSet, signingKeyType);
+            return signTestVc(userId, cri, claimsSet, signingKeyType);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     public static VerifiableCredential generateVerifiableCredential(
-            String userId, String criId, TestVc vcClaim) {
-        return generateVerifiableCredential(userId, criId, vcClaim, KeyType.EC);
+            String userId, Cri cri, TestVc vcClaim) {
+        return generateVerifiableCredential(userId, cri, vcClaim, KeyType.EC);
     }
 
     public static VerifiableCredential generateVerifiableCredential(
-            String userId, String criId, TestVc vcClaim, KeyType signingKeyType) {
+            String userId, Cri cri, TestVc vcClaim, KeyType signingKeyType) {
         try {
             return generateVerifiableCredential(
-                    userId, criId, vcClaim, null, Instant.now(), signingKeyType);
+                    userId, cri, vcClaim, null, Instant.now(), signingKeyType);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -122,7 +122,7 @@ public class VerifiableCredentialGenerator {
 
     public static VerifiableCredential generateVerifiableCredential(
             String userId,
-            String criId,
+            Cri cri,
             TestVc vcClaim,
             String issuer,
             String vot,
@@ -130,13 +130,13 @@ public class VerifiableCredentialGenerator {
             String vtm)
             throws Exception {
         return generateVerifiableCredential(
-                userId, criId, vcClaim, issuer, vot, jti, vtm, KeyType.EC);
+                userId, cri, vcClaim, issuer, vot, jti, vtm, KeyType.EC);
     }
 
     @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public static VerifiableCredential generateVerifiableCredential(
             String userId,
-            String criId,
+            Cri cri,
             TestVc vcClaim,
             String issuer,
             String vot,
@@ -155,16 +155,16 @@ public class VerifiableCredentialGenerator {
                         .claim(JWT_ID, jti)
                         .claim(VC_VTM, vtm)
                         .build();
-        return signTestVc(userId, criId, claimsSet, signingKeyType);
+        return signTestVc(userId, cri, claimsSet, signingKeyType);
     }
 
     public static VerifiableCredential generateVerifiableCredential(
-            String userId, String criId, TestVc vcClaim, Instant nbf) {
-        return generateVerifiableCredential(userId, criId, vcClaim, nbf, KeyType.EC);
+            String userId, Cri cri, TestVc vcClaim, Instant nbf) {
+        return generateVerifiableCredential(userId, cri, vcClaim, nbf, KeyType.EC);
     }
 
     public static VerifiableCredential generateVerifiableCredential(
-            String userId, String criId, TestVc vcClaim, Instant nbf, KeyType signingKeyType) {
+            String userId, Cri cri, TestVc vcClaim, Instant nbf, KeyType signingKeyType) {
         try {
             JWTClaimsSet claimsSet =
                     new JWTClaimsSet.Builder()
@@ -173,21 +173,21 @@ public class VerifiableCredentialGenerator {
                             .claim(NOT_BEFORE, nbf.getEpochSecond())
                             .claim(VC_CLAIM, vcClaim)
                             .build();
-            return signTestVc(userId, criId, claimsSet, signingKeyType);
+            return signTestVc(userId, cri, claimsSet, signingKeyType);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     private static VerifiableCredential signTestVc(
-            String userId, String criId, JWTClaimsSet claimsSet, KeyType signingKeyType)
+            String userId, Cri cri, JWTClaimsSet claimsSet, KeyType signingKeyType)
             throws Exception {
         if (EC.equals(signingKeyType)) {
-            return signTestVcWithEc(userId, criId, claimsSet);
+            return signTestVcWithEc(userId, cri, claimsSet);
         }
 
         if (RSA.equals(signingKeyType)) {
-            return signTestVcWithRSA(userId, criId, claimsSet);
+            return signTestVcWithRSA(userId, cri, claimsSet);
         }
 
         throw new RuntimeException("Signing key type is not EC or RSA");
@@ -196,7 +196,7 @@ public class VerifiableCredentialGenerator {
     // TODO: PYIC-5171 Replace this method
     // Same comments for signTestVcWithRSA
     private static VerifiableCredential signTestVcWithEc(
-            String userId, String criId, JWTClaimsSet claimsSet) throws Exception {
+            String userId, Cri cri, JWTClaimsSet claimsSet) throws Exception {
         var kf = KeyFactory.getInstance(KeyType.EC.getValue());
 
         var privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(EC_PRIVATE_KEY));
@@ -210,11 +210,11 @@ public class VerifiableCredentialGenerator {
         // Parsing and serialising here allows us to cast like before.
         // The casting will be replaced in PYIC-5171 and so should this.
         return VerifiableCredential.fromValidJwt(
-                userId, criId, SignedJWT.parse(signedJWT.serialize()));
+                userId, cri, SignedJWT.parse(signedJWT.serialize()));
     }
 
     private static VerifiableCredential signTestVcWithRSA(
-            String userId, String criId, JWTClaimsSet claimsSet) throws Exception {
+            String userId, Cri cri, JWTClaimsSet claimsSet) throws Exception {
         var kf = KeyFactory.getInstance(KeyType.RSA.getValue());
 
         var privateKeySpec =
@@ -227,7 +227,7 @@ public class VerifiableCredentialGenerator {
         signedJWT.sign(signer);
 
         return VerifiableCredential.fromValidJwt(
-                userId, criId, SignedJWT.parse(signedJWT.serialize()));
+                userId, cri, SignedJWT.parse(signedJWT.serialize()));
     }
 
     public static Map<String, Object> vcClaim(Map<String, Object> attributes) {

--- a/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/service/CriResponseServiceTest.java
+++ b/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/service/CriResponseServiceTest.java
@@ -120,7 +120,7 @@ class CriResponseServiceTest {
             VerifiableCredential vc, Instant dateCreated) {
         CriResponseItem criResponseItem = new CriResponseItem();
         criResponseItem.setUserId(vc.getUserId());
-        criResponseItem.setCredentialIssuer(vc.getCriId());
+        criResponseItem.setCredentialIssuer(vc.getCri().getId());
         criResponseItem.setIssuerResponse(vc.getVcString());
         criResponseItem.setDateCreated(dateCreated);
         criResponseItem.setStatus(CriResponseService.STATUS_PENDING);

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
@@ -95,7 +95,7 @@ public class EvcsService {
             try {
                 var jwt = SignedJWT.parse(vc.vc());
                 var cri = configService.getCriByIssuer(jwt.getJWTClaimsSet().getIssuer());
-                var credential = VerifiableCredential.fromValidJwt(userId, cri.getId(), jwt);
+                var credential = VerifiableCredential.fromValidJwt(userId, cri, jwt);
                 if (!credentials.containsKey(vc.state())) {
                     credentials.put(vc.state(), new ArrayList<>());
                 }

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsMigrationServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsMigrationServiceTest.java
@@ -33,7 +33,7 @@ class EvcsMigrationServiceTest {
     void testMigrateExistingIdentity() throws Exception {
         VCS.forEach(
                 credential -> {
-                    if (credential.getCriId().equals(EXPERIAN_FRAUD.getId())) {
+                    if (credential.getCri().equals(EXPERIAN_FRAUD)) {
                         credential.setMigrated(null);
                     } else {
                         credential.setMigrated(Instant.now());

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsServiceTest.java
@@ -369,8 +369,8 @@ class EvcsServiceTest {
                 (vcs.stream()
                         .filter(
                                 vc ->
-                                        vc.getCriId().equals(Cri.ADDRESS.getId())
-                                                || vc.getCriId().equals(Cri.DCMAW.getId()))
+                                        vc.getCri().equals(Cri.ADDRESS)
+                                                || vc.getCri().equals(Cri.DCMAW))
                         .count()));
     }
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -164,7 +164,7 @@ public class UserIdentityService {
             var filterValidVCs = filterValidVCs(vcs);
             if (filterValidVCs.size() == 1) {
                 return configService
-                        .getOauthCriActiveConnectionConfig(filterValidVCs.get(0).getCriId())
+                        .getOauthCriActiveConnectionConfig(filterValidVCs.get(0).getCri().getId())
                         .isRequiresAdditionalEvidence();
             }
         }
@@ -376,7 +376,7 @@ public class UserIdentityService {
             IdentityClaim identityClaim = getIdentityClaim(vc);
             String missingNames = getMissingNames(identityClaim.getName());
             if (!missingNames.isBlank()) {
-                if (CRI_TYPES_EXCLUDED_FOR_NAME_CORRELATION.contains(vc.getCriId())) {
+                if (CRI_TYPES_EXCLUDED_FOR_NAME_CORRELATION.contains(vc.getCri().getId())) {
                     continue;
                 }
                 addLogMessage(vc, "Names missing from VC: " + missingNames);
@@ -395,7 +395,7 @@ public class UserIdentityService {
         for (var vc : vcs) {
             IdentityClaim identityClaim = getIdentityClaim(vc);
             if (isBirthDateEmpty(identityClaim.getBirthDate())) {
-                if (CRI_TYPES_EXCLUDED_FOR_DOB_CORRELATION.contains(vc.getCriId())) {
+                if (CRI_TYPES_EXCLUDED_FOR_DOB_CORRELATION.contains(vc.getCri().getId())) {
                     continue;
                 }
                 addLogMessage(vc, "Birthdate property is missing from VC");
@@ -615,7 +615,7 @@ public class UserIdentityService {
                             .with(
                                     LOG_MESSAGE_DESCRIPTION.getFieldName(),
                                     "Nino property is missing from VC")
-                            .with(LOG_CRI_ISSUER.getFieldName(), ninoVc.get().getCriId());
+                            .with(LOG_CRI_ISSUER.getFieldName(), ninoVc.get().getCri().getId());
             LOGGER.warn(mapMessage);
 
             return Optional.empty();
@@ -646,7 +646,7 @@ public class UserIdentityService {
                             .with(
                                     LOG_MESSAGE_DESCRIPTION.getFieldName(),
                                     "Passport property is missing from VC")
-                            .with(LOG_CRI_ISSUER.getFieldName(), passportVc.get().getCriId());
+                            .with(LOG_CRI_ISSUER.getFieldName(), passportVc.get().getCri().getId());
             LOGGER.warn(mapMessage);
 
             return Optional.empty();
@@ -678,7 +678,9 @@ public class UserIdentityService {
                             .with(
                                     LOG_MESSAGE_DESCRIPTION.getFieldName(),
                                     "Driving Permit property is missing from VC")
-                            .with(LOG_CRI_ISSUER.getFieldName(), drivingPermitVc.get().getCriId());
+                            .with(
+                                    LOG_CRI_ISSUER.getFieldName(),
+                                    drivingPermitVc.get().getCri().getId());
             LOGGER.warn(mapMessage);
 
             return Optional.empty();
@@ -693,13 +695,15 @@ public class UserIdentityService {
     }
 
     private Optional<VerifiableCredential> findVc(String criName, List<VerifiableCredential> vcs) {
-        return vcs.stream().filter(credential -> credential.getCriId().equals(criName)).findFirst();
+        return vcs.stream()
+                .filter(credential -> credential.getCri().getId().equals(criName))
+                .findFirst();
     }
 
     private Optional<VerifiableCredential> findVc(
             List<String> criNames, List<VerifiableCredential> vcs) {
         return vcs.stream()
-                .filter(credential -> criNames.contains(credential.getCriId()))
+                .filter(credential -> criNames.contains(credential.getCri().getId()))
                 .findFirst();
     }
 
@@ -766,7 +770,7 @@ public class UserIdentityService {
         StringMapMessage logMessage =
                 new StringMapMessage()
                         .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), error)
-                        .with(LOG_CRI_ISSUER.getFieldName(), vc.getCriId());
+                        .with(LOG_CRI_ISSUER.getFieldName(), vc.getCri().getId());
         LOGGER.warn(logMessage);
     }
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -93,9 +93,13 @@ public class VcHelper {
     public static List<VerifiableCredential> filterVCBasedOnProfileType(
             List<VerifiableCredential> vcs, ProfileType profileType) {
         if (profileType.equals(ProfileType.GPG45)) {
-            return vcs.stream().filter(vc -> !OPERATIONAL_CRIS.contains(vc.getCriId())).toList();
+            return vcs.stream()
+                    .filter(vc -> !OPERATIONAL_CRIS.contains(vc.getCri().getId()))
+                    .toList();
         } else {
-            return vcs.stream().filter(vc -> (OPERATIONAL_CRIS.contains(vc.getCriId()))).toList();
+            return vcs.stream()
+                    .filter(vc -> (OPERATIONAL_CRIS.contains(vc.getCri().getId())))
+                    .toList();
         }
     }
 

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -67,8 +67,8 @@ public class VerifiableCredentialService {
 
     public void deleteHmrcInheritedIdentityIfPresent(List<VerifiableCredential> vcs) {
         for (var vc : vcs) {
-            if (HMRC_MIGRATION.getId().equals(vc.getCriId())) {
-                deleteVcStoreItem(vc.getUserId(), vc.getCriId());
+            if (HMRC_MIGRATION.equals(vc.getCri())) {
+                deleteVcStoreItem(vc.getUserId(), vc.getCri().getId());
             }
         }
     }
@@ -89,7 +89,7 @@ public class VerifiableCredentialService {
             LOGGER.info(message);
         }
         for (var vc : vcs) {
-            deleteVcStoreItem(vc.getUserId(), vc.getCriId());
+            deleteVcStoreItem(vc.getUserId(), vc.getCri().getId());
         }
     }
 

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidator.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidator.java
@@ -19,6 +19,7 @@ import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
@@ -66,11 +67,11 @@ public class VerifiableCredentialValidator {
     }
 
     public List<VerifiableCredential> parseAndValidate(
-            String userId, String criId, List<String> vcs, String signingKey, String componentId)
+            String userId, Cri cri, List<String> vcs, String signingKey, String componentId)
             throws VerifiableCredentialException {
         var validVcs = new ArrayList<VerifiableCredential>();
         for (String vc : vcs) {
-            validVcs.add(parseAndValidate(userId, criId, vc, signingKey, componentId, false));
+            validVcs.add(parseAndValidate(userId, cri, vc, signingKey, componentId, false));
         }
         return validVcs;
     }
@@ -78,7 +79,7 @@ public class VerifiableCredentialValidator {
     @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public VerifiableCredential parseAndValidate(
             String userId,
-            String criId,
+            Cri cri,
             String vcString,
             String signingKey,
             String componentId,
@@ -89,7 +90,7 @@ public class VerifiableCredentialValidator {
             validateSignature(vcJwt, signingKey);
             validateClaimsSet(vcJwt, componentId, userId, skipSubjectCheck);
 
-            var vc = VerifiableCredential.fromValidJwt(userId, criId, vcJwt);
+            var vc = VerifiableCredential.fromValidJwt(userId, cri, vcJwt);
 
             validateCiCodes(vc);
 

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
@@ -57,7 +57,8 @@ class VerifiableCredentialServiceTest {
 
         assertEquals(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getUserId(), vcStoreItem.getUserId());
         assertEquals(
-                PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCriId(), vcStoreItem.getCredentialIssuer());
+                PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCri().getId(),
+                vcStoreItem.getCredentialIssuer());
         assertEquals(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(), vcStoreItem.getCredential());
     }
 
@@ -81,7 +82,7 @@ class VerifiableCredentialServiceTest {
     void shouldReturnCredentialIssuersFromDataStoreForSpecificUserId()
             throws CredentialParseException {
         var userId = PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getUserId();
-        var testCredentialIssuer = PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCriId();
+        var testCredentialIssuer = PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCri();
         var credentialItem = List.of(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.toVcStoreItem());
 
         when(mockDataStore.getItems(userId)).thenReturn(credentialItem);
@@ -90,24 +91,23 @@ class VerifiableCredentialServiceTest {
 
         assertTrue(
                 vcs.stream()
-                        .map(VerifiableCredential::getCriId)
+                        .map(VerifiableCredential::getCri)
                         .anyMatch(testCredentialIssuer::equals));
     }
 
     @Test
     void shouldReturnCredentialFromDataStoreForSpecificCri() throws CredentialParseException {
         var ipvSessionId = "ipvSessionId";
-        var criId = PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCriId();
+        var cri = PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCri();
 
-        when(mockDataStore.getItem(ipvSessionId, criId))
+        when(mockDataStore.getItem(ipvSessionId, cri.getId()))
                 .thenReturn(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.toVcStoreItem());
 
-        var retrievedCredentialItem = verifiableCredentialService.getVc(ipvSessionId, criId);
+        var retrievedCredentialItem = verifiableCredentialService.getVc(ipvSessionId, cri.getId());
 
         assertEquals(
                 PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getUserId(), retrievedCredentialItem.getUserId());
-        assertEquals(
-                PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCriId(), retrievedCredentialItem.getCriId());
+        assertEquals(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCri(), retrievedCredentialItem.getCri());
         assertEquals(
                 PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
                 retrievedCredentialItem.getVcString());
@@ -124,9 +124,9 @@ class VerifiableCredentialServiceTest {
         verify(mockDataStore)
                 .delete(
                         PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getUserId(),
-                        PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCriId());
-        verify(mockDataStore).delete(experianVc1.getUserId(), experianVc1.getCriId());
-        verify(mockDataStore).delete(experianVc2.getUserId(), experianVc2.getCriId());
+                        PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCri().getId());
+        verify(mockDataStore).delete(experianVc1.getUserId(), experianVc1.getCri().getId());
+        verify(mockDataStore).delete(experianVc2.getUserId(), experianVc2.getCri().getId());
     }
 
     @Test
@@ -145,7 +145,7 @@ class VerifiableCredentialServiceTest {
 
         // Assert
         verify(mockDataStore, times(1))
-                .delete(inheritedIdentityVc.getUserId(), inheritedIdentityVc.getCriId());
+                .delete(inheritedIdentityVc.getUserId(), inheritedIdentityVc.getCri().getId());
     }
 
     @Test

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java
@@ -72,14 +72,14 @@ class VerifiableCredentialValidatorTest {
         var vc =
                 vcJwtValidator.parseAndValidate(
                         TEST_USER,
-                        PASSPORT.getId(),
+                        PASSPORT,
                         PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         false);
 
         assertEquals(TEST_USER, vc.getUserId());
-        assertEquals(PASSPORT.getId(), vc.getCriId());
+        assertEquals(PASSPORT, vc.getCri());
         assertEquals(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(), vc.getVcString());
     }
 
@@ -88,14 +88,14 @@ class VerifiableCredentialValidatorTest {
         var vc =
                 vcJwtValidator.parseAndValidate(
                         TEST_USER,
-                        Cri.PASSPORT.getId(),
+                        Cri.PASSPORT,
                         PASSPORT_NON_DCMAW_SUCCESSFUL_RSA_SIGNED_VC.getVcString(),
                         VALID_RSA_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         false);
 
         assertEquals(TEST_USER, vc.getUserId());
-        assertEquals(Cri.PASSPORT.getId(), vc.getCriId());
+        assertEquals(Cri.PASSPORT, vc.getCri());
         assertEquals(PASSPORT_NON_DCMAW_SUCCESSFUL_RSA_SIGNED_VC.getVcString(), vc.getVcString());
     }
 
@@ -107,14 +107,14 @@ class VerifiableCredentialValidatorTest {
         var vc =
                 vcJwtValidator.parseAndValidate(
                         TEST_USER,
-                        PASSPORT.getId(),
+                        PASSPORT,
                         vcString,
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         false);
 
         assertEquals(TEST_USER, vc.getUserId());
-        assertEquals(PASSPORT.getId(), vc.getCriId());
+        assertEquals(PASSPORT, vc.getCri());
         assertEquals(vcString, vc.getVcString());
     }
 
@@ -123,13 +123,13 @@ class VerifiableCredentialValidatorTest {
         var vcs =
                 vcJwtValidator.parseAndValidate(
                         TEST_USER,
-                        PASSPORT.getId(),
+                        PASSPORT,
                         List.of(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString()),
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID);
 
         assertEquals(TEST_USER, vcs.get(0).getUserId());
-        assertEquals(PASSPORT.getId(), vcs.get(0).getCriId());
+        assertEquals(PASSPORT, vcs.get(0).getCri());
         assertEquals(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(), vcs.get(0).getVcString());
     }
 
@@ -139,13 +139,13 @@ class VerifiableCredentialValidatorTest {
         var vc =
                 vcJwtValidator.parseAndValidate(
                         "not the user",
-                        PASSPORT.getId(),
+                        PASSPORT,
                         PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         true);
 
-        assertEquals(PASSPORT.getId(), vc.getCriId());
+        assertEquals(PASSPORT, vc.getCri());
         assertEquals(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(), vc.getVcString());
     }
 
@@ -157,7 +157,7 @@ class VerifiableCredentialValidatorTest {
                         () -> {
                             vcJwtValidator.parseAndValidate(
                                     "not the user",
-                                    PASSPORT.getId(),
+                                    PASSPORT,
                                     PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
@@ -177,7 +177,7 @@ class VerifiableCredentialValidatorTest {
                         () -> {
                             vcJwtValidator.parseAndValidate(
                                     TEST_USER,
-                                    PASSPORT.getId(),
+                                    PASSPORT,
                                     PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
                                     VALID_EC_SIGNING_KEY,
                                     "not the component id",
@@ -197,7 +197,7 @@ class VerifiableCredentialValidatorTest {
                         () -> {
                             vcJwtValidator.parseAndValidate(
                                     TEST_USER,
-                                    PASSPORT.getId(),
+                                    PASSPORT,
                                     PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString(),
                                     INVALID_EC_SIGNING_KEY, // intentionally not valid
                                     TEST_COMPONENT_ID,
@@ -223,14 +223,14 @@ class VerifiableCredentialValidatorTest {
         var vc =
                 vcJwtValidator.parseAndValidate(
                         TEST_USER,
-                        PASSPORT.getId(),
+                        PASSPORT,
                         verifiableCredentialsWithDerSignature.serialize(),
                         VALID_EC_SIGNING_KEY,
                         TEST_COMPONENT_ID,
                         false);
 
         assertEquals(TEST_USER, vc.getUserId());
-        assertEquals(PASSPORT.getId(), vc.getCriId());
+        assertEquals(PASSPORT, vc.getCri());
         assertEquals(verifiableCredentialsWithDerSignature.serialize(), vc.getVcString());
     }
 
@@ -252,7 +252,7 @@ class VerifiableCredentialValidatorTest {
                         () -> {
                             vcJwtValidator.parseAndValidate(
                                     TEST_USER,
-                                    PASSPORT.getId(),
+                                    PASSPORT,
                                     verifiableCredentialsWithDerSignature.serialize(),
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
@@ -275,7 +275,7 @@ class VerifiableCredentialValidatorTest {
                         () -> {
                             vcJwtValidator.parseAndValidate(
                                     TEST_USER,
-                                    PASSPORT.getId(),
+                                    PASSPORT,
                                     vcPassportM1aWithCI().getVcString(),
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
@@ -299,7 +299,7 @@ class VerifiableCredentialValidatorTest {
                         () -> {
                             vcJwtValidator.parseAndValidate(
                                     TEST_USER,
-                                    TICF.getId(),
+                                    TICF,
                                     vcTicfWithCi().getVcString(),
                                     VALID_EC_SIGNING_KEY,
                                     "https://ticf.stubs.account.gov.uk",
@@ -329,7 +329,7 @@ class VerifiableCredentialValidatorTest {
                         () -> {
                             underTest.parseAndValidate(
                                     TEST_USER,
-                                    PASSPORT.getId(),
+                                    PASSPORT,
                                     vcPassportM1aWithCI().getVcString(),
                                     VALID_EC_SIGNING_KEY,
                                     TEST_COMPONENT_ID,
@@ -350,7 +350,7 @@ class VerifiableCredentialValidatorTest {
                         () -> {
                             vcJwtValidator.parseAndValidate(
                                     TEST_USER,
-                                    Cri.PASSPORT.getId(),
+                                    Cri.PASSPORT,
                                     vcPassportM1aWithCI().getVcString(),
                                     "not a valid signing key",
                                     TEST_COMPONENT_ID,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Use the CRI enum rather than a string in VerifiableCredential

### What changed
 - VerifiableCredential class
 - Assoicated method calls and tests that use the CRI 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

Since the CRI enum was introduced in an earlier PR, we can use it in the Verifiable Credential to ensure that all passed CRI ids are valid

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-6816

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

