### PR TITLE
BAU: Render journey map better on small screens

### DIFF
--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -24,18 +24,19 @@ const JOURNEY_TYPES = {
 };
 
 const CRI_NAMES = {
-    address: 'Address CRI',
-    claimedIdentity: 'Claimed Identity CRI',
-    bav: 'Bank account CRI',
-    dcmaw: 'DCMAW (app) CRI',
-    drivingLicence: 'Driving licence (web) CRI',
-    f2f: 'Face-to-face CRI',
-    fraud: 'Experian fraud CRI',
-    hmrcKbv: 'HMRC KBV CRI',
-    kbv: 'Experian KBV CRI',
-    nino: 'NINO CRI',
-    ukPassport: 'Passport (web) CRI',
-    ticf: 'TICF CRI',
+    address: 'Address',
+    claimedIdentity: 'Claimed Identity',
+    bav: 'Bank account',
+    dcmaw: 'DCMAW (app)',
+    drivingLicence: 'Driving licence (web)',
+    dwpKbv: 'DWP KBV',
+    f2f: 'Face-to-face',
+    fraud: 'Experian fraud',
+    hmrcKbv: 'HMRC KBV',
+    kbv: 'Experian KBV',
+    nino: 'HMRC check (NINO)',
+    ukPassport: 'Passport (web)',
+    ticf: 'TICF',
 };
 
 mermaid.initialize({
@@ -158,7 +159,7 @@ const updateView = async () => {
 
 // Render the journey map SVG
 const renderSvg = async (selectedJourney, formData) => {
-    const diagram = render(journeyMaps[selectedJourney], nestedJourneys, formData);
+    const diagram = render(selectedJourney, journeyMaps, nestedJourneys, formData);
     const diagramElement = document.getElementById('diagram');
     const { svg, bindFunctions } = await mermaid.render('diagramSvg', diagram);
     diagramElement.innerHTML = svg;

--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -1,3 +1,4 @@
+const topDownJourneys = ['INITIAL_JOURNEY_SELECTION'];
 const errorJourneys = ['TECHNICAL_ERROR'];
 const failureJourneys = ['INELIGIBLE', 'FAILED'];
 
@@ -237,9 +238,9 @@ const calcOrphanStates = (journeyMap) => {
     return Object.keys(journeyMap).filter(state => !uniqueTargetedStates.includes(state));
 };
 
-export const render = (journeyMap, nestedJourneys, formData = new FormData()) => {
+export const render = (selectedJourney, journeyMaps, nestedJourneys, formData = new FormData()) => {
     // Copy to avoid mutating the input
-    const journeyMapCopy = JSON.parse(JSON.stringify(journeyMap));
+    const journeyMapCopy = JSON.parse(JSON.stringify(journeyMaps[selectedJourney]));
 
     if (formData.has('expandNestedJourneys')) {
         expandNestedJourneys(journeyMapCopy.states, nestedJourneys, formData);
@@ -253,9 +254,11 @@ export const render = (journeyMap, nestedJourneys, formData = new FormData()) =>
 
     const { statesMermaid } = renderStates(journeyMapCopy, states);
 
+    const direction = topDownJourneys.includes(selectedJourney) ? 'TD' : 'LR';
+
     // These styles should be kept in sync with the key in style.css
     const mermaid =
-`graph LR
+`graph ${direction}
     classDef process fill:#ffa,stroke:#000;
     classDef page fill:#ae8,stroke:#000;
     classDef cri fill:#faf,stroke:#000;

--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -36,7 +36,7 @@ body {
     display: flex;
     margin: 16px 0;
     overflow: hidden;
-    max-height: 450px;
+    max-height: 500px;
     transition: max-height 0.15s ease-out, margin 0.15s ease-out;
 }
 #header-content.hidden {


### PR DESCRIPTION
At the moment the journey map renders fairly poorly on small screens - the options panel bunches up and overflows the header, and specifically the initial journey selection screen looks quite poor now there are so many different options.

Before:
![image](https://github.com/govuk-one-login/ipv-core-back/assets/142887793/97a96072-e0fb-4a72-a27e-e8fef70c26fb)

After:
![image](https://github.com/govuk-one-login/ipv-core-back/assets/142887793/b7e99edc-c1e0-4707-8ddf-0dbc6a731aca)
