### PR TITLE
PYIC-6959: Create json report from api-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ local-running/bin/
 # User-specific secrets
 secrets.gradle
 
-api-tests/cucumber-report.html
+api-tests/reports/*
+!api-tests/reports/.gitkeep
 api-tests/.npmrc
 api-tests/.env

--- a/api-tests/.prettierignore
+++ b/api-tests/.prettierignore
@@ -1,1 +1,1 @@
-*.html
+reports/

--- a/api-tests/cucumber.js
+++ b/api-tests/cucumber.js
@@ -1,6 +1,9 @@
 export default {
   parallel: 2,
-  format: ["html:cucumber-report.html"],
+  format: [
+    "html:reports/api-tests-cucumber-report.html",
+    "json:reports/api-tests-cucumber-report.json",
+  ],
   publish: true,
   retry: 1,
   loader: ["ts-node/esm"],


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Create json report from api-tests

### Why did it change

The secure pipeline needs test reports to be in a particular format, and it expects cucumber reports to be JSON. This is the same as what we do with the selenium tests.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6959](https://govukverify.atlassian.net/browse/PYIC-6959)


[PYIC-6959]: https://govukverify.atlassian.net/browse/PYIC-6959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ