### PR TITLE
PYIC-6961: Return build-client-oauth-response before checking session

### DIFF
--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -64,6 +64,8 @@ class ProcessJourneyEventHandlerTest {
             "/journey/testWithContext?currentPage=";
     private static final String JOURNEY_EVENT_TWO_WITH_CORRECT_CURRENT_PAGE =
             "/journey/eventTwo?currentPage=page-id-for-page-state";
+    private static final String JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE =
+            "/journey/build-client-oauth-response";
     private static final String TEST_IP = "1.2.3.4";
     private static final String TEST_SESSION_ID = "test-session-id";
     private static final String TIMEOUT_UNRECOVERABLE_STATE = "TIMEOUT_UNRECOVERABLE_PAGE";
@@ -184,6 +186,21 @@ class ProcessJourneyEventHandlerTest {
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, output.get(STATUS_CODE));
         assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getCode(), output.get(CODE));
         assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), output.get(MESSAGE));
+    }
+
+    @Test
+    void shouldReturnResponseForBuildClientOAuthResponseEvent() throws Exception {
+        var input =
+                JourneyRequest.builder()
+                        .ipAddress(TEST_IP)
+                        .journey(JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE)
+                        .ipvSessionId(null)
+                        .build();
+
+        Map<String, Object> output =
+                getProcessJourneyStepHandler().handleRequest(input, mockContext);
+
+        assertEquals(JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE, output.get("journey"));
     }
 
     @Test
@@ -374,7 +391,7 @@ class ProcessJourneyEventHandlerTest {
         Map<String, Object> output =
                 getProcessJourneyStepHandler().handleRequest(input, mockContext);
 
-        assertEquals("/journey/build-client-oauth-response", output.get("journey"));
+        assertEquals(JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE, output.get("journey"));
     }
 
     @Test


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return build-client-oauth-response before checking session

### Why did it change

If a user has lost their session when returning from a CRI (very possibly because the redirect has opened a different browser), then we show them a recoverable error page with a continue button. That button fires a `build-client-oauth-response` event into core-back.

Core-back should see that event and return a
`build-client-oauth-response` journey, which the step function uses to invoke the lambda to actually close the OAuth session with the client.

Instead we've been throwing an error due to the ipvSessionId not existing.

This changes the logic to return that special case response before we try to check the session ID.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6961](https://govukverify.atlassian.net/browse/PYIC-6961)


[PYIC-6961]: https://govukverify.atlassian.net/browse/PYIC-6961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ