### PR TITLE
PYIC-6816: use cri enum in SessionCredentialItem and SessionCredentialsService

### DIFF
--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
@@ -113,18 +113,10 @@ class BuildUserIdentityHandlerTest {
         List<SessionCredentialItem> sessionCredentials = new ArrayList<>();
         var passportCredential =
                 new SessionCredentialItem(
-                        IPV_SESSION_ID,
-                        DCMAW.getId(),
-                        passportVcBuilder.buildSignedJwt(),
-                        true,
-                        null);
+                        IPV_SESSION_ID, DCMAW, passportVcBuilder.buildSignedJwt(), true, null);
         var addressCredential =
                 new SessionCredentialItem(
-                        IPV_SESSION_ID,
-                        ADDRESS.getId(),
-                        addressVcBuilder.buildSignedJwt(),
-                        true,
-                        null);
+                        IPV_SESSION_ID, ADDRESS, addressVcBuilder.buildSignedJwt(), true, null);
         sessionCredentials.add(passportCredential);
         sessionCredentials.add(addressCredential);
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredential.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredential.java
@@ -99,6 +99,6 @@ public class VerifiableCredential {
     public SessionCredentialItem toSessionCredentialItem(
             String ipvSessionId, boolean receivedThisSession) {
         return new SessionCredentialItem(
-                ipvSessionId, cri.getId(), signedJwt, receivedThisSession, migrated);
+                ipvSessionId, cri, signedJwt, receivedThisSession, migrated);
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItem.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbIgnor
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.Cri;
 
 import java.time.Instant;
 
@@ -28,12 +29,12 @@ public class SessionCredentialItem implements DynamodbItem {
 
     public SessionCredentialItem(
             String ipvSessionId,
-            String criId,
+            Cri cri,
             SignedJWT signedCredJwt,
             boolean receivedThisSession,
             Instant migrated) {
         this.ipvSessionId = ipvSessionId;
-        this.sortKey = String.format(SORT_KEY_TEMPLATE, criId, signedCredJwt.getSignature());
+        this.sortKey = String.format(SORT_KEY_TEMPLATE, cri.getId(), signedCredJwt.getSignature());
         this.credential = signedCredJwt.serialize();
         this.receivedThisSession = receivedThisSession;
         this.migrated = migrated;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/VerifiableCredentialTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.Cri.DRIVING_LICENCE;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
 
 class VerifiableCredentialTest {
@@ -153,7 +154,7 @@ class VerifiableCredentialTest {
     void fromSessionCredentialItemShouldCreateAVerifiableCredential() throws Exception {
         var now = Instant.now();
         var sessionCredentialItem =
-                new SessionCredentialItem(SESSION_ID, CRI_ID, vcFixture.getSignedJwt(), true, now);
+                new SessionCredentialItem(SESSION_ID, CRI, vcFixture.getSignedJwt(), true, now);
         var generatedVc =
                 VerifiableCredential.fromSessionCredentialItem(sessionCredentialItem, USER_ID);
 
@@ -169,7 +170,7 @@ class VerifiableCredentialTest {
     void fromSessionCredentialItemShouldThrowCredentialParseExceptionIfVCParserThrowsException() {
         var now = Instant.now();
         var sessionCredentialItem =
-                new SessionCredentialItem(SESSION_ID, CRI_ID, vcFixture.getSignedJwt(), true, now);
+                new SessionCredentialItem(SESSION_ID, CRI, vcFixture.getSignedJwt(), true, now);
         try (MockedStatic<VerifiableCredentialParser> mockVcParser =
                 mockStatic(VerifiableCredentialParser.class)) {
             mockVcParser
@@ -189,7 +190,7 @@ class VerifiableCredentialTest {
         var mockSignedJwt = mock(SignedJWT.class);
         when(mockSignedJwt.serialize()).thenReturn("👽");
         var sessionCredentialItem =
-                new SessionCredentialItem(SESSION_ID, CRI_ID, mockSignedJwt, true, null);
+                new SessionCredentialItem(SESSION_ID, CRI, mockSignedJwt, true, null);
 
         assertThrows(
                 CredentialParseException.class,
@@ -206,7 +207,7 @@ class VerifiableCredentialTest {
 
         var expected =
                 new SessionCredentialItem(
-                        SESSION_ID, "drivingLicence", vcFixture.getSignedJwt(), true, now);
+                        SESSION_ID, DRIVING_LICENCE, vcFixture.getSignedJwt(), true, now);
 
         assertEquals(expected.getIpvSessionId(), sessionCredentialItem.getIpvSessionId());
         assertEquals(expected.getSortKey(), sessionCredentialItem.getSortKey());

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItemTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/SessionCredentialItemTest.java
@@ -12,10 +12,10 @@ import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 
 @ExtendWith(MockitoExtension.class)
 class SessionCredentialItemTest {
-    private static final String CRI_ID = "cri-id";
     private static final String SESSION_ID = "session-id";
     private static final String SIGNATURE = "signature";
     @Mock private SignedJWT mockJwt;
@@ -25,16 +25,16 @@ class SessionCredentialItemTest {
     public void setUp() {
         when(mockJwt.getSignature()).thenReturn(Base64URL.encode(SIGNATURE));
         sessionCredentialItem =
-                new SessionCredentialItem(SESSION_ID, CRI_ID, mockJwt, true, Instant.now());
+                new SessionCredentialItem(SESSION_ID, ADDRESS, mockJwt, true, Instant.now());
     }
 
     @Test
     void shouldCorrectlyFormSortKey() {
-        assertEquals("cri-id#c2lnbmF0dXJl", sessionCredentialItem.getSortKey());
+        assertEquals("address#c2lnbmF0dXJl", sessionCredentialItem.getSortKey());
     }
 
     @Test
     void getCriIdShouldDoWhatYouThinkItShould() {
-        assertEquals(CRI_ID, sessionCredentialItem.getCriId());
+        assertEquals(ADDRESS.getId(), sessionCredentialItem.getCriId());
     }
 }

--- a/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
+++ b/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
@@ -175,7 +175,7 @@ public class CriStoringService {
                 if (criId.equals(ADDRESS.getId())) {
                     // Remove any existing address VC from session credentials - for 6MFC
                     sessionCredentialsService.deleteSessionCredentialsForCri(
-                            ipvSessionItem.getIpvSessionId(), ADDRESS.getId());
+                            ipvSessionItem.getIpvSessionId(), ADDRESS);
                 }
                 sessionCredentialsService.persistCredentials(
                         List.of(vc), ipvSessionItem.getIpvSessionId(), true);

--- a/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
+++ b/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
@@ -233,8 +233,7 @@ class CriStoringServiceTest {
 
         // Assert
         verify(mockSessionCredentialsService)
-                .deleteSessionCredentialsForCri(
-                        mockIpvSessionItem.getIpvSessionId(), ADDRESS.getId());
+                .deleteSessionCredentialsForCri(mockIpvSessionItem.getIpvSessionId(), ADDRESS);
         verify(mockSessionCredentialsService)
                 .persistCredentials(List.of(vc), mockIpvSessionItem.getIpvSessionId(), true);
         verify(mockIpvSessionItem, times(0)).setRiskAssessmentCredential(vc.getVcString());

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType;
@@ -137,8 +138,9 @@ public class SessionCredentialsService {
         }
     }
 
-    public void deleteSessionCredentialsForCri(String ipvSessionId, String criId)
+    public void deleteSessionCredentialsForCri(String ipvSessionId, Cri cri)
             throws VerifiableCredentialException {
+        var criId = cri.getId();
         try {
             var deleted = dataStore.delete(dataStore.getItemsBySortKeyPrefix(ipvSessionId, criId));
             LOGGER.info(

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -105,21 +105,21 @@ class SessionCredentialsServiceTest {
             var item1 =
                     new SessionCredentialItem(
                             SESSION_ID,
-                            CREDENTIAL_1.getCri().getId(),
+                            CREDENTIAL_1.getCri(),
                             CREDENTIAL_1.getSignedJwt(),
                             false,
                             now);
             var item2 =
                     new SessionCredentialItem(
                             SESSION_ID,
-                            CREDENTIAL_2.getCri().getId(),
+                            CREDENTIAL_2.getCri(),
                             CREDENTIAL_2.getSignedJwt(),
                             false,
                             now.plusSeconds(10));
             var item3 =
                     new SessionCredentialItem(
                             SESSION_ID,
-                            CREDENTIAL_3.getCri().getId(),
+                            CREDENTIAL_3.getCri(),
                             CREDENTIAL_3.getSignedJwt(),
                             true,
                             null);
@@ -144,7 +144,7 @@ class SessionCredentialsServiceTest {
             var item1 =
                     new SessionCredentialItem(
                             SESSION_ID,
-                            CREDENTIAL_1.getCri().getId(),
+                            CREDENTIAL_1.getCri(),
                             CREDENTIAL_1.getSignedJwt(),
                             false,
                             null);
@@ -168,7 +168,7 @@ class SessionCredentialsServiceTest {
 
             var sessionCredentialItem =
                     new SessionCredentialItem(
-                            SESSION_ID, CREDENTIAL_1.getCri().getId(), mockSignedJwt, false, null);
+                            SESSION_ID, CREDENTIAL_1.getCri(), mockSignedJwt, false, null);
             when(mockDataStore.getItems(SESSION_ID)).thenReturn(List.of(sessionCredentialItem));
 
             var caughtException =
@@ -228,7 +228,7 @@ class SessionCredentialsServiceTest {
                     .thenReturn(List.of(sessionCredentialItem));
 
             sessionCredentialService.deleteSessionCredentialsForCri(
-                    SESSION_ID, CREDENTIAL_1.getCri().getId());
+                    SESSION_ID, CREDENTIAL_1.getCri());
 
             verify(mockDataStore)
                     .getItemsBySortKeyPrefix(SESSION_ID, CREDENTIAL_1.getCri().getId());
@@ -329,7 +329,7 @@ class SessionCredentialsServiceTest {
                             VerifiableCredentialException.class,
                             () ->
                                     sessionCredentialService.deleteSessionCredentialsForCri(
-                                            SESSION_ID, CREDENTIAL_1.getCri().getId()));
+                                            SESSION_ID, CREDENTIAL_1.getCri()));
 
             assertEquals(
                     HTTPResponse.SC_SERVER_ERROR, verifiableCredentialException.getResponseCode());
@@ -348,7 +348,7 @@ class SessionCredentialsServiceTest {
                             VerifiableCredentialException.class,
                             () ->
                                     sessionCredentialService.deleteSessionCredentialsForCri(
-                                            SESSION_ID, CREDENTIAL_1.getCri().getId()));
+                                            SESSION_ID, CREDENTIAL_1.getCri()));
 
             assertEquals(
                     HTTPResponse.SC_SERVER_ERROR, verifiableCredentialException.getResponseCode());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Use the CRI enum rather than a string in the SessionCredentialItem and SessionCredentialsService

### What changed 
- SessionCredentialItem
 - SessionCredentialsService
 - Assoicated method calls and tests that use the CriCallbackRequest object

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

Since the CRI enum was introduced in an earlier PR, we can use it in the code where a string CRI ID is used, to ensure that all passed CRI ids are valid

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-6816

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

