### PR TITLE
PYIC-7021: add vot p1, p2 check for the account intervention audit event

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -184,6 +184,7 @@ public class BuildClientOauthResponseHandler
 
             var isReproveIdentity = clientOAuthSessionItem.getReproveIdentity();
             if (Boolean.TRUE.equals(isReproveIdentity)) {
+                Vot vot = ipvSessionItem.getVot();
                 auditService.sendAuditEvent(
                         AuditEvent.createWithoutDeviceInformation(
                                 AuditEventTypes.IPV_ACCOUNT_INTERVENTION_END,
@@ -191,7 +192,7 @@ public class BuildClientOauthResponseHandler
                                 auditEventUser,
                                 AuditExtensionAccountIntervention.newReproveIdentity(
                                         ipvSessionItem.getErrorCode() == null
-                                                && Vot.P2.equals(ipvSessionItem.getVot()))));
+                                                && (Vot.P2.equals(vot) || Vot.P1.equals(vot)))));
             }
 
             var message =

--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -185,6 +185,7 @@ public class BuildClientOauthResponseHandler
             var isReproveIdentity = clientOAuthSessionItem.getReproveIdentity();
             if (Boolean.TRUE.equals(isReproveIdentity)) {
                 Vot vot = ipvSessionItem.getVot();
+                List<String> vtr = clientOAuthSessionItem.getVtr();
                 auditService.sendAuditEvent(
                         AuditEvent.createWithoutDeviceInformation(
                                 AuditEventTypes.IPV_ACCOUNT_INTERVENTION_END,
@@ -192,7 +193,7 @@ public class BuildClientOauthResponseHandler
                                 auditEventUser,
                                 AuditExtensionAccountIntervention.newReproveIdentity(
                                         ipvSessionItem.getErrorCode() == null
-                                                && (Vot.P2.equals(vot) || Vot.P1.equals(vot)))));
+                                                && vtr.contains(vot.toString()))));
             }
 
             var message =

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -138,7 +138,7 @@ class BuildClientOauthResponseHandlerTest {
     @ParameterizedTest
     @EnumSource(
             value = Vot.class,
-            names = {"P0", "P2"})
+            names = {"P0", "P1", "P2"})
     void shouldReturn200OnSuccessfulOauthRequestForReproveIdentity(Vot vot)
             throws SqsException, URISyntaxException {
         when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
@@ -173,7 +173,11 @@ class BuildClientOauthResponseHandlerTest {
         AuditExtensionAccountIntervention extensions =
                 (AuditExtensionAccountIntervention) capturedValues.get(1).getExtensions();
         assertEquals("reprove_identity", extensions.getType());
-        assertEquals(vot == Vot.P2, extensions.getSuccess());
+        if (Vot.P0.equals(vot)) {
+            assertEquals(false, extensions.getSuccess());
+        } else {
+            assertEquals(true, extensions.getSuccess());
+        }
 
         URI expectedRedirectUrl =
                 new URIBuilder("https://example.com")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Update IPV_ACCOUNT_INTERVENTION_END audit event for P1

### What changed

- Added check for P1 vot

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To send audit event with correct success status

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7021](https://govukverify.atlassian.net/browse/PYIC-7021)

Audit event for P1 journey.

<img width="665" alt="Screenshot 2024-07-22 at 13 47 27" src="https://github.com/user-attachments/assets/3e9deb49-d771-4a97-a02a-fcd56787731f">

Audit event for unsucessfull reapprove (P2 requested but user has P1)

<img width="660" alt="Screenshot 2024-07-22 at 13 43 51" src="https://github.com/user-attachments/assets/e465de7b-e5e9-4f90-a087-a1b00df433f2">


[PYIC-7021]: https://govukverify.atlassian.net/browse/PYIC-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ