### PR TITLE
PYIC-6867: remove fail-with-no-ci event for the hmrc kbv journey events

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -633,8 +633,6 @@ states:
       criId: hmrcKbv
     parent: CRI_STATE
     events:
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       next:
         targetState: EVALUATE_GPG45_SCORES
       enhanced-verification:
@@ -661,8 +659,6 @@ states:
       criId: hmrcKbv
     parent: CRI_STATE
     events:
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       next:
         targetState: EVALUATE_GPG45_SCORES
       enhanced-verification:
@@ -1337,8 +1333,6 @@ states:
       criId: hmrcKbv
     parent: CRI_STATE
     events:
-      fail-with-no-ci:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       next:
         targetState: EVALUATE_GPG45_SCORES
       enhanced-verification:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Remove fail-with-no-ci event for the hmrc kbv journey events

### What changed

- Removed fail-with-no-ci event for the hmrc kbv journey events

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- Not in use

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6867](https://govukverify.atlassian.net/browse/PYIC-6867)


[PYIC-6867]: https://govukverify.atlassian.net/browse/PYIC-6867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ