### PR TITLE
PYIC-7003 Suppress EVCS errors if reads are not enabled

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -355,71 +355,74 @@ public class CheckExistingIdentityHandler
         var tacticalVcs = verifiableCredentialService.getVcs(userId);
 
         if (configService.enabled(EVCS_WRITE_ENABLED) || configService.enabled(EVCS_READ_ENABLED)) {
-            try {
-                var evcsVcs =
-                        evcsService.getVerifiableCredentialsByState(
-                                userId, evcsAccessToken, CURRENT, PENDING_RETURN);
-
-                // Use pending return vcs to determine identity if available
-                var evcsIdentityVcs = evcsVcs.get(PENDING_RETURN);
-                var isPendingEvcs = true;
-                var hasPartiallyMigratedVcs = false;
-                VerifiableCredentialBundle vcBundle = null;
-                if (isNullOrEmpty(evcsIdentityVcs)) {
-                    evcsIdentityVcs = evcsVcs.get(CURRENT);
-                    isPendingEvcs = false;
-                }
-                if (!isNullOrEmpty(evcsIdentityVcs)) {
-                    vcBundle =
-                            new VerifiableCredentialBundle(
-                                    configService.enabled(EVCS_READ_ENABLED)
-                                            ? evcsIdentityVcs
-                                            : tacticalVcs,
-                                    true,
-                                    isPendingEvcs);
-
-                    hasPartiallyMigratedVcs =
-                            hasPartiallyMigratedVcs(
-                                    tacticalVcs,
-                                    evcsIdentityVcs,
-                                    isPendingEvcs,
-                                    vcBundle.isF2fIdentity());
-
-                    if (hasPartiallyMigratedVcs) {
-                        // use tactical vcs but with evcs flags so that the store-identity lambda is
-                        // called next and updates the evcs pending one
-                        vcBundle = new VerifiableCredentialBundle(tacticalVcs, true, true);
-                    }
-                }
-                logIdentityMismatches(tacticalVcs, evcsVcs, hasPartiallyMigratedVcs);
-                // only use these evcs vcs if they exist and have been fully migrated
-                if (vcBundle != null) {
-                    return vcBundle;
-                }
-            } catch (EvcsServiceException e) {
-                if (configService.enabled(EVCS_READ_ENABLED)) {
-                    throw e;
-                } else {
-                    LOGGER.error(LogHelper.buildErrorMessage("Failed to read EVCS VCs", e));
-                }
+            var bundle = getEvcsCredentialBundle(userId, evcsAccessToken, tacticalVcs);
+            if (bundle != null) {
+                return bundle;
             }
         }
+
         return new VerifiableCredentialBundle(tacticalVcs, false, false);
+    }
+
+    private VerifiableCredentialBundle getEvcsCredentialBundle(
+            String userId, String evcsAccessToken, List<VerifiableCredential> tacticalVcs)
+            throws CredentialParseException, EvcsServiceException {
+        try {
+            var evcsVcs =
+                    evcsService.getVerifiableCredentialsByState(
+                            userId, evcsAccessToken, CURRENT, PENDING_RETURN);
+
+            // Use pending return vcs to determine identity if available
+            var evcsIdentityVcs = evcsVcs.get(PENDING_RETURN);
+            var isPendingEvcs = true;
+            if (isNullOrEmpty(evcsIdentityVcs)) {
+                evcsIdentityVcs = evcsVcs.get(CURRENT);
+                isPendingEvcs = false;
+            }
+
+            // Check for partially migrated pending identity
+            var hasPartiallyMigratedVcs =
+                    hasPartiallyMigratedVcs(tacticalVcs, evcsIdentityVcs, isPendingEvcs);
+            logIdentityMismatches(tacticalVcs, evcsVcs, hasPartiallyMigratedVcs);
+
+            if (!isNullOrEmpty(evcsIdentityVcs)) {
+                if (hasPartiallyMigratedVcs) {
+                    // use tactical vcs but with evcs flags so that the store-identity lambda is
+                    // called next and updates the evcs pending one
+                    return new VerifiableCredentialBundle(tacticalVcs, true, true);
+                } else {
+                    return new VerifiableCredentialBundle(
+                            configService.enabled(EVCS_READ_ENABLED)
+                                    ? evcsIdentityVcs
+                                    : tacticalVcs,
+                            true,
+                            isPendingEvcs);
+                }
+            }
+        } catch (EvcsServiceException e) {
+            if (configService.enabled(EVCS_READ_ENABLED)) {
+                throw e;
+            } else {
+                LOGGER.error(LogHelper.buildErrorMessage("Failed to read EVCS VCs", e));
+            }
+        }
+        return null;
     }
 
     private boolean hasPartiallyMigratedVcs(
             List<VerifiableCredential> tacticalVcs,
             List<VerifiableCredential> evcsVcs,
-            boolean isPending,
-            boolean isF2f) {
+            boolean isPending) {
 
         if (!isPending) {
             return false;
         }
+
         // EVCS contains only a pending F2F VC
-        if (isF2f && evcsVcs.size() == 1) {
+        if (evcsVcs.size() == 1 && F2F.equals(evcsVcs.get(0).getCri())) {
             return true;
         }
+
         // Tactical contains the same as pending EVCS, with one extra F2F VC
         if (tacticalVcs.size() == evcsVcs.size() + 1) {
 

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -49,6 +49,7 @@ import java.util.List;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAudit;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForF2F;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_ASYNC_WRITE_ENABLED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ISSUER;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_CODE;
@@ -213,8 +214,17 @@ public class ProcessAsyncCriCredentialHandler
             postMitigatingVc(vc);
 
             if (configService.enabled(EVCS_ASYNC_WRITE_ENABLED)) {
-                evcsService.storePendingVc(vc);
-                vc.setMigrated(Instant.now());
+                try {
+                    evcsService.storePendingVc(vc);
+                    vc.setMigrated(Instant.now());
+                } catch (EvcsServiceException e) {
+                    if (configService.enabled(EVCS_READ_ENABLED)) {
+                        throw e;
+                    } else {
+                        LOGGER.error(
+                                LogHelper.buildErrorMessage("Failed to store EVCS async VC", e));
+                    }
+                }
             }
             verifiableCredentialService.persistUserCredentials(vc);
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -45,8 +45,6 @@ states:
             targetState: CRI_TICF_BEFORE_REUSE
           deleteDetailsEnabled:
             targetState: IDENTITY_REUSE_PAGE_TEST
-          coiEnabled:
-            targetState: IDENTITY_REUSE_PAGE_COI
 
   CRI_TICF_BEFORE_REUSE:
     response:

--- a/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
+++ b/lambdas/store-identity/src/test/java/uk/gov/di/ipv/core/storeidentity/StoreIdentityHandlerTest.java
@@ -12,6 +12,7 @@ import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -132,7 +133,9 @@ class StoreIdentityHandlerTest {
         when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockClientOauthSessionDetailsService.getClientOAuthSession(CLIENT_SESSION_ID))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockSessionCredentialService.getCredentials(SESSION_ID, USER_ID)).thenReturn(VCS);
+        Mockito.lenient()
+                .when(mockSessionCredentialService.getCredentials(SESSION_ID, USER_ID))
+                .thenReturn(VCS);
         when(mockConfigService.getSsmParameter(ConfigurationVariable.COMPONENT_ID))
                 .thenReturn(COMPONENT_ID);
     }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsMigrationService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsMigrationService.java
@@ -27,8 +27,7 @@ public class EvcsMigrationService {
 
     @ExcludeFromGeneratedCoverageReport
     public EvcsMigrationService(ConfigService configService) {
-        this.evcsService = new EvcsService(configService);
-        this.verifiableCredentialService = new VerifiableCredentialService(configService);
+        this(new EvcsService(configService), new VerifiableCredentialService(configService));
     }
 
     @Tracing

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsMigrationServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsMigrationServiceTest.java
@@ -3,27 +3,26 @@ package uk.gov.di.ipv.core.library.service;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
-import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
-import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_FRAUD;
-import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_EXPERIAN_FRAUD_VC;
-import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.VC_ADDRESS;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcAddressEmpty;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudNotExpired;
 
 @ExtendWith(MockitoExtension.class)
 class EvcsMigrationServiceTest {
     private static final String TEST_USER_ID = "a-user-id";
-    private static final List<VerifiableCredential> VCS =
-            List.of(vcDrivingPermit(), VC_ADDRESS, M1A_EXPERIAN_FRAUD_VC);
+
+    @Captor ArgumentCaptor<List<VerifiableCredential>> vcsToUpdateCaptor;
 
     @Mock EvcsService mockEvcsService;
     @Mock VerifiableCredentialService mockVerifiableCredentialService;
@@ -31,20 +30,11 @@ class EvcsMigrationServiceTest {
 
     @Test
     void testMigrateExistingIdentity() throws Exception {
-        VCS.forEach(
-                credential -> {
-                    if (credential.getCri().equals(EXPERIAN_FRAUD)) {
-                        credential.setMigrated(null);
-                    } else {
-                        credential.setMigrated(Instant.now());
-                    }
-                });
-        ArgumentCaptor<List<VerifiableCredential>> vcsToUpdateCaptor =
-                ArgumentCaptor.forClass(List.class);
+        var vcs = List.of(vcDrivingPermit(), vcAddressEmpty(), vcFraudNotExpired());
 
-        evcsMigrationService.migrateExistingIdentity(TEST_USER_ID, VCS);
+        evcsMigrationService.migrateExistingIdentity(TEST_USER_ID, vcs);
 
-        verify(mockEvcsService).storeMigratedIdentity(TEST_USER_ID, VCS);
+        verify(mockEvcsService).storeMigratedIdentity(TEST_USER_ID, vcs);
         verify(mockVerifiableCredentialService).updateIdentity(vcsToUpdateCaptor.capture());
         vcsToUpdateCaptor.getValue().forEach(vc -> assertNotNull(vc.getMigrated()));
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Suppress EVCS errors that occur while EVCS reads are not enabled

### Why did it change

Until EVCS reads are enabled, the EVCS records are not being used as a source of truth, so we can ignore failures and fall back to existing behaviour.

### Issue tracking

- [PYIC-7003](https://govukverify.atlassian.net/browse/PYIC-7003)

[PYIC-7003]: https://govukverify.atlassian.net/browse/PYIC-7003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ