### PR TITLE
PYIC-7010: rename prove identity bank account to prove identity no photo id

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -179,7 +179,7 @@ states:
   BANK_ACCOUNT_START_PAGE:
     response:
       type: page
-      pageId: prove-identity-bank-account
+      pageId: prove-identity-no-photo-id
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_M2B


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- rename prove identity bank account to prove identity no photo id

### What changed

- Renamed pageId from `prove-identity-bank-account` to  `prove-identity-no-photo-id`

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To use context/common page for no photo id journies.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7010](https://govukverify.atlassian.net/browse/PYIC-7010)


[PYIC-7010]: https://govukverify.atlassian.net/browse/PYIC-7010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ