### PR TITLE
PYIC-6855 Change made to update DataStore to allow delete multiple items in a batch request.

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/BatchDeleteException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/BatchDeleteException.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.core.library.exceptions;
 
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
 public class BatchDeleteException extends Exception {
     public BatchDeleteException(String message) {
         super(message);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/BatchDeleteException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/BatchDeleteException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+public class BatchDeleteException extends Exception {
+    public BatchDeleteException(String message) {
+        super(message);
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -157,10 +157,12 @@ public class DataStore<T extends DynamodbItem> {
         return table.deleteItem(key);
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public void deleteAllByPartition(String partitionValue) {
         delete(getItems(partitionValue));
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public int delete(List<T> items) {
         if (!items.isEmpty()) {
             BatchWriteResult batchWriteResult =
@@ -181,6 +183,7 @@ public class DataStore<T extends DynamodbItem> {
         return items.size();
     }
 
+    @ExcludeFromGeneratedCoverageReport
     private WriteBatch createWriteBatchForDeleteItems(List<T> items) {
         WriteBatch.Builder<T> builder =
                 WriteBatch.builder(this.typeParameterClass).mappedTableResource(this.table);
@@ -190,6 +193,7 @@ public class DataStore<T extends DynamodbItem> {
         return builder.build();
     }
 
+    @ExcludeFromGeneratedCoverageReport
     private BatchWriteResult processBatchWrite(WriteBatch writeBatch) {
         return getClient()
                 .batchWriteItem(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.exceptions.BatchDeleteException;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.DynamodbItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
@@ -174,11 +175,12 @@ public class DataStore<T extends DynamodbItem> {
                     batchWriteResult.unprocessedDeleteItemsForTable(this.table);
             if (!unprocessedItems.isEmpty()) {
                 String errMessage = "Failed during batch deletion.";
-                LOGGER.error(errMessage);
+                LOGGER.error(LogHelper.buildLogMessage(errMessage));
                 throw new BatchDeleteException(errMessage);
             }
+        } else {
+            LOGGER.info(LogHelper.buildLogMessage("No items to delete"));
         }
-        LOGGER.info("No items to delete");
     }
 
     @ExcludeFromGeneratedCoverageReport

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/DataStoreTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/DataStoreTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.library.persistence;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -23,7 +22,6 @@ import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -257,50 +255,5 @@ class DataStoreTest {
         verify(mockDynamoDbTable).deleteItem(keyCaptor.capture());
         assertEquals(PARTITION_VALUE, keyCaptor.getValue().partitionKeyValue().s());
         assertEquals(SORT_KEY_VALUE, keyCaptor.getValue().sortKeyValue().get().s());
-    }
-
-    @Disabled
-    @Test
-    void deleteWithItemListShouldDeleteAllItems() {
-        var item1 = AuthorizationCodeItem.builder().authCode("1").build();
-        var item2 = AuthorizationCodeItem.builder().authCode("2").build();
-        var item3 = AuthorizationCodeItem.builder().authCode("3").build();
-        setupMockForDeletion(item1, item2, item3);
-
-        dataStore.delete(List.of(item1, item2, item3));
-
-        verify(mockDynamoDbEnhancedClient).batchWriteItem(any(BatchWriteItemEnhancedRequest.class));
-    }
-
-    @Disabled
-    @Test
-    void deleteAllByPartitionShouldDeleteItemsFromDynamoDbTableViaPartitionKey() {
-        var item1 = AuthorizationCodeItem.builder().authCode("1").build();
-        var item2 = AuthorizationCodeItem.builder().authCode("2").build();
-        var item3 = AuthorizationCodeItem.builder().authCode("3").build();
-
-        setupMockForDeletion(item1, item2, item3);
-        when(mockPageIterable.stream()).thenReturn(Stream.of(mockPage));
-        when(mockPage.items()).thenReturn(List.of(item1, item2, item3));
-        when(mockDynamoDbTable.query(any(QueryConditional.class))).thenReturn(mockPageIterable);
-
-        dataStore.deleteAllByPartition(PARTITION_VALUE);
-
-        verify(mockDynamoDbTable)
-                .query(
-                        QueryConditional.keyEqualTo(
-                                Key.builder().partitionValue(PARTITION_VALUE).build()));
-        verify(mockDynamoDbEnhancedClient).batchWriteItem(any(BatchWriteItemEnhancedRequest.class));
-    }
-
-    private void setupMockForDeletion(
-            AuthorizationCodeItem item1, AuthorizationCodeItem item2, AuthorizationCodeItem item3) {
-        when(mockDynamoDbTable.tableName()).thenReturn(TEST_TABLE_NAME);
-        when(mockDynamoDbTable.tableSchema())
-                .thenReturn(TableSchema.fromBean(AuthorizationCodeItem.class));
-        when(mockDynamoDbTable.keyFrom(any()))
-                .thenReturn(Key.builder().partitionValue(item1.getAuthCode()).build())
-                .thenReturn(Key.builder().partitionValue(item2.getAuthCode()).build())
-                .thenReturn(Key.builder().partitionValue(item3.getAuthCode()).build());
     }
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -147,7 +147,7 @@ public class SessionCredentialsService {
                     LogHelper.buildLogMessage(
                             String.format(
                                     "Deleted %d credentials for %s from session credentials table",
-                                    deleted.size(), criId)));
+                                    deleted, criId)));
         } catch (Exception e) {
             LOGGER.error(
                     LogHelper.buildErrorMessage(

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -142,12 +142,14 @@ public class SessionCredentialsService {
             throws VerifiableCredentialException {
         var criId = cri.getId();
         try {
-            var deleted = dataStore.delete(dataStore.getItemsBySortKeyPrefix(ipvSessionId, criId));
+            List<SessionCredentialItem> itemsToDelete =
+                    dataStore.getItemsBySortKeyPrefix(ipvSessionId, criId);
+            dataStore.delete(itemsToDelete);
             LOGGER.info(
                     LogHelper.buildLogMessage(
                             String.format(
                                     "Deleted %d credentials for %s from session credentials table",
-                                    deleted, criId)));
+                                    itemsToDelete.size(), criId)));
         } catch (Exception e) {
             LOGGER.error(
                     LogHelper.buildErrorMessage(

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -1,11 +1,13 @@
 package uk.gov.di.ipv.core.library.verifiablecredential.service;
 
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
+import uk.gov.di.ipv.core.library.exceptions.BatchDeleteException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
@@ -17,6 +19,7 @@ import java.util.List;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
 import static uk.gov.di.ipv.core.library.domain.Cri.HMRC_MIGRATION;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_DELETE_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_STORE_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_UPDATE_IDENTITY;
 
@@ -79,6 +82,9 @@ public class VerifiableCredentialService {
         try {
             dataStore.deleteAllByPartition(userId);
             vcs.stream().map(VerifiableCredential::toVcStoreItem).forEach(dataStore::create);
+        } catch (BatchDeleteException e) {
+            throw new VerifiableCredentialException(
+                    HTTPResponse.SC_SERVER_ERROR, FAILED_TO_DELETE_CREDENTIAL);
         } catch (Exception e) {
             throw new VerifiableCredentialException(SC_SERVER_ERROR, FAILED_TO_STORE_IDENTITY);
         }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -2,14 +2,12 @@ package uk.gov.di.ipv.core.library.verifiablecredential.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
-import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -21,7 +19,6 @@ import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
 import static uk.gov.di.ipv.core.library.domain.Cri.HMRC_MIGRATION;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_STORE_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_UPDATE_IDENTITY;
-import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 
 public class VerifiableCredentialService {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -73,27 +70,7 @@ public class VerifiableCredentialService {
         }
     }
 
-    public void deleteVcs(List<VerifiableCredential> vcs, Boolean isUserInitiated) {
-        if (!vcs.isEmpty()) {
-            var message =
-                    new StringMapMessage()
-                            .with(
-                                    LOG_MESSAGE_DESCRIPTION.getFieldName(),
-                                    "Deleting existing issued VCs.")
-                            .with(
-                                    LogHelper.LogField.LOG_NUMBER_OF_VCS.getFieldName(),
-                                    String.valueOf(vcs.size()))
-                            .with(
-                                    LogHelper.LogField.LOG_IS_USER_INITIATED.getFieldName(),
-                                    String.valueOf(isUserInitiated));
-            LOGGER.info(message);
-        }
-        for (var vc : vcs) {
-            deleteVcStoreItem(vc.getUserId(), vc.getCri().getId());
-        }
-    }
-
-    public void deleteVcStoreItem(String userId, String criId) {
+    private void deleteVcStoreItem(String userId, String criId) {
         dataStore.delete(userId, criId);
     }
 

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
+import uk.gov.di.ipv.core.library.exceptions.BatchDeleteException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
@@ -204,7 +205,8 @@ class SessionCredentialsServiceTest {
         }
 
         @Test
-        void deleteSessionCredentialShouldThrowVerifiableCredentialExceptionIfProblemDeleting() {
+        void deleteSessionCredentialShouldThrowVerifiableCredentialExceptionIfProblemDeleting()
+                throws BatchDeleteException {
             doThrow(new IllegalStateException())
                     .when(mockDataStore)
                     .deleteAllByPartition(SESSION_ID);
@@ -338,10 +340,11 @@ class SessionCredentialsServiceTest {
         }
 
         @Test
-        void deleteSessionCredentialsForCriShouldThrowIfProblemDeleting() {
+        void deleteSessionCredentialsForCriShouldThrowIfProblemDeleting()
+                throws BatchDeleteException {
             when(mockDataStore.getItemsBySortKeyPrefix(SESSION_ID, CREDENTIAL_1.getCri().getId()))
                     .thenReturn(List.of());
-            when(mockDataStore.delete(any())).thenThrow(new IllegalStateException());
+            doThrow(new IllegalStateException()).when(mockDataStore).delete(any());
 
             var verifiableCredentialException =
                     assertThrows(

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
@@ -114,22 +114,6 @@ class VerifiableCredentialServiceTest {
     }
 
     @Test
-    void shouldDeleteAllExistingVCs() {
-        var experianVc1 = vcExperianFraudScoreOne();
-        var experianVc2 = vcExperianFraudScoreTwo();
-        var vcs = List.of(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, experianVc1, experianVc2);
-
-        verifiableCredentialService.deleteVcs(vcs, true);
-
-        verify(mockDataStore)
-                .delete(
-                        PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getUserId(),
-                        PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getCri().getId());
-        verify(mockDataStore).delete(experianVc1.getUserId(), experianVc1.getCri().getId());
-        verify(mockDataStore).delete(experianVc2.getUserId(), experianVc2.getCri().getId());
-    }
-
-    @Test
     void shouldDeleteInheritedIdentityIfPresent() throws Exception {
         // Arrange
         var inheritedIdentityVc = vcHmrcMigrationPCL250NoEvidence();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Allow deletion of multiple items in a batch request to dynamoDB.

### What changed
Change made to DataStore to allow delete multiple items in a batch request.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6855](https://govukverify.atlassian.net/browse/PYIC-6855)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-6855]: https://govukverify.atlassian.net/browse/PYIC-6855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ