### PR TITLE
PYIC-6755-fix: Fix references to Vot attributes for Inherited Identity case

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -186,6 +186,7 @@ public class EvaluateGpg45ScoresHandler
             var requestedVotsByStrength = clientOAuthSessionItem.getRequestedVotsByStrength();
             var supportedGpg45ProfilesByVotStrength =
                     requestedVotsByStrength.stream()
+                            .filter(vot -> vot.getSupportedGpg45Profiles() != null)
                             .flatMap(vot -> vot.getSupportedGpg45Profiles().stream())
                             .toList();
             var matchedProfile =

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -538,6 +538,27 @@ class EvaluateGpg45ScoresHandlerTest {
         verify(ipvSessionItem).setVot(Vot.P2);
     }
 
+    @Test
+    void shouldReturnJourneyMetForMeetingMediumConfidencesWhenVtrIncludesVotWithNoGpg45Profiles()
+            throws Exception {
+        when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        clientOAuthSessionItem.setVtr(List.of("P1", "P2", "PCL200"));
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(P1_AND_P2_PROFILES)))
+                .thenReturn(Optional.of(M1A));
+        when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+        when(userIdentityService.checkRequiresAdditionalEvidence(any())).thenReturn(false);
+
+        JourneyResponse response =
+                toResponseClass(
+                        evaluateGpg45ScoresHandler.handleRequest(request, context),
+                        JourneyResponse.class);
+
+        assertEquals(JOURNEY_MET.getJourney(), response.getJourney());
+        verify(ipvSessionItem).setVot(Vot.P2);
+    }
+
     private <T> T toResponseClass(Map<String, Object> handlerOutput, Class<T> responseClass) {
         return OBJECT_MAPPER.convertValue(handlerOutput, responseClass);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Filter null supported gpg45 profiles before making stream

### Why did it change

- Fix bug preventing build passing

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6755](https://govukverify.atlassian.net/browse/PYIC-6755)


[PYIC-6755]: https://govukverify.atlassian.net/browse/PYIC-6755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ