### PR TITLE
PYIC-5097: Add routing for DWP KBV CRI stub

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -64,6 +64,9 @@ public class CriCheckingService {
     private static final JourneyResponse JOURNEY_TEMPORARILY_UNAVAILABLE =
             new JourneyResponse(JOURNEY_TEMPORARILY_UNAVAILABLE_PATH);
     private static final JourneyResponse JOURNEY_ERROR = new JourneyResponse(JOURNEY_ERROR_PATH);
+    private static final JourneyResponse JOURNEY_INVALID_REQUEST =
+            new JourneyResponse(JourneyUris.JOURNEY_INVALID_REQUEST_PATH);
+
     private static final List<String> ALLOWED_OAUTH_ERROR_CODES =
             Arrays.asList(
                     OAuth2Error.INVALID_REQUEST_CODE,
@@ -137,6 +140,7 @@ public class CriCheckingService {
         return (switch (errorCode) {
             case OAuth2Error.ACCESS_DENIED_CODE -> JOURNEY_ACCESS_DENIED;
             case OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE -> JOURNEY_TEMPORARILY_UNAVAILABLE;
+            case OAuth2Error.INVALID_REQUEST_CODE -> JOURNEY_INVALID_REQUEST;
             default -> JOURNEY_ERROR;
         });
     }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -53,6 +53,7 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ACCESS_
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_FAIL_WITH_NO_CI_PATH;
+import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_INVALID_REQUEST_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NEXT_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_TEMPORARILY_UNAVAILABLE_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_VCS_NOT_CORRELATED;
@@ -128,6 +129,28 @@ class CriCheckingServiceTest {
 
         // Assert
         assertEquals(new JourneyResponse(JOURNEY_ACCESS_DENIED_PATH), journeyResponse);
+    }
+
+    @Test
+    void handleCallbackErrorShouldReturnJourneyInvalidRequestIfInCallbackRequest()
+            throws SqsException {
+        // Arrange
+        var callbackRequest =
+                CriCallbackRequest.builder()
+                        .credentialIssuerId(TEST_CRI_ID)
+                        .error(OAuth2Error.INVALID_REQUEST_CODE)
+                        .errorDescription(TEST_ERROR_DESCRIPTION)
+                        .build();
+        var clientOauthSessionItem = ClientOAuthSessionItem.builder().build();
+        when(mockConfigService.getSsmParameter(ConfigurationVariable.COMPONENT_ID))
+                .thenReturn(TEST_COMPONENT_ID);
+
+        // Act
+        var journeyResponse =
+                criCheckingService.handleCallbackError(callbackRequest, clientOauthSessionItem);
+
+        // Assert
+        assertEquals(new JourneyResponse(JOURNEY_INVALID_REQUEST_PATH), journeyResponse);
     }
 
     @Test

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -56,6 +56,9 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED
+      invalid-request:
+        targetJourney: FAILED
+        targetState: FAILED
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
@@ -507,15 +510,21 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_NINO_J6
+        targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
-        targetState: CRI_NINO_J6
+        targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
   # Driving licence journey (J3)
   CRI_DRIVING_LICENCE_J3:
@@ -569,10 +578,13 @@ states:
         scoreThreshold: 2
     events:
       met:
-        targetState: CRI_NINO_J6
+        targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       unmet:
         targetJourney: FAILED
         targetState: FAILED
@@ -663,6 +675,59 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
+  # DWP KBV journey (J7)
+  CRI_DWP_KBV_J7:
+    response:
+      type: cri
+      criId: dwpKbv
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+
+  CRI_DWP_KBV_M2B:
+    response:
+      type: cri
+      criId: dwpKbv
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+
   # No photo id journey (M2B)
   CRI_CLAIMED_IDENTITY_M2B:
     response:
@@ -711,15 +776,21 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_HMRC_KBV_M2B
+        targetState: CRI_DWP_KBV_M2B
         checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+          dwpKbv:
+            targetState: CRI_HMRC_KBV_M2B
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
       enhanced-verification:
-        targetState: CRI_HMRC_KBV_M2B
+        targetState: CRI_DWP_KBV_M2B
         checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+          dwpKbv:
+            targetState: CRI_HMRC_KBV_M2B
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
 
   PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B:
     response:
@@ -1118,10 +1189,13 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: MITIGATION_PP_CRI_NINO
+        targetState: MITIGATION_CRI_DWP_KBV
         checkIfDisabled:
-          hmrcKbv:
-            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+          dwpKbv:
+            targetState: MITIGATION_PP_CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
@@ -1203,10 +1277,13 @@ states:
         scoreThreshold: 2
     events:
       met:
-        targetState: MITIGATION_PP_CRI_NINO
+        targetState: MITIGATION_CRI_DWP_KBV
         checkIfDisabled:
-          hmrcKbv:
-            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+          dwpKbv:
+            targetState: MITIGATION_PP_CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       unmet:
         targetJourney: FAILED
         targetState: FAILED
@@ -1256,6 +1333,22 @@ states:
         targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       next:
         targetState: EVALUATE_GPG45_SCORES
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_CRI_DWP_KBV:
+    response:
+      type: cri
+      criId: dwpKbv
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+      invalid-request:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -30,6 +30,9 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      invalid-request:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -34,6 +34,9 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED
+      invalid-request:
+        targetJourney: FAILED
+        targetState: FAILED
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -27,6 +27,9 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      invalid-request:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -63,6 +63,9 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      invalid-request:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -38,4 +38,5 @@ public class JourneyUris {
             "/journey/temporarily-unavailable";
     public static final String JOURNEY_UNMET_PATH = "/journey/unmet";
     public static final String JOURNEY_VCS_NOT_CORRELATED = "/journey/vcs-not-correlated";
+    public static final String JOURNEY_INVALID_REQUEST_PATH = "/journey/invalid-request";
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Route to DWP KBV CRI when enabled (and HMRC KBV CRI disabled) Should be disabled by default with a feature set to enable.

Handle exit routes as per Request/Response formats | Error handling maintaining existing HMRC KBV CRI exit behaviour for now, whereby we fall back to Experian KBV: 

- access_denied (user abandon or timeout) -> Experian KBV start page 
- invalid_request (thin file) -> Experian KBV start page 
- server_error -> technical error page
- temporarily_unavailable -> technical error page
- fail with V03 CI -> mitigation as normal

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5097](https://govukverify.atlassian.net/browse/PYIC-5097)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-5097]: https://govukverify.atlassian.net/browse/PYIC-5097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ