### PR TITLE
PYIC-6883: Use async client for Audit service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ spotless {
 subprojects {
 	task allDeps(type: DependencyReportTask) {}
 	configurations.all {
+		exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
 		exclude group: 'software.amazon.awssdk', module: 'apache-client'
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ spotless {
 subprojects {
 	task allDeps(type: DependencyReportTask) {}
 	configurations.all {
-		exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
 		exclude group: 'software.amazon.awssdk', module: 'apache-client'
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ awsSdkKms = { module = "software.amazon.awssdk:kms" }
 awsSdkLambda = { module = "software.amazon.awssdk:lambda" }
 awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
 awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
+awsSdkCrtClient = { module = "software.amazon.awssdk:aws-crt-client" }
 commonsCodec = "commons-codec:commons-codec:1.17.0"
 diVocab = "uk.gov.di.model:di-data-model-jackson:v1.7.1"
 hamcrest = "org.hamcrest:hamcrest:2.2"

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -73,7 +73,7 @@ public class BuildClientOauthResponseHandler
         this.sessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.authRequestValidator = new AuthRequestValidator(configService);
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
     }
 
     public BuildClientOauthResponseHandler(
@@ -225,6 +225,8 @@ public class BuildClientOauthResponseHandler
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -8,13 +8,17 @@ import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.buildclientoauthresponse.domain.ClientResponse;
@@ -64,8 +68,9 @@ class BuildClientOauthResponseHandlerTest {
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
     private static final String TEST_CLIENT_OAUTH_SESSION_ID =
             SecureTokenHelper.getInstance().generate();
-    public static final String TEST_FEATURE_SET = "fs-001";
+    private static final String TEST_FEATURE_SET = "fs-001";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String SKIP_CHECK_AUDIT_EVENT_WAIT_TAG = "skipCheckAuditEventWait";
 
     @Mock private Context context;
     @Mock private IpvSessionService mockSessionService;
@@ -73,20 +78,21 @@ class BuildClientOauthResponseHandlerTest {
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionService;
     @Mock private AuthRequestValidator mockAuthRequestValidator;
     @Mock private AuditService mockAuditService;
-
-    private BuildClientOauthResponseHandler handler;
+    @InjectMocks private BuildClientOauthResponseHandler handler;
     private String authorizationCode;
 
     @BeforeEach
     void setUp() {
         authorizationCode = new AuthorizationCode().getValue();
-        handler =
-                new BuildClientOauthResponseHandler(
-                        mockSessionService,
-                        mockConfigService,
-                        mockClientOAuthSessionService,
-                        mockAuthRequestValidator,
-                        mockAuditService);
+    }
+
+    @AfterEach
+    void checkAuditEventWait(TestInfo testInfo) {
+        if (!testInfo.getTags().contains(SKIP_CHECK_AUDIT_EVENT_WAIT_TAG)) {
+            InOrder auditInOrder = inOrder(mockAuditService);
+            auditInOrder.verify(mockAuditService).awaitAuditEvents();
+            auditInOrder.verifyNoMoreInteractions();
+        }
     }
 
     @Test
@@ -286,6 +292,7 @@ class BuildClientOauthResponseHandlerTest {
     }
 
     @Test
+    @Tag(SKIP_CHECK_AUDIT_EVENT_WAIT_TAG)
     void shouldReturn400IfCanNotParseAuthRequestFromQueryStringParams() {
         when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
                 .thenReturn(ValidationResult.createValidResult());

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -131,7 +131,7 @@ public class BuildCriOauthRequestHandler
     public BuildCriOauthRequestHandler() {
         this.configService = new ConfigService();
         this.signerFactory = new KmsEs256SignerFactory();
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
@@ -252,6 +252,8 @@ public class BuildCriOauthRequestHandler
                     e,
                     SC_INTERNAL_SERVER_ERROR,
                     FAILED_TO_PARSE_EVIDENCE_REQUESTED);
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -16,6 +16,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -75,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -271,6 +274,13 @@ class BuildCriOauthRequestHandlerTest {
         ipvSessionItem.setIpvSessionId(SESSION_ID);
         ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setEmailAddress(TEST_EMAIL_ADDRESS);
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(mockAuditService);
+        auditInOrder.verify(mockAuditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @Test

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -84,7 +84,7 @@ public class BuildUserIdentityHandler extends UserIdentityRequestHandler
     public BuildUserIdentityHandler() {
         super(OPENID);
         this.userIdentityService = new UserIdentityService(configService);
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.ciMitService = new CiMitService(configService);
         this.ciMitUtilityService = new CiMitUtilityService(configService);
     }
@@ -161,6 +161,8 @@ public class BuildUserIdentityHandler extends UserIdentityRequestHandler
             return getExpiredAccessTokenApiGatewayProxyResponseEvent(e.getExpiredAt());
         } catch (InvalidScopeException e) {
             return getAccessDeniedApiGatewayProxyResponseEvent();
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -12,10 +12,12 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -68,6 +70,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -175,6 +178,13 @@ class BuildUserIdentityHandlerTest {
         ipvSessionItem.setFeatureSet("someCoolNewThing");
 
         clientOAuthSessionItem = getClientAuthSessionItemWithScope(OPENID_SCOPE);
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(mockAuditService);
+        auditInOrder.verify(mockAuditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @Test

--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandler.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandler.java
@@ -52,6 +52,7 @@ public class CallDcmawAsyncCriHandler
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final DcmawAsyncCriService dcmawAsyncCriService;
     private final CriStoringService criStoringService;
+    private final AuditService auditService;
 
     @ExcludeFromGeneratedCoverageReport
     public CallDcmawAsyncCriHandler() {
@@ -59,10 +60,11 @@ public class CallDcmawAsyncCriHandler
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.dcmawAsyncCriService = new DcmawAsyncCriService(configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.criStoringService =
                 new CriStoringService(
                         configService,
-                        new AuditService(AuditService.getSqsClient(), configService),
+                        auditService,
                         new CriResponseService(configService),
                         new SessionCredentialsService(configService),
                         new CiMitService(configService));
@@ -73,12 +75,14 @@ public class CallDcmawAsyncCriHandler
             IpvSessionService ipvSessionService,
             ClientOAuthSessionDetailsService clientOAuthSessionDetailsService,
             DcmawAsyncCriService dcmawAsyncCriService,
-            CriStoringService criStoringService) {
+            CriStoringService criStoringService,
+            AuditService auditService) {
         this.configService = configService;
         this.ipvSessionService = ipvSessionService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
         this.dcmawAsyncCriService = dcmawAsyncCriService;
         this.criStoringService = criStoringService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -134,6 +138,7 @@ public class CallDcmawAsyncCriHandler
             if (ipvSessionItem != null) {
                 ipvSessionService.updateIpvSession(ipvSessionItem);
             }
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandlerTest.java
+++ b/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandlerTest.java
@@ -2,9 +2,11 @@ package uk.gov.di.ipv.core.calldcmawasynccri;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -14,6 +16,7 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
@@ -26,6 +29,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
@@ -54,12 +58,20 @@ class CallDcmawAsyncCriHandlerTest {
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionDetailsService;
     @Mock private DcmawAsyncCriService mockDcmawAsyncCriService;
     @Mock private CriStoringService mockCriStoringService;
+    @Mock private AuditService mockAuditService;
     private static final IpvSessionItem mockIpvSessionItem = new IpvSessionItem();
     @InjectMocks private CallDcmawAsyncCriHandler callDcmawAsyncCriHandler;
 
     @BeforeEach
     public void setUp() {
         mockIpvSessionItem.setIpvSessionId("a-session-id");
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(mockAuditService);
+        auditInOrder.verify(mockAuditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @Test

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -59,6 +59,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
     private final CiMitService ciMitService;
     private final CiMitUtilityService ciMitUtilityService;
     private final CriStoringService criStoringService;
+    private final AuditService auditService;
 
     @ExcludeFromGeneratedCoverageReport
     public CallTicfCriHandler() {
@@ -68,10 +69,11 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
         this.ticfCriService = new TicfCriService(configService);
         this.ciMitService = new CiMitService(configService);
         this.ciMitUtilityService = new CiMitUtilityService(configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.criStoringService =
                 new CriStoringService(
                         configService,
-                        new AuditService(AuditService.getSqsClient(), configService),
+                        auditService,
                         null,
                         new SessionCredentialsService(configService),
                         ciMitService);
@@ -85,7 +87,8 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
             TicfCriService ticfCriService,
             CiMitService ciMitService,
             CiMitUtilityService ciMitUtilityService,
-            CriStoringService criStoringService) {
+            CriStoringService criStoringService,
+            AuditService auditService) {
         this.configService = configService;
         this.ipvSessionService = ipvSessionService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
@@ -93,6 +96,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
         this.ciMitService = ciMitService;
         this.ciMitUtilityService = ciMitUtilityService;
         this.criStoringService = criStoringService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -133,6 +137,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
             if (ipvSessionItem != null) {
                 ipvSessionService.updateIpvSession(ipvSessionItem);
             }
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -96,7 +96,7 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
     @ExcludeFromGeneratedCoverageReport
     public CheckCoiHandler() {
         this.configService = new ConfigService();
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
@@ -212,6 +212,8 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, SC_INTERNAL_SERVER_ERROR, UNKNOWN_CHECK_TYPE)
                     .toObjectMap();
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -55,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -83,6 +86,7 @@ class CheckCoiHandlerTest {
     private static final String CLIENT_SESSION_ID = "client-session-id";
     private static final String USER_ID = "user-id";
     private static final String DEVICE_INFORMATION = "dummy-device-information";
+
     @Mock private ConfigService mockConfigService;
     @Mock private AuditService mockAuditService;
     @Mock private IpvSessionService mockIpvSessionService;
@@ -111,6 +115,13 @@ class CheckCoiHandlerTest {
         when(mockVerifiableCredentialService.getVcs(USER_ID)).thenReturn(List.of(M1A_ADDRESS_VC));
         when(mockSessionCredentialService.getCredentials(IPV_SESSION_ID, USER_ID))
                 .thenReturn(List.of(M1A_EXPERIAN_FRAUD_VC));
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(mockAuditService);
+        auditInOrder.verify(mockAuditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @Nested

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -184,7 +184,7 @@ public class CheckExistingIdentityHandler
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator();
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.criResponseService = new CriResponseService(configService);
         this.ciMitService = new CiMitService(configService);
@@ -231,6 +231,8 @@ public class CheckExistingIdentityHandler
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -171,6 +172,7 @@ class CheckExistingIdentityHandlerTest {
     private static VerifiableCredential pcl200Vc;
     private static VerifiableCredential pcl250Vc;
     private static VerifiableCredential gpg45Vc = vcDrivingPermit();
+
     @Mock private Context context;
     @Mock private UserIdentityService userIdentityService;
     @Mock private CriResponseService criResponseService;
@@ -227,6 +229,13 @@ class CheckExistingIdentityHandlerTest {
                         .vtr(List.of(P2.name()))
                         .evcsAccessToken(EVCS_TEST_TOKEN)
                         .build();
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(auditService);
+        auditInOrder.verify(auditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @Test

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -100,7 +100,7 @@ public class EvaluateGpg45ScoresHandler
         this.userIdentityService = new UserIdentityService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator();
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.sessionCredentialsService = new SessionCredentialsService(configService);
@@ -159,6 +159,8 @@ public class EvaluateGpg45ScoresHandler
             LOGGER.error(LogHelper.buildErrorMessage("Unable to parse credential", e));
             return buildJourneyErrorResponse(
                     ErrorResponse.FAILED_TO_PARSE_SUCCESSFUL_VC_STORE_ITEMS);
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.evaluategpg45scores;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -135,6 +136,13 @@ class EvaluateGpg45ScoresHandlerTest {
                         .clientId("test-client")
                         .govukSigninJourneyId(TEST_JOURNEY_ID)
                         .build();
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(auditService);
+        auditInOrder.verify(auditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @Test

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -113,7 +113,7 @@ public class InitialiseIpvSessionHandler
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
         this.kmsRsaDecrypter = new KmsRsaDecrypter();
         this.jarValidator = new JarValidator(kmsRsaDecrypter, configService);
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
     }
 
     @SuppressWarnings("java:S107") // Methods should not have too many parameters
@@ -308,6 +308,8 @@ public class InitialiseIpvSessionHandler
                     LogHelper.buildErrorMessage("Failed to check if stronger vot vc present.", e));
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatus.SC_BAD_REQUEST, ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -18,6 +18,7 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +30,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -92,6 +94,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -196,6 +199,13 @@ class InitialiseIpvSessionHandlerTest {
         clientOAuthSessionItem.setUserId(TEST_USER_ID);
         clientOAuthSessionItem.setGovukSigninJourneyId("test-journey-id");
         clientOAuthSessionItem.setVtr(List.of("Cl.Cm.P2", "Cl.Cm.PCL200"));
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(mockAuditService);
+        auditInOrder.verify(mockAuditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @Test

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,6 +46,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -105,6 +108,13 @@ class ProcessAsyncCriCredentialHandlerTest {
     @BeforeEach
     void setUp() {
         F2F_VC = vcF2fM1a();
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(auditService);
+        auditInOrder.verify(auditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @ParameterizedTest

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -97,7 +97,7 @@ public class ProcessJourneyEventHandler
     @ExcludeFromGeneratedCoverageReport
     public ProcessJourneyEventHandler() throws IOException {
         this.configService = new ConfigService();
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionService = new ClientOAuthSessionDetailsService(configService);
         this.stateMachines =
@@ -171,6 +171,8 @@ public class ProcessJourneyEventHandler
         } catch (SqsException e) {
             return StepFunctionHelpers.generateErrorOutputMap(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/restore-vcs/src/main/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandler.java
+++ b/lambdas/restore-vcs/src/main/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandler.java
@@ -77,7 +77,7 @@ public class RestoreVcsHandler implements RequestStreamHandler {
                         VcStoreItem.class,
                         DataStore.getClient(),
                         configService);
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
     }
 
     @Override
@@ -105,6 +105,8 @@ public class RestoreVcsHandler implements RequestStreamHandler {
             LOGGER.error(
                     LogHelper.buildErrorMessage(
                             "Stopped restoring VCs because of failure to send audit event", e));
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/restore-vcs/src/test/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandlerTest.java
+++ b/lambdas/restore-vcs/src/test/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandlerTest.java
@@ -1,9 +1,11 @@
 package uk.gov.di.ipv.core.restorevcs;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,6 +21,7 @@ import java.io.InputStream;
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_SUCCESSFUL_VC;
@@ -31,6 +34,13 @@ class RestoreVcsHandlerTest {
     @Mock private AuditService mockAuditService;
     @InjectMocks private RestoreVcsHandler restoreVcsHandler;
     @Captor private ArgumentCaptor<AuditEvent> auditEventArgumentCaptor;
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(mockAuditService);
+        auditInOrder.verify(mockAuditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
+    }
 
     @Test
     void shouldRestoreVc() throws Exception {

--- a/lambdas/revoke-vcs/src/main/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandler.java
+++ b/lambdas/revoke-vcs/src/main/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandler.java
@@ -78,7 +78,7 @@ public class RevokeVcsHandler implements RequestStreamHandler {
                         VcStoreItem.class,
                         DataStore.getClient(),
                         configService);
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
     }
 
     @Override
@@ -110,6 +110,7 @@ public class RevokeVcsHandler implements RequestStreamHandler {
         } finally {
             objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
             objectMapper.writeValue(outputStream, result);
+            auditService.awaitAuditEvents();
         }
     }
 

--- a/lambdas/revoke-vcs/src/test/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandlerTest.java
+++ b/lambdas/revoke-vcs/src/test/java/uk/gov/di/ipv/core/revokevcs/RevokeVcsHandlerTest.java
@@ -1,9 +1,11 @@
 package uk.gov.di.ipv.core.revokevcs;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,6 +26,7 @@ import java.time.Instant;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +42,13 @@ class RevokeVcsHandlerTest {
     @Mock private AuditService mockAuditService;
     @InjectMocks private RevokeVcsHandler revokeVcsHandler;
     @Captor private ArgumentCaptor<AuditEvent> auditEventArgumentCaptor;
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(mockAuditService);
+        auditInOrder.verify(mockAuditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
+    }
 
     @Test
     void shouldRevokeVc() throws Exception {

--- a/lambdas/store-identity/src/main/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandler.java
+++ b/lambdas/store-identity/src/main/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandler.java
@@ -81,7 +81,7 @@ public class StoreIdentityHandler implements RequestHandler<ProcessRequest, Map<
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.sessionCredentialsService = new SessionCredentialsService(configService);
         this.verifiableCredentialService = new VerifiableCredentialService(configService);
-        this.auditService = new AuditService(AuditService.getSqsClient(), configService);
+        this.auditService = new AuditService(AuditService.getSqsClients(), configService);
         this.evcsService = new EvcsService(configService);
     }
 
@@ -151,6 +151,8 @@ public class StoreIdentityHandler implements RequestHandler<ProcessRequest, Map<
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, SC_SERVER_ERROR, FAILED_TO_SEND_AUDIT_EVENT)
                     .toObjectMap();
+        } finally {
+            auditService.awaitAuditEvents();
         }
     }
 }

--- a/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
+++ b/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
@@ -2,12 +2,14 @@ package uk.gov.di.ipv.core.storeidentity;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -131,6 +134,13 @@ class StoreIdentityHandlerTest {
         when(mockSessionCredentialService.getCredentials(SESSION_ID, USER_ID)).thenReturn(VCS);
         when(mockConfigService.getSsmParameter(ConfigurationVariable.COMPONENT_ID))
                 .thenReturn(COMPONENT_ID);
+    }
+
+    @AfterEach
+    void checkAuditEventWait() {
+        InOrder auditInOrder = inOrder(mockAuditService);
+        auditInOrder.verify(mockAuditService).awaitAuditEvents();
+        auditInOrder.verifyNoMoreInteractions();
     }
 
     @Test

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
+			libs.awsSdkCrtClient,
 			libs.awsSdkUrlConnectionClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/exception/AuditException.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/exception/AuditException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.exception;
+
+public class AuditException extends RuntimeException {
+    public AuditException(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
@@ -54,7 +55,10 @@ public class AuditService {
                         .region(EU_WEST_2)
                         .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build(),
-                SqsAsyncClient.builder().region(EU_WEST_2).build());
+                SqsAsyncClient.builder()
+                        .region(EU_WEST_2)
+                        .httpClientBuilder(AwsCrtAsyncHttpClient.builder())
+                        .build());
     }
 
     public void sendAuditEvent(AuditEvent auditEvent) throws SqsException {

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -68,7 +68,7 @@ public class AuditService {
     }
 
     public void awaitAuditEvents() {
-        if (!configService.enabled(SQS_ASYNC)) {
+        if (events.isEmpty()) {
             return;
         }
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -2,46 +2,95 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
+import uk.gov.di.ipv.core.library.exception.AuditException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import static software.amazon.awssdk.regions.Region.EU_WEST_2;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SQS_ASYNC;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.SQS_AUDIT_EVENT_QUEUE_URL;
 
 public class AuditService {
-    private final SqsClient sqs;
-    private final String queueUrl;
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final SqsClients sqsClients;
     private final ObjectMapper objectMapper;
+    private final ConfigService configService;
+    private List<CompletableFuture<SendMessageResponse>> events = new ArrayList<>();
 
-    public AuditService(SqsClient sqs, ConfigService configService) {
-        this.sqs = sqs;
-        this.queueUrl = configService.getEnvironmentVariable(SQS_AUDIT_EVENT_QUEUE_URL);
+    public AuditService(SqsClients sqsClients, ConfigService configService) {
+        this.sqsClients = sqsClients;
+        this.configService = configService;
         this.objectMapper = new ObjectMapper();
     }
 
-    public AuditService(SqsClient sqs, ConfigService configService, ObjectMapper objectMapper) {
-        this.sqs = sqs;
-        this.queueUrl = configService.getEnvironmentVariable(SQS_AUDIT_EVENT_QUEUE_URL);
+    public AuditService(
+            SqsClients sqsClients, ConfigService configService, ObjectMapper objectMapper) {
+        this.sqsClients = sqsClients;
+        this.configService = configService;
         this.objectMapper = objectMapper;
     }
 
-    public static SqsClient getSqsClient() {
-        return SqsClient.builder()
-                .region(EU_WEST_2)
-                .httpClientBuilder(UrlConnectionHttpClient.builder())
-                .build();
+    // Credentials Provider should be set explicitly when creating a new "AwsClient" - not for
+    // SnapStart...
+    @SuppressWarnings("java:S6242")
+    @ExcludeFromGeneratedCoverageReport
+    public static SqsClients getSqsClients() {
+        return new SqsClients(
+                SqsClient.builder()
+                        .region(EU_WEST_2)
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .build(),
+                SqsAsyncClient.builder().region(EU_WEST_2).build());
     }
 
     public void sendAuditEvent(AuditEvent auditEvent) throws SqsException {
+        var sendMessageRequest = buildSendMessageRequest(auditEvent);
+
+        if (configService.enabled(SQS_ASYNC)) {
+            events.add(sqsClients.sqsAsyncClient().sendMessage(sendMessageRequest));
+        } else {
+            sqsClients.sqsClient().sendMessage(sendMessageRequest);
+        }
+    }
+
+    public void awaitAuditEvents() {
+        if (!configService.enabled(SQS_ASYNC)) {
+            return;
+        }
+
         try {
-            sqs.sendMessage(
-                    SendMessageRequest.builder()
-                            .queueUrl(queueUrl)
-                            .messageBody(objectMapper.writeValueAsString(auditEvent))
-                            .build());
+            var eventsToWait = events;
+            events = new ArrayList<>();
+            CompletableFuture.allOf(eventsToWait.toArray(new CompletableFuture[0])).get();
+        } catch (InterruptedException | ExecutionException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to send audit event(s)", e));
+            throw new AuditException("Failed to send audit event(s)", e);
+        }
+    }
+
+    private SendMessageRequest buildSendMessageRequest(AuditEvent auditEvent) throws SqsException {
+        try {
+            return SendMessageRequest.builder()
+                    .queueUrl(configService.getEnvironmentVariable(SQS_AUDIT_EVENT_QUEUE_URL))
+                    .messageBody(objectMapper.writeValueAsString(auditEvent))
+                    .build();
         } catch (JsonProcessingException e) {
             throw new SqsException(e);
         }

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/SqsClients.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/SqsClients.java
@@ -1,0 +1,6 @@
+package uk.gov.di.ipv.core.library.service;
+
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+public record SqsClients(SqsClient sqsClient, SqsAsyncClient sqsAsyncClient) {}

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
@@ -461,6 +461,11 @@ class AuditServiceTest {
                     .when(() -> CompletableFuture.allOf(any(CompletableFuture[].class)))
                     .thenReturn(mockAllOfCompletableFuture);
 
+            var event =
+                    AuditEvent.createWithoutDeviceInformation(
+                            AuditEventTypes.IPV_JOURNEY_START, null, null, null, null);
+            auditService.sendAuditEvent(event);
+
             var auditException =
                     assertThrows(AuditException.class, () -> auditService.awaitAuditEvents());
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -12,7 +12,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     EVCS_READ_ENABLED("evcsReadEnabled"),
     EVCS_TOKEN_READ_ENABLED("evcsTokenReadEnabled"),
     MFA_RESET("mfaResetEnabled"),
-    P1_JOURNEYS_ENABLED("p1JourneysEnabled");
+    P1_JOURNEYS_ENABLED("p1JourneysEnabled"),
+    SQS_ASYNC("sqsAsync");
 
     private final String name;
 


### PR DESCRIPTION
**Not to be merged before https://github.com/govuk-one-login/ipv-core-common-infra/pull/995**

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use async client for Audit service

### Why did it change

This adds the option to use an async SQS client for the Audit Service.

Inititally we want this behind a feature flag, in case we find any issues with it. This requires having two clients ready. Hopefully this won't add too much overhead as they'll only be initialized when used for the first time.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6883](https://govukverify.atlassian.net/browse/PYIC-6883)


[PYIC-6883]: https://govukverify.atlassian.net/browse/PYIC-6883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ