### PR TITLE
PYIC-6965: API tests : Create Successful P2 identity from Mobile Passport Journey

### DIFF
--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-valid/credentialSubject.json
@@ -1,0 +1,28 @@
+{
+  "passport": [
+    {
+      "expiryDate": "2030-01-01",
+      "icaoIssuerCode": "GBR",
+      "documentNumber": "321654987"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "Kenneth"
+        },
+        {
+          "type": "FamilyName",
+          "value": "Decerqueira"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-valid/evidence.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-valid/evidence.json
@@ -1,0 +1,15 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "checkMethod": "vri"
+    },
+    {
+      "biometricVerificationProcessLevel": 3,
+      "checkMethod": "bvr"
+    }
+  ],
+  "validityScore": 2,
+  "strengthScore": 3,
+  "type": "IdentityCheck"
+}

--- a/api-tests/features/new-p2-identity.feature
+++ b/api-tests/features/new-p2-identity.feature
@@ -1,12 +1,31 @@
 Feature: App journey
 
   @Build
-  Scenario: Successful P2 identity
+  Scenario: Successful P2 identity using DL
     Given I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+  @Build
+  Scenario: Successful P2 identity using Passport
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
     Then I get a 'page-dcmaw-success' page response
     When I submit a 'next' event
     Then I get an 'address' CRI response


### PR DESCRIPTION
## Proposed changes

### What changed

API Test : New BDD Scenario was added for Mobile Passport Journey

### Why did it change

Increase Mobile Passport P2 BDD Test Coverage

### Issue tracking
- [PYIC-6965](https://govukverify.atlassian.net/browse/PYIC-6965)

[PYIC-6965]: https://govukverify.atlassian.net/browse/PYIC-6965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ