### PR TITLE
PYIC-6897: handle case where one f2f in evcs

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -385,12 +385,12 @@ public class CheckExistingIdentityHandler
                 if (hasPartiallyMigratedVcs) {
                     // use tactical vcs but with evcs flags so that the store-identity lambda is
                     // called next and updates the evcs pending one
-                    return new VerifiableCredentialBundle(tacticalVcs, true, true);
+                    vcBundle = new VerifiableCredentialBundle(tacticalVcs, true, true);
                 }
             }
             logIdentityMismatches(tacticalVcs, evcsVcs, hasPartiallyMigratedVcs);
             // only use these evcs vcs if they exist and have been fully migrated
-            if (vcBundle != null && !hasPartiallyMigratedVcs) {
+            if (vcBundle != null) {
                 return vcBundle;
             }
         }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -381,6 +381,21 @@ public class CheckExistingIdentityHandler
                                 evcsIdentityVcs,
                                 isPendingEvcs,
                                 vcBundle.isF2fIdentity());
+
+                if (hasPartiallyMigratedVcs) {
+                    var vcs = vcBundle.credentials;
+                    if (evcsIdentityVcs.size() == 1
+                            && F2F.equals(evcsIdentityVcs.get(0).getCri())) {
+                        // get the evcs f2f and add it to the tactical vcs if it does not exist
+                        var evcsVc = evcsIdentityVcs.get(0);
+                        if (!vcs.stream()
+                                .anyMatch(vc -> vc.getVcString().equals(evcsVc.getVcString()))) {
+
+                            vcs.add(evcsVc);
+                            return new VerifiableCredentialBundle(vcs, true, true);
+                        }
+                    }
+                }
             }
             logIdentityMismatches(tacticalVcs, evcsVcs, hasPartiallyMigratedVcs);
             // only use these evcs vcs if they exist and have been fully migrated

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -382,19 +382,12 @@ public class CheckExistingIdentityHandler
                                 isPendingEvcs,
                                 vcBundle.isF2fIdentity());
 
-                if (hasPartiallyMigratedVcs) {
-                    var vcs = vcBundle.credentials;
-                    if (evcsIdentityVcs.size() == 1
-                            && F2F.equals(evcsIdentityVcs.get(0).getCri())) {
-                        // get the evcs f2f and add it to the tactical vcs if it does not exist
-                        var evcsVc = evcsIdentityVcs.get(0);
-                        if (!vcs.stream()
-                                .anyMatch(vc -> vc.getVcString().equals(evcsVc.getVcString()))) {
-
-                            vcs.add(evcsVc);
-                            return new VerifiableCredentialBundle(vcs, true, true);
-                        }
-                    }
+                if (hasPartiallyMigratedVcs
+                        && evcsIdentityVcs.size() == 1
+                        && F2F.equals(evcsIdentityVcs.get(0).getCri())) {
+                    // use tactical vcs but with evcs flags so that the store-identity lambda is
+                    // called next and updates the evcs pending one
+                    return new VerifiableCredentialBundle(tacticalVcs, true, true);
                 }
             }
             logIdentityMismatches(tacticalVcs, evcsVcs, hasPartiallyMigratedVcs);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -382,9 +382,7 @@ public class CheckExistingIdentityHandler
                                 isPendingEvcs,
                                 vcBundle.isF2fIdentity());
 
-                if (hasPartiallyMigratedVcs
-                        && evcsIdentityVcs.size() == 1
-                        && F2F.equals(evcsIdentityVcs.get(0).getCri())) {
+                if (hasPartiallyMigratedVcs) {
                     // use tactical vcs but with evcs flags so that the store-identity lambda is
                     // called next and updates the evcs pending one
                     return new VerifiableCredentialBundle(tacticalVcs, true, true);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -391,36 +391,7 @@ class CheckExistingIdentityHandlerTest {
         }
 
         @Test
-        void shouldReturnJourneyReuseResponseIfVcIsF2fAndHasPartiallyMigratedSingleVc()
-                throws CredentialParseException, EvcsServiceException,
-                        HttpResponseExceptionWithErrorBody, VerifiableCredentialException {
-            when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
-            when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
-            var f2fVc = vcF2fM1a();
-            f2fVc.setMigrated(Instant.now());
-            when(mockVerifiableCredentialService.getVcs(any())).thenReturn(List.of(gpg45Vc, f2fVc));
-            when(mockEvcsService.getVerifiableCredentialsByState(
-                            any(), any(), any(EvcsVCState.class), any(EvcsVCState.class)))
-                    .thenReturn(Map.of(PENDING_RETURN, List.of(f2fVc)));
-
-            when(criResponseService.getFaceToFaceRequest(any())).thenReturn(new CriResponseItem());
-            when(gpg45ProfileEvaluator.getFirstMatchingProfile(
-                            any(), eq(P2.getSupportedGpg45Profiles())))
-                    .thenReturn(Optional.of(Gpg45Profile.M1A));
-            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-
-            JourneyResponse journeyResponse =
-                    toResponseClass(
-                            checkExistingIdentityHandler.handleRequest(event, context),
-                            JourneyResponse.class);
-
-            assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
-            // pending vcs should not be migrated
-            verify(mockEvcsMigrationService, never()).migrateExistingIdentity(any(), any());
-        }
-
-        @Test
-        void shouldReturnJourneyReuseResponseIfVcIsF2fAndHasPartiallyMigratedVcs()
+        void shouldReturnJourneyReuseStoreResponseIfVcIsF2fAndHasPartiallyMigratedVcs()
                 throws CredentialParseException, EvcsServiceException,
                         HttpResponseExceptionWithErrorBody, VerifiableCredentialException {
             when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
@@ -447,9 +418,9 @@ class CheckExistingIdentityHandlerTest {
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);
 
-            assertEquals(JOURNEY_REUSE, journeyResponse);
-            // non-migrated vc should be migrated
-            verify(mockEvcsMigrationService).migrateExistingIdentity(TEST_USER_ID, List.of(f2fVc3));
+            assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
+            // pending vcs should not be migrated
+            verify(mockEvcsMigrationService, never()).migrateExistingIdentity(any(), any());
         }
 
         @Test

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -414,10 +414,9 @@ class CheckExistingIdentityHandlerTest {
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);
 
-            assertEquals(JOURNEY_REUSE, journeyResponse);
-            // non-migrated vc should be migrated
-            verify(mockEvcsMigrationService)
-                    .migrateExistingIdentity(TEST_USER_ID, List.of(gpg45Vc));
+            assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
+            // pending vcs should not be migrated
+            verify(mockEvcsMigrationService, never()).migrateExistingIdentity(any(), any());
         }
 
         @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

In checkExistingIdentity lambda, use the tactical vcs if there are partially migrated credentials, with the evcs flags set so that the next store lambda is called next

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
So that partially migrated credentials do not get migrated again (resulting in conflict in evcs service)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-6897

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

