### PR TITLE
PYIC-6738: Put targetVot on clientOauthSession:

### DIFF
--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -116,11 +116,7 @@ public class BuildUserIdentityHandler extends UserIdentityRequestHandler
 
             var vcs = sessionCredentialsService.getCredentials(ipvSessionId, userId);
 
-            // PYIC-6901 there's probably a better way of getting the target Vot rather than
-            // re-calculating it here. Can we store it in the session in CheckExistingIdentity?
-            // We only actually need this to calculate CI breaches for return codes and the audit
-            // message
-            var targetVot = clientOAuthSessionItem.getLowestStrengthRequestedVot(configService);
+            var targetVot = clientOAuthSessionItem.getTargetVot();
             var acheivedVot = ipvSessionItem.getVot();
             var userIdentity =
                     userIdentityService.generateUserIdentity(

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -82,7 +82,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.P1_JOURNEYS_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.TICF_CRI_BETA;
 import static uk.gov.di.ipv.core.library.domain.Cri.CIMIT;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
@@ -280,6 +279,7 @@ class BuildUserIdentityHandlerTest {
         clientOAuthSessionItem.setVtr(List.of("P2", "P1"));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
+        clientOAuthSessionItem.setTargetVot(Vot.P1);
         when(mockCiMitService.getContraIndicatorsVc(any(), any(), any()))
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
@@ -289,7 +289,6 @@ class BuildUserIdentityHandlerTest {
         when(mockContraIndicators.hasMitigations()).thenReturn(true);
         when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(false);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
-        when(mockConfigService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(VC_ADDRESS));
 
@@ -1053,6 +1052,7 @@ class BuildUserIdentityHandlerTest {
                 .clientId("test-client")
                 .govukSigninJourneyId("test-journey-id")
                 .vtr(List.of("P2"))
+                .targetVot(Vot.P2)
                 .scope(scope)
                 .build();
     }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -518,7 +518,7 @@ public class CheckExistingIdentityHandler
             VerifiableCredentialBundle vcBundle,
             boolean areGpg45VcsCorrelated)
             throws ParseException, SqsException, VerifiableCredentialException,
-                    EvcsServiceException, HttpResponseExceptionWithErrorBody {
+                    EvcsServiceException {
         // Check for attained vot from requested vots
         var strongestAttainedVotFromVtr =
                 getStrongestAttainedVotForVtr(

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -307,7 +307,7 @@ public class CheckExistingIdentityHandler
                 return profileMatchResponse.get();
             }
 
-            // Update targetVot now we know we must use gpg45 to make it
+            // Update targetVot to be gpg45 if needed
             clientOAuthSessionItem.updateTargetVotForGpg45Only(
                     configService.enabled(P1_JOURNEYS_ENABLED));
             clientOAuthSessionDetailsService.updateClientOauthSession(clientOAuthSessionItem);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -133,8 +133,6 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REPROVE
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_WITH_STORE_PATH;
 
-// TODO: Add assertions clientOauthSession is updated
-
 @ExtendWith(MockitoExtension.class)
 class CheckExistingIdentityHandlerTest {
     private static final String TEST_SESSION_ID = "test-session-id";

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -133,6 +133,8 @@ import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REPROVE
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_REUSE_WITH_STORE_PATH;
 
+// TODO: Add assertions clientOauthSession is updated
+
 @ExtendWith(MockitoExtension.class)
 class CheckExistingIdentityHandlerTest {
     private static final String TEST_SESSION_ID = "test-session-id";
@@ -232,6 +234,7 @@ class CheckExistingIdentityHandlerTest {
                         .govukSigninJourneyId(TEST_JOURNEY_ID)
                         .reproveIdentity(false)
                         .vtr(List.of(P2.name()))
+                        .targetVot(TEST_VOT)
                         .evcsAccessToken(EVCS_TEST_TOKEN)
                         .build();
     }
@@ -263,8 +266,10 @@ class CheckExistingIdentityHandlerTest {
     void shouldReturnJourneyNewGpg45LowIdentityForP1Vtr() throws Exception {
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
+        clientOAuthSessionItem.setTargetVot(P1);
         when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
         when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
+        when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
         when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -1187,6 +1192,7 @@ class CheckExistingIdentityHandlerTest {
         var testContraIndicators = ContraIndicators.builder().build();
         when(ipvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
+        clientOAuthSessionItem.setTargetVot(P1);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(ciMitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
@@ -1194,7 +1200,6 @@ class CheckExistingIdentityHandlerTest {
         when(configService.enabled(EVCS_WRITE_ENABLED)).thenReturn(false);
         when(configService.enabled(EVCS_READ_ENABLED)).thenReturn(false);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
-        when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
 
         JourneyResponse journeyResponse =
                 toResponseClass(

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -216,7 +216,8 @@ class InitialiseIpvSessionHandlerTest {
 
     @Test
     void shouldReturnIpvSessionIdWhenProvidedValidRequest()
-            throws JsonProcessingException, JarValidationException, ParseException, SqsException {
+            throws JsonProcessingException, JarValidationException, ParseException, SqsException,
+                    HttpResponseExceptionWithErrorBody {
         ArgumentCaptor<String> evcsAccessTokenCaptor = ArgumentCaptor.forClass(String.class);
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
@@ -249,7 +250,8 @@ class InitialiseIpvSessionHandlerTest {
 
     @Test
     void shouldReturnIpvSessionIdAndSendAuditEventWhenProvidedValidReproveRequest()
-            throws JsonProcessingException, JarValidationException, ParseException, SqsException {
+            throws JsonProcessingException, JarValidationException, ParseException, SqsException,
+                    HttpResponseExceptionWithErrorBody {
         ArgumentCaptor<String> evcsAccessTokenCaptor = ArgumentCaptor.forClass(String.class);
         // Arrange
         when(mockConfigService.enabled(any(FeatureFlag.class))).thenReturn(false);
@@ -329,7 +331,8 @@ class InitialiseIpvSessionHandlerTest {
 
     @Test
     void shouldReturnIpvSessionIdWhenProvidedValidRequest_andSaveEvcsAccessToken()
-            throws JsonProcessingException, JarValidationException, ParseException, SqsException {
+            throws JsonProcessingException, JarValidationException, ParseException, SqsException,
+                    HttpResponseExceptionWithErrorBody {
         ArgumentCaptor<String> evcsAccessTokenCaptor = ArgumentCaptor.forClass(String.class);
 
         var evcsAccessTokenClaims =
@@ -464,7 +467,8 @@ class InitialiseIpvSessionHandlerTest {
     @MethodSource("getVtrTestValues")
     void shouldIpvSessionIdIfMissingVtrAndReverificationJourney(List<String> vtrList)
             throws JsonProcessingException, InvalidKeySpecException, NoSuchAlgorithmException,
-                    JOSEException, ParseException, JarValidationException {
+                    JOSEException, ParseException, JarValidationException,
+                    HttpResponseExceptionWithErrorBody {
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                 .thenReturn(ipvSessionItem);

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -231,11 +231,9 @@ public class CriCheckingService {
 
             // Check CI levels against the lowest confidence identity requested so we don't send the
             // user on an unnecessary mitigation journey.
-            var lowestConfidenceRequested =
-                    clientOAuthSessionItem.getLowestStrengthRequestedGpg45Vot(configService);
+            var targetVot = clientOAuthSessionItem.getTargetVot();
             var journeyResponse =
-                    ciMitUtilityService.getMitigationJourneyIfBreaching(
-                            cis, lowestConfidenceRequested);
+                    ciMitUtilityService.getMitigationJourneyIfBreaching(cis, targetVot);
             if (journeyResponse.isPresent()) {
                 return journeyResponse.get();
             }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -45,11 +45,9 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.P1_JOURNEYS_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ACCESS_DENIED_PATH;
@@ -500,10 +498,11 @@ class CriCheckingServiceTest {
         var vcs = List.of(M1A_ADDRESS_VC);
         var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
         clientOAuthSessionItem.setVtr(List.of("P1", "P2"));
-        when(mockConfigService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
+        clientOAuthSessionItem.setTargetVot(Vot.P1);
         when(mockCiMitService.getContraIndicators(any(), any(), any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
-        when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), eq(Vot.P1)))
+        when(mockCimitUtilityService.getMitigationJourneyIfBreaching(
+                        TEST_CONTRA_INDICATORS, Vot.P1))
                 .thenReturn(Optional.empty());
         when(mockUserIdentityService.areVcsCorrelated(any())).thenReturn(true);
         mockedVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -106,7 +106,8 @@ public enum ErrorResponse {
     ERROR_CALLING_DCMAW_ASYNC_CRI(1089, "Error calling the DCMAW Async CRI"),
     FAILED_TO_UPDATE_IDENTITY(1090, "Failed to update identity"),
     INVALID_SIGNING_KEY_TYPE(1091, "Signing key is invalid type. Must be EC or RSA"),
-    UNEXPECTED_CREDENTIAL_TYPE(1092, "Unexpected credential type");
+    UNEXPECTED_CREDENTIAL_TYPE(1092, "Unexpected credential type"),
+    INVALID_VTR(1093, "Vtr does not include any attainable Vots");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/ClientOAuthSessionItem.java
@@ -38,6 +38,7 @@ public class ClientOAuthSessionItem implements DynamodbItem {
     private long ttl;
     private String evcsAccessToken;
 
+    @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public ClientOAuthSessionItem(
             String clientOAuthSessionId,
             String responseType,

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/ClientOauthSessionItemTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/ClientOauthSessionItemTest.java
@@ -16,6 +16,8 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+// TODO: Add test for ArrayIndexOutOfBoundsException exception
+
 @ExtendWith(MockitoExtension.class)
 class ClientOauthSessionItemTest {
     @Mock private ConfigService mockConfigService;
@@ -44,7 +46,35 @@ class ClientOauthSessionItemTest {
                         List.of(Vot.P2, Vot.PCL250, Vot.PCL200, Vot.P1)));
     }
 
-    // would need to add tests for updating targetVot
+    @Test
+    void updateTargetVotForGpg45Only_ShouldUpdateSessionWithNewTargetVot_WhenP1IsDisabled()
+            throws HttpResponseExceptionWithErrorBody {
+        // Arrange
+        var vtr = List.of("P2", "PCL200", "PCL250", "P1");
+        var clientOAuthSessionItem = ClientOAuthSessionItem.builder().vtr(vtr).build();
+        var isP1JourneysEnabled = false;
+
+        // Act
+        clientOAuthSessionItem.updateTargetVotForGpg45Only(isP1JourneysEnabled);
+
+        // Assert
+        assertEquals(Vot.P2, clientOAuthSessionItem.getTargetVot());
+    }
+
+    @Test
+    void updateTargetVotForGpg45Only_ShouldUpdateSessionWithNewTargetVot_WhenP1IsEnabled()
+            throws HttpResponseExceptionWithErrorBody {
+        // Arrange
+        var vtr = List.of("P2", "PCL200", "PCL250", "P1");
+        var clientOAuthSessionItem = ClientOAuthSessionItem.builder().vtr(vtr).build();
+        var isP1JourneysEnabled = true;
+
+        // Act
+        clientOAuthSessionItem.updateTargetVotForGpg45Only(isP1JourneysEnabled);
+
+        // Assert
+        assertEquals(Vot.P1, clientOAuthSessionItem.getTargetVot());
+    }
 
     @Test
     void getLowestStrengthRequestedVot_ShouldIgnoreP1_WhenP1IsDisabled()
@@ -74,5 +104,59 @@ class ClientOauthSessionItemTest {
 
         // Assert
         assertEquals(Vot.P1, result);
+    }
+
+    @Test
+    void constructor_ShouldSetTargetVot_WhenP1IsDisabled()
+            throws HttpResponseExceptionWithErrorBody {
+        // Arrange
+        var vtr = List.of("P2", "PCL200", "PCL250", "P1");
+        var isP1JourneysEnabled = false;
+
+        // Act
+        var clientOauthSessionItem =
+                new ClientOAuthSessionItem(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        vtr,
+                        null,
+                        isP1JourneysEnabled);
+
+        // Assert
+        assertEquals(Vot.PCL200, clientOauthSessionItem.getTargetVot());
+    }
+
+    @Test
+    void constructor_ShouldSetTargetVot_WhenP1IsEnabled()
+            throws HttpResponseExceptionWithErrorBody {
+        // Arrange
+        var vtr = List.of("P2", "PCL200", "PCL250", "P1");
+        var isP1JourneysEnabled = true;
+
+        // Act
+        var clientOauthSessionItem =
+                new ClientOAuthSessionItem(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        vtr,
+                        null,
+                        isP1JourneysEnabled);
+
+        // Assert
+        assertEquals(Vot.P1, clientOauthSessionItem.getTargetVot());
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/ClientOauthSessionItemTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/ClientOauthSessionItemTest.java
@@ -16,8 +16,6 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-// TODO: Add test for ArrayIndexOutOfBoundsException exception
-
 @ExtendWith(MockitoExtension.class)
 class ClientOauthSessionItemTest {
     @Mock private ConfigService mockConfigService;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/ClientOauthSessionItemTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/item/ClientOauthSessionItemTest.java
@@ -8,14 +8,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.P1_JOURNEYS_ENABLED;
 
 @ExtendWith(MockitoExtension.class)
 class ClientOauthSessionItemTest {
@@ -45,71 +44,33 @@ class ClientOauthSessionItemTest {
                         List.of(Vot.P2, Vot.PCL250, Vot.PCL200, Vot.P1)));
     }
 
-    @Test
-    void
-            getLowestStrengthRequestedGpg45Vot_ShouldReturnGpg45Vot_WhenWeakerNonGpg45VotAlsoRequested() {
-        // Arrange
-        var vtr = List.of("P2", "PCL200");
-        var underTest = ClientOAuthSessionItem.builder().vtr(vtr).build();
-
-        // Act
-        var result = underTest.getLowestStrengthRequestedGpg45Vot(mockConfigService);
-
-        // Assert
-        assertEquals(Vot.P2, result);
-    }
+    // would need to add tests for updating targetVot
 
     @Test
-    void getLowestStrengthRequestedGpg45Vot_ShouldIgnoreP1_WhenP1IsDisabled() {
-        // Arrange
-        var vtr = List.of("P2", "P1");
-        var underTest = ClientOAuthSessionItem.builder().vtr(vtr).build();
-        when(mockConfigService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(false);
-
-        // Act
-        var result = underTest.getLowestStrengthRequestedGpg45Vot(mockConfigService);
-
-        // Assert
-        assertEquals(Vot.P2, result);
-    }
-
-    @Test
-    void getLowestStrengthRequestedGpg45Vot_ShouldReturnP1_WhenP1IsEnabled() {
-        // Arrange
-        var vtr = List.of("P2", "P1");
-        var underTest = ClientOAuthSessionItem.builder().vtr(vtr).build();
-        when(mockConfigService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
-
-        // Act
-        var result = underTest.getLowestStrengthRequestedGpg45Vot(mockConfigService);
-
-        // Assert
-        assertEquals(Vot.P1, result);
-    }
-
-    @Test
-    void getLowestStrengthRequestedVot_ShouldIgnoreP1_WhenP1IsDisabled() {
+    void getLowestStrengthRequestedVot_ShouldIgnoreP1_WhenP1IsDisabled()
+            throws HttpResponseExceptionWithErrorBody {
         // Arrange
         var vtr = List.of("P2", "PCL200", "PCL250", "P1");
         var underTest = ClientOAuthSessionItem.builder().vtr(vtr).build();
-        when(mockConfigService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(false);
+        var isP1JourneysEnabled = false;
 
         // Act
-        var result = underTest.getLowestStrengthRequestedVot(mockConfigService);
+        var result = underTest.getLowestStrengthRequestedVot(isP1JourneysEnabled);
 
         // Assert
         assertEquals(Vot.PCL200, result);
     }
 
     @Test
-    void getLowestStrengthRequestedVot_ShouldReturnP1_WhenP1IsEnabled() {
+    void getLowestStrengthRequestedVot_ShouldReturnP1_WhenP1IsEnabled()
+            throws HttpResponseExceptionWithErrorBody {
         // Arrange
         var vtr = List.of("PCL200", "P1");
         var underTest = ClientOAuthSessionItem.builder().vtr(vtr).build();
-        when(mockConfigService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
+        var isP1JourneysEnabled = true;
 
         // Act
-        var result = underTest.getLowestStrengthRequestedVot(mockConfigService);
+        var result = underTest.getLowestStrengthRequestedVot(isP1JourneysEnabled);
 
         // Assert
         assertEquals(Vot.P1, result);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
@@ -7,11 +7,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 
 import java.text.ParseException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -66,7 +68,8 @@ class ClientOAuthSessionDetailsServiceTest {
     }
 
     @Test
-    void shouldCreateClientOAuthSessionItem() throws ParseException {
+    void shouldCreateClientOAuthSessionItem()
+            throws ParseException, HttpResponseExceptionWithErrorBody {
         String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
 
         JWTClaimsSet testClaimSet =
@@ -77,6 +80,7 @@ class ClientOAuthSessionDetailsServiceTest {
                         .claim("govuk_signin_journey_id", "test-journey-id")
                         .claim("reprove_identity", false)
                         .claim("scope", "test-scope")
+                        .claim("vtr", List.of("P2"))
                         .subject("test-user-id")
                         .build();
         ClientOAuthSessionItem clientOAuthSessionItem =
@@ -90,31 +94,10 @@ class ClientOAuthSessionDetailsServiceTest {
                 ArgumentCaptor.forClass(ClientOAuthSessionItem.class);
         verify(mockDataStore)
                 .create(clientOAuthSessionItemArgumentCaptor.capture(), eq(BACKEND_SESSION_TTL));
+        var storedClientOauthSessionItem = clientOAuthSessionItemArgumentCaptor.getValue();
+
         assertEquals(clientOAuthSessionId, clientOAuthSessionItem.getClientOAuthSessionId());
-        assertEquals(
-                clientOAuthSessionItem.getClientId(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getClientId());
-        assertEquals(
-                clientOAuthSessionItem.getResponseType(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getResponseType());
-        assertEquals(
-                clientOAuthSessionItem.getRedirectUri(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getRedirectUri());
-        assertEquals(
-                clientOAuthSessionItem.getState(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getState());
-        assertEquals(
-                clientOAuthSessionItem.getUserId(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getUserId());
-        assertEquals(
-                clientOAuthSessionItem.getEvcsAccessToken(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getEvcsAccessToken());
-        assertEquals(
-                clientOAuthSessionItem.getGovukSigninJourneyId(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getGovukSigninJourneyId());
-        assertEquals(
-                clientOAuthSessionItem.getScope(),
-                clientOAuthSessionItemArgumentCaptor.getValue().getScope());
+        assertEquals(clientOAuthSessionItem, storedClientOauthSessionItem);
         assertFalse(clientOAuthSessionItem.getReproveIdentity());
     }
 


### PR DESCRIPTION
- construct in InitialiseIpvSession
- and update if no profile matched in CheckExistingIdentityHandler

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- 

### Why did it change

- 

### Issue tracking

- [PYIC-6738](https://govukverify.atlassian.net/browse/PYIC-6738)

[PYIC-6738]: https://govukverify.atlassian.net/browse/PYIC-6738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Need to add assertions session updated to unit tests
And add test for ArrayIndexOutOfBoundsException exception