### PR TITLE
PYIC-6986 Implement reset identity from user Pending F2F page visit.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2874,6 +2874,8 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           SESSION_CREDENTIALS_TABLE_NAME: !Ref SessionCredentialsTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
+          USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
+          CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2907,12 +2909,18 @@ Resources:
             ParameterName: !Sub ${Environment}/core/*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/evcs/api-key-*
         - DynamoDBCrudPolicy:
             TableName: !Ref SessionCredentialsTable
         - DynamoDBCrudPolicy:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref UserIssuedCredentialsV2Table
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CRIResponseTable
       AutoPublishAlias: live
 
   ResetSessionIdentityFunctionLogGroup:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
@@ -55,19 +55,19 @@ states:
     events:
       next:
         targetState:
-          RESET_SESSION_IDENTITY
+          RESET_PENDING_F2F_SESSION_IDENTITY
         auditEvents:
           - IPV_F2F_USER_CANCEL_START
       end:
         targetState:
           PENDING_PAGE_TEST
 
-  RESET_SESSION_IDENTITY:
+  RESET_PENDING_F2F_SESSION_IDENTITY:
     response:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: ALL
+        resetType: PENDING_F2F_ALL
     events:
       next:
         targetState: DETAILS_DELETED_PAGE
@@ -81,7 +81,7 @@ states:
       pageId: pyi-details-deleted
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
+        targetJourney: INITIAL_JOURNEY_SELECTION
         targetState: START
 
   RETURN_TO_RP:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-pending.yaml
@@ -13,7 +13,7 @@ states:
       next:
         targetState: PENDING_PAGE
         checkFeatureFlag:
-          deleteDetailsEnabled:
+          pendingF2FResetEnabled:
             targetState: PENDING_PAGE_TEST
 
   # Journey states

--- a/lambdas/reset-session-identity/build.gradle
+++ b/lambdas/reset-session-identity/build.gradle
@@ -10,7 +10,9 @@ dependencies {
 			libs.awsLambdaJavaEvents,
 			project(":libs:common-services"),
 			project(":libs:journey-uris"),
-			project(":libs:verifiable-credentials")
+			project(":libs:verifiable-credentials"),
+			project(":libs:cri-response-service"),
+			project(':libs:evcs-service')
 
 	aspect libs.powertoolsLogging,
 			libs.powertoolsTracing,

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -10,6 +10,8 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
+import uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType;
+import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.UnknownResetTypeException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -19,13 +21,20 @@ import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.service.CriResponseService;
+import uk.gov.di.ipv.core.library.service.EvcsService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
+import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
 import java.util.Map;
 
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
+import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
+import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_RESET_TYPE;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
@@ -41,16 +50,25 @@ public class ResetSessionIdentityHandler
     private final IpvSessionService ipvSessionService;
     private final SessionCredentialsService sessionCredentialsService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
+    private final CriResponseService criResponseService;
+    private final VerifiableCredentialService verifiableCredentialService;
+    private final EvcsService evcsService;
 
     public ResetSessionIdentityHandler(
             ConfigService configService,
             IpvSessionService ipvSessionService,
             SessionCredentialsService sessionCredentialsService,
-            ClientOAuthSessionDetailsService clientOAuthSessionDetailsService) {
+            ClientOAuthSessionDetailsService clientOAuthSessionDetailsService,
+            CriResponseService criResponseService,
+            VerifiableCredentialService verifiableCredentialService,
+            EvcsService evcsService) {
         this.configService = configService;
         this.ipvSessionService = ipvSessionService;
         this.sessionCredentialsService = sessionCredentialsService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
+        this.criResponseService = criResponseService;
+        this.verifiableCredentialService = verifiableCredentialService;
+        this.evcsService = evcsService;
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -59,6 +77,9 @@ public class ResetSessionIdentityHandler
         this.ipvSessionService = new IpvSessionService(configService);
         this.sessionCredentialsService = new SessionCredentialsService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
+        this.criResponseService = new CriResponseService(configService);
+        this.verifiableCredentialService = new VerifiableCredentialService(configService);
+        this.evcsService = new EvcsService(configService);
     }
 
     @Override
@@ -81,13 +102,36 @@ public class ResetSessionIdentityHandler
             ipvSessionItem.setVot(P0);
             ipvSessionService.updateIpvSession(ipvSessionItem);
 
+            SessionCredentialsResetType sessionCredentialsResetType =
+                    RequestHelper.getSessionCredentialsResetType(input);
             sessionCredentialsService.deleteSessionCredentialsForResetType(
-                    ipvSessionId, RequestHelper.getSessionCredentialsResetType(input));
+                    ipvSessionId, sessionCredentialsResetType);
+
+            if (sessionCredentialsResetType.equals(PENDING_F2F_ALL)) {
+                String userId = clientOAuthSessionItem.getUserId();
+                criResponseService.deleteCriResponseItem(userId, F2F);
+                verifiableCredentialService.deleteVCs(userId);
+                try {
+                    if (configService.enabled(EVCS_WRITE_ENABLED)) {
+                        evcsService.updatePendingIdentity(
+                                userId, clientOAuthSessionItem.getEvcsAccessToken());
+                    }
+                } catch (EvcsServiceException e) {
+                    if (configService.enabled(EVCS_READ_ENABLED)) {
+                        throw e;
+                    } else {
+                        LOGGER.error(
+                                LogHelper.buildErrorMessage("Failed to update EVCS identity", e));
+                    }
+                }
+            }
 
             LOGGER.info(LogHelper.buildLogMessage("Session credentials deleted"));
 
             return JOURNEY_NEXT;
-        } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
+        } catch (HttpResponseExceptionWithErrorBody
+                | VerifiableCredentialException
+                | EvcsServiceException e) {
             LOGGER.error(LogHelper.buildErrorMessage(e.getErrorResponse().getMessage(), e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -143,7 +143,7 @@ public class ResetSessionIdentityHandler
             throws EvcsServiceException {
         try {
             if (configService.enabled(EVCS_WRITE_ENABLED)) {
-                evcsService.updatePendingIdentity(userId, evcsAccessToken);
+                evcsService.abandonPendingIdentity(userId, evcsAccessToken);
             }
         } catch (EvcsServiceException e) {
             if (configService.enabled(EVCS_READ_ENABLED)) {

--- a/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
+++ b/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
@@ -153,7 +153,7 @@ class ResetSessionIdentityHandlerTest {
                         ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
         verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
         verify(mockVerifiableCredentialService).deleteVCs(TEST_USER_ID);
-        verify(mockEvcsService).updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
 
         assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
     }
@@ -169,7 +169,7 @@ class ResetSessionIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         doThrow(EvcsServiceException.class)
                 .when(mockEvcsService)
-                .updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+                .abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
 
         ProcessRequest event =
                 ProcessRequest.processRequestBuilder()
@@ -192,7 +192,7 @@ class ResetSessionIdentityHandlerTest {
                         ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
         verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
         verify(mockVerifiableCredentialService).deleteVCs(TEST_USER_ID);
-        verify(mockEvcsService).updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
 
         assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
     }
@@ -210,7 +210,7 @@ class ResetSessionIdentityHandlerTest {
                         new EvcsServiceException(
                                 HTTPResponse.SC_SERVER_ERROR, FAILED_AT_EVCS_HTTP_REQUEST_SEND))
                 .when(mockEvcsService)
-                .updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+                .abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
 
         ProcessRequest event =
                 ProcessRequest.processRequestBuilder()
@@ -230,7 +230,7 @@ class ResetSessionIdentityHandlerTest {
                         ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
         verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
         verify(mockVerifiableCredentialService).deleteVCs(TEST_USER_ID);
-        verify(mockEvcsService).updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
 
         assertEquals(JOURNEY_ERROR_PATH, journeyResponse.get("journey"));
         assertEquals(500, journeyResponse.get(STATUS_CODE));

--- a/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
+++ b/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.resetsessionidentity;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
+import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
@@ -19,8 +21,11 @@ import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.VcStoreItem;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.service.CriResponseService;
+import uk.gov.di.ipv.core.library.service.EvcsService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
+import uk.gov.di.ipv.core.library.verifiablecredential.service.VerifiableCredentialService;
 
 import java.util.Map;
 
@@ -32,11 +37,16 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_WRITE_ENABLED;
+import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_AT_EVCS_HTTP_REQUEST_SEND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_DELETE_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_IPV_SESSION_ID;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.NAME_ONLY_CHANGE;
+import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 
@@ -52,6 +62,7 @@ class ResetSessionIdentityHandlerTest {
     private static final String TEST_FEATURE_SET = "test-feature-set";
     private static final String TEST_EMAIL_ADDRESS = "test.test@example.com";
     private static final String STATUS_CODE = "statusCode";
+    public static final String TEST_EVCS_TOKEN = "test-evcs-token";
     private static IpvSessionItem ipvSessionItem;
     private static ClientOAuthSessionItem clientOAuthSessionItem;
 
@@ -60,6 +71,9 @@ class ResetSessionIdentityHandlerTest {
     @Mock private IpvSessionService mockIpvSessionService;
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionDetailsService;
     @Mock private Context mockContext;
+    @Mock private CriResponseService mockCriResponseService;
+    @Mock private VerifiableCredentialService mockVerifiableCredentialService;
+    @Mock private EvcsService mockEvcsService;
     @InjectMocks private ResetSessionIdentityHandler resetSessionIdentityHandler;
     @Mock private ConfigService mockConfigService;
 
@@ -79,6 +93,7 @@ class ResetSessionIdentityHandlerTest {
                         .userId(TEST_USER_ID)
                         .clientId("test-client")
                         .govukSigninJourneyId(TEST_JOURNEY_ID)
+                        .evcsAccessToken(TEST_EVCS_TOKEN)
                         .build();
     }
 
@@ -92,7 +107,7 @@ class ResetSessionIdentityHandlerTest {
                 ProcessRequest.processRequestBuilder()
                         .ipvSessionId(TEST_SESSION_ID)
                         .featureSet(TEST_FEATURE_SET)
-                        .lambdaInput(Map.of("resetType", "ALL"))
+                        .lambdaInput(Map.of("resetType", ALL.name()))
                         .build();
 
         // Act
@@ -111,12 +126,125 @@ class ResetSessionIdentityHandlerTest {
     }
 
     @Test
+    void handleRequestShouldCleanupVcsAndReturnNext_forPendingF2f() throws Exception {
+        // Arrange
+        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
+        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        ProcessRequest event =
+                ProcessRequest.processRequestBuilder()
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .featureSet(TEST_FEATURE_SET)
+                        .lambdaInput(Map.of("resetType", PENDING_F2F_ALL.name()))
+                        .build();
+
+        // Act
+        JourneyResponse journeyResponse =
+                OBJECT_MAPPER.convertValue(
+                        resetSessionIdentityHandler.handleRequest(event, mockContext),
+                        JourneyResponse.class);
+
+        // Assert
+        verifyVotSetToP0();
+
+        verify(mockSessionCredentialsService)
+                .deleteSessionCredentialsForResetType(
+                        ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
+        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
+        verify(mockVerifiableCredentialService).deleteVCs(TEST_USER_ID);
+        verify(mockEvcsService).updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+
+        assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
+    }
+
+    @Test
+    void
+            handleRequestShouldCleanupVcsAndReturnNext_forPendingF2f_evenWhenEvcsFailsAndEvcsReadsIsNotEnabled()
+                    throws Exception {
+        // Arrange
+        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
+        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        doThrow(EvcsServiceException.class)
+                .when(mockEvcsService)
+                .updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+
+        ProcessRequest event =
+                ProcessRequest.processRequestBuilder()
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .featureSet(TEST_FEATURE_SET)
+                        .lambdaInput(Map.of("resetType", PENDING_F2F_ALL.name()))
+                        .build();
+
+        // Act
+        JourneyResponse journeyResponse =
+                OBJECT_MAPPER.convertValue(
+                        resetSessionIdentityHandler.handleRequest(event, mockContext),
+                        JourneyResponse.class);
+
+        // Assert
+        verifyVotSetToP0();
+
+        verify(mockSessionCredentialsService)
+                .deleteSessionCredentialsForResetType(
+                        ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
+        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
+        verify(mockVerifiableCredentialService).deleteVCs(TEST_USER_ID);
+        verify(mockEvcsService).updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+
+        assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnErrorJourney_forPendingF2f_evenWhenEvcsFailsAndEvcsReadsIsEnabled()
+            throws Exception {
+        // Arrange
+        when(mockConfigService.enabled(EVCS_WRITE_ENABLED)).thenReturn(true);
+        when(mockConfigService.enabled(EVCS_READ_ENABLED)).thenReturn(true);
+        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        doThrow(
+                        new EvcsServiceException(
+                                HTTPResponse.SC_SERVER_ERROR, FAILED_AT_EVCS_HTTP_REQUEST_SEND))
+                .when(mockEvcsService)
+                .updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+
+        ProcessRequest event =
+                ProcessRequest.processRequestBuilder()
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .featureSet(TEST_FEATURE_SET)
+                        .lambdaInput(Map.of("resetType", PENDING_F2F_ALL.name()))
+                        .build();
+
+        // Act
+        var journeyResponse = resetSessionIdentityHandler.handleRequest(event, mockContext);
+
+        // Assert
+        verifyVotSetToP0();
+
+        verify(mockSessionCredentialsService)
+                .deleteSessionCredentialsForResetType(
+                        ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
+        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
+        verify(mockVerifiableCredentialService).deleteVCs(TEST_USER_ID);
+        verify(mockEvcsService).updatePendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+
+        assertEquals(JOURNEY_ERROR_PATH, journeyResponse.get("journey"));
+        assertEquals(500, journeyResponse.get(STATUS_CODE));
+        assertEquals(FAILED_AT_EVCS_HTTP_REQUEST_SEND.getCode(), journeyResponse.get("code"));
+        assertEquals(FAILED_AT_EVCS_HTTP_REQUEST_SEND.getMessage(), journeyResponse.get("message"));
+    }
+
+    @Test
     void shouldReturnErrorJourneyIfIpvSessionIdMissing() {
         // Arrange
         ProcessRequest event =
                 ProcessRequest.processRequestBuilder()
                         .featureSet(TEST_FEATURE_SET)
-                        .lambdaInput(Map.of("resetType", "ALL"))
+                        .lambdaInput(Map.of("resetType", ALL.name()))
                         .build();
 
         // Act
@@ -142,7 +270,7 @@ class ResetSessionIdentityHandlerTest {
                 ProcessRequest.processRequestBuilder()
                         .ipvSessionId(TEST_SESSION_ID)
                         .featureSet(TEST_FEATURE_SET)
-                        .lambdaInput(Map.of("resetType", "NAME_ONLY_CHANGE"))
+                        .lambdaInput(Map.of("resetType", NAME_ONLY_CHANGE.name()))
                         .build();
 
         // Act

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
@@ -3,5 +3,6 @@ package uk.gov.di.ipv.core.library.enums;
 public enum SessionCredentialsResetType {
     ALL,
     NAME_ONLY_CHANGE,
-    ADDRESS_ONLY_CHANGE;
+    ADDRESS_ONLY_CHANGE,
+    PENDING_F2F_ALL;
 }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
@@ -121,7 +121,7 @@ public class EvcsService {
                                 credential.getVcString(), PENDING_RETURN, null, OFFLINE)));
     }
 
-    public void updatePendingIdentity(String userId, String evcsAccessToken)
+    public void abandonPendingIdentity(String userId, String evcsAccessToken)
             throws EvcsServiceException {
         List<EvcsUpdateUserVCsDto> vcsToUpdates =
                 getUserVCs(userId, evcsAccessToken, PENDING_RETURN).stream()

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/service/EvcsServiceTest.java
@@ -353,7 +353,7 @@ class EvcsServiceTest {
         when(mockEvcsClient.getUserVcs(
                         TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, List.of(PENDING_RETURN)))
                 .thenReturn(evcsGetUserVcsWithPendingAllExistingDto);
-        evcsService.updatePendingIdentity(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN);
+        evcsService.abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN);
 
         InOrder mockOrderVerifier = Mockito.inOrder(mockEvcsClient);
         mockOrderVerifier

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -100,7 +100,7 @@ public class SessionCredentialsService {
             var sessionCredentialItems = dataStore.getItems(ipvSessionId);
             var vcsToDelete =
                     switch (resetType) {
-                        case ALL -> sessionCredentialItems;
+                        case ALL, PENDING_F2F_ALL -> sessionCredentialItems;
                         case ADDRESS_ONLY_CHANGE -> sessionCredentialItems.stream()
                                 .filter(
                                         item ->

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -73,6 +73,14 @@ public class VerifiableCredentialService {
         }
     }
 
+    public void deleteVCs(String userId) throws VerifiableCredentialException {
+        try {
+            dataStore.deleteAllByPartition(userId);
+        } catch (Exception e) {
+            throw new VerifiableCredentialException(SC_SERVER_ERROR, FAILED_TO_DELETE_CREDENTIAL);
+        }
+    }
+
     private void deleteVcStoreItem(String userId, String criId) {
         dataStore.delete(userId, criId);
     }

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialServiceTest.java
@@ -37,6 +37,7 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_UPDATE_I
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.EXPIRED_M1A_EXPERIAN_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_SUCCESSFUL_VC;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.TEST_SUBJECT;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreOne;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreTwo;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL250NoEvidence;
@@ -116,6 +117,15 @@ class VerifiableCredentialServiceTest {
     }
 
     @Test
+    void shouldDeleteAllExistingVCsForPartitionKeyUserId() throws Exception {
+        verifiableCredentialService.deleteVCs(TEST_SUBJECT);
+
+        ArgumentCaptor<String> userIdCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockDataStore).deleteAllByPartition(userIdCaptor.capture());
+        assertEquals(TEST_SUBJECT, userIdCaptor.getValue());
+    }
+
+    @Test
     void shouldDeleteInheritedIdentityIfPresent() throws Exception {
         // Arrange
         var inheritedIdentityVc = vcHmrcMigrationPCL250NoEvidence();
@@ -176,7 +186,7 @@ class VerifiableCredentialServiceTest {
     }
 
     @Test
-    void storeIdentityShouldThrowIfFailureToDeleteExistingVc() throws BatchDeleteException {
+    void storeIdentityShouldThrowIfFailureToDeleteExistingVc() throws Exception {
         doThrow(new BatchDeleteException("Deletion failed"))
                 .when(mockDataStore)
                 .deleteAllByPartition(USER_ID);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Implement reset identity from user Pending F2F page visit.

### What changed
Changes made in reset lambda to handle identity reset from the pending f2f journey.
- delete user f2f rec from CriResponse table
- delete user VCs from tactical storagety.
- update evcs storage for user vc's (PENDING_RETURN -> ABANDONED)

Update sessionCredential and verifiableCredential service.
Also added operation in evcsService to update pending identity

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6986](https://govukverify.atlassian.net/browse/PYIC-6986)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-6986]: https://govukverify.atlassian.net/browse/PYIC-6986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ