### PR TITLE
Revert "PYIC-6883 Try Async AWS CRT Client"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ spotless {
 subprojects {
 	task allDeps(type: DependencyReportTask) {}
 	configurations.all {
-		exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
 		exclude group: 'software.amazon.awssdk', module: 'apache-client'
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ awsSdkKms = { module = "software.amazon.awssdk:kms" }
 awsSdkLambda = { module = "software.amazon.awssdk:lambda" }
 awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
 awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
-awsSdkCrtClient = { module = "software.amazon.awssdk:aws-crt-client" }
 commonsCodec = "commons-codec:commons-codec:1.17.0"
 diVocab = "uk.gov.di.model:di-data-model-jackson:v1.7.1"
 hamcrest = "org.hamcrest:hamcrest:2.2"

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsSdkCrtClient,
 			libs.awsSdkUrlConnectionClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/AuditService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
@@ -55,10 +54,7 @@ public class AuditService {
                         .region(EU_WEST_2)
                         .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build(),
-                SqsAsyncClient.builder()
-                        .region(EU_WEST_2)
-                        .httpClientBuilder(AwsCrtAsyncHttpClient.builder())
-                        .build());
+                SqsAsyncClient.builder().region(EU_WEST_2).build());
     }
 
     public void sendAuditEvent(AuditEvent auditEvent) throws SqsException {


### PR DESCRIPTION
I was hoping the async client might not be affected, and it worked in several test deployments in my dev environment, however this change caused the occasional segfaults to re-emerge.

There is some risk that the Netty client actually slows things down (negating the advantage of async audit events), so we'll want to keep an eye on this.