### PR TITLE
PYIC-6816: use cri enum in config service

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -86,7 +86,6 @@ public class BuildCriOauthRequestHandler
         implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final String DCMAW_CRI_ID = "dcmaw";
     public static final String SHARED_CLAIM_ATTR_NAME = "name";
     public static final String SHARED_CLAIM_ATTR_BIRTH_DATE = "birthDate";
     public static final String SHARED_CLAIM_ATTR_ADDRESS = "address";
@@ -159,16 +158,7 @@ public class BuildCriOauthRequestHandler
                                 ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID)
                         .toObjectMap();
             }
-            Cri cri;
-            try {
-                cri = Cri.fromId(criId);
-            } catch (IllegalArgumentException e) {
-                return new JourneyErrorResponse(
-                                JOURNEY_ERROR_PATH,
-                                SC_BAD_REQUEST,
-                                ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID)
-                        .toObjectMap();
-            }
+            var cri = Cri.fromId(criId);
             LogHelper.attachCriIdToLogs(cri);
 
             String criContext = getJourneyParameter(input, CONTEXT);
@@ -263,6 +253,12 @@ public class BuildCriOauthRequestHandler
                     e,
                     SC_INTERNAL_SERVER_ERROR,
                     FAILED_TO_PARSE_EVIDENCE_REQUESTED);
+        } catch (IllegalArgumentException e) {
+            return new JourneyErrorResponse(
+                            JOURNEY_ERROR_PATH,
+                            SC_BAD_REQUEST,
+                            ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID)
+                    .toObjectMap();
         } finally {
             auditService.awaitAuditEvents();
         }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -296,7 +296,7 @@ class BuildCriOauthRequestHandlerTest {
 
         // Assert
         assertErrorResponse(
-                HttpStatus.SC_BAD_REQUEST, response, ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
+                HttpStatus.SC_BAD_REQUEST, response, ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
     }
 
     @Test

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -88,6 +88,7 @@ import static uk.gov.di.ipv.core.library.domain.Cri.CLAIMED_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.Cri.HMRC_KBV;
+import static uk.gov.di.ipv.core.library.domain.Cri.PASSPORT;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_2;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_3;
@@ -103,11 +104,6 @@ import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.v
 class BuildCriOauthRequestHandlerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final String CLAIMED_IDENTITY_CRI = CLAIMED_IDENTITY.getId();
-    private static final String DCMAW_CRI = DCMAW.getId();
-    private static final String F2F_CRI = F2F.getId();
-    private static final String HMRC_KBV_CRI = HMRC_KBV.getId();
-    private static final String CRI_ID = "PassportIssuer";
     private static final String CRI_TOKEN_URL = "http://www.example.com";
     private static final String CRI_CREDENTIAL_URL = "http://www.example.com/credential";
     private static final String CRI_AUTHORIZE_URL = "http://www.example.com/authorize";
@@ -125,7 +121,7 @@ class BuildCriOauthRequestHandlerTest {
     private static final String CONTEXT = "context";
     private static final String TEST_CONTEXT = "test_context";
     private static final String CRI_WITH_CONTEXT =
-            String.format("%s?%s=%s", CLAIMED_IDENTITY_CRI, CONTEXT, TEST_CONTEXT);
+            String.format("%s?%s=%s", CLAIMED_IDENTITY.getId(), CONTEXT, TEST_CONTEXT);
     private static final String EVIDENCE_REQUEST = "evidenceRequest";
     private static final String EVIDENCE_REQUESTED = "evidence_requested";
     private static final EvidenceRequest TEST_EVIDENCE_REQUESTED = new EvidenceRequest("gpg45", 2);
@@ -163,11 +159,13 @@ class BuildCriOauthRequestHandlerTest {
         CRI_WITH_EVIDENCE_REQUEST =
                 String.format(
                         "%s?%s=%s",
-                        CLAIMED_IDENTITY_CRI, EVIDENCE_REQUEST, TEST_EVIDENCE_REQUESTED.toBase64());
+                        CLAIMED_IDENTITY.getId(),
+                        EVIDENCE_REQUEST,
+                        TEST_EVIDENCE_REQUESTED.toBase64());
         CRI_WITH_CONTEXT_AND_EVIDENCE_REQUEST =
                 String.format(
                         "%s?%s=%s&%s=%s",
-                        CLAIMED_IDENTITY_CRI,
+                        CLAIMED_IDENTITY.getId(),
                         CONTEXT,
                         TEST_CONTEXT,
                         EVIDENCE_REQUEST,
@@ -324,12 +322,12 @@ class BuildCriOauthRequestHandlerTest {
     void shouldReceive200ResponseCodeAndReturnCredentialIssuerResponseWithoutResponseTypeParam()
             throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -356,7 +354,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -368,7 +366,7 @@ class BuildCriOauthRequestHandlerTest {
         URIBuilder redirectUri = new URIBuilder(response.getCri().getRedirectUrl());
         List<NameValuePair> queryParams = redirectUri.getQueryParams();
 
-        assertEquals(CRI_ID, response.getCri().getId());
+        assertEquals(PASSPORT.getId(), response.getCri().getId());
 
         Optional<NameValuePair> client_id =
                 queryParams.stream()
@@ -407,8 +405,8 @@ class BuildCriOauthRequestHandlerTest {
             shouldReceive200ResponseCodeAndReturnCredentialIssuerResponseWithoutResponseTypeParamForAllVCsAreNotSuccess()
                     throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
@@ -440,7 +438,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -452,7 +450,7 @@ class BuildCriOauthRequestHandlerTest {
         URIBuilder redirectUri = new URIBuilder(response.getCri().getRedirectUrl());
         List<NameValuePair> queryParams = redirectUri.getQueryParams();
 
-        assertEquals(CRI_ID, response.getCri().getId());
+        assertEquals(PASSPORT.getId(), response.getCri().getId());
 
         Optional<NameValuePair> client_id =
                 queryParams.stream()
@@ -491,12 +489,12 @@ class BuildCriOauthRequestHandlerTest {
             shouldReceive200ResponseCodeAndReturnCredentialIssuerResponseWithFullUrlJourneyAndWithoutResponseTypeParam()
                     throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -522,7 +520,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -534,7 +532,7 @@ class BuildCriOauthRequestHandlerTest {
         URIBuilder redirectUri = new URIBuilder(response.getCri().getRedirectUrl());
         List<NameValuePair> queryParams = redirectUri.getQueryParams();
 
-        assertEquals(CRI_ID, response.getCri().getId());
+        assertEquals(PASSPORT.getId(), response.getCri().getId());
 
         Optional<NameValuePair> client_id =
                 queryParams.stream()
@@ -574,12 +572,12 @@ class BuildCriOauthRequestHandlerTest {
             shouldReceive200ResponseCodeAndReturnCredentialIssuerResponseWithoutBaseJourneyUrlAndResponseTypeParam()
                     throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -605,7 +603,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -617,7 +615,7 @@ class BuildCriOauthRequestHandlerTest {
         URIBuilder redirectUri = new URIBuilder(response.getCri().getRedirectUrl());
         List<NameValuePair> queryParams = redirectUri.getQueryParams();
 
-        assertEquals(CRI_ID, response.getCri().getId());
+        assertEquals(PASSPORT.getId(), response.getCri().getId());
 
         Optional<NameValuePair> client_id =
                 queryParams.stream()
@@ -656,12 +654,12 @@ class BuildCriOauthRequestHandlerTest {
     void shouldReceive200ResponseCodeAndReturnCredentialIssuerResponseWithResponseTypeParam()
             throws Exception {
         // Arrange
-        when(configService.getActiveConnection(DCMAW_CRI)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, DCMAW_CRI))
+        when(configService.getActiveConnection(DCMAW)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, DCMAW))
                 .thenReturn(dcmawOauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -687,7 +685,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, DCMAW_CRI))
+                        .journey(String.format(JOURNEY_BASE_URL, DCMAW.getId()))
                         .build();
 
         // Act
@@ -699,7 +697,7 @@ class BuildCriOauthRequestHandlerTest {
         URIBuilder redirectUri = new URIBuilder(response.getCri().getRedirectUrl());
         List<NameValuePair> queryParams = redirectUri.getQueryParams();
 
-        assertEquals(DCMAW_CRI, response.getCri().getId());
+        assertEquals(DCMAW.getId(), response.getCri().getId());
 
         Optional<NameValuePair> client_id =
                 queryParams.stream()
@@ -738,7 +736,7 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldReturn400IfSessionIdIsNull() throws JsonProcessingException {
         // Arrange
-        JourneyRequest input = JourneyRequest.builder().journey(CRI_ID).build();
+        JourneyRequest input = JourneyRequest.builder().journey(PASSPORT.getId()).build();
 
         // Act
         var responseJson = handleRequest(input, context);
@@ -828,12 +826,12 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldDeduplicateSharedClaims() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -859,7 +857,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -894,12 +892,12 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldNotDeduplicateSharedClaimsIfFullNameDifferent() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -925,7 +923,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -958,12 +956,12 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldDeduplicateNamesThatAppearInDifferentVCs() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -989,7 +987,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -1041,12 +1039,12 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldRemoveExtraAddressClaimsAndOnlyUseValuesFromTheAddressVC() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -1077,7 +1075,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -1112,12 +1110,12 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldNotIncludeFailedVcsInTheSharedClaims() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, false);
@@ -1143,7 +1141,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -1179,14 +1177,14 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldOnlyAllowCRIConfiguredSharedClaimAttr() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CRI_ID)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CRI_ID))
+        when(configService.getActiveConnection(PASSPORT)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, PASSPORT))
                 .thenReturn(oauthCriConfig);
-        when(configService.getAllowedSharedAttributes(CRI_ID))
+        when(configService.getAllowedSharedAttributes(PASSPORT))
                 .thenReturn("name,birthDate,address,emailAddress");
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         ipvSessionItem.setEmailAddress(null);
@@ -1218,7 +1216,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, CRI_ID))
+                        .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
         // Act
@@ -1253,14 +1251,14 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldOnlyEmailForF2FAndAllowCRIConfiguredSharedClaimAttr() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(F2F_CRI)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, F2F_CRI))
+        when(configService.getActiveConnection(F2F)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, F2F))
                 .thenReturn(f2FOauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
-        when(configService.getAllowedSharedAttributes(F2F_CRI))
+        when(configService.getAllowedSharedAttributes(F2F))
                 .thenReturn("name,birthDate,address,emailAddress");
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -1293,7 +1291,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, F2F_CRI))
+                        .journey(String.format(JOURNEY_BASE_URL, F2F.getId()))
                         .build();
 
         // Act
@@ -1328,14 +1326,14 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldIncludeSocialSecurityRecordInSharedClaimsIfConfigured() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(HMRC_KBV_CRI)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, HMRC_KBV_CRI))
+        when(configService.getActiveConnection(HMRC_KBV)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, HMRC_KBV))
                 .thenReturn(hmrcKbvOauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
-        when(configService.getAllowedSharedAttributes(HMRC_KBV_CRI))
+        when(configService.getAllowedSharedAttributes(HMRC_KBV))
                 .thenReturn("name,birthDate,address,socialSecurityRecord");
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
@@ -1366,7 +1364,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, HMRC_KBV_CRI))
+                        .journey(String.format(JOURNEY_BASE_URL, HMRC_KBV.getId()))
                         .build();
 
         // Act
@@ -1401,8 +1399,8 @@ class BuildCriOauthRequestHandlerTest {
     void shouldIncludeGivenParametersIntoCriResponseIfInJourneyUri(
             String journeyUri, Map<String, Object> expectedClaims) throws Exception {
         // Arrange
-        when(configService.getActiveConnection(CLAIMED_IDENTITY_CRI)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CLAIMED_IDENTITY_CRI))
+        when(configService.getActiveConnection(CLAIMED_IDENTITY)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CLAIMED_IDENTITY))
                 .thenReturn(claimedIdentityOauthCriConfig);
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("5000");

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -180,7 +180,7 @@ public class BuildProvenUserIdentityDetailsHandler
         for (var vc : vcs) {
             if (vc.getCri().equals(ADDRESS)
                     && userIdentityService.isVcSuccessful(
-                            currentVcStatuses, configService.getComponentId(vc.getCri().getId()))) {
+                            currentVcStatuses, configService.getComponentId(vc.getCri()))) {
                 JsonNode addressNode =
                         mapper.readTree(SignedJWT.parse(vc.getVcString()).getPayload().toString())
                                 .path(VC_CLAIM)

--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandler.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandler.java
@@ -90,7 +90,7 @@ public class CallDcmawAsyncCriHandler
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(ProcessRequest request, Context context) {
         LogHelper.attachComponentId(configService);
-        LogHelper.attachCriIdToLogs(DCMAW_ASYNC.getId());
+        LogHelper.attachCriIdToLogs(DCMAW_ASYNC);
         List<String> featureSets = RequestHelper.getFeatureSet(request);
         configService.setFeatureSet(featureSets);
 

--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
@@ -54,8 +54,8 @@ public class DcmawAsyncCriService {
             ClientOAuthSessionItem clientOAuthSessionItem,
             IpvSessionItem ipvSessionItem)
             throws CriApiException, JsonProcessingException {
-        final String criId = DCMAW_ASYNC.getId();
-        String connection = configService.getActiveConnection(criId);
+
+        String connection = configService.getActiveConnection(DCMAW_ASYNC);
 
         ipvSessionItem.setCriOAuthSessionId(oauthState);
         ipvSessionService.updateIpvSession(ipvSessionItem);
@@ -63,7 +63,7 @@ public class DcmawAsyncCriService {
         var criOAuthSessionItem =
                 criOAuthSessionService.persistCriOAuthSession(
                         oauthState,
-                        criId,
+                        DCMAW_ASYNC,
                         clientOAuthSessionItem.getClientOAuthSessionId(),
                         connection);
 

--- a/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java
+++ b/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java
@@ -81,13 +81,13 @@ class DcmawAsyncCriServiceTest {
                         .build();
 
         when(mockCriOAuthSessionService.persistCriOAuthSession(
-                        CRI_OAUTH_STATE, DCMAW_ASYNC.getId(), CLIENT_OAUTH_SESSION_ID, CONNECTION))
+                        CRI_OAUTH_STATE, DCMAW_ASYNC, CLIENT_OAUTH_SESSION_ID, CONNECTION))
                 .thenReturn(criOAuthSessionItem);
 
         when(mockConfigService.getOauthCriConfig(criOAuthSessionItem)).thenReturn(criConfig);
         when(mockConfigService.getCriOAuthClientSecret(criOAuthSessionItem))
                 .thenReturn(TEST_SECRET);
-        when(mockConfigService.getActiveConnection(DCMAW_ASYNC.getId())).thenReturn(CONNECTION);
+        when(mockConfigService.getActiveConnection(DCMAW_ASYNC)).thenReturn(CONNECTION);
 
         var accessToken = new BearerAccessToken(ACCESS_TOKEN);
         when(mockCriApiService.fetchAccessToken(CRI_CLIENT_ID, TEST_SECRET, criOAuthSessionItem))

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -104,7 +104,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
     @Logging(clearState = true)
     public Map<String, Object> handleRequest(ProcessRequest request, Context context) {
         LogHelper.attachComponentId(configService);
-        LogHelper.attachCriIdToLogs(TICF.getId());
+        LogHelper.attachCriIdToLogs(TICF);
 
         IpvSessionItem ipvSessionItem = null;
         try {

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -73,7 +73,7 @@ public class TicfCriService {
             ClientOAuthSessionItem clientOAuthSessionItem, IpvSessionItem ipvSessionItem)
             throws TicfCriServiceException {
         try {
-            RestCriConfig ticfCriConfig = configService.getRestCriConfig(TICF.getId());
+            RestCriConfig ticfCriConfig = configService.getRestCriConfig(TICF);
 
             TicfCriDto ticfCriRequest =
                     new TicfCriDto(
@@ -100,7 +100,7 @@ public class TicfCriService {
             if (ticfCriConfig.isRequiresApiKey()) {
                 httpRequestBuilder.header(
                         X_API_KEY_HEADER,
-                        configService.getCriPrivateApiKeyForActiveConnection(TICF.getId()));
+                        configService.getCriPrivateApiKeyForActiveConnection(TICF));
             }
             httpRequestBuilder.header("Content-Type", "application/json; charset=utf-8");
 

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/pact/ticfCri/ContractTest.java
@@ -111,8 +111,8 @@ class ContractTest {
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         var ipvSessionItem = getIpvSessionItem();
         var clientOAuthSessionItem = getClientOAuthSessionItem();
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF.getId()))
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF))
                 .thenReturn(PRIVATE_API_KEY);
         when(mockSessionCredentialsService.getCredentials(
                         ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId(), true))
@@ -180,8 +180,8 @@ class ContractTest {
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         var ipvSessionItem = getIpvSessionItem();
         var clientOAuthSessionItem = getClientOAuthSessionItem();
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF.getId()))
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF))
                 .thenReturn(PRIVATE_API_KEY);
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(Map.of("B00", new ContraIndicatorConfig()));
@@ -251,8 +251,8 @@ class ContractTest {
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         var ipvSessionItem = getIpvSessionItem();
         var clientOAuthSessionItem = getClientOAuthSessionItem();
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF.getId()))
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF))
                 .thenReturn(PRIVATE_API_KEY);
         when(mockSessionCredentialsService.getCredentials(
                         ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId(), true))
@@ -324,8 +324,8 @@ class ContractTest {
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         var ipvSessionItem = getIpvSessionItem();
         var clientOAuthSessionItem = getClientOAuthSessionItem();
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF.getId()))
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF))
                 .thenReturn(PRIVATE_API_KEY);
         when(mockSessionCredentialsService.getCredentials(
                         ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId(), true))
@@ -386,8 +386,8 @@ class ContractTest {
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         var ipvSessionItem = getIpvSessionItem();
         var clientOAuthSessionItem = getClientOAuthSessionItem();
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF.getId()))
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF))
                 .thenReturn(PRIVATE_API_KEY);
         when(mockSessionCredentialsService.getCredentials(
                         ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId(), true))
@@ -452,8 +452,8 @@ class ContractTest {
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         var ipvSessionItem = getIpvSessionItem();
         var clientOAuthSessionItem = getClientOAuthSessionItem();
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF.getId()))
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF))
                 .thenReturn(PRIVATE_API_KEY);
         when(mockSessionCredentialsService.getCredentials(
                         ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId(), true))
@@ -519,8 +519,8 @@ class ContractTest {
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         var ipvSessionItem = getIpvSessionItem();
         var clientOAuthSessionItem = getClientOAuthSessionItem();
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(credentialIssuerConfig);
-        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF.getId()))
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(credentialIssuerConfig);
+        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF))
                 .thenReturn(PRIVATE_API_KEY);
         when(mockConfigService.getContraIndicatorConfigMap())
                 .thenReturn(Map.of("B00", new ContraIndicatorConfig()));

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriServiceTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriServiceTest.java
@@ -109,10 +109,8 @@ class TicfCriServiceTest {
                         .componentId("https://ticf-cri.example.com")
                         .requiresApiKey(true)
                         .build();
-        when(mockConfigService.getRestCriConfig(TICF.getId()))
-                .thenReturn(ticfConfigWithApiKeyRequired);
-        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF.getId()))
-                .thenReturn("api-key");
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(ticfConfigWithApiKeyRequired);
+        when(mockConfigService.getCriPrivateApiKeyForActiveConnection(TICF)).thenReturn("api-key");
         when(mockSessionCredentialsService.getCredentials(SESSION_ID, USER_ID, true))
                 .thenReturn(List.of(M1B_DCMAW_VC));
         when(mockHttpClient.send(any(HttpRequest.class), any(BodyHandler.class)))
@@ -147,7 +145,7 @@ class TicfCriServiceTest {
 
     @Test
     void getTicfVcShouldNotIncludeApiKeyIfNotRequired() throws Exception {
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(ticfCriConfig);
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(ticfCriConfig);
         when(mockHttpClient.send(any(HttpRequest.class), any(BodyHandler.class)))
                 .thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatus.SC_OK);
@@ -163,7 +161,7 @@ class TicfCriServiceTest {
     @ParameterizedTest
     @ValueSource(ints = {199, 300})
     void getTicfVcShouldReturnEmptyListIfNon200HttpResponse(int statusCode) throws Exception {
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(ticfCriConfig);
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(ticfCriConfig);
         when(mockHttpClient.send(any(HttpRequest.class), any(BodyHandler.class)))
                 .thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(statusCode);
@@ -194,7 +192,7 @@ class TicfCriServiceTest {
             })
     void getTicfVcShouldReturnEmptyListIfHttpClientEncountersException(Class<?> exceptionToThrow)
             throws Exception {
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(ticfCriConfig);
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(ticfCriConfig);
         when(mockHttpClient.send(any(), any()))
                 .thenThrow((Throwable) exceptionToThrow.getConstructor().newInstance());
 
@@ -204,7 +202,7 @@ class TicfCriServiceTest {
 
     @Test
     void getTicfVcShouldThrowIfCanNotParseResponseBody() throws Exception {
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(ticfCriConfig);
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(ticfCriConfig);
         when(mockHttpClient.send(any(HttpRequest.class), any(BodyHandler.class)))
                 .thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatus.SC_OK);
@@ -220,7 +218,7 @@ class TicfCriServiceTest {
         TicfCriDto ticfCriResponseWithoutCreds =
                 new TicfCriDto(VTR_VALUE, Vot.P2, TRUSTMARK, USER_ID, GOVUK_JOURNEY_ID, List.of());
 
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(ticfCriConfig);
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(ticfCriConfig);
         when(mockHttpClient.send(any(HttpRequest.class), any(BodyHandler.class)))
                 .thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatus.SC_OK);
@@ -240,7 +238,7 @@ class TicfCriServiceTest {
         var someCredential = "some credential";
         var ticfResponse = new TicfCriDto(null, null, null, null, null, List.of(someCredential));
 
-        when(mockConfigService.getRestCriConfig(TICF.getId())).thenReturn(ticfCriConfig);
+        when(mockConfigService.getRestCriConfig(TICF)).thenReturn(ticfCriConfig);
         when(mockHttpClient.send(any(HttpRequest.class), any(BodyHandler.class)))
                 .thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatus.SC_OK);

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -431,7 +431,7 @@ public class InitialiseIpvSessionHandler
                                     inheritedIdentityJwtList.size())));
         }
 
-        var inheritedIdentityCriConfig = configService.getCriConfig(HMRC_MIGRATION.getId());
+        var inheritedIdentityCriConfig = configService.getCriConfig(HMRC_MIGRATION);
 
         // The HMRC inherited identity VC will contain an HMRC-specific pairwise identifier
         // rather than our internal user id, so we cannot validate it against the OAuth user id.

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -671,8 +671,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                             PCL250_MIGRATION_VC
                                                                                     .getVcString())))))
                                     .build());
-            when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
-                    .thenReturn(TEST_CRI_CONFIG);
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION)).thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
                             HMRC_MIGRATION,
@@ -730,8 +729,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                             PCL200_MIGRATION_VC
                                                                                     .getVcString())))))
                                     .build());
-            when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
-                    .thenReturn(TEST_CRI_CONFIG);
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION)).thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
                             HMRC_MIGRATION,
@@ -786,8 +784,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                             PCL200_MIGRATION_VC
                                                                                     .getVcString())))))
                                     .build());
-            when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
-                    .thenReturn(TEST_CRI_CONFIG);
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION)).thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
                             HMRC_MIGRATION,
@@ -860,8 +857,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                             PCL200_MIGRATION_VC
                                                                                     .getVcString())))))
                                     .build());
-            when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
-                    .thenReturn(TEST_CRI_CONFIG);
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION)).thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
                             HMRC_MIGRATION,
@@ -921,8 +917,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                                     .getVcString())))))
                                     .build());
 
-            when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
-                    .thenReturn(TEST_CRI_CONFIG);
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION)).thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
                             HMRC_MIGRATION,
@@ -1155,8 +1150,7 @@ class InitialiseIpvSessionHandlerTest {
                                                             INHERITED_IDENTITY_JWT_CLAIM_NAME,
                                                             Map.of(VALUES, List.of("🌭")))))
                                     .build());
-            when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
-                    .thenReturn(TEST_CRI_CONFIG);
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION)).thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
                             HMRC_MIGRATION,
@@ -1221,8 +1215,7 @@ class InitialiseIpvSessionHandlerTest {
                                                                             PCL200_MIGRATION_VC
                                                                                     .getVcString())))))
                                     .build());
-            when(mockConfigService.getCriConfig(HMRC_MIGRATION.getId()))
-                    .thenReturn(TEST_CRI_CONFIG);
+            when(mockConfigService.getCriConfig(HMRC_MIGRATION)).thenReturn(TEST_CRI_CONFIG);
             when(mockVerifiableCredentialValidator.parseAndValidate(
                             TEST_USER_ID,
                             HMRC_MIGRATION,

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -190,7 +190,7 @@ public class ProcessAsyncCriCredentialHandler
 
         var oauthCriConfig =
                 configService.getOauthCriActiveConnectionConfig(
-                        successAsyncCriResponse.getCredentialIssuer().getId());
+                        successAsyncCriResponse.getCredentialIssuer());
 
         var vcs =
                 verifiableCredentialValidator.parseAndValidate(

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -188,7 +188,7 @@ class ProcessAsyncCriCredentialHandlerTest {
 
         when(criResponseService.getCriResponseItem(TEST_USER_ID, TEST_CRI))
                 .thenReturn(TEST_CRI_RESPONSE_ITEM);
-        when(configService.getOauthCriActiveConnectionConfig(TEST_CREDENTIAL_ISSUER_ID))
+        when(configService.getOauthCriActiveConnectionConfig(F2F))
                 .thenReturn(TEST_CREDENTIAL_ISSUER_CONFIG);
         doThrow(VerifiableCredentialException.class)
                 .when(verifiableCredentialValidator)
@@ -379,7 +379,7 @@ class ProcessAsyncCriCredentialHandlerTest {
     }
 
     private void mockCredentialIssuerConfig() {
-        when(configService.getOauthCriActiveConnectionConfig(TEST_CREDENTIAL_ISSUER_ID))
+        when(configService.getOauthCriActiveConnectionConfig(F2F))
                 .thenReturn(TEST_CREDENTIAL_ISSUER_CONFIG);
     }
 

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -273,7 +273,7 @@ public class ProcessCriCallbackHandler
                 clientOAuthSessionItem.getGovukSigninJourneyId());
         LogHelper.attachIpvSessionIdToLogs(callbackRequest.getIpvSessionId());
         LogHelper.attachFeatureSetToLogs(callbackRequest.getFeatureSet());
-        LogHelper.attachCriIdToLogs(callbackRequest.getCredentialIssuer().getId());
+        LogHelper.attachCriIdToLogs(callbackRequest.getCredentialIssuer());
         LogHelper.attachComponentId(configService);
 
         // Validate callback request

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -163,16 +163,11 @@ public class CriCheckingService {
             CriCallbackRequest callbackRequest, CriOAuthSessionItem criOAuthSessionItem)
             throws InvalidCriCallbackRequestException {
         var ipvSessionId = callbackRequest.getIpvSessionId();
-        var criId = callbackRequest.getCredentialIssuerId();
         var state = callbackRequest.getState();
         var authorisationCode = callbackRequest.getAuthorizationCode();
 
         if (StringUtils.isBlank(authorisationCode)) {
             throw new InvalidCriCallbackRequestException(ErrorResponse.MISSING_AUTHORIZATION_CODE);
-        }
-        if (StringUtils.isBlank(criId)) {
-            throw new InvalidCriCallbackRequestException(
-                    ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
         }
         if (StringUtils.isBlank(ipvSessionId)) {
             throw new InvalidCriCallbackRequestException(ErrorResponse.MISSING_IPV_SESSION_ID);
@@ -184,8 +179,14 @@ public class CriCheckingService {
                 || !state.equals(criOAuthSessionItem.getCriOAuthSessionId())) {
             throw new InvalidCriCallbackRequestException(ErrorResponse.INVALID_OAUTH_STATE);
         }
-        if (configService.getOauthCriActiveConnectionConfig(callbackRequest.getCredentialIssuer())
-                == null) {
+        try {
+            var cri = callbackRequest.getCredentialIssuer();
+            if (cri == null) {
+                throw new InvalidCriCallbackRequestException(
+                        ErrorResponse.MISSING_CREDENTIAL_ISSUER_ID);
+            }
+
+        } catch (IllegalArgumentException e) {
             throw new InvalidCriCallbackRequestException(
                     ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
         }

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -184,7 +184,8 @@ public class CriCheckingService {
                 || !state.equals(criOAuthSessionItem.getCriOAuthSessionId())) {
             throw new InvalidCriCallbackRequestException(ErrorResponse.INVALID_OAUTH_STATE);
         }
-        if (configService.getOauthCriActiveConnectionConfig(criId) == null) {
+        if (configService.getOauthCriActiveConnectionConfig(callbackRequest.getCredentialIssuer())
+                == null) {
             throw new InvalidCriCallbackRequestException(
                     ErrorResponse.INVALID_CREDENTIAL_ISSUER_ID);
         }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -22,7 +22,6 @@ import uk.gov.di.ipv.core.library.domain.ScopeConstants;
 import uk.gov.di.ipv.core.library.domain.cimitvc.ContraIndicator;
 import uk.gov.di.ipv.core.library.domain.cimitvc.Mitigation;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
-import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.exceptions.SqsException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -282,8 +281,6 @@ class CriCheckingServiceTest {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
         var criOAuthSessionItem = buildValidCriOAuthSessionItem(callbackRequest.getState());
-        when(mockConfigService.getOauthCriActiveConnectionConfig(any()))
-                .thenReturn(OauthCriConfig.builder().build());
 
         // Act & Assert
         assertDoesNotThrow(
@@ -375,8 +372,8 @@ class CriCheckingServiceTest {
     void validateCallbackRequestShouldThrowExceptionWhenCredentialIssuerIdIsInvalid() {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
+        callbackRequest.setCredentialIssuerId("invalid");
         var criOAuthSessionItem = buildValidCriOAuthSessionItem(callbackRequest.getState());
-        when(mockConfigService.getOauthCriActiveConnectionConfig(any())).thenReturn(null);
 
         // Act & Assert
         assertThrows(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.util.List;
@@ -98,8 +99,8 @@ public class LogHelper {
         attachFieldToLogs(LogField.LOG_CLIENT_ID, clientId);
     }
 
-    public static void attachCriIdToLogs(String criId) {
-        attachFieldToLogs(LOG_CRI_ID, criId);
+    public static void attachCriIdToLogs(Cri cri) {
+        attachFieldToLogs(LOG_CRI_ID, cri.getId());
     }
 
     public static void attachIpvSessionIdToLogs(String sessionId) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -175,8 +175,8 @@ public class ConfigService {
         return Arrays.asList(redirectUrlStrings.split(CLIENT_REDIRECT_URL_SEPARATOR));
     }
 
-    public String getCriPrivateApiKeyForActiveConnection(String criId) {
-        return getApiKeyFromSecretManager(criId, getActiveConnection(criId));
+    public String getCriPrivateApiKeyForActiveConnection(Cri cri) {
+        return getApiKeyFromSecretManager(cri, getActiveConnection(cri));
     }
 
     public String getAppApiKey(String appId) {
@@ -185,51 +185,50 @@ public class ConfigService {
 
     public String getCriPrivateApiKey(CriOAuthSessionItem criOAuthSessionItem) {
         return getApiKeyFromSecretManager(
-                criOAuthSessionItem.getCriId(), criOAuthSessionItem.getConnection());
+                Cri.fromId(criOAuthSessionItem.getCriId()), criOAuthSessionItem.getConnection());
     }
 
     public String getCriOAuthClientSecret(CriOAuthSessionItem criOAuthSessionItem) {
         return getOAuthClientSecretFromSecretManager(
-                criOAuthSessionItem.getCriId(), criOAuthSessionItem.getConnection());
+                Cri.fromId(criOAuthSessionItem.getCriId()), criOAuthSessionItem.getConnection());
     }
 
-    public OauthCriConfig getOauthCriActiveConnectionConfig(String credentialIssuerId) {
-        return getOauthCriConfigForConnection(
-                getActiveConnection(credentialIssuerId), credentialIssuerId);
+    public OauthCriConfig getOauthCriActiveConnectionConfig(Cri cri) {
+        return getOauthCriConfigForConnection(getActiveConnection(cri), cri);
     }
 
     public OauthCriConfig getOauthCriConfig(CriOAuthSessionItem criOAuthSessionItem) {
         return getOauthCriConfigForConnection(
-                criOAuthSessionItem.getConnection(), criOAuthSessionItem.getCriId());
+                criOAuthSessionItem.getConnection(), Cri.fromId(criOAuthSessionItem.getCriId()));
     }
 
-    public OauthCriConfig getOauthCriConfigForConnection(String connection, String criId) {
-        return getCriConfigForType(connection, criId, OauthCriConfig.class);
+    public OauthCriConfig getOauthCriConfigForConnection(String connection, Cri cri) {
+        return getCriConfigForType(connection, cri, OauthCriConfig.class);
     }
 
-    public RestCriConfig getRestCriConfig(String criId) {
-        return getCriConfigForType(getActiveConnection(criId), criId, RestCriConfig.class);
+    public RestCriConfig getRestCriConfig(Cri cri) {
+        return getCriConfigForType(getActiveConnection(cri), cri, RestCriConfig.class);
     }
 
-    public CriConfig getCriConfig(String criId) {
-        return getCriConfigForType(getActiveConnection(criId), criId, CriConfig.class);
+    public CriConfig getCriConfig(Cri cri) {
+        return getCriConfigForType(getActiveConnection(cri), cri, CriConfig.class);
     }
 
-    public String getActiveConnection(String credentialIssuerId) {
+    public String getActiveConnection(Cri cri) {
         final String pathTemplate =
                 ConfigurationVariable.CREDENTIAL_ISSUERS.getPath() + "/%s/activeConnection";
-        return getSsmParameterWithOverride(pathTemplate, credentialIssuerId);
+        return getSsmParameterWithOverride(pathTemplate, cri.getId());
     }
 
-    public String getComponentId(String credentialIssuerId) {
-        var criConfig = getOauthCriActiveConnectionConfig(credentialIssuerId);
+    public String getComponentId(Cri cri) {
+        var criConfig = getOauthCriActiveConnectionConfig(cri);
         return criConfig.getComponentId();
     }
 
-    public String getAllowedSharedAttributes(String credentialIssuerId) {
+    public String getAllowedSharedAttributes(Cri cri) {
         final String pathTemplate =
                 ConfigurationVariable.CREDENTIAL_ISSUERS.getPath() + "/%s/allowedSharedAttributes";
-        return getSsmParameterWithOverride(pathTemplate, credentialIssuerId);
+        return getSsmParameterWithOverride(pathTemplate, cri.getId());
     }
 
     public boolean isEnabled(String credentialIssuerId) {
@@ -321,7 +320,8 @@ public class ConfigService {
         return null;
     }
 
-    private String getApiKeyFromSecretManager(String criId, String connection) {
+    private String getApiKeyFromSecretManager(Cri cri, String connection) {
+        String criId = cri.getId();
         String secretId =
                 String.format(
                         "/%s/credential-issuers/%s/connections/%s/api-key",
@@ -357,7 +357,8 @@ public class ConfigService {
         }
     }
 
-    private String getOAuthClientSecretFromSecretManager(String criId, String connection) {
+    private String getOAuthClientSecretFromSecretManager(Cri cri, String connection) {
+        String criId = cri.getId();
         String secretId =
                 String.format(
                         "/%s/credential-issuers/%s/connections/%s/oauth-client-secret",
@@ -378,8 +379,8 @@ public class ConfigService {
         return secretValue;
     }
 
-    private <T> T getCriConfigForType(String connection, String criId, Class<T> configType) {
-
+    private <T> T getCriConfigForType(String connection, Cri cri, Class<T> configType) {
+        String criId = cri.getId();
         final String pathTemplate =
                 ConfigurationVariable.CREDENTIAL_ISSUERS.getPath() + "/%s/connections/%s";
         try {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 
@@ -36,12 +37,12 @@ public class CriOAuthSessionService {
     }
 
     public CriOAuthSessionItem persistCriOAuthSession(
-            String state, String criId, String clientOAuthSessionId, String connection) {
+            String state, Cri cri, String clientOAuthSessionId, String connection) {
 
         CriOAuthSessionItem criOAuthSessionItem =
                 CriOAuthSessionItem.builder()
                         .criOAuthSessionId(state)
-                        .criId(criId)
+                        .criId(cri.getId())
                         .clientOAuthSessionId(clientOAuthSessionId)
                         .connection(connection)
                         .build();

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -125,8 +125,7 @@ class ConfigServiceTest {
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(oauthCriJsonConfig);
 
-            OauthCriConfig result =
-                    configService.getOauthCriActiveConnectionConfig(Cri.PASSPORT.getId());
+            OauthCriConfig result = configService.getOauthCriActiveConnectionConfig(Cri.PASSPORT);
 
             assertEquals(expectedOauthCriConfig, result);
         }
@@ -154,7 +153,7 @@ class ConfigServiceTest {
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(oauthCriJsonConfig);
 
-            var result = configService.getOauthCriConfigForConnection("stub", Cri.PASSPORT.getId());
+            var result = configService.getOauthCriConfigForConnection("stub", Cri.PASSPORT);
 
             assertEquals(expectedOauthCriConfig, result);
         }
@@ -165,10 +164,9 @@ class ConfigServiceTest {
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenThrow(ParameterNotFoundException.builder().build());
 
-            var criId = Cri.PASSPORT.getId();
             assertThrows(
                     NoConfigForConnectionException.class,
-                    () -> configService.getOauthCriConfigForConnection("stub", criId));
+                    () -> configService.getOauthCriConfigForConnection("stub", Cri.PASSPORT));
         }
 
         @Test
@@ -183,7 +181,7 @@ class ConfigServiceTest {
                                     "{\"credentialUrl\":\"https://testCredentialUrl\",\"signingKey\":%s,\"componentId\":\"https://testComponentId\",\"requiresApiKey\":\"true\"}",
                                     EC_PRIVATE_KEY_JWK_DOUBLE_ENCODED));
 
-            RestCriConfig restCriConfig = configService.getRestCriConfig(Cri.ADDRESS.getId());
+            RestCriConfig restCriConfig = configService.getRestCriConfig(Cri.ADDRESS);
 
             var expectedRestCriConfig =
                     RestCriConfig.builder()
@@ -208,7 +206,7 @@ class ConfigServiceTest {
                                     "{\"signingKey\":%s,\"componentId\":\"https://testComponentId\"}",
                                     EC_PRIVATE_KEY_JWK_DOUBLE_ENCODED));
 
-            CriConfig criConfig = configService.getCriConfig(Cri.PASSPORT.getId());
+            CriConfig criConfig = configService.getCriConfig(Cri.PASSPORT);
 
             var expectedCriConfig =
                     CriConfig.builder()
@@ -232,7 +230,7 @@ class ConfigServiceTest {
                                     "{\"signingKey\":%s,\"componentId\":\"%s\"}",
                                     EC_PRIVATE_KEY_JWK_DOUBLE_ENCODED, testComponentId));
 
-            assertEquals(testComponentId, configService.getComponentId(Cri.PASSPORT.getId()));
+            assertEquals(testComponentId, configService.getComponentId(Cri.PASSPORT));
         }
     }
 
@@ -253,7 +251,7 @@ class ConfigServiceTest {
     class OauthCriConfigItems {
 
         private void setupTestData(
-                String credentialIssuer,
+                Cri credentialIssuer,
                 String attributeName,
                 String baseValue,
                 String featureSet,
@@ -264,13 +262,13 @@ class ConfigServiceTest {
                 when(ssmProvider.get(
                                 String.format(
                                         "/test/core/credentialIssuers/%s/%s",
-                                        credentialIssuer, attributeName)))
+                                        credentialIssuer.getId(), attributeName)))
                         .thenReturn(baseValue);
             } else {
                 when(ssmProvider.getMultiple(
                                 String.format(
                                         "/test/core/features/%s/credentialIssuers/%s",
-                                        featureSet, credentialIssuer)))
+                                        featureSet, credentialIssuer.getId())))
                         .thenReturn(Map.of(attributeName, featureSetValue));
             }
         }
@@ -282,7 +280,7 @@ class ConfigServiceTest {
                 String featureSetActiveConnection,
                 String featureSet,
                 String expectedActiveConnection) {
-            final String credentialIssuer = Cri.PASSPORT.getId();
+            final var credentialIssuer = Cri.PASSPORT;
             setupTestData(
                     credentialIssuer,
                     "activeConnection",
@@ -300,12 +298,12 @@ class ConfigServiceTest {
                 String featureSetIsEnabled,
                 String featureSet,
                 String expectedIsEnabled) {
-            final String credentialIssuer = Cri.PASSPORT.getId();
+            final var credentialIssuer = Cri.PASSPORT;
             setupTestData(
                     credentialIssuer, "enabled", baseIsEnabled, featureSet, featureSetIsEnabled);
             assertEquals(
                     Boolean.parseBoolean(expectedIsEnabled),
-                    configService.isEnabled(credentialIssuer));
+                    configService.isEnabled(credentialIssuer.getId()));
         }
 
         @ParameterizedTest
@@ -320,7 +318,7 @@ class ConfigServiceTest {
                 String featureSetAllowedSharedAttributes,
                 String featureSet,
                 String expectedIAllowedSharedAttributes) {
-            final String credentialIssuer = Cri.PASSPORT.getId();
+            final var credentialIssuer = Cri.PASSPORT;
             setupTestData(
                     credentialIssuer,
                     "allowedSharedAttributes",
@@ -411,7 +409,7 @@ class ConfigServiceTest {
         when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                 .thenReturn("stub");
 
-        String apiKey = configService.getCriPrivateApiKeyForActiveConnection(Cri.PASSPORT.getId());
+        String apiKey = configService.getCriPrivateApiKeyForActiveConnection(Cri.PASSPORT);
 
         assertEquals("api-key-value", apiKey);
     }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
+import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 
 @ExtendWith(MockitoExtension.class)
 class CriOAuthSessionServiceTest {
@@ -51,14 +52,14 @@ class CriOAuthSessionServiceTest {
         CriOAuthSessionItem criOAuthSessionItem =
                 CriOAuthSessionItem.builder()
                         .criOAuthSessionId("testState")
-                        .criId("testAddress")
+                        .criId(ADDRESS.getId())
                         .connection("main")
                         .build();
 
         CriOAuthSessionItem result =
                 criOauthSessionService.persistCriOAuthSession(
                         criOAuthSessionItem.getCriOAuthSessionId(),
-                        criOAuthSessionItem.getCriId(),
+                        ADDRESS,
                         criOAuthSessionItem.getClientOAuthSessionId(),
                         criOAuthSessionItem.getConnection());
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -160,7 +160,7 @@ public class UserIdentityService {
             var filterValidVCs = filterValidVCs(vcs);
             if (filterValidVCs.size() == 1) {
                 return configService
-                        .getOauthCriActiveConnectionConfig(filterValidVCs.get(0).getCri().getId())
+                        .getOauthCriActiveConnectionConfig(filterValidVCs.get(0).getCri())
                         .isRequiresAdditionalEvidence();
             }
         }

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -2073,7 +2073,7 @@ class UserIdentityServiceTest {
         Arrays.stream(Cri.values())
                 .forEach(
                         credentialIssuer ->
-                                when(mockConfigService.getComponentId(credentialIssuer.getId()))
+                                when(mockConfigService.getComponentId(credentialIssuer))
                                         .thenReturn(credentialIssuer.getId()));
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Change config service methods that take a string cri id as a parameter to use the Cri enum instead

### What changed

<!-- Describe the changes in detail - the "what"-->
 - Changes to config service methods
 - Changes to any code/tests that use the config service methods
 - Changes to BuildCriOauthRequestHandler.java where string cri is passed

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-6816

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

