### PR TITLE
BAU Fix journey map

### DIFF
--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -7,7 +7,6 @@ const DEFAULT_JOURNEY_TYPE = 'INITIAL_JOURNEY_SELECTION';
 
 const JOURNEY_TYPES = {
     INITIAL_JOURNEY_SELECTION: 'Initial journey selection',
-    NEW_P1_IDENTITY: 'New P1 identity',
     NEW_P2_IDENTITY: 'New P2 identity',
     REUSE_EXISTING_IDENTITY: 'Reuse existing identity',
     UPDATE_NAME: 'Update name',


### PR DESCRIPTION
The journey map is borked because we've added NEW_P1_IDENTITY - it looks for `new-p1-identity.yaml` which doesn't exist as we're still using the P2 journey definition for now.