### PR TITLE
PYIC-5512: Remove reprove identity feature flag

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -222,7 +222,7 @@ public class InitialiseIpvSessionHandler
                 }
             }
 
-            var isReproveIdentity = isReproveIdentity(claimsSet);
+            var isReproveIdentity = claimsSet.getBooleanClaim(REPROVE_IDENTITY_KEY);
             AuditExtensionsIpvJourneyStart extensionsIpvJourneyStart =
                     new AuditExtensionsIpvJourneyStart(isReproveIdentity, vtr);
 
@@ -325,12 +325,6 @@ public class InitialiseIpvSessionHandler
                     claimsSet,
                     e);
         }
-    }
-
-    private Boolean isReproveIdentity(JWTClaimsSet claimsSet) throws ParseException {
-        return configService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_ENABLED)
-                ? claimsSet.getBooleanClaim(REPROVE_IDENTITY_KEY)
-                : null;
     }
 
     private static boolean isListEmpty(List<String> list) {

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -45,6 +45,7 @@ import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionAccountInterv
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsVcEvidence;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedInheritedIdentity;
 import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
+import uk.gov.di.ipv.core.library.config.FeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.CriConfig;
@@ -85,7 +86,6 @@ import static com.nimbusds.oauth2.sdk.OAuth2Error.INVALID_REQUEST_OBJECT_CODE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -101,7 +101,6 @@ import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLE
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_TOKEN_READ_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.REPROVE_IDENTITY_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.Cri.HMRC_MIGRATION;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.REVERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.ADDRESS_CLAIM_NAME;
@@ -236,8 +235,7 @@ class InitialiseIpvSessionHandlerTest {
             throws JsonProcessingException, JarValidationException, ParseException, SqsException {
         ArgumentCaptor<String> evcsAccessTokenCaptor = ArgumentCaptor.forClass(String.class);
         // Arrange
-        when(mockConfigService.enabled(REPROVE_IDENTITY_ENABLED)).thenReturn(true);
-        when(mockConfigService.enabled(not(eq(REPROVE_IDENTITY_ENABLED)))).thenReturn(false);
+        when(mockConfigService.enabled(any(FeatureFlag.class))).thenReturn(false);
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                 .thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -4,7 +4,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     UNUSED_PLACEHOLDER("unusedPlaceHolder"),
     RESET_IDENTITY("resetIdentity"),
     INHERITED_IDENTITY("inheritedIdentity"),
-    REPROVE_IDENTITY_ENABLED("reproveIdentityEnabled"),
     REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
     TICF_CRI_BETA("ticfCriBeta"),
     EVCS_WRITE_ENABLED("evcsWriteEnabled"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 
@@ -55,13 +54,7 @@ public class ClientOAuthSessionDetailsService {
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
         clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
         clientOAuthSessionItem.setScope(claimsSet.getStringClaim("scope"));
-
-        Boolean reproveIdentity =
-                configService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_ENABLED)
-                        ? claimsSet.getBooleanClaim("reprove_identity")
-                        : null;
-
-        clientOAuthSessionItem.setReproveIdentity(reproveIdentity);
+        clientOAuthSessionItem.setReproveIdentity(claimsSet.getBooleanClaim("reprove_identity"));
         clientOAuthSessionItem.setEvcsAccessToken(evcsAccessToken);
         dataStore.create(clientOAuthSessionItem, BACKEND_SESSION_TTL);
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
@@ -7,7 +7,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -69,8 +68,6 @@ class ClientOAuthSessionDetailsServiceTest {
     @Test
     void shouldCreateClientOAuthSessionItem() throws ParseException {
         String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
-
-        when(mockConfigService.enabled(CoreFeatureFlag.REPROVE_IDENTITY_ENABLED)).thenReturn(true);
 
         JWTClaimsSet testClaimSet =
                 new JWTClaimsSet.Builder()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove reprove identity feature flag

### Why did it change

The feature is now fully enabled

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5512](https://govukverify.atlassian.net/browse/PYIC-5512)


[PYIC-5512]: https://govukverify.atlassian.net/browse/PYIC-5512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ