### PR TITLE
PYIC-6899: use dynamic vot for the f2f cri evidence request

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -176,8 +176,8 @@ public class BuildCriOauthRequestHandler
 
             String govukSigninJourneyId = clientOAuthSessionItem.getGovukSigninJourneyId();
 
-            List<Vot> vot = clientOAuthSessionItem.getRequestedVotsByStrength();
-            Vot minimumRequestedVotsByStrength = vot.isEmpty() ? Vot.P2 : vot.get(0);
+            Vot minimumRequestedVotByStrength =
+                    clientOAuthSessionItem.getLowestStrengthRequestedGpg45Vot(configService);
 
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
@@ -192,7 +192,7 @@ public class BuildCriOauthRequestHandler
                             cri,
                             criContext,
                             criEvidenceRequest,
-                            minimumRequestedVotsByStrength);
+                            minimumRequestedVotByStrength);
 
             CriResponse criResponse = getCriResponse(criConfig, jweObject, cri);
 
@@ -304,7 +304,7 @@ public class BuildCriOauthRequestHandler
             Cri cri,
             String context,
             EvidenceRequest evidenceRequest,
-            Vot minimumRequestedVotsByStrength)
+            Vot requestedVot)
             throws HttpResponseExceptionWithErrorBody, ParseException, JOSEException,
                     VerifiableCredentialException {
 
@@ -315,7 +315,7 @@ public class BuildCriOauthRequestHandler
                 getSharedAttributesForUser(ipvSessionItem, vcs, cri);
 
         if (cri.equals(F2F)) {
-            evidenceRequest = getEvidenceRequestForF2F(vcs, minimumRequestedVotsByStrength);
+            evidenceRequest = getEvidenceRequestForF2F(vcs, requestedVot);
         }
         SignedJWT signedJWT =
                 AuthorizationRequestHelper.createSignedJWT(

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -176,6 +176,9 @@ public class BuildCriOauthRequestHandler
 
             String govukSigninJourneyId = clientOAuthSessionItem.getGovukSigninJourneyId();
 
+            List<Vot> vot = clientOAuthSessionItem.getRequestedVotsByStrength();
+            Vot minimumRequestedVotsByStrength = vot.isEmpty() ? Vot.P2 : vot.get(0);
+
             LogHelper.attachGovukSigninJourneyIdToLogs(govukSigninJourneyId);
 
             String oauthState = SecureTokenHelper.getInstance().generate();
@@ -188,7 +191,8 @@ public class BuildCriOauthRequestHandler
                             govukSigninJourneyId,
                             cri,
                             criContext,
-                            criEvidenceRequest);
+                            criEvidenceRequest,
+                            minimumRequestedVotsByStrength);
 
             CriResponse criResponse = getCriResponse(criConfig, jweObject, cri);
 
@@ -299,7 +303,8 @@ public class BuildCriOauthRequestHandler
             String govukSigninJourneyId,
             Cri cri,
             String context,
-            EvidenceRequest evidenceRequest)
+            EvidenceRequest evidenceRequest,
+            Vot minimumRequestedVotsByStrength)
             throws HttpResponseExceptionWithErrorBody, ParseException, JOSEException,
                     VerifiableCredentialException {
 
@@ -310,7 +315,7 @@ public class BuildCriOauthRequestHandler
                 getSharedAttributesForUser(ipvSessionItem, vcs, cri);
 
         if (cri.equals(F2F)) {
-            evidenceRequest = getEvidenceRequestForF2F(vcs);
+            evidenceRequest = getEvidenceRequestForF2F(vcs, minimumRequestedVotsByStrength);
         }
         SignedJWT signedJWT =
                 AuthorizationRequestHelper.createSignedJWT(
@@ -328,11 +333,12 @@ public class BuildCriOauthRequestHandler
         return AuthorizationRequestHelper.createJweObject(rsaEncrypter, signedJWT);
     }
 
-    private EvidenceRequest getEvidenceRequestForF2F(List<VerifiableCredential> vcs) {
+    private EvidenceRequest getEvidenceRequestForF2F(
+            List<VerifiableCredential> vcs, Vot minimumRequestedVotsByStrength) {
         var gpg45Scores = gpg45ProfileEvaluator.buildScore(vcs);
         List<Gpg45Scores> requiredEvidences =
                 gpg45Scores.calculateGpg45ScoresRequiredToMeetAProfile(
-                        Vot.P2.getSupportedGpg45Profiles());
+                        minimumRequestedVotsByStrength.getSupportedGpg45Profiles());
 
         OptionalInt minViableStrengthOpt =
                 requiredEvidences.stream()

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -1328,14 +1328,14 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldSetEvidenceRequestForF2FWithMinStrengthScoreForP1() throws Exception {
         // Arrange
-        when(configService.getActiveConnection(F2F_CRI)).thenReturn(MAIN_CONNECTION);
-        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, F2F_CRI))
+        when(configService.getActiveConnection(F2F)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, F2F))
                 .thenReturn(f2FOauthCriConfig);
         when(configService.getSsmParameter(JWT_TTL_SECONDS)).thenReturn("900");
         when(configService.getSsmParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
-        when(configService.getComponentId(ADDRESS.getId()))
+        when(configService.getComponentId(ADDRESS))
                 .thenReturn(addressOauthCriConfig.getComponentId());
-        when(configService.getAllowedSharedAttributes(F2F_CRI))
+        when(configService.getAllowedSharedAttributes(F2F))
                 .thenReturn("name,birthDate,address,emailAddress");
         when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
@@ -1358,9 +1358,9 @@ class BuildCriOauthRequestHandlerTest {
                                         ADDRESS,
                                         vcClaim(CREDENTIAL_ATTRIBUTES_3),
                                         ADDRESS_ISSUER)));
-        clientOAuthSessionItem.setVtr(List.of("P1"));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
+        clientOAuthSessionItem.setVtr(List.of("P1"));
         when(mockGpg45ProfileEvaluator.buildScore(any()))
                 .thenReturn(new Gpg45Scores(1, 1, 3, 3, 3));
         when(mockKmsEs256SignerFactory.getSigner(any()))
@@ -1370,7 +1370,7 @@ class BuildCriOauthRequestHandlerTest {
                 JourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
-                        .journey(String.format(JOURNEY_BASE_URL, F2F_CRI))
+                        .journey(String.format(JOURNEY_BASE_URL, F2F.getId()))
                         .build();
 
         // Act

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -83,6 +83,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.P1_JOURNEYS_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.Cri.CLAIMED_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
@@ -1325,8 +1326,7 @@ class BuildCriOauthRequestHandlerTest {
     }
 
     @Test
-    void shouldOnlyEmailForF2FAndAllowCRIConfiguredSharedClaimAttrWithCorrectStrengthScore()
-            throws Exception {
+    void shouldSetEvidenceRequestForF2FWithMinStrengthScoreForP1() throws Exception {
         // Arrange
         when(configService.getActiveConnection(F2F_CRI)).thenReturn(MAIN_CONNECTION);
         when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, F2F_CRI))
@@ -1337,6 +1337,7 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(addressOauthCriConfig.getComponentId());
         when(configService.getAllowedSharedAttributes(F2F_CRI))
                 .thenReturn("name,birthDate,address,emailAddress");
+        when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
         when(mockSessionCredentialService.getCredentials(SESSION_ID, TEST_USER_ID))

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
@@ -7,10 +7,14 @@ import lombok.NoArgsConstructor;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.ProfileType;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.P1_JOURNEYS_ENABLED;
 
 @DynamoDbBean
 @ExcludeFromGeneratedCoverageReport
@@ -45,5 +49,25 @@ public class ClientOAuthSessionItem implements DynamodbItem {
         return Vot.SUPPORTED_VOTS_BY_DESCENDING_STRENGTH.stream()
                 .filter(vot -> vtr.contains(vot.name()))
                 .toList();
+    }
+
+    public Vot getLowestStrengthRequestedGpg45Vot(ConfigService configService) {
+        var requestedGpg45VotsByStrengthDescending =
+                getRequestedVotsByStrength().stream()
+                        .filter(vot -> vot.getProfileType() == ProfileType.GPG45)
+                        .toList();
+
+        var lowestStrengthRequestedGpg45Vot =
+                requestedGpg45VotsByStrengthDescending.get(
+                        requestedGpg45VotsByStrengthDescending.size() - 1);
+
+        if (lowestStrengthRequestedGpg45Vot == Vot.P1
+                && !configService.enabled(P1_JOURNEYS_ENABLED)) {
+            lowestStrengthRequestedGpg45Vot =
+                    requestedGpg45VotsByStrengthDescending.get(
+                            requestedGpg45VotsByStrengthDescending.size() - 2);
+        }
+
+        return lowestStrengthRequestedGpg45Vot;
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ScoresTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ScoresTest.java
@@ -13,6 +13,7 @@ import static uk.gov.di.ipv.core.library.gpg45.Gpg45Scores.EV_32;
 import static uk.gov.di.ipv.core.library.gpg45.Gpg45Scores.EV_33;
 import static uk.gov.di.ipv.core.library.gpg45.Gpg45Scores.EV_42;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.H2D;
+import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.L1A;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1A;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1B;
 
@@ -69,6 +70,10 @@ class Gpg45ScoresTest {
                 Arrays.asList(new Gpg45Scores(EV_32, 0, 0, 2)),
                 new Gpg45Scores(EV_22, 1, 2, 0)
                         .calculateGpg45ScoresRequiredToMeetAProfile(Arrays.asList(M1B)));
+        assertEquals(
+                Arrays.asList(new Gpg45Scores(EV_22, 0, 0, 1)),
+                new Gpg45Scores(List.of(), 0, 1, 0)
+                        .calculateGpg45ScoresRequiredToMeetAProfile(Arrays.asList(L1A)));
     }
 
     @Test

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/ClientOauthSessionItemTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/ClientOauthSessionItemTest.java
@@ -1,16 +1,27 @@
 package uk.gov.di.ipv.core.library.persistence.item;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.P1_JOURNEYS_ENABLED;
 
+@ExtendWith(MockitoExtension.class)
 class ClientOauthSessionItemTest {
+
+    @Mock private ConfigService mockConfigService;
+
     @ParameterizedTest
     @MethodSource("vtrRequestedVotsByStrength")
     void getRequestedVotsByStrengthShouldReturnCorrectVots(
@@ -33,5 +44,47 @@ class ClientOauthSessionItemTest {
                 Arguments.of(
                         List.of("PCL200", "P1", "P2", "PCL250"),
                         List.of(Vot.P2, Vot.PCL250, Vot.PCL200, Vot.P1)));
+    }
+
+    @Test
+    void
+            getLowestStrengthRequestedGpg45Vot_ShouldReturnGpg45Vot_WhenWeakerNonGpg45VotAlsoRequested() {
+        // Arrange
+        var vtr = List.of("P2", "PCL200");
+        var underTest = ClientOAuthSessionItem.builder().vtr(vtr).build();
+
+        // Act
+        var result = underTest.getLowestStrengthRequestedGpg45Vot(mockConfigService);
+
+        // Assert
+        assertEquals(Vot.P2, result);
+    }
+
+    @Test
+    void getLowestStrengthRequestedGpg45Vot_ShouldIgnoreP1_WhenP1IsDisabled() {
+        // Arrange
+        var vtr = List.of("P2", "P1");
+        var underTest = ClientOAuthSessionItem.builder().vtr(vtr).build();
+        when(mockConfigService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(false);
+
+        // Act
+        var result = underTest.getLowestStrengthRequestedGpg45Vot(mockConfigService);
+
+        // Assert
+        assertEquals(Vot.P2, result);
+    }
+
+    @Test
+    void getLowestStrengthRequestedGpg45Vot_ShouldReturnP1_WhenP1IsEnabled() {
+        // Arrange
+        var vtr = List.of("P2", "P1");
+        var underTest = ClientOAuthSessionItem.builder().vtr(vtr).build();
+        when(mockConfigService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
+
+        // Act
+        var result = underTest.getLowestStrengthRequestedGpg45Vot(mockConfigService);
+
+        // Assert
+        assertEquals(Vot.P1, result);
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Use dynamic vot for the f2f cri evidence request

### What changed

- Change f2f evidence request logic to include vot dynamicallay

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- Support low strength F2F documents for thin file users

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6899](https://govukverify.atlassian.net/browse/PYIC-6899)

 P2 Journey evidence request
 
<img width="515" alt="Screenshot 2024-07-10 at 14 23 00" src="https://github.com/govuk-one-login/ipv-core-back/assets/3963744/042627b4-12f6-41fe-a5e6-86494224abcc">


P1 Journey evidence request

<img width="463" alt="Screenshot 2024-07-10 at 14 24 06" src="https://github.com/govuk-one-login/ipv-core-back/assets/3963744/7748493b-73da-40e7-8852-2e6780f162c9">


[PYIC-6899]: https://govukverify.atlassian.net/browse/PYIC-6899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ