### PR TITLE
PYIC-6903: remove flag for reading evcs access token

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -69,7 +69,6 @@ import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForInheritedIdentity;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JAR_KMS_ENCRYPTION_KEY_ID;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_TOKEN_READ_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.Cri.HMRC_MIGRATION;
@@ -369,17 +368,12 @@ public class InitialiseIpvSessionHandler
     @Tracing
     private String getEvcsAccessToken(JWTClaimsSet claimsSet)
             throws RecoverableJarValidationException, ParseException {
-
-        var writeEnabled = configService.enabled(EVCS_WRITE_ENABLED);
-        var readEnabled = configService.enabled(EVCS_READ_ENABLED);
-        if (!configService.enabled(EVCS_TOKEN_READ_ENABLED) && !writeEnabled && !readEnabled) {
-            return null;
-        }
         try {
             return validateEvcsAccessToken(
                     getJarUserInfo(claimsSet).map(JarUserInfo::evcsAccessToken), claimsSet);
         } catch (RecoverableJarValidationException | ParseException e) {
-            if (writeEnabled || readEnabled) {
+            if (configService.enabled(EVCS_WRITE_ENABLED)
+                    || configService.enabled(EVCS_READ_ENABLED)) {
                 throw e;
             } else {
                 return null;

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -98,7 +98,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsIpvJourneyStart.REPROVE_IDENTITY_KEY;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_TOKEN_READ_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.REPROVE_IDENTITY_ENABLED;
@@ -282,8 +281,6 @@ class InitialiseIpvSessionHandlerTest {
                 .thenReturn(ipvSessionItem);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
-        when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
-        when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
 
@@ -336,9 +333,6 @@ class InitialiseIpvSessionHandlerTest {
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(getValidClaimsBuilder().claim(CLAIMS, evcsAccessTokenClaims).build());
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
-        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-        when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
-        when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
 
         // Act
         APIGatewayProxyResponseEvent response =
@@ -651,7 +645,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -711,7 +704,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -768,7 +760,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -841,7 +832,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -931,7 +921,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
 
             // Act
             APIGatewayProxyResponseEvent response;
@@ -972,7 +961,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
 
             // Act
             APIGatewayProxyResponseEvent response =
@@ -997,7 +985,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1040,7 +1027,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1096,7 +1082,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(true);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1146,7 +1131,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()
@@ -1209,7 +1193,6 @@ class InitialiseIpvSessionHandlerTest {
             when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
             when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
-            when(mockConfigService.enabled(EVCS_TOKEN_READ_ENABLED)).thenReturn(false);
             when(mockJarValidator.validateRequestJwt(any(), any()))
                     .thenReturn(
                             getValidClaimsBuilder()

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -10,7 +10,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     EVCS_WRITE_ENABLED("evcsWriteEnabled"),
     EVCS_ASYNC_WRITE_ENABLED("evcsAsyncWriteEnabled"),
     EVCS_READ_ENABLED("evcsReadEnabled"),
-    EVCS_TOKEN_READ_ENABLED("evcsTokenReadEnabled"),
     MFA_RESET("mfaResetEnabled"),
     P1_JOURNEYS_ENABLED("p1JourneysEnabled");
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Remove the EVCS token read flag

### What changed

<!-- Describe the changes in detail - the "what"-->

Removal of the flag to read the evcs token so that we try and read the token by default

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

Following testing in staging, journeys with and without the EVCS token supplied have succeeded (and stored the evcs token if supplied) so we can confidently remove this feature flag so that we start storing the EVCS tokens in production

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-6903

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

