### PR TITLE
IPS-608: Remove rusty-actions

### DIFF
--- a/.github/workflows/secure-post-merge-delete-account.yml
+++ b/.github/workflows/secure-post-merge-delete-account.yml
@@ -58,13 +58,6 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_DELETE_ACCOUNT_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./deploy-delete-user-data/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM validate
         working-directory: ./deploy-delete-user-data
         run: sam validate --region ${{ env.AWS_REGION }}

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -61,13 +61,6 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./deploy/template.yaml
-          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
-
       - name: SAM validate
         working-directory: ./deploy
         run: sam validate --region ${{ env.AWS_REGION }}


### PR DESCRIPTION
### What changed

- Removed obsolete and redundant rusty-actions workflow step
 
### Why did it change

- This is obsolete and now handled by the dev-platform upload action

### Issue tracking

- [IPS-608](https://govukverify.atlassian.net/browse/IPS-608)
- These changes have been made in Lime already, e.g. https://github.com/govuk-one-login/ipv-cri-uk-passport-api/pull/132/files

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-608]: https://govukverify.atlassian.net/browse/IPS-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ