### PR TITLE
PYIC-5759: update audit event helper to use parsed VCs

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -341,7 +341,7 @@ public class InitialiseIpvSessionHandler
             AuditEventUser auditEventUser,
             String deviceInformation)
             throws RecoverableJarValidationException, ParseException, CredentialParseException,
-                    SqsException, HttpResponseExceptionWithErrorBody {
+                    SqsException {
         try {
             var inheritedIdentityVc =
                     validateHmrcInheritedIdentity(userId, inheritedIdentityJwtClaim);

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -504,8 +504,7 @@ public class InitialiseIpvSessionHandler
             VerifiableCredential inheritedIdentityVc,
             AuditEventUser auditEventUser,
             String deviceInformation)
-            throws SqsException, CredentialParseException, UnrecognisedVotException,
-                    HttpResponseExceptionWithErrorBody {
+            throws SqsException, CredentialParseException, UnrecognisedVotException {
         try {
             auditService.sendAuditEvent(
                     AuditEvent.createWithDeviceInformation(

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -341,7 +341,7 @@ public class InitialiseIpvSessionHandler
             AuditEventUser auditEventUser,
             String deviceInformation)
             throws RecoverableJarValidationException, ParseException, CredentialParseException,
-                    SqsException {
+                    SqsException, HttpResponseExceptionWithErrorBody {
         try {
             var inheritedIdentityVc =
                     validateHmrcInheritedIdentity(userId, inheritedIdentityJwtClaim);
@@ -504,7 +504,8 @@ public class InitialiseIpvSessionHandler
             VerifiableCredential inheritedIdentityVc,
             AuditEventUser auditEventUser,
             String deviceInformation)
-            throws SqsException, CredentialParseException, UnrecognisedVotException {
+            throws SqsException, CredentialParseException, UnrecognisedVotException,
+                    HttpResponseExceptionWithErrorBody {
         try {
             auditService.sendAuditEvent(
                     AuditEvent.createWithDeviceInformation(

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -59,6 +59,8 @@ import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.fixtures.TestFixtures;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.helpers.TestVc;
+import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
+import uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -69,6 +71,7 @@ import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialValidator;
+import uk.gov.di.model.NamePart;
 
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -814,9 +817,9 @@ class InitialiseIpvSessionHandlerTest {
             var expectedAge =
                     Period.between(LocalDate.parse(TestVc.DEFAULT_DOB), LocalDate.now()).getYears();
             var expectedExtension =
-                    new AuditExtensionsVcEvidence(
+                    new AuditExtensionsVcEvidence<>(
                             "https://orch.stubs.account.gov.uk/migration/v1",
-                            OBJECT_MAPPER.valueToTree(List.of()),
+                            List.of(),
                             null,
                             Vot.PCL200,
                             Boolean.TRUE,
@@ -824,12 +827,19 @@ class InitialiseIpvSessionHandlerTest {
             assertEquals(expectedExtension, extension);
             var restricted =
                     (AuditRestrictedInheritedIdentity) inheritedIdentityAuditEvent.getRestricted();
-            assertEquals(
-                    "[{\"nameParts\":[{\"value\":\"KENNETH\",\"type\":\"GivenName\"},{\"value\":\"DECERQUEIRA\",\"type\":\"FamilyName\"}]}]",
-                    OBJECT_MAPPER.writeValueAsString(restricted.name()));
-            assertEquals(
-                    "[{\"value\":\"1965-07-08\"}]",
-                    OBJECT_MAPPER.writeValueAsString(restricted.birthDate()));
+            var expectedName =
+                    List.of(
+                            NameGenerator.createName(
+                                    List.of(
+                                            NameGenerator.NamePartGenerator.createNamePart(
+                                                    "KENNETH", NamePart.NamePartType.GIVEN_NAME),
+                                            NameGenerator.NamePartGenerator.createNamePart(
+                                                    "DECERQUEIRA",
+                                                    NamePart.NamePartType.FAMILY_NAME))));
+
+            var expectedBirthDate = List.of(BirthDateGenerator.createBirthDate("1965-07-08"));
+            assertEquals(expectedName, restricted.name());
+            assertEquals(expectedBirthDate, restricted.birthDate());
             assertEquals(
                     "[{\"personalNumber\":\"AB123456C\"}]",
                     OBJECT_MAPPER.writeValueAsString(restricted.socialSecurityRecord()));

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -59,8 +59,6 @@ import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.fixtures.TestFixtures;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.helpers.TestVc;
-import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
-import uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -119,6 +117,10 @@ import static uk.gov.di.ipv.core.library.domain.VocabConstants.PASSPORT_CLAIM_NA
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL200NoEvidence;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL250NoEvidence;
+import static uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator.createBirthDate;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.NamePartGenerator.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
+import static uk.gov.di.ipv.core.library.helpers.vocab.SocialSecurityRecordDetailsGenerator.createSocialSecurityRecordDetails;
 
 @ExtendWith(MockitoExtension.class)
 class InitialiseIpvSessionHandlerTest {
@@ -829,20 +831,22 @@ class InitialiseIpvSessionHandlerTest {
                     (AuditRestrictedInheritedIdentity) inheritedIdentityAuditEvent.getRestricted();
             var expectedName =
                     List.of(
-                            NameGenerator.createName(
+                            createName(
                                     List.of(
-                                            NameGenerator.NamePartGenerator.createNamePart(
+                                            createNamePart(
                                                     "KENNETH", NamePart.NamePartType.GIVEN_NAME),
-                                            NameGenerator.NamePartGenerator.createNamePart(
+                                            createNamePart(
                                                     "DECERQUEIRA",
                                                     NamePart.NamePartType.FAMILY_NAME))));
 
-            var expectedBirthDate = List.of(BirthDateGenerator.createBirthDate("1965-07-08"));
+            var expectedBirthDate = List.of(createBirthDate("1965-07-08"));
+            var expectedSocialSecurityRecord =
+                    List.of(
+                            createSocialSecurityRecordDetails(
+                                    "AB123456C")); // pragma: allowlist secret
             assertEquals(expectedName, restricted.name());
             assertEquals(expectedBirthDate, restricted.birthDate());
-            assertEquals(
-                    "[{\"personalNumber\":\"AB123456C\"}]",
-                    OBJECT_MAPPER.writeValueAsString(restricted.socialSecurityRecord()));
+            assertEquals(expectedSocialSecurityRecord, restricted.socialSecurityRecord());
 
             assertEquals(
                     AuditEventTypes.IPV_JOURNEY_START,

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -815,7 +815,7 @@ class InitialiseIpvSessionHandlerTest {
             assertEquals(
                     AuditEventTypes.IPV_INHERITED_IDENTITY_VC_RECEIVED,
                     inheritedIdentityAuditEvent.getEventName());
-            var extension = (AuditExtensionsVcEvidence) inheritedIdentityAuditEvent.getExtensions();
+            var extension = inheritedIdentityAuditEvent.getExtensions();
             var expectedAge =
                     Period.between(LocalDate.parse(TestVc.DEFAULT_DOB), LocalDate.now()).getYears();
             var expectedExtension =

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -819,7 +819,7 @@ class InitialiseIpvSessionHandlerTest {
             var expectedAge =
                     Period.between(LocalDate.parse(TestVc.DEFAULT_DOB), LocalDate.now()).getYears();
             var expectedExtension =
-                    new AuditExtensionsVcEvidence<>(
+                    new AuditExtensionsVcEvidence(
                             "https://orch.stubs.account.gov.uk/migration/v1",
                             List.of(),
                             null,

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -134,7 +134,8 @@ public class ProcessAsyncCriCredentialHandler
                 | UnrecognisedVotException
                 | CiPostMitigationsException
                 | CredentialParseException
-                | EvcsServiceException | HttpResponseExceptionWithErrorBody e) {
+                | EvcsServiceException
+                | HttpResponseExceptionWithErrorBody e) {
             LOGGER.error(LogHelper.buildErrorMessage("Failed to process VC response message.", e));
             return List.of(new SQSBatchResponse.BatchItemFailure(message.getMessageId()));
         } catch (VerifiableCredentialException e) {

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -258,7 +258,7 @@ public class ProcessAsyncCriCredentialHandler
 
     @Tracing
     void sendIpvVcConsumedAuditEvent(AuditEventUser auditEventUser, VerifiableCredential vc)
-            throws SqsException, HttpResponseExceptionWithErrorBody {
+            throws SqsException {
         AuditEvent auditEvent =
                 AuditEvent.createWithoutDeviceInformation(
                         AuditEventTypes.IPV_F2F_CRI_VC_CONSUMED,

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -133,7 +134,7 @@ public class ProcessAsyncCriCredentialHandler
                 | UnrecognisedVotException
                 | CiPostMitigationsException
                 | CredentialParseException
-                | EvcsServiceException e) {
+                | EvcsServiceException | HttpResponseExceptionWithErrorBody e) {
             LOGGER.error(LogHelper.buildErrorMessage("Failed to process VC response message.", e));
             return List.of(new SQSBatchResponse.BatchItemFailure(message.getMessageId()));
         } catch (VerifiableCredentialException e) {
@@ -180,7 +181,8 @@ public class ProcessAsyncCriCredentialHandler
     private void processSuccessAsyncCriResponse(SuccessAsyncCriResponse successAsyncCriResponse)
             throws ParseException, SqsException, CiPutException, AsyncVerifiableCredentialException,
                     CiPostMitigationsException, VerifiableCredentialException,
-                    UnrecognisedVotException, CredentialParseException, EvcsServiceException {
+                    UnrecognisedVotException, CredentialParseException, EvcsServiceException,
+                    HttpResponseExceptionWithErrorBody {
         final CriResponseItem criResponseItem =
                 criResponseService.getCriResponseItem(
                         successAsyncCriResponse.getUserId(),
@@ -255,7 +257,7 @@ public class ProcessAsyncCriCredentialHandler
 
     @Tracing
     void sendIpvVcConsumedAuditEvent(AuditEventUser auditEventUser, VerifiableCredential vc)
-            throws SqsException, CredentialParseException {
+            throws SqsException, HttpResponseExceptionWithErrorBody {
         AuditEvent auditEvent =
                 AuditEvent.createWithoutDeviceInformation(
                         AuditEventTypes.IPV_F2F_CRI_VC_CONSUMED,

--- a/lambdas/restore-vcs/src/main/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandler.java
+++ b/lambdas/restore-vcs/src/main/java/uk/gov/di/ipv/core/restorevcs/RestoreVcsHandler.java
@@ -13,7 +13,6 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
-import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsVcEvidence;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -188,7 +187,9 @@ public class RestoreVcsHandler implements RequestStreamHandler {
             throws SqsException, UnrecognisedVotException, CredentialParseException {
         var auditEventUser = new AuditEventUser(userId, null, null, null);
 
-        AuditExtensionsVcEvidence auditExtensions =
+        var vc = VerifiableCredential.fromVcStoreItem(vcStoreItem);
+
+        var auditExtensions =
                 getExtensionsForAudit(VerifiableCredential.fromVcStoreItem(vcStoreItem), null);
 
         var auditEvent =

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsVcEvidence.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsVcEvidence.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.enums.Vot;
 
+import java.util.List;
+
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @ExcludeFromGeneratedCoverageReport
 public record AuditExtensionsVcEvidence<TEvidence>(
         String iss,
-        TEvidence evidence,
+        List<TEvidence> evidence,
         @JsonInclude(NON_NULL) Boolean successful,
         @JsonInclude(NON_NULL) Vot vot,
         @JsonInclude(NON_NULL) Boolean isUkIssued,

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsVcEvidence.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsVcEvidence.java
@@ -9,9 +9,9 @@ import java.util.List;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @ExcludeFromGeneratedCoverageReport
-public record AuditExtensionsVcEvidence<T>(
+public record AuditExtensionsVcEvidence(
         String iss,
-        List<T> evidence,
+        List<?> evidence,
         @JsonInclude(NON_NULL) Boolean successful,
         @JsonInclude(NON_NULL) Vot vot,
         @JsonInclude(NON_NULL) Boolean isUkIssued,

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsVcEvidence.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsVcEvidence.java
@@ -1,16 +1,15 @@
 package uk.gov.di.ipv.core.library.auditing.extension;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.enums.Vot;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @ExcludeFromGeneratedCoverageReport
-public record AuditExtensionsVcEvidence(
+public record AuditExtensionsVcEvidence<TEvidence>(
         String iss,
-        JsonNode evidence,
+        TEvidence evidence,
         @JsonInclude(NON_NULL) Boolean successful,
         @JsonInclude(NON_NULL) Vot vot,
         @JsonInclude(NON_NULL) Boolean isUkIssued,

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsVcEvidence.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionsVcEvidence.java
@@ -9,9 +9,9 @@ import java.util.List;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @ExcludeFromGeneratedCoverageReport
-public record AuditExtensionsVcEvidence<TEvidence>(
+public record AuditExtensionsVcEvidence<T>(
         String iss,
-        List<TEvidence> evidence,
+        List<T> evidence,
         @JsonInclude(NON_NULL) Boolean successful,
         @JsonInclude(NON_NULL) Vot vot,
         @JsonInclude(NON_NULL) Boolean isUkIssued,

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.auditing.helpers;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsVcEvidence;
@@ -22,17 +21,15 @@ import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 public class AuditExtensionsHelper {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private AuditExtensionsHelper() {}
 
     public static AuditExtensionsVcEvidence getExtensionsForAudit(
             VerifiableCredential vc, Boolean isSuccessful) throws UnrecognisedVotException {
-        var jwtClaimsSet = vc.getClaimsSet();
+        var issuer = vc.getClaimsSet().getIssuer();
         var vot = VcHelper.getVcVot(vc);
         var isUkIssued = VcHelper.checkIfDocUKIssuedForCredential(vc);
         var age = VcHelper.extractAgeFromCredential(vc);
-        var issuer = jwtClaimsSet.getIssuer();
 
         if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
             var identityChecks = identityCheckCredential.getEvidence();
@@ -48,8 +45,7 @@ public class AuditExtensionsHelper {
                     issuer, riskAssessments, isSuccessful, vot, isUkIssued, age);
         }
 
-        return new AuditExtensionsVcEvidence<>(
-                jwtClaimsSet.getIssuer(), null, isSuccessful, vot, isUkIssued, age);
+        return new AuditExtensionsVcEvidence<>(issuer, null, isSuccessful, vot, isUkIssued, age);
     }
 
     public static AuditRestrictedF2F getRestrictedAuditDataForF2F(VerifiableCredential vc)
@@ -86,7 +82,7 @@ public class AuditExtensionsHelper {
 
             return new AuditRestrictedF2F(name);
         } else {
-            LOGGER.error(LogHelper.buildLogMessage("VC not of type IdentityCheckCredential."));
+            LOGGER.warn(LogHelper.buildLogMessage("VC not of type IdentityCheckCredential."));
             return new AuditRestrictedF2F(null);
         }
     }

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -9,7 +9,6 @@ import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedInheritedId
 import uk.gov.di.ipv.core.library.auditing.restricted.DeviceInformation;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
-import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -83,7 +82,7 @@ public class AuditExtensionsHelper {
 
     public static AuditRestrictedInheritedIdentity getRestrictedAuditDataForInheritedIdentity(
             VerifiableCredential vc, String deviceInformation)
-            throws CredentialParseException, HttpResponseExceptionWithErrorBody {
+            throws HttpResponseExceptionWithErrorBody {
         if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
             var credentialSubject = getCredentialSubjectOrThrow(identityCheckCredential);
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -13,12 +13,9 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
-import uk.gov.di.model.IdentityCheck;
 import uk.gov.di.model.IdentityCheckCredential;
 import uk.gov.di.model.IdentityCheckSubject;
 import uk.gov.di.model.RiskAssessmentCredential;
-
-import java.util.List;
 
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 
@@ -40,7 +37,7 @@ public class AuditExtensionsHelper {
         if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
             var identityChecks = identityCheckCredential.getEvidence();
 
-            return new AuditExtensionsVcEvidence<List<IdentityCheck>>(
+            return new AuditExtensionsVcEvidence<>(
                     issuer, identityChecks, isSuccessful, vot, isUkIssued, age);
         }
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.library.auditing.helpers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import org.apache.logging.log4j.LogManager;
@@ -129,15 +128,6 @@ public class AuditExtensionsHelper {
                     new DeviceInformation(deviceInformation));
         } catch (JsonProcessingException e) {
             throw new CredentialParseException("Unable to parse VC for inherited ID audit data", e);
-        }
-    }
-
-    private static List<Name> getNameFromCredentialSubject(JsonNode credentialSubject)
-            throws CredentialParseException {
-        try {
-            return OBJECT_MAPPER.treeToValue(credentialSubject.path(VC_NAME), LIST_NAME_TYPE);
-        } catch (JsonProcessingException e) {
-            throw new CredentialParseException("Unable to get name list from credential subject");
         }
     }
 }

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -1,18 +1,13 @@
 package uk.gov.di.ipv.core.library.auditing.helpers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.CollectionType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsVcEvidence;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedF2F;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedInheritedIdentity;
 import uk.gov.di.ipv.core.library.auditing.restricted.DeviceInformation;
-import uk.gov.di.ipv.core.library.domain.BirthDate;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.Name;
-import uk.gov.di.ipv.core.library.domain.SocialSecurityRecord;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -20,30 +15,16 @@ import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.model.IdentityCheckCredential;
-
-import java.util.List;
+import uk.gov.di.model.IdentityCheckSubject;
 
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
-import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.CLAIMS_CLAIM;
-import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_BIRTH_DATE;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CLAIM;
-import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_CREDENTIAL_SUBJECT;
 import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_EVIDENCE;
-import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_NAME;
-import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC_SOCIAL_SECURITY_RECORD;
 
 public class AuditExtensionsHelper {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    public static final com.fasterxml.jackson.databind.type.CollectionType LIST_NAME_TYPE =
-            OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, Name.class);
-    private static final CollectionType LIST_BIRTH_DATE_TYPE =
-            OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, BirthDate.class);
-    private static final CollectionType LIST_SOCIAL_SECURITY_RECORD_TYPE =
-            OBJECT_MAPPER
-                    .getTypeFactory()
-                    .constructCollectionType(List.class, SocialSecurityRecord.class);
 
     private AuditExtensionsHelper() {}
 
@@ -64,15 +45,7 @@ public class AuditExtensionsHelper {
             throws HttpResponseExceptionWithErrorBody {
 
         if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
-            var credentialSubject = identityCheckCredential.getCredentialSubject();
-
-            if (credentialSubject == null) {
-                LOGGER.error(
-                        LogHelper.buildLogMessage(
-                                ErrorResponse.CREDENTIAL_SUBJECT_MISSING.getMessage()));
-                throw new HttpResponseExceptionWithErrorBody(
-                        500, ErrorResponse.CREDENTIAL_SUBJECT_MISSING);
-            }
+            var credentialSubject = getCredentialSubjectOrThrow(identityCheckCredential);
 
             var name = credentialSubject.getName();
 
@@ -109,25 +82,35 @@ public class AuditExtensionsHelper {
     }
 
     public static AuditRestrictedInheritedIdentity getRestrictedAuditDataForInheritedIdentity(
-            VerifiableCredential vc, String deviceInformation) throws CredentialParseException {
-        var credentialSubject =
-                OBJECT_MAPPER
-                        .valueToTree(vc.getClaimsSet())
-                        .path(CLAIMS_CLAIM)
-                        .path(VC_CLAIM)
-                        .path(VC_CREDENTIAL_SUBJECT);
+            VerifiableCredential vc, String deviceInformation)
+            throws CredentialParseException, HttpResponseExceptionWithErrorBody {
+        if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
+            var credentialSubject = getCredentialSubjectOrThrow(identityCheckCredential);
 
-        try {
             return new AuditRestrictedInheritedIdentity(
-                    OBJECT_MAPPER.treeToValue(credentialSubject.path(VC_NAME), LIST_NAME_TYPE),
-                    OBJECT_MAPPER.treeToValue(
-                            credentialSubject.path(VC_BIRTH_DATE), LIST_BIRTH_DATE_TYPE),
-                    OBJECT_MAPPER.treeToValue(
-                            credentialSubject.path(VC_SOCIAL_SECURITY_RECORD),
-                            LIST_SOCIAL_SECURITY_RECORD_TYPE),
+                    credentialSubject.getName(),
+                    credentialSubject.getBirthDate(),
+                    credentialSubject.getSocialSecurityRecord(),
                     new DeviceInformation(deviceInformation));
-        } catch (JsonProcessingException e) {
-            throw new CredentialParseException("Unable to parse VC for inherited ID audit data", e);
+        } else {
+            LOGGER.error(LogHelper.buildLogMessage("VC must be of type IdentityCheckCredential."));
+            throw new HttpResponseExceptionWithErrorBody(
+                    500, ErrorResponse.CREDENTIAL_SUBJECT_MISSING);
         }
+    }
+
+    private static IdentityCheckSubject getCredentialSubjectOrThrow(
+            IdentityCheckCredential credential) throws HttpResponseExceptionWithErrorBody {
+        var credentialSubject = credential.getCredentialSubject();
+
+        if (credentialSubject == null) {
+            LOGGER.error(
+                    LogHelper.buildLogMessage(
+                            ErrorResponse.CREDENTIAL_SUBJECT_MISSING.getMessage()));
+            throw new HttpResponseExceptionWithErrorBody(
+                    500, ErrorResponse.CREDENTIAL_SUBJECT_MISSING);
+        }
+
+        return credentialSubject;
     }
 }

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -24,7 +24,7 @@ public class AuditExtensionsHelper {
 
     private AuditExtensionsHelper() {}
 
-    public static AuditExtensionsVcEvidence<?> getExtensionsForAudit(
+    public static AuditExtensionsVcEvidence getExtensionsForAudit(
             VerifiableCredential vc, Boolean isSuccessful) throws UnrecognisedVotException {
         var issuer = vc.getClaimsSet().getIssuer();
         var vot = VcHelper.getVcVot(vc);
@@ -34,18 +34,18 @@ public class AuditExtensionsHelper {
         if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
             var identityChecks = identityCheckCredential.getEvidence();
 
-            return new AuditExtensionsVcEvidence<>(
+            return new AuditExtensionsVcEvidence(
                     issuer, identityChecks, isSuccessful, vot, isUkIssued, age);
         }
 
         if (vc.getCredential() instanceof RiskAssessmentCredential riskAssessmentCredential) {
             var riskAssessments = riskAssessmentCredential.getEvidence();
 
-            return new AuditExtensionsVcEvidence<>(
+            return new AuditExtensionsVcEvidence(
                     issuer, riskAssessments, isSuccessful, vot, isUkIssued, age);
         }
 
-        return new AuditExtensionsVcEvidence<>(issuer, null, isSuccessful, vot, isUkIssued, age);
+        return new AuditExtensionsVcEvidence(issuer, null, isSuccessful, vot, isUkIssued, age);
     }
 
     public static AuditRestrictedF2F getRestrictedAuditDataForF2F(VerifiableCredential vc)

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -24,7 +24,7 @@ public class AuditExtensionsHelper {
 
     private AuditExtensionsHelper() {}
 
-    public static AuditExtensionsVcEvidence getExtensionsForAudit(
+    public static AuditExtensionsVcEvidence<?> getExtensionsForAudit(
             VerifiableCredential vc, Boolean isSuccessful) throws UnrecognisedVotException {
         var issuer = vc.getClaimsSet().getIssuer();
         var vot = VcHelper.getVcVot(vc);

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -16,7 +16,6 @@ import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.model.IdentityCheck;
 import uk.gov.di.model.IdentityCheckCredential;
 import uk.gov.di.model.IdentityCheckSubject;
-import uk.gov.di.model.RiskAssessment;
 import uk.gov.di.model.RiskAssessmentCredential;
 
 import java.util.List;
@@ -48,7 +47,7 @@ public class AuditExtensionsHelper {
         if (vc.getCredential() instanceof RiskAssessmentCredential riskAssessmentCredential) {
             var riskAssessments = riskAssessmentCredential.getEvidence();
 
-            return new AuditExtensionsVcEvidence<List<RiskAssessment>>(
+            return new AuditExtensionsVcEvidence<>(
                     issuer, riskAssessments, isSuccessful, vot, isUkIssued, age);
         }
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelper.java
@@ -86,9 +86,8 @@ public class AuditExtensionsHelper {
 
             return new AuditRestrictedF2F(name);
         } else {
-            LOGGER.error(LogHelper.buildLogMessage("VC must be of type IdentityCheckCredential."));
-            throw new HttpResponseExceptionWithErrorBody(
-                    500, ErrorResponse.CREDENTIAL_SUBJECT_MISSING);
+            LOGGER.error(LogHelper.buildLogMessage("VC not of type IdentityCheckCredential."));
+            return new AuditRestrictedF2F(null);
         }
     }
 
@@ -106,7 +105,7 @@ public class AuditExtensionsHelper {
         } else {
             LOGGER.error(LogHelper.buildLogMessage("VC must be of type IdentityCheckCredential."));
             throw new HttpResponseExceptionWithErrorBody(
-                    500, ErrorResponse.CREDENTIAL_SUBJECT_MISSING);
+                    500, ErrorResponse.UNEXPECTED_CREDENTIAL_TYPE);
         }
     }
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedF2F.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedF2F.java
@@ -3,7 +3,7 @@ package uk.gov.di.ipv.core.library.auditing.restricted;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.Name;
+import uk.gov.di.model.Name;
 
 import java.util.List;
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedInheritedIdentity.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedInheritedIdentity.java
@@ -2,9 +2,9 @@ package uk.gov.di.ipv.core.library.auditing.restricted;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.BirthDate;
-import uk.gov.di.ipv.core.library.domain.Name;
-import uk.gov.di.ipv.core.library.domain.SocialSecurityRecord;
+import uk.gov.di.model.BirthDate;
+import uk.gov.di.model.Name;
+import uk.gov.di.model.SocialSecurityRecordDetails;
 
 import java.util.List;
 
@@ -12,7 +12,7 @@ import java.util.List;
 public record AuditRestrictedInheritedIdentity(
         List<Name> name,
         List<BirthDate> birthDate,
-        List<SocialSecurityRecord> socialSecurityRecord,
+        List<SocialSecurityRecordDetails> socialSecurityRecord,
         @JsonProperty(value = "device_information", required = true)
                 DeviceInformation deviceInformation)
         implements AuditRestrictedWithDeviceInformation {}

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.TestVc;
 import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
 import uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator;
@@ -21,7 +19,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAudit;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForF2F;
@@ -133,8 +130,7 @@ class AuditExtensionsHelperTest {
     }
 
     @Test
-    void getRestrictedAuditDataForF2FShouldReturnEmptyAuditRestrictedF2fIfInvalidVcType()
-            throws Exception {
+    void getRestrictedAuditDataForF2FShouldReturnEmptyAuditRestrictedF2fIfInvalidVcType() {
         var restricted = getRestrictedAuditDataForF2F(VC_ADDRESS);
 
         assertNull(restricted.getName());
@@ -142,16 +138,11 @@ class AuditExtensionsHelperTest {
     }
 
     @Test
-    void getRestrictedAuditDataForF2FShouldThrowIfNullCredentialSubject() {
-        HttpResponseExceptionWithErrorBody thrownException =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () ->
-                                getRestrictedAuditDataForF2F(
-                                        vcDrivingPermitNoCredentialSubjectProperty()));
+    void getRestrictedAuditDataForF2FShouldNullValuesIfNullCredentialSubject() {
+        var restricted = getRestrictedAuditDataForF2F(vcDrivingPermitNoCredentialSubjectProperty());
 
-        assertEquals(500, thrownException.getResponseCode());
-        assertEquals(ErrorResponse.CREDENTIAL_SUBJECT_MISSING, thrownException.getErrorResponse());
+        assertNull(restricted.getName());
+        assertNull(restricted.getDocExpiryDate());
     }
 
     @Test
@@ -182,29 +173,31 @@ class AuditExtensionsHelperTest {
     }
 
     @Test
-    void getRestrictedAuditDataForInheritedIdentityShouldThrowIfInvalidVcType() {
-        HttpResponseExceptionWithErrorBody thrownException =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () ->
-                                getRestrictedAuditDataForInheritedIdentity(
-                                        VC_ADDRESS, "test-device-info"));
+    void getRestrictedAuditDataForInheritedIdentityShouldReturnNullValuesIfInvalidVcType()
+            throws Exception {
+        var restricted = getRestrictedAuditDataForInheritedIdentity(VC_ADDRESS, "test_device_data");
 
-        assertEquals(500, thrownException.getResponseCode());
-        assertEquals(ErrorResponse.UNEXPECTED_CREDENTIAL_TYPE, thrownException.getErrorResponse());
+        assertNull(restricted.name());
+        assertNull(restricted.birthDate());
+        assertNull(restricted.socialSecurityRecord());
+        assertEquals(
+                "{\"encoded\":\"test_device_data\"}",
+                OBJECT_MAPPER.writeValueAsString(restricted.deviceInformation()));
     }
 
     @Test
-    void getRestrictedAuditDataForInheritedIdentityShouldThrowIfMissingCredentialSubject() {
-        HttpResponseExceptionWithErrorBody thrownException =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () ->
-                                getRestrictedAuditDataForInheritedIdentity(
-                                        vcDrivingPermitNoCredentialSubjectProperty(),
-                                        "test-device-info"));
+    void
+            getRestrictedAuditDataForInheritedIdentityShouldReturnNullValuesIfMissingCredentialSubject()
+                    throws Exception {
+        var restricted =
+                getRestrictedAuditDataForInheritedIdentity(
+                        vcDrivingPermitNoCredentialSubjectProperty(), "test_device_data");
 
-        assertEquals(500, thrownException.getResponseCode());
-        assertEquals(ErrorResponse.CREDENTIAL_SUBJECT_MISSING, thrownException.getErrorResponse());
+        assertNull(restricted.name());
+        assertNull(restricted.birthDate());
+        assertNull(restricted.socialSecurityRecord());
+        assertEquals(
+                "{\"encoded\":\"test_device_data\"}",
+                OBJECT_MAPPER.writeValueAsString(restricted.deviceInformation()));
     }
 }

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
@@ -4,12 +4,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsVcEvidence;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.TestVc;
+import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
+import uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator;
+import uk.gov.di.ipv.core.library.helpers.vocab.SocialSecurityRecordDetailsGenerator;
+import uk.gov.di.model.IdentityCheck;
+import uk.gov.di.model.NamePart;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -21,7 +28,6 @@ import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForInheritedIdentity;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_SUCCESSFUL_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.VC_ADDRESS;
-import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcAddressTwo;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitMissingDrivingPermit;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitNoCredentialSubjectProperty;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitNonDcmaw;
@@ -35,50 +41,58 @@ class AuditExtensionsHelperTest {
 
     @Test
     void shouldGetVerifiableCredentialExtensionsForAudit() throws Exception {
-        var auditExtensions = getExtensionsForAudit(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, false);
+        AuditExtensionsVcEvidence<IdentityCheck> auditExtensions =
+                getExtensionsForAudit(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, false);
         var expectedAge =
                 Period.between(LocalDate.parse(TestVc.DEFAULT_DOB), LocalDate.now()).getYears();
         assertFalse(auditExtensions.successful());
         assertTrue(auditExtensions.isUkIssued());
         assertEquals(expectedAge, auditExtensions.age());
         assertEquals("https://review-p.staging.account.gov.uk", auditExtensions.iss());
-        assertEquals(2, auditExtensions.evidence().get(0).get("validityScore").asInt());
-        assertEquals(4, auditExtensions.evidence().get(0).get("strengthScore").asInt());
+        assertEquals(2, auditExtensions.evidence().get(0).getValidityScore());
+        assertEquals(4, auditExtensions.evidence().get(0).getStrengthScore());
         assertEquals(
-                "1c04edf0-a205-4585-8877-be6bd1776a39",
-                auditExtensions.evidence().get(0).get("txn").asText());
+                "1c04edf0-a205-4585-8877-be6bd1776a39", auditExtensions.evidence().get(0).getTxn());
         assertEquals(
                 2,
-                auditExtensions
-                        .evidence()
-                        .get(0)
-                        .get("checkDetails")
-                        .findValues("dataCheck")
-                        .size());
+                auditExtensions.evidence().get(0).getCheckDetails().stream()
+                        .filter(checkDetail -> checkDetail.getDataCheck() != null)
+                        .count());
     }
 
     @Test
     void shouldGetPassportRestrictedDataForAudit() throws Exception {
         var restrictedData = getRestrictedAuditDataForF2F(PASSPORT_NON_DCMAW_SUCCESSFUL_VC);
-        assertEquals(
-                "{\"name\":[{\"nameParts\":[{\"value\":\"KENNETH\",\"type\":\"GivenName\"},{\"value\":\"DECERQUEIRA\",\"type\":\"FamilyName\"}]}],\"docExpiryDate\":\"2030-01-01\"}",
-                OBJECT_MAPPER.writeValueAsString(restrictedData));
+        var expectedName =
+                List.of(
+                        NameGenerator.createName(
+                                List.of(
+                                        NameGenerator.NamePartGenerator.createNamePart(
+                                                "KENNETH", NamePart.NamePartType.GIVEN_NAME),
+                                        NameGenerator.NamePartGenerator.createNamePart(
+                                                "DECERQUEIRA",
+                                                NamePart.NamePartType.FAMILY_NAME))));
+
+        assertEquals(expectedName, restrictedData.getName());
+        assertEquals("2030-01-01", restrictedData.getDocExpiryDate());
     }
 
     @Test
     void shouldGetDLRestrictedDataForAudit() throws Exception {
         var restrictedData = getRestrictedAuditDataForF2F(vcDrivingPermitNonDcmaw());
-        assertEquals(
-                "{\"name\":[{\"nameParts\":[{\"value\":\"Alice\",\"type\":\"GivenName\"},{\"value\":\"Jane\",\"type\":\"GivenName\"},{\"value\":\"Parker\",\"type\":\"FamilyName\"}]}],\"docExpiryDate\":\"2032-02-02\"}",
-                OBJECT_MAPPER.writeValueAsString(restrictedData));
-    }
+        var expectedName =
+                List.of(
+                        NameGenerator.createName(
+                                List.of(
+                                        NameGenerator.NamePartGenerator.createNamePart(
+                                                "Alice", NamePart.NamePartType.GIVEN_NAME),
+                                        NameGenerator.NamePartGenerator.createNamePart(
+                                                "Jane", NamePart.NamePartType.GIVEN_NAME),
+                                        NameGenerator.NamePartGenerator.createNamePart(
+                                                "Parker", NamePart.NamePartType.FAMILY_NAME))));
 
-    @Test
-    void shouldGetRestrictedDataWithoutDocForAudit() throws Exception {
-        var restrictedData = getRestrictedAuditDataForF2F(vcAddressTwo());
-        assertEquals(
-                "{\"name\":[{\"nameParts\":[{\"value\":\"Alice\",\"type\":\"GivenName\"},{\"value\":\"Jane\",\"type\":\"GivenName\"},{\"value\":\"Parker\",\"type\":\"FamilyName\"}]}],\"docExpiryDate\":null}",
-                OBJECT_MAPPER.writeValueAsString(restrictedData));
+        assertEquals(expectedName, restrictedData.getName());
+        assertEquals("2032-02-02", restrictedData.getDocExpiryDate());
     }
 
     @Test
@@ -106,14 +120,12 @@ class AuditExtensionsHelperTest {
     }
 
     @Test
-    void getRestrictedAuditDataForF2FShouldThrowIfInvalidVcType() {
-        HttpResponseExceptionWithErrorBody thrownException =
-                assertThrows(
-                        HttpResponseExceptionWithErrorBody.class,
-                        () -> getRestrictedAuditDataForF2F(VC_ADDRESS));
+    void getRestrictedAuditDataForF2FShouldReturnEmptyAuditRestrictedF2fIfInvalidVcType()
+            throws Exception {
+        var restricted = getRestrictedAuditDataForF2F(VC_ADDRESS);
 
-        assertEquals(500, thrownException.getResponseCode());
-        assertEquals(ErrorResponse.UNEXPECTED_CREDENTIAL_TYPE, thrownException.getErrorResponse());
+        assertNull(restricted.getName());
+        assertNull(restricted.getDocExpiryDate());
     }
 
     @Test
@@ -134,15 +146,23 @@ class AuditExtensionsHelperTest {
         var restricted =
                 getRestrictedAuditDataForInheritedIdentity(vcHmrcMigration(), "test_device_data");
 
-        assertEquals(
-                "[{\"nameParts\":[{\"value\":\"KENNETH\",\"type\":\"GivenName\"},{\"value\":\"DECERQUEIRA\",\"type\":\"FamilyName\"}]}]",
-                OBJECT_MAPPER.writeValueAsString(restricted.name()));
-        assertEquals(
-                "[{\"value\":\"1965-07-08\"}]",
-                OBJECT_MAPPER.writeValueAsString(restricted.birthDate()));
-        assertEquals(
-                "[{\"personalNumber\":\"AB123456C\"}]",
-                OBJECT_MAPPER.writeValueAsString(restricted.socialSecurityRecord()));
+        var expectedName =
+                List.of(
+                        NameGenerator.createName(
+                                List.of(
+                                        NameGenerator.NamePartGenerator.createNamePart(
+                                                "KENNETH", NamePart.NamePartType.GIVEN_NAME),
+                                        NameGenerator.NamePartGenerator.createNamePart(
+                                                "DECERQUEIRA",
+                                                NamePart.NamePartType.FAMILY_NAME))));
+        var expectedBirthDate = List.of(BirthDateGenerator.createBirthDate("1965-07-08"));
+        var expectedSocialSecurityRecord =
+                List.of(
+                        SocialSecurityRecordDetailsGenerator.createSocialSecurityRecordDetails(
+                                "AB123456C")); // pragma: allowlist secret
+        assertEquals(expectedName, restricted.name());
+        assertEquals(expectedBirthDate, restricted.birthDate());
+        assertEquals(expectedSocialSecurityRecord, restricted.socialSecurityRecord());
         assertEquals(
                 "{\"encoded\":\"test_device_data\"}",
                 OBJECT_MAPPER.writeValueAsString(restricted.deviceInformation()));
@@ -172,6 +192,6 @@ class AuditExtensionsHelperTest {
                                         "test-device-info"));
 
         assertEquals(500, thrownException.getResponseCode());
-        assertEquals(ErrorResponse.UNEXPECTED_CREDENTIAL_TYPE, thrownException.getErrorResponse());
+        assertEquals(ErrorResponse.CREDENTIAL_SUBJECT_MISSING, thrownException.getErrorResponse());
     }
 }

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
@@ -71,7 +71,7 @@ class AuditExtensionsHelperTest {
     }
 
     @Test
-    void shouldGetPassportRestrictedDataForAudit() throws Exception {
+    void shouldGetPassportRestrictedDataForAudit() {
         var restrictedData = getRestrictedAuditDataForF2F(PASSPORT_NON_DCMAW_SUCCESSFUL_VC);
         var expectedName =
                 List.of(
@@ -88,7 +88,7 @@ class AuditExtensionsHelperTest {
     }
 
     @Test
-    void shouldGetDLRestrictedDataForAudit() throws Exception {
+    void shouldGetDLRestrictedDataForAudit() {
         var restrictedData = getRestrictedAuditDataForF2F(vcDrivingPermitNonDcmaw());
         var expectedName =
                 List.of(
@@ -106,25 +106,25 @@ class AuditExtensionsHelperTest {
     }
 
     @Test
-    void shouldGetPassportExpiryDateForAudit() throws Exception {
+    void shouldGetPassportExpiryDateForAudit() {
         var auditNameParts = getRestrictedAuditDataForF2F(PASSPORT_NON_DCMAW_SUCCESSFUL_VC);
         assertEquals("2030-01-01", auditNameParts.getDocExpiryDate());
     }
 
     @Test
-    void shouldNotGetExpiryDateForAudit() throws Exception {
+    void shouldNotGetExpiryDateForAudit() {
         var auditNameParts = getRestrictedAuditDataForF2F(vcDrivingPermitMissingDrivingPermit());
         assertNull(auditNameParts.getDocExpiryDate());
     }
 
     @Test
-    void shouldGetBRPExpiryDateForAudit() throws Exception {
+    void shouldGetBRPExpiryDateForAudit() {
         var auditNameParts = getRestrictedAuditDataForF2F(vcF2fBrp());
         assertEquals("2030-07-13", auditNameParts.getDocExpiryDate());
     }
 
     @Test
-    void shouldGetIdCardExpiryDateForAudit() throws Exception {
+    void shouldGetIdCardExpiryDateForAudit() {
         var auditNameParts = getRestrictedAuditDataForF2F(vcF2fIdCard());
         assertEquals("2031-08-02", auditNameParts.getDocExpiryDate());
     }

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsVcEvidence;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.TestVc;
@@ -43,36 +42,35 @@ class AuditExtensionsHelperTest {
 
     @Test
     void shouldGetIdentityCheckVerifiableCredentialExtensionsForAudit() throws Exception {
-        var auditExtensions =
-                (AuditExtensionsVcEvidence<IdentityCheck>)
-                        getExtensionsForAudit(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, false);
+        var auditExtensions = getExtensionsForAudit(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, false);
+        var evidence = (List<IdentityCheck>) auditExtensions.evidence();
+
         var expectedAge =
                 Period.between(LocalDate.parse(TestVc.DEFAULT_DOB), LocalDate.now()).getYears();
         assertFalse(auditExtensions.successful());
         assertTrue(auditExtensions.isUkIssued());
         assertEquals(expectedAge, auditExtensions.age());
         assertEquals("https://review-p.staging.account.gov.uk", auditExtensions.iss());
-        assertEquals(2, auditExtensions.evidence().get(0).getValidityScore());
-        assertEquals(4, auditExtensions.evidence().get(0).getStrengthScore());
-        assertEquals(
-                "1c04edf0-a205-4585-8877-be6bd1776a39", auditExtensions.evidence().get(0).getTxn());
+        assertEquals(2, evidence.get(0).getValidityScore());
+        assertEquals(4, evidence.get(0).getStrengthScore());
+        assertEquals("1c04edf0-a205-4585-8877-be6bd1776a39", evidence.get(0).getTxn());
         assertEquals(
                 2,
-                auditExtensions.evidence().get(0).getCheckDetails().stream()
+                evidence.get(0).getCheckDetails().stream()
                         .filter(checkDetail -> checkDetail.getDataCheck() != null)
                         .count());
     }
 
     @Test
     void shouldGetRiskAssessmentVerifiableCredentialExtensionsForAudit() throws Exception {
-        var auditExtensions =
-                (AuditExtensionsVcEvidence<RiskAssessment>) getExtensionsForAudit(vcTicf(), false);
+        var auditExtensions = getExtensionsForAudit(vcTicf(), false);
+        var evidence = (List<RiskAssessment>) auditExtensions.evidence();
+
         assertFalse(auditExtensions.successful());
         assertNull(auditExtensions.isUkIssued());
         assertNull(auditExtensions.age());
         assertEquals("https://ticf.stubs.account.gov.uk", auditExtensions.iss());
-        assertEquals(
-                "963deeb5-a52c-4030-a69a-3184f77a4f18", auditExtensions.evidence().get(0).getTxn());
+        assertEquals("963deeb5-a52c-4030-a69a-3184f77a4f18", evidence.get(0).getTxn());
     }
 
     @Test

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
@@ -147,4 +147,31 @@ class AuditExtensionsHelperTest {
                 "{\"encoded\":\"test_device_data\"}",
                 OBJECT_MAPPER.writeValueAsString(restricted.deviceInformation()));
     }
+
+    @Test
+    void getRestrictedAuditDataForInheritedIdentityShouldThrowIfInvalidVcType() {
+        HttpResponseExceptionWithErrorBody thrownException =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () ->
+                                getRestrictedAuditDataForInheritedIdentity(
+                                        VC_ADDRESS, "test-device-info"));
+
+        assertEquals(500, thrownException.getResponseCode());
+        assertEquals(ErrorResponse.UNEXPECTED_CREDENTIAL_TYPE, thrownException.getErrorResponse());
+    }
+
+    @Test
+    void getRestrictedAuditDataForInheritedIdentityShouldThrowIfMissingCredentialSubject() {
+        HttpResponseExceptionWithErrorBody thrownException =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () ->
+                                getRestrictedAuditDataForInheritedIdentity(
+                                        vcDrivingPermitNoCredentialSubjectProperty(),
+                                        "test-device-info"));
+
+        assertEquals(500, thrownException.getResponseCode());
+        assertEquals(ErrorResponse.UNEXPECTED_CREDENTIAL_TYPE, thrownException.getErrorResponse());
+    }
 }

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.TestVc;
 
 import java.time.LocalDate;
 import java.time.Period;
-import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/helpers/AuditExtensionsHelperTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator;
 import uk.gov.di.ipv.core.library.helpers.vocab.SocialSecurityRecordDetailsGenerator;
 import uk.gov.di.model.IdentityCheck;
 import uk.gov.di.model.NamePart;
+import uk.gov.di.model.RiskAssessment;
 
 import java.time.LocalDate;
 import java.time.Period;
@@ -34,15 +35,17 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitNonD
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcF2fBrp;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcF2fIdCard;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigration;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcTicf;
 
 @ExtendWith(MockitoExtension.class)
 class AuditExtensionsHelperTest {
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
-    void shouldGetVerifiableCredentialExtensionsForAudit() throws Exception {
-        AuditExtensionsVcEvidence<IdentityCheck> auditExtensions =
-                getExtensionsForAudit(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, false);
+    void shouldGetIdentityCheckVerifiableCredentialExtensionsForAudit() throws Exception {
+        var auditExtensions =
+                (AuditExtensionsVcEvidence<IdentityCheck>)
+                        getExtensionsForAudit(PASSPORT_NON_DCMAW_SUCCESSFUL_VC, false);
         var expectedAge =
                 Period.between(LocalDate.parse(TestVc.DEFAULT_DOB), LocalDate.now()).getYears();
         assertFalse(auditExtensions.successful());
@@ -58,6 +61,18 @@ class AuditExtensionsHelperTest {
                 auditExtensions.evidence().get(0).getCheckDetails().stream()
                         .filter(checkDetail -> checkDetail.getDataCheck() != null)
                         .count());
+    }
+
+    @Test
+    void shouldGetRiskAssessmentVerifiableCredentialExtensionsForAudit() throws Exception {
+        var auditExtensions =
+                (AuditExtensionsVcEvidence<RiskAssessment>) getExtensionsForAudit(vcTicf(), false);
+        assertFalse(auditExtensions.successful());
+        assertNull(auditExtensions.isUkIssued());
+        assertNull(auditExtensions.age());
+        assertEquals("https://ticf.stubs.account.gov.uk", auditExtensions.iss());
+        assertEquals(
+                "963deeb5-a52c-4030-a69a-3184f77a4f18", auditExtensions.evidence().get(0).getTxn());
     }
 
     @Test

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/AuditServiceTest.java
@@ -25,11 +25,11 @@ import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsUserIdentity
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedF2F;
 import uk.gov.di.ipv.core.library.domain.AuditEventReturnCode;
-import uk.gov.di.ipv.core.library.domain.Name;
-import uk.gov.di.ipv.core.library.domain.NameParts;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exception.AuditException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
+import uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator;
+import uk.gov.di.model.NamePart;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -334,7 +334,12 @@ class AuditServiceTest {
     void shouldSendMessageToSqsQueueWithRestrictedF2F(boolean sqsAsyncEnabled) throws Exception {
         // Arrange
         when(mockConfigService.enabled(SQS_ASYNC)).thenReturn(sqsAsyncEnabled);
-        List<Name> name = List.of(new Name(List.of(new NameParts("first_name", "TestUser"))));
+        List<uk.gov.di.model.Name> name =
+                List.of(
+                        NameGenerator.createName(
+                                List.of(
+                                        NameGenerator.NamePartGenerator.createNamePart(
+                                                "first_name", NamePart.NamePartType.GIVEN_NAME))));
         var event =
                 AuditEvent.createWithoutDeviceInformation(
                         AuditEventTypes.IPV_JOURNEY_START,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -105,7 +105,8 @@ public enum ErrorResponse {
     UNKNOWN_RESET_TYPE(1088, "unknown resetType received"),
     ERROR_CALLING_DCMAW_ASYNC_CRI(1089, "Error calling the DCMAW Async CRI"),
     FAILED_TO_UPDATE_IDENTITY(1090, "Failed to update identity"),
-    INVALID_SIGNING_KEY_TYPE(1091, "Signing key is invalid type. Must be EC or RSA");
+    INVALID_SIGNING_KEY_TYPE(1091, "Signing key is invalid type. Must be EC or RSA"),
+    UNEXPECTED_CREDENTIAL_TYPE(1092, "Unexpected credential type");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -739,16 +739,6 @@ public interface VcFixtures {
                 Instant.ofEpochSecond(1697097326));
     }
 
-    static VerifiableCredential vcDrivingPermitIncorrectType() {
-        return generateVerifiableCredential(
-                "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
-                DRIVING_LICENCE,
-                TestVc.builder()
-                        .type(new String[] {VERIFIABLE_CREDENTIAL_TYPE, ADDRESS_CREDENTIAL_TYPE})
-                        .build(),
-                Instant.ofEpochSecond(1705986521));
-    }
-
     static VerifiableCredential vcDrivingPermitNoCredentialSubjectProperty() {
         return generateVerifiableCredential(
                 "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
@@ -758,8 +748,18 @@ public interface VcFixtures {
                         .evidence(DCMAW_EVIDENCE_VRI_CHECK)
                         .type(
                                 new String[] {
-                                    VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE
+                                        VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE
                                 })
+                        .build(),
+                Instant.ofEpochSecond(1705986521));
+    }
+
+    static VerifiableCredential vcDrivingPermitIncorrectType() {
+        return generateVerifiableCredential(
+                "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
+                DRIVING_LICENCE,
+                TestVc.builder()
+                        .type(new String[] {VERIFIABLE_CREDENTIAL_TYPE, ADDRESS_CREDENTIAL_TYPE})
                         .build(),
                 Instant.ofEpochSecond(1705986521));
     }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -748,7 +748,7 @@ public interface VcFixtures {
                         .evidence(DCMAW_EVIDENCE_VRI_CHECK)
                         .type(
                                 new String[] {
-                                        VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE
+                                    VERIFIABLE_CREDENTIAL_TYPE, IDENTITY_CHECK_CREDENTIAL_TYPE
                                 })
                         .build(),
                 Instant.ofEpochSecond(1705986521));

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/vocab/SocialSecurityRecordDetailsGenerator.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/vocab/SocialSecurityRecordDetailsGenerator.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.core.library.helpers.vocab;
+
+import uk.gov.di.model.SocialSecurityRecordDetails;
+
+public class SocialSecurityRecordDetailsGenerator {
+    private SocialSecurityRecordDetailsGenerator() {}
+
+    public static SocialSecurityRecordDetails createSocialSecurityRecordDetails(
+            String personalNumber) {
+        var socialSecurityRecord = new SocialSecurityRecordDetails();
+        socialSecurityRecord.setPersonalNumber(personalNumber);
+        return socialSecurityRecord;
+    }
+}

--- a/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
+++ b/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
@@ -19,7 +19,6 @@ import uk.gov.di.ipv.core.library.domain.ScopeConstants;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
 import uk.gov.di.ipv.core.library.enums.CriResourceRetrievedType;
-import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -145,8 +144,7 @@ public class CriStoringService {
             ClientOAuthSessionItem clientOAuthSessionItem,
             IpvSessionItem ipvSessionItem)
             throws SqsException, CiPutException, CiPostMitigationsException,
-                    VerifiableCredentialException, UnrecognisedVotException,
-                    CredentialParseException {
+                    VerifiableCredentialException, UnrecognisedVotException {
         var userId = clientOAuthSessionItem.getUserId();
         var govukSigninJourneyId = clientOAuthSessionItem.getGovukSigninJourneyId();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updates:
- AuditExtensionsHelper and associated unit tests to use parsed VCs
- AuditRestrictedF2F to use vocab classes
- AuditExtensionsVcEvidence to a generic to adapt to various evidence types

| Examples | Before changes | After changes |
|-|-|-|
| Audit event with evidence | <img width="424" alt="Screenshot 2024-07-09 at 17 30 04" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/8c01cb11-33ce-46d3-8c20-948c1dcaf0bb"> | <img width="392" alt="Screenshot 2024-07-09 at 17 36 08" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/83a49bcc-a113-4627-a3d3-2575780e2aaf"> |
| Audit event without evidence |  <img width="363" alt="Screenshot 2024-07-09 at 17 31 25" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/0acf4a6c-8754-44c4-be21-d449db2d4ee0"> | <img width="360" alt="Screenshot 2024-07-09 at 17 37 28" src="https://github.com/govuk-one-login/ipv-core-back/assets/120715154/cff8fcba-b6e5-496e-b87f-23ef8e3e81ed"> |



### Why did it change
We want to use the classes provided by vocab instead of the current json handling.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5759](https://govukverify.atlassian.net/browse/PYIC-5759)


[PYIC-5759]: https://govukverify.atlassian.net/browse/PYIC-5759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ