### PR TITLE
PYIC-5759: update identity claim to use vocab classes

### DIFF
--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
+			libs.diVocab,
 			project(":libs:common-services"),
 			project(":libs:verifiable-credentials"),
 			project(":libs:user-identity-service")

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -20,7 +20,6 @@ import uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain.ProvenUserIdenti
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.exceptions.ProvenUserIdentityDetailsException;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.Address;
-import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.ProfileType;
@@ -41,6 +40,7 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
+import uk.gov.di.model.BirthDate;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -163,7 +163,7 @@ public class BuildProvenUserIdentityDetailsHandler
                         500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
             }
 
-            BirthDate birthDate =
+            var birthDate =
                     mapper.convertValue(identityClaim.get().getBirthDate().get(0), BirthDate.class);
 
             return new NameAndDateOfBirth(

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/NameAndDateOfBirth.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/NameAndDateOfBirth.java
@@ -1,9 +1,0 @@
-package uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain;
-
-import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.model.NamePart;
-
-import java.util.List;
-
-@ExcludeFromGeneratedCoverageReport
-public record NameAndDateOfBirth(String name, List<NamePart> nameParts, String dateOfBirth) {}

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/NameAndDateOfBirth.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/NameAndDateOfBirth.java
@@ -1,9 +1,9 @@
 package uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain;
 
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.NameParts;
+import uk.gov.di.model.NamePart;
 
 import java.util.List;
 
 @ExcludeFromGeneratedCoverageReport
-public record NameAndDateOfBirth(String name, List<NameParts> nameParts, String dateOfBirth) {}
+public record NameAndDateOfBirth(String name, List<NamePart> nameParts, String dateOfBirth) {}

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/ProvenUserIdentityDetails.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/domain/ProvenUserIdentityDetails.java
@@ -7,7 +7,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.Address;
-import uk.gov.di.ipv.core.library.domain.NameParts;
+import uk.gov.di.model.NamePart;
 
 import java.util.List;
 
@@ -17,14 +17,14 @@ import java.util.List;
 @Builder
 public class ProvenUserIdentityDetails {
     @JsonProperty private final String name;
-    @JsonProperty private final List<NameParts> nameParts;
+    @JsonProperty private final List<NamePart> nameParts;
     @JsonProperty private final String dateOfBirth;
     @JsonProperty private final List<Address> addresses;
 
     @JsonCreator
     public ProvenUserIdentityDetails(
             @JsonProperty(value = "name") String name,
-            @JsonProperty(value = "nameParts") List<NameParts> nameParts,
+            @JsonProperty(value = "nameParts") List<NamePart> nameParts,
             @JsonProperty(value = "dateOfBirth") String dateOfBirth,
             @JsonProperty(value = "addresses") List<Address> addresses) {
         this.name = name;

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -22,7 +22,6 @@ import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
-import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -57,6 +56,8 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcPassportM1aFailed
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcPassportMissingBirthDate;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcPassportMissingName;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcVerificationM1a;
+import static uk.gov.di.ipv.core.library.helpers.NameHelper.NamePartHelper.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.NameHelper.createName;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
 
@@ -482,9 +483,9 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     private Optional<IdentityClaim> createIdentityClaim() {
         var names =
                 Collections.singletonList(
-                        NameHelper.createName(
+                        createName(
                                 Collections.singletonList(
-                                        NameHelper.NamePartHelper.createNamePart(
+                                        createNamePart(
                                                 "KENNETH DECERQUEIRA",
                                                 NamePart.NamePartType.GIVEN_NAME))));
 

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -16,7 +16,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain.ProvenUserIdentityDetails;
 import uk.gov.di.ipv.core.library.domain.Address;
-import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.Name;
@@ -24,6 +23,7 @@ import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -485,7 +485,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                         new Name(
                                 Collections.singletonList(
                                         new NameParts("KENNETH DECERQUEIRA", "dummyType"))));
-        var birthDates = Collections.singletonList(new BirthDate("1965-07-08"));
+
+        var birthDates = Collections.singletonList(BirthDateHelper.createBirthDate("1965-07-08"));
 
         return Optional.of(new IdentityClaim(names, birthDates));
     }

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -21,8 +21,8 @@ import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
-import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
+import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
@@ -56,10 +56,10 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcPassportM1aFailed
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcPassportMissingBirthDate;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcPassportMissingName;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcVerificationM1a;
-import static uk.gov.di.ipv.core.library.helpers.NameHelper.NamePartHelper.createNamePart;
-import static uk.gov.di.ipv.core.library.helpers.NameHelper.createName;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IPV_SESSION_ID_HEADER;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.IP_ADDRESS_HEADER;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.NamePartGenerator.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
 
 @ExtendWith(MockitoExtension.class)
 class BuildProvenUserIdentityDetailsHandlerTest {
@@ -489,7 +489,8 @@ class BuildProvenUserIdentityDetailsHandlerTest {
                                                 "KENNETH DECERQUEIRA",
                                                 NamePart.NamePartType.GIVEN_NAME))));
 
-        var birthDates = Collections.singletonList(BirthDateHelper.createBirthDate("1965-07-08"));
+        var birthDates =
+                Collections.singletonList(BirthDateGenerator.createBirthDate("1965-07-08"));
 
         return Optional.of(new IdentityClaim(names, birthDates));
     }

--- a/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
+++ b/lambdas/build-proven-user-identity-details/src/test/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandlerTest.java
@@ -18,12 +18,11 @@ import uk.gov.di.ipv.core.buildprovenuseridentitydetails.domain.ProvenUserIdenti
 import uk.gov.di.ipv.core.library.domain.Address;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
-import uk.gov.di.ipv.core.library.domain.Name;
-import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
+import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -33,6 +32,7 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
+import uk.gov.di.model.NamePart;
 
 import java.util.Collections;
 import java.util.List;
@@ -482,9 +482,11 @@ class BuildProvenUserIdentityDetailsHandlerTest {
     private Optional<IdentityClaim> createIdentityClaim() {
         var names =
                 Collections.singletonList(
-                        new Name(
+                        NameHelper.createName(
                                 Collections.singletonList(
-                                        new NameParts("KENNETH DECERQUEIRA", "dummyType"))));
+                                        NameHelper.NamePartHelper.createNamePart(
+                                                "KENNETH DECERQUEIRA",
+                                                NamePart.NamePartType.GIVEN_NAME))));
 
         var birthDates = Collections.singletonList(BirthDateHelper.createBirthDate("1965-07-08"));
 

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -24,7 +24,6 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsUserIdentity;
 import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.domain.AuditEventReturnCode;
-import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -43,6 +42,7 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -54,6 +54,7 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
+import uk.gov.di.model.BirthDate;
 import uk.gov.di.model.DrivingPermitDetails;
 import uk.gov.di.model.PassportDetails;
 import uk.gov.di.model.PostalAddress;
@@ -154,7 +155,9 @@ class BuildUserIdentityHandlerTest {
         List<Name> names =
                 Collections.singletonList(
                         new Name(Collections.singletonList(new NameParts("GivenName", "Daniel"))));
-        List<BirthDate> birthDates = Collections.singletonList(new BirthDate("1990-02-10"));
+
+        List<BirthDate> birthDates =
+                Collections.singletonList(BirthDateHelper.createBirthDate("1990-02-10"));
 
         userIdentity =
                 new UserIdentity(

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -40,8 +40,8 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
-import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
+import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -90,8 +90,8 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.PASSPORT_JSON_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.VC_ADDRESS;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcTicf;
-import static uk.gov.di.ipv.core.library.helpers.NameHelper.NamePartHelper.createNamePart;
-import static uk.gov.di.ipv.core.library.helpers.NameHelper.createName;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.NamePartGenerator.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
 
 @ExtendWith(MockitoExtension.class)
 class BuildUserIdentityHandlerTest {
@@ -162,7 +162,7 @@ class BuildUserIdentityHandlerTest {
                                                 "Daniel", NamePart.NamePartType.GIVEN_NAME))));
 
         List<BirthDate> birthDates =
-                Collections.singletonList(BirthDateHelper.createBirthDate("1990-02-10"));
+                Collections.singletonList(BirthDateGenerator.createBirthDate("1990-02-10"));
 
         userIdentity =
                 new UserIdentity(

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -41,7 +41,6 @@ import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
-import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -91,6 +90,8 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.PASSPORT_JSON_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.VC_ADDRESS;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcTicf;
+import static uk.gov.di.ipv.core.library.helpers.NameHelper.NamePartHelper.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.NameHelper.createName;
 
 @ExtendWith(MockitoExtension.class)
 class BuildUserIdentityHandlerTest {
@@ -155,9 +156,9 @@ class BuildUserIdentityHandlerTest {
 
         List<Name> names =
                 Collections.singletonList(
-                        NameHelper.createName(
+                        createName(
                                 Collections.singletonList(
-                                        NameHelper.NamePartHelper.createNamePart(
+                                        createNamePart(
                                                 "Daniel", NamePart.NamePartType.GIVEN_NAME))));
 
         List<BirthDate> birthDates =

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -29,8 +29,6 @@ import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.JourneyState;
-import uk.gov.di.ipv.core.library.domain.Name;
-import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.domain.ReturnCode;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
@@ -43,6 +41,7 @@ import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
+import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -56,6 +55,8 @@ import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.model.BirthDate;
 import uk.gov.di.model.DrivingPermitDetails;
+import uk.gov.di.model.Name;
+import uk.gov.di.model.NamePart;
 import uk.gov.di.model.PassportDetails;
 import uk.gov.di.model.PostalAddress;
 import uk.gov.di.model.SocialSecurityRecordDetails;
@@ -154,7 +155,10 @@ class BuildUserIdentityHandlerTest {
 
         List<Name> names =
                 Collections.singletonList(
-                        new Name(Collections.singletonList(new NameParts("GivenName", "Daniel"))));
+                        NameHelper.createName(
+                                Collections.singletonList(
+                                        NameHelper.NamePartHelper.createNamePart(
+                                                "Daniel", NamePart.NamePartType.GIVEN_NAME))));
 
         List<BirthDate> birthDates =
                 Collections.singletonList(BirthDateHelper.createBirthDate("1990-02-10"));

--- a/lambdas/check-coi/build.gradle
+++ b/lambdas/check-coi/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
 	implementation libs.bundles.awsLambda,
+			libs.diVocab,
 			project(":libs:common-services"),
 			project(":libs:audit-service"),
 			project(":libs:journey-uris"),

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -20,8 +20,6 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCoiCheck;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
-import uk.gov.di.ipv.core.library.domain.Name;
-import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
 import uk.gov.di.ipv.core.library.domain.ScopeConstants;
@@ -34,6 +32,7 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
+import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -44,6 +43,7 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
+import uk.gov.di.model.NamePart;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -121,11 +121,14 @@ class CheckCoiHandlerTest {
         }
 
         private Optional<IdentityClaim> getMockIdentityClaim() {
-            var mockNameParts = new NameParts("Kenneth Decerqueira", "full-name");
+            var mockNameParts =
+                    NameHelper.NamePartHelper.createNamePart(
+                            "Kenneth Decerqueira", NamePart.NamePartType.FAMILY_NAME);
             var mockBirthDate = BirthDateHelper.createBirthDate("1965-07-08");
             return Optional.of(
                     new IdentityClaim(
-                            List.of(new Name(List.of(mockNameParts))), List.of(mockBirthDate)));
+                            List.of(NameHelper.createName(List.of(mockNameParts))),
+                            List.of(mockBirthDate)));
         }
 
         @Nested

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -32,7 +32,6 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
-import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -72,6 +71,8 @@ import static uk.gov.di.ipv.core.library.enums.CoiCheckType.FULL_NAME_AND_DOB;
 import static uk.gov.di.ipv.core.library.enums.CoiCheckType.GIVEN_NAMES_AND_DOB;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_EXPERIAN_FRAUD_VC;
+import static uk.gov.di.ipv.core.library.helpers.NameHelper.NamePartHelper.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.NameHelper.createName;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_COI_CHECK_FAILED_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_COI_CHECK_PASSED_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -122,13 +123,11 @@ class CheckCoiHandlerTest {
 
         private Optional<IdentityClaim> getMockIdentityClaim() {
             var mockNameParts =
-                    NameHelper.NamePartHelper.createNamePart(
-                            "Kenneth Decerqueira", NamePart.NamePartType.FAMILY_NAME);
+                    createNamePart("Kenneth Decerqueira", NamePart.NamePartType.FAMILY_NAME);
             var mockBirthDate = BirthDateHelper.createBirthDate("1965-07-08");
             return Optional.of(
                     new IdentityClaim(
-                            List.of(NameHelper.createName(List.of(mockNameParts))),
-                            List.of(mockBirthDate)));
+                            List.of(createName(List.of(mockNameParts))), List.of(mockBirthDate)));
         }
 
         @Nested

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -31,7 +31,7 @@ import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
-import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
+import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -71,8 +71,8 @@ import static uk.gov.di.ipv.core.library.enums.CoiCheckType.FULL_NAME_AND_DOB;
 import static uk.gov.di.ipv.core.library.enums.CoiCheckType.GIVEN_NAMES_AND_DOB;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_EXPERIAN_FRAUD_VC;
-import static uk.gov.di.ipv.core.library.helpers.NameHelper.NamePartHelper.createNamePart;
-import static uk.gov.di.ipv.core.library.helpers.NameHelper.createName;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.NamePartGenerator.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_COI_CHECK_FAILED_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_COI_CHECK_PASSED_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -124,7 +124,7 @@ class CheckCoiHandlerTest {
         private Optional<IdentityClaim> getMockIdentityClaim() {
             var mockNameParts =
                     createNamePart("Kenneth Decerqueira", NamePart.NamePartType.FAMILY_NAME);
-            var mockBirthDate = BirthDateHelper.createBirthDate("1965-07-08");
+            var mockBirthDate = BirthDateGenerator.createBirthDate("1965-07-08");
             return Optional.of(
                     new IdentityClaim(
                             List.of(createName(List.of(mockNameParts))), List.of(mockBirthDate)));

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCoiCheck;
-import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.Name;
@@ -34,6 +33,7 @@ import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.helpers.BirthDateHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -122,7 +122,7 @@ class CheckCoiHandlerTest {
 
         private Optional<IdentityClaim> getMockIdentityClaim() {
             var mockNameParts = new NameParts("Kenneth Decerqueira", "full-name");
-            var mockBirthDate = new BirthDate("1965-07-08");
+            var mockBirthDate = BirthDateHelper.createBirthDate("1965-07-08");
             return Optional.of(
                     new IdentityClaim(
                             List.of(new Name(List.of(mockNameParts))), List.of(mockBirthDate)));

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -74,6 +74,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.text.ParseException;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
@@ -91,6 +92,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -786,8 +788,14 @@ class InitialiseIpvSessionHandlerTest {
             when(mockVerifiableCredentialService.getVc(TEST_USER_ID, HMRC_MIGRATION.getId()))
                     .thenReturn(null);
 
-            // Act
-            initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+            try (MockedStatic<LocalDate> mockLocalDate =
+                    mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+                var mockTodayDate = LocalDate.of(2024, 7, 7);
+                mockLocalDate.when(LocalDate::now).thenReturn(mockTodayDate);
+
+                // Act
+                initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+            }
 
             // Assert
             ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 			libs.awsSdkUrlConnectionClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
+			libs.diVocab,
 			project(":libs:common-services"),
 			project(":libs:gpg45-evaluator"),
 			project(":libs:verifiable-credentials")

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
@@ -3,8 +3,8 @@ package uk.gov.di.ipv.core.library.auditing.restricted;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.Name;
+import uk.gov.di.model.BirthDate;
 
 import java.util.List;
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
@@ -3,8 +3,8 @@ package uk.gov.di.ipv.core.library.auditing.restricted;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.Name;
 import uk.gov.di.model.BirthDate;
+import uk.gov.di.model.Name;
 
 import java.util.List;
 

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
@@ -3,12 +3,18 @@ package uk.gov.di.ipv.core.library.auditing.helpers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsVcEvidence;
+
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAudit;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForF2F;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForInheritedIdentity;
@@ -23,10 +29,17 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigration;
 @ExtendWith(MockitoExtension.class)
 class AuditExtensionsHelperTest {
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final LocalDate mockTodayDate = LocalDate.of(2024, 7, 7);
 
     @Test
     void shouldGetVerifiableCredentialExtensionsForAudit() throws Exception {
-        var auditExtensions = getExtensionsForAudit(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, false);
+        AuditExtensionsVcEvidence auditExtensions;
+        try (MockedStatic<LocalDate> mockLocalDate =
+                mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+            mockLocalDate.when(LocalDate::now).thenReturn(mockTodayDate);
+            auditExtensions = getExtensionsForAudit(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, false);
+        }
+
         assertFalse(auditExtensions.successful());
         assertTrue(auditExtensions.isUkIssued());
         assertEquals(58, auditExtensions.age());

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IdentityClaim.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IdentityClaim.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import uk.gov.di.model.BirthDate;
 
 import java.util.List;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IdentityClaim.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IdentityClaim.java
@@ -24,6 +24,7 @@ public class IdentityClaim {
     }
 
     // Return the first name that we have (they should all be the same for now)
+    // and concatenate all the name parts together into a single string.
     @JsonIgnore
     public String getFullName() {
         StringBuilder nameBuilder = new StringBuilder();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IdentityClaim.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IdentityClaim.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import uk.gov.di.model.BirthDate;
+import uk.gov.di.model.Name;
+import uk.gov.di.model.NamePart;
 
 import java.util.List;
 
@@ -24,11 +26,23 @@ public class IdentityClaim {
     // Return the first name that we have (they should all be the same for now)
     @JsonIgnore
     public String getFullName() {
-        return name.get(0).getFullName();
+        StringBuilder nameBuilder = new StringBuilder();
+        name.get(0)
+                .getNameParts()
+                .forEach(
+                        namePart -> {
+                            if (nameBuilder.isEmpty()) {
+                                nameBuilder.append(namePart.getValue());
+                            } else {
+                                nameBuilder.append(" ").append(namePart.getValue());
+                            }
+                        });
+
+        return nameBuilder.toString();
     }
 
     @JsonIgnore
-    public List<NameParts> getNameParts() {
+    public List<NamePart> getNameParts() {
         return name.get(0).getNameParts();
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Name.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Name.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 
@@ -16,21 +15,5 @@ public class Name {
 
     public List<NameParts> getNameParts() {
         return nameParts;
-    }
-
-    // Concatenate all the name parts together into a single string.
-    @JsonIgnore
-    public String getFullName() {
-        StringBuilder nameBuilder = new StringBuilder();
-        nameParts.forEach(
-                namePart -> {
-                    if (nameBuilder.isEmpty()) {
-                        nameBuilder.append(namePart.getValue());
-                    } else {
-                        nameBuilder.append(" ").append(namePart.getValue());
-                    }
-                });
-
-        return nameBuilder.toString();
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/BirthDateHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/BirthDateHelper.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import uk.gov.di.model.BirthDate;
+
+public class BirthDateHelper {
+    public static BirthDate createBirthDate(String value) {
+        var birthDate = new BirthDate();
+        birthDate.setValue(value);
+        return birthDate;
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/BirthDateHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/BirthDateHelper.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.core.library.helpers;
 import uk.gov.di.model.BirthDate;
 
 public class BirthDateHelper {
+    private BirthDateHelper() {}
+
     public static BirthDate createBirthDate(String value) {
         var birthDate = new BirthDate();
         birthDate.setValue(value);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import uk.gov.di.model.Name;
+import uk.gov.di.model.NamePart;
+
+import java.util.List;
+
+public class NameHelper {
+    public static Name createName(List<NamePart> nameParts) {
+        var name = new Name();
+        name.setNameParts(nameParts);
+        return name;
+    }
+
+    public static class NamePartHelper {
+        public static NamePart createNamePart(String value, NamePart.NamePartType type) {
+            var namePart = new NamePart();
+            namePart.setValue(value);
+            namePart.setType(type);
+            return namePart;
+        }
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
@@ -6,6 +6,8 @@ import uk.gov.di.model.NamePart;
 import java.util.List;
 
 public class NameHelper {
+    private NameHelper() {}
+
     public static Name createName(List<NamePart> nameParts) {
         var name = new Name();
         name.setNameParts(nameParts);
@@ -13,6 +15,8 @@ public class NameHelper {
     }
 
     public static class NamePartHelper {
+        private NamePartHelper() {}
+
         public static NamePart createNamePart(String value, NamePart.NamePartType type) {
             var namePart = new NamePart();
             namePart.setValue(value);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/IdentityClaimTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/IdentityClaimTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.model.BirthDate;
 
 import java.util.Arrays;
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/IdentityClaimTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/IdentityClaimTest.java
@@ -1,11 +1,15 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.model.BirthDate;
+import uk.gov.di.model.NamePart;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.ipv.core.library.helpers.NameHelper.NamePartHelper.createNamePart;
 
 class IdentityClaimTest {
 
@@ -15,15 +19,23 @@ class IdentityClaimTest {
         var underTest =
                 new IdentityClaim(
                         Arrays.asList(
-                                new Name(
+                                NameHelper.createName(
                                         Arrays.asList(
-                                                new NameParts("FirstNamePart1", "dummyType"),
-                                                new NameParts("FirstNamePart2", "dummyType"))),
-                                new Name(
+                                                createNamePart(
+                                                        "FirstNamePart1",
+                                                        NamePart.NamePartType.GIVEN_NAME),
+                                                createNamePart(
+                                                        "FirstNamePart2",
+                                                        NamePart.NamePartType.FAMILY_NAME))),
+                                NameHelper.createName(
                                         Arrays.asList(
-                                                new NameParts("SecondNamePart1", "dummyType"),
-                                                new NameParts("SecondNamePart2", "dummyType")))),
-                        Arrays.asList(new BirthDate()));
+                                                createNamePart(
+                                                        "SecondNamePart1",
+                                                        NamePart.NamePartType.GIVEN_NAME),
+                                                createNamePart(
+                                                        "SecondNamePart2",
+                                                        NamePart.NamePartType.FAMILY_NAME)))),
+                        List.of(new BirthDate()));
 
         // Act
         var result = underTest.getFullName();
@@ -38,15 +50,23 @@ class IdentityClaimTest {
         var underTest =
                 new IdentityClaim(
                         Arrays.asList(
-                                new Name(
+                                NameHelper.createName(
                                         Arrays.asList(
-                                                new NameParts("FirstNamePart1", "dummyType"),
-                                                new NameParts("FirstNamePart2", "dummyType"))),
-                                new Name(
+                                                createNamePart(
+                                                        "FirstNamePart1",
+                                                        NamePart.NamePartType.GIVEN_NAME),
+                                                createNamePart(
+                                                        "FirstNamePart2",
+                                                        NamePart.NamePartType.FAMILY_NAME))),
+                                NameHelper.createName(
                                         Arrays.asList(
-                                                new NameParts("SecondNamePart1", "dummyType"),
-                                                new NameParts("SecondNamePart2", "dummyType")))),
-                        Arrays.asList(new BirthDate()));
+                                                createNamePart(
+                                                        "SecondNamePart1",
+                                                        NamePart.NamePartType.GIVEN_NAME),
+                                                createNamePart(
+                                                        "SecondNamePart2",
+                                                        NamePart.NamePartType.FAMILY_NAME)))),
+                        List.of(new BirthDate()));
 
         // Act
         var result = underTest.getNameParts();

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/IdentityClaimTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/IdentityClaimTest.java
@@ -1,7 +1,7 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.di.ipv.core.library.helpers.NameHelper;
+import uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator;
 import uk.gov.di.model.BirthDate;
 import uk.gov.di.model.NamePart;
 
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.di.ipv.core.library.helpers.NameHelper.NamePartHelper.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.NamePartGenerator.createNamePart;
 
 class IdentityClaimTest {
 
@@ -19,7 +19,7 @@ class IdentityClaimTest {
         var underTest =
                 new IdentityClaim(
                         Arrays.asList(
-                                NameHelper.createName(
+                                NameGenerator.createName(
                                         Arrays.asList(
                                                 createNamePart(
                                                         "FirstNamePart1",
@@ -27,7 +27,7 @@ class IdentityClaimTest {
                                                 createNamePart(
                                                         "FirstNamePart2",
                                                         NamePart.NamePartType.FAMILY_NAME))),
-                                NameHelper.createName(
+                                NameGenerator.createName(
                                         Arrays.asList(
                                                 createNamePart(
                                                         "SecondNamePart1",
@@ -50,7 +50,7 @@ class IdentityClaimTest {
         var underTest =
                 new IdentityClaim(
                         Arrays.asList(
-                                NameHelper.createName(
+                                NameGenerator.createName(
                                         Arrays.asList(
                                                 createNamePart(
                                                         "FirstNamePart1",
@@ -58,7 +58,7 @@ class IdentityClaimTest {
                                                 createNamePart(
                                                         "FirstNamePart2",
                                                         NamePart.NamePartType.FAMILY_NAME))),
-                                NameHelper.createName(
+                                NameGenerator.createName(
                                         Arrays.asList(
                                                 createNamePart(
                                                         "SecondNamePart1",

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/NameTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/NameTest.java
@@ -9,34 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class NameTest {
 
     @Test
-    void getFullName_whenCalledWithOneNameWithOneNamePart_ReturnsTheNamePart() {
-        // Arrange
-        var underTest = new Name(Arrays.asList(new NameParts("SingleNamePart", "dummyType")));
-
-        // Act
-        var result = underTest.getFullName();
-
-        // Assert
-        assertEquals("SingleNamePart", result);
-    }
-
-    @Test
-    void getFullName_whenCalledWithOneNameWithMultipleNameParts_ReturnsTheNamePartsConcatenated() {
-        // Arrange
-        var underTest =
-                new Name(
-                        Arrays.asList(
-                                new NameParts("FirstNamePart", "dummyType"),
-                                new NameParts("SecondNamePart", "dummyType")));
-
-        // Act
-        var result = underTest.getFullName();
-
-        // Assert
-        assertEquals("FirstNamePart SecondNamePart", result);
-    }
-
-    @Test
     void getNameParts_whenCalledWithOneNameWithOneNamePart_ReturnsTheNamePart() {
         // Arrange
         var underTest = new Name(Arrays.asList(new NameParts("SingleNamePart", "dummyType")));

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/vocab/BirthDateGenerator.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/vocab/BirthDateGenerator.java
@@ -1,9 +1,9 @@
-package uk.gov.di.ipv.core.library.helpers;
+package uk.gov.di.ipv.core.library.helpers.vocab;
 
 import uk.gov.di.model.BirthDate;
 
-public class BirthDateHelper {
-    private BirthDateHelper() {}
+public class BirthDateGenerator {
+    private BirthDateGenerator() {}
 
     public static BirthDate createBirthDate(String value) {
         var birthDate = new BirthDate();

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/vocab/NameGenerator.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/vocab/NameGenerator.java
@@ -1,12 +1,12 @@
-package uk.gov.di.ipv.core.library.helpers;
+package uk.gov.di.ipv.core.library.helpers.vocab;
 
 import uk.gov.di.model.Name;
 import uk.gov.di.model.NamePart;
 
 import java.util.List;
 
-public class NameHelper {
-    private NameHelper() {}
+public class NameGenerator {
+    private NameGenerator() {}
 
     public static Name createName(List<NamePart> nameParts) {
         var name = new Name();
@@ -14,8 +14,8 @@ public class NameHelper {
         return name;
     }
 
-    public static class NamePartHelper {
-        private NamePartHelper() {}
+    public static class NamePartGenerator {
+        private NamePartGenerator() {}
 
         public static NamePart createNamePart(String value, NamePart.NamePartType type) {
             var namePart = new NamePart();

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -515,7 +515,7 @@ public class UserIdentityService {
     private IdentityClaim getIdentityClaim(VerifiableCredential vc) {
         if (vc.getCredential().getCredentialSubject() instanceof PersonWithIdentity person) {
 
-            List<uk.gov.di.model.Name> names = requireNonNullElse(person.getName(), List.of());
+            List<Name> names = requireNonNullElse(person.getName(), List.of());
 
             List<BirthDate> birthDates = requireNonNullElse(person.getBirthDate(), List.of());
 
@@ -746,7 +746,7 @@ public class UserIdentityService {
         return vcs.stream().filter(this::isEvidenceVc).toList();
     }
 
-    private String getMissingNames(List<uk.gov.di.model.Name> names) {
+    private String getMissingNames(List<Name> names) {
         if (CollectionUtils.isEmpty(names)) {
             return "Name list";
         }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -9,7 +9,6 @@ import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
-import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.domain.ProfileType;
 import uk.gov.di.ipv.core.library.domain.ReturnCode;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
@@ -45,8 +44,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
-import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import static java.util.Objects.requireNonNullElse;
+import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COI_CHECK_FAMILY_NAME_CHARS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_ALWAYS_REQUIRED;
@@ -503,12 +502,6 @@ public class UserIdentityService {
                 .distinct()
                 .sorted()
                 .map(ReturnCode::new)
-                .toList();
-    }
-
-    private List<NameParts> getNamePartsFromCredentialSubjectName(uk.gov.di.model.Name name) {
-        return name.getNameParts().stream()
-                .map(np -> new NameParts(np.getValue(), np.getType().toString()))
                 .toList();
     }
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.awssdk.utils.StringUtils;
-import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ContraIndicators;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -26,6 +25,7 @@ import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.model.AddressCredential;
+import uk.gov.di.model.BirthDate;
 import uk.gov.di.model.DrivingPermitDetails;
 import uk.gov.di.model.IdentityCheck;
 import uk.gov.di.model.IdentityCheckCredential;
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
+import static java.util.Objects.requireNonNullElse;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COI_CHECK_FAMILY_NAME_CHARS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_ALWAYS_REQUIRED;
@@ -522,12 +523,7 @@ public class UserIdentityService {
                                     .toList()
                             : List.of();
 
-            List<BirthDate> birthDates =
-                    person.getBirthDate() != null
-                            ? person.getBirthDate().stream()
-                                    .map(bd -> new BirthDate(bd.getValue()))
-                                    .toList()
-                            : List.of();
+            List<BirthDate> birthDates = requireNonNullElse(person.getBirthDate(), List.of());
 
             return new IdentityClaim(names, birthDates);
 

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -41,6 +41,7 @@ import uk.gov.di.ipv.core.library.exceptions.NoVcStatusForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.fixtures.TestFixtures;
 import uk.gov.di.model.DrivingPermitDetails;
+import uk.gov.di.model.NamePart;
 import uk.gov.di.model.PassportDetails;
 import uk.gov.di.model.PostalAddress;
 import uk.gov.di.model.SocialSecurityRecordDetails;
@@ -991,7 +992,9 @@ class UserIdentityServiceTest {
         // Assert
         IdentityClaim identityClaim = credentials.getIdentityClaim();
 
-        assertEquals("GivenName", identityClaim.getName().get(0).getNameParts().get(0).getType());
+        assertEquals(
+                NamePart.NamePartType.GIVEN_NAME,
+                identityClaim.getName().get(0).getNameParts().get(0).getType());
         assertEquals("KENNETH", identityClaim.getName().get(0).getNameParts().get(0).getValue());
 
         assertEquals("1965-07-08", identityClaim.getBirthDate().get(0).getValue());
@@ -1019,7 +1022,9 @@ class UserIdentityServiceTest {
         // Assert
         IdentityClaim identityClaim = credentials.getIdentityClaim();
 
-        assertEquals("GivenName", identityClaim.getName().get(0).getNameParts().get(0).getType());
+        assertEquals(
+                NamePart.NamePartType.GIVEN_NAME,
+                identityClaim.getName().get(0).getNameParts().get(0).getType());
         assertEquals("KENNETH", identityClaim.getName().get(0).getNameParts().get(0).getValue());
 
         assertEquals("1965-07-08", identityClaim.getBirthDate().get(0).getValue());
@@ -1984,7 +1989,9 @@ class UserIdentityServiceTest {
         assertEquals("test-sub", credentials.getSub());
 
         IdentityClaim identityClaim = credentials.getIdentityClaim();
-        assertEquals("GivenName", identityClaim.getName().get(0).getNameParts().get(0).getType());
+        assertEquals(
+                NamePart.NamePartType.GIVEN_NAME,
+                identityClaim.getName().get(0).getNameParts().get(0).getType());
         assertEquals("KENNETH", identityClaim.getName().get(0).getNameParts().get(0).getValue());
         assertEquals("1965-07-08", identityClaim.getBirthDate().get(0).getValue());
     }
@@ -2003,7 +2010,9 @@ class UserIdentityServiceTest {
         assertEquals("test-sub", credentials.getSub());
 
         IdentityClaim identityClaim = credentials.getIdentityClaim();
-        assertEquals("GivenName", identityClaim.getName().get(0).getNameParts().get(0).getType());
+        assertEquals(
+                NamePart.NamePartType.GIVEN_NAME,
+                identityClaim.getName().get(0).getNameParts().get(0).getType());
         assertEquals("KENNETH", identityClaim.getName().get(0).getNameParts().get(0).getValue());
         assertEquals("1965-07-08", identityClaim.getBirthDate().get(0).getValue());
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update `IdentityClaim` to use Name and NamePart classes from vocab.

User JSON info for name and birth date before and after changes:
| Before | After |
| - | - |
| <img width="585" alt="Screenshot 2024-07-07 at 18 09 57" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/d1c78524-255a-4f65-ade3-f725984ed751"> | <img width="597" alt="Screenshot 2024-07-07 at 18 20 15" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/fe1a1196-d6aa-4810-830c-7f71e0bdbff8"> |

### Why did it change

We want to use the classes provided by vocab instead of the current json handling.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5759](https://govukverify.atlassian.net/browse/PYIC-5759)


[PYIC-5759]: https://govukverify.atlassian.net/browse/PYIC-5759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ