### PR TITLE
PYIC-7018: Add Low Confidence Journey Map

### DIFF
--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -7,6 +7,7 @@ const DEFAULT_JOURNEY_TYPE = 'INITIAL_JOURNEY_SELECTION';
 
 const JOURNEY_TYPES = {
     INITIAL_JOURNEY_SELECTION: 'Initial journey selection',
+    NEW_P1_IDENTITY: 'New P1 identity',
     NEW_P2_IDENTITY: 'New P2 identity',
     EVALUATE_SCORES: 'Evaluate scores',
     REUSE_EXISTING_IDENTITY: 'Reuse existing identity',

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -376,11 +376,17 @@ states:
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
   # Driving licence journey (J3)
   CRI_DRIVING_LICENCE_J3:
@@ -411,11 +417,17 @@ states:
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
   # F2F journey (J4)
   CRI_CLAIMED_IDENTITY_J4:
@@ -448,9 +460,6 @@ states:
     events:
       next:
         targetState: CRI_HMRC_KBV_J6
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       fail-with-no-ci:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
@@ -998,6 +1007,9 @@ states:
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
@@ -1065,22 +1077,14 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: MITIGATION_CHECK_FRAUD_SCORE
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  MITIGATION_CHECK_FRAUD_SCORE:
-    response:
-      type: process
-      lambda: check-gpg45-score
-    events:
-      met:
         targetState: MITIGATION_CRI_DWP_KBV
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
-      unmet:
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
 
@@ -1093,9 +1097,6 @@ states:
     events:
       next:
         targetState: MITIGATION_CRI_HMRC_KBV
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       fail-with-no-ci:
         targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -1,6 +1,6 @@
 name: New P1 Identity
 description: >-
-  The routes a user can take to prove their identity to a low
+  The routes a user so they can prove their identity to a low
   confidence level (P1).
 
 states:
@@ -16,7 +16,6 @@ states:
         targetState: REPROVE_IDENTITY_START
 
   # Q's:
-  # - No photo id journey doesn't have bav CRI intentional?
   # - Multiple doc page Nino skip eligibility page?
   # - StrategicApp placeholder?
   # - Ticket for new f2f volumes?
@@ -75,6 +74,9 @@ states:
     events:
       appTriage:
         targetState: CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
           dcmaw:
             targetState: NINO_START_PAGE
@@ -84,7 +86,6 @@ states:
                 checkIfDisabled:
                   f2f:
                     targetState: PYI_ESCAPE
-
       end:
         targetState: NINO_START_PAGE
         checkIfDisabled:
@@ -93,6 +94,18 @@ states:
             checkIfDisabled:
               f2f:
                 targetState: PYI_ESCAPE
+
+  STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
 
   NINO_START_PAGE:
     response:
@@ -120,8 +133,8 @@ states:
       pageId: page-ipv-identity-postoffice-start
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
@@ -193,8 +206,8 @@ states:
       pageId: pyi-post-office
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
@@ -222,6 +235,95 @@ states:
       next:
         targetState: IDENTITY_START_PAGE
 
+  PYI_CRI_ESCAPE:
+    response:
+      type: page
+      pageId: pyi-cri-escape
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+
+  PYI_CRI_ESCAPE_NO_F2F:
+    response:
+      type: page
+      pageId: pyi-cri-escape-no-f2f
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  CRI_DCMAW_PYI_ESCAPE:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      not-found:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: FAILED
+            targetState: FAILED
+      access-denied:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      temporarily-unavailable:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      fail-with-no-ci:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      enhanced-verification:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
   # DCMAW journey
   POST_DCMAW_SUCCESS_PAGE:
     response:
@@ -235,8 +337,8 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: EVALUATE_GPG45_SCORES_AND_FINISH
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
@@ -303,23 +405,21 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: EVALUATE_GPG45_SCORES_AND_FINISH
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       invalid-request:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID # send to CRI_HMRC_KBV_NO_PHOTO_ID first?
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID # send to CRI_HMRC_KBV_NO_PHOTO_ID first?
       enhanced-verification:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: MITIGATION_OPTIONS_WITH_F2F_NO_PHOTO_ID
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: enhanced-verification
         checkIfDisabled:
           f2f:
-            targetJourney: NEW_P2_IDENTITY
-            targetState: MITIGATION_OPTIONS_NO_PHOTO_ID
+            targetState: MITIGATION_KBV_OPTIONS
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:
@@ -334,23 +434,21 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: EVALUATE_GPG45_SCORES_AND_FINISH
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       invalid-request:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: MITIGATION_OPTIONS_WITH_F2F_NO_PHOTO_ID
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: enhanced-verification
         checkIfDisabled:
           f2f:
-            targetJourney: NEW_P2_IDENTITY
-            targetState: MITIGATION_OPTIONS_NO_PHOTO_ID
+            targetState: MITIGATION_KBV_OPTIONS
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:
@@ -372,22 +470,18 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: EVALUATE_GPG45_SCORES_AND_FINISH
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       fail-with-no-ci:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: KBV_DROPOUT_NO_PHOTO_ID
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
-            targetJourney: NEW_P2_IDENTITY
-            targetState: KBV_DROPOUT_NO_PHOTO_ID_NO_F2F
+            targetState: PYI_CRI_ESCAPE_NO_F2F
       enhanced-verification:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: KBV_FAIL_NO_PHOTO_ID
+        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
-            targetJourney: NEW_P2_IDENTITY
-            targetState: MITIGATION_OPTIONS_NO_PHOTO_ID
+            targetState: MITIGATION_KBV_OPTIONS
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:
@@ -397,6 +491,28 @@ states:
         auditContext:
           mitigationType: enhanced-verification
 
+  PYI_KBV_DROPOUT_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+      context: dropout
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
   # Passport journey
   CRI_UK_PASSPORT:
     response:
@@ -405,7 +521,6 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
         targetState: ADDRESS_AND_FRAUD_PASSPORT
       access-denied:
         targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
@@ -413,12 +528,31 @@ states:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
       alternate-doc-invalid-passport:
-        targetJourney: NEW_P2_JOURNEY
-        targetState: ALTERNATE_DOC_INVALID_PASSPORT
+        targetState: MITIGATION_05_OPTIONS
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: invalid-passport
+
+  ADDRESS_AND_FRAUD_PASSPORT:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_DWP_KBV
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: CRI_DWP_KBV
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
   # Driving licence journey
   CRI_DRIVING_LICENCE:
@@ -428,17 +562,573 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: ADDRESS_AND_FRAUD_DRIVING_LICENCE
+        targetState: ADDRESS_AND_FRAUD_DL
       access-denied:
         targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
       alternate-doc-invalid-dl:
-        targetJourney: NEW_P2_JOURNEY
-        targetState: ALTERNATE_DOC_INVALID_DL
+        targetState: MITIGATION_03_OPTIONS
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: invalid-dl
+
+  ADDRESS_AND_FRAUD_DL:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CHECK_FRAUD_SCORE_DL
+      enhanced-verification:
+        targetState: CHECK_FRAUD_SCORE_DL
+
+  CHECK_FRAUD_SCORE_DL:
+    response:
+      type: process
+      lambda: check-gpg45-score
+    events:
+      met:
+        targetState: CRI_DWP_KBV
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # DWP KBV journey
+  CRI_DWP_KBV:
+    response:
+      type: cri
+      criId: dwpKbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_KBV_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+
+  # HMRC KBV journey
+  CRI_NINO:
+    response:
+      type: cri
+      criId: nino
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_HMRC_KBV
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  CRI_HMRC_KBV:
+    response:
+      type: cri
+      criId: hmrcKbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_KBV_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  # Experian KBV Journey
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV
+
+  CRI_EXPERIAN_KBV:
+    response:
+      type: cri
+      criId: kbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PYI_CRI_ESCAPE
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_KBV_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+
+  # Mitigation Journeys
+
+  # Mitigation journey (01)
+  MITIGATION_01_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-document-start
+    events:
+      appTriage:
+        targetState: MITIGATION_01_CRI_DCMAW
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: MITIGATION_01_STRATEGIC_APP_TRIAGE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetState: MITIGATION_01_F2F_START_PAGE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_CRI_DCMAW:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED
+      access-denied:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      temporarily-unavailable:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      fail-with-no-ci:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      enhanced-verification:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_F2F_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-postoffice-start
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  MITIGATION_01_PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  # Mitigation journey (02)
+  MITIGATION_02_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options-no-f2f
+    events:
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  MITIGATION_02_OPTIONS_WITH_F2F:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+      context: no-photo-id
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  # Mitigation journey (03) same session - invalid-dl
+  MITIGATION_03_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-driving-licence-no-match-another-way
+    events:
+      next:
+        targetState: MITIGATION_PP_CRI_UK_PASSPORT
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Mitigation journey (04) separate session - invalid-dl
+  MITIGATION_04_DL_NO_MATCH_PAGE:
+    response:
+      type: page
+      pageId: pyi-driving-licence-no-match
+    events:
+      next:
+        targetState: MITIGATION_04_IDENTITY_START_PAGE
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-dl
+
+  MITIGATION_04_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: pyi-continue-with-passport
+    events:
+      next:
+        targetState: MITIGATION_PP_CRI_UK_PASSPORT
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Passport journey (MITIGATION)
+  MITIGATION_PP_CRI_UK_PASSPORT:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
+      access-denied:
+        targetState: MITIGATION_PP_PROVE_ANOTHER_WAY
+
+  MITIGATION_PP_PROVE_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: prove-identity-no-other-photo-id
+      context: passport
+    events:
+      back:
+        targetState: MITIGATION_PP_CRI_UK_PASSPORT
+      returnToRp:
+        targetJourney: FAILED
+        targetState: FAILED_SKIP_MESSAGE
+
+  # Address and Fraud journey (MITIGATION)
+  MITIGATION_PP_ADDRESS_AND_FRAUD:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: MITIGATION_CRI_DWP_KBV
+        checkIfDisabled:
+          dwpKbv:
+            targetState: MITIGATION_PP_CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Mitigation journey (05) same session - invalid-passport
+  MITIGATION_05_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-passport-no-match-another-way
+    events:
+      next:
+        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  # Mitigation journey (06) separate session - invalid-passport
+  MITIGATION_06_PASSPORT_NO_MATCH_PAGE:
+    response:
+      type: page
+      pageId: pyi-passport-no-match
+    events:
+      next:
+        targetState: MITIGATION_06_IDENTITY_START_PAGE
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-passport
+
+  MITIGATION_06_IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: pyi-continue-with-driving-licence
+    events:
+      next:
+        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  MITIGATION_DL_CRI_DRIVING_LICENCE:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
+      access-denied:
+        targetState: MITIGATION_DL_PROVE_ANOTHER_WAY
+
+  MITIGATION_DL_PROVE_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: prove-identity-no-other-photo-id
+      context: drivingLicence
+    events:
+      back:
+        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+      returnToRp:
+        targetJourney: FAILED
+        targetState: FAILED_SKIP_MESSAGE
+
+  MITIGATION_DL_ADDRESS_AND_FRAUD:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: MITIGATION_CHECK_FRAUD_SCORE
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_CHECK_FRAUD_SCORE:
+    response:
+      type: process
+      lambda: check-gpg45-score
+    events:
+      met:
+        targetState: MITIGATION_CRI_DWP_KBV
+        checkIfDisabled:
+          dwpKbv:
+            targetState: MITIGATION_PP_CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Common Mitigation states - invalid-dl/invalid-passport
+  MITIGATION_PP_CRI_NINO:
+    response:
+      type: cri
+      criId: nino
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: MITIGATION_CRI_HMRC_KBV
+      fail-with-no-ci:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: MITIGATION_CRI_EXPERIAN_KBV
+
+  MITIGATION_CRI_EXPERIAN_KBV:
+    response:
+      type: cri
+      criId: kbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_CRI_HMRC_KBV:
+    response:
+      type: cri
+      criId: hmrcKbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+      invalid-request:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_CRI_DWP_KBV:
+    response:
+      type: cri
+      criId: dwpKbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      invalid-request:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_KBV_FAIL_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  F2F_FAILED_MITIGATION_PAGE:
+    response:
+      type: page
+      pageId: pyi-f2f-technical
+    events:
+      next:
+        targetState: MITIGATION_01_IDENTITY_START_PAGE
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+      end:
+        targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -97,7 +97,7 @@ states:
         targetState: ERROR_NO_TICF
 
   # Journey states
-  REPROVE_IDENTITY_START: # do I need this?
+  REPROVE_IDENTITY_START:
     response:
       type: page
       pageId: reprove-identity-start

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -20,17 +20,7 @@ states:
   # - Multiple doc page Nino skip eligibility page?
   # - StrategicApp placeholder?
   # - Ticket for new f2f volumes?
-  # - Mitigations?
   # - "Route to DCMAW" on NINO CRI?
-
-  # Proposal
-  # - New web app journey
-  #   - Can lead to no photo id journey
-  #
-  # - Generally:
-  #   - Don't add any mitigations yet (saves time & allows clearer picture before re-evaluation)
-
-  # talk to joe - he may have an idea with how to extract sub-journeys
 
   # Parent states
   CRI_STATE:
@@ -211,7 +201,7 @@ states:
       end:
         targetState: PYI_ESCAPE
 
-  PYI_ESCAPE: # is this right?
+  PYI_ESCAPE:
     response:
       type: page
       pageId: pyi-escape
@@ -261,14 +251,14 @@ states:
     events:
       next:
         targetState: CRI_NINO_NO_PHOTO_ID
-      access-denied:
-        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID # ?
+      enhanced-verification:
+        targetState: CRI_NINO_NO_PHOTO_ID
 
   CRI_NINO_NO_PHOTO_ID:
     response:
       type: cri
       criId: nino
-      evidenceRequest: # ?
+      evidenceRequest: # Is this still the same ?
         scoringPolicy: gpg45
         strengthScore: 2
     parent: CRI_STATE
@@ -319,6 +309,22 @@ states:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID # send to CRI_HMRC_KBV_NO_PHOTO_ID first?
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID # send to CRI_HMRC_KBV_NO_PHOTO_ID first?
+      enhanced-verification:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: MITIGATION_OPTIONS_WITH_F2F_NO_PHOTO_ID
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: MITIGATION_OPTIONS_NO_PHOTO_ID
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+      # do we not also want to point people downstream to (surely HMRC) Experian if they get fail-no-ci?
 
   CRI_HMRC_KBV_NO_PHOTO_ID:
     response:
@@ -334,6 +340,21 @@ states:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: MITIGATION_OPTIONS_WITH_F2F_NO_PHOTO_ID
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: MITIGATION_OPTIONS_NO_PHOTO_ID
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
 
   PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
     response:
@@ -355,11 +376,26 @@ states:
         targetState: EVALUATE_GPG45_SCORES_AND_FINISH
       fail-with-no-ci:
         targetJourney: NEW_P2_IDENTITY
-        targetState: KBV_DROPOUT
+        targetState: KBV_DROPOUT_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
             targetJourney: NEW_P2_IDENTITY
-            targetState: KBV_DROPOUT_NO_F2F
+            targetState: KBV_DROPOUT_NO_PHOTO_ID_NO_F2F
+      enhanced-verification:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: KBV_FAIL_NO_PHOTO_ID
+        checkIfDisabled:
+          f2f:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: MITIGATION_OPTIONS_NO_PHOTO_ID
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
 
   # Passport journey
   CRI_UK_PASSPORT:
@@ -376,6 +412,13 @@ states:
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-passport:
+        targetJourney: NEW_P2_JOURNEY
+        targetState: ALTERNATE_DOC_INVALID_PASSPORT
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-passport
 
   # Driving licence journey
   CRI_DRIVING_LICENCE:
@@ -392,3 +435,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-dl:
+        targetJourney: NEW_P2_JOURNEY
+        targetState: ALTERNATE_DOC_INVALID_DL
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-dl

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -1,0 +1,394 @@
+name: New P1 Identity
+description: >-
+  The routes a user can take to prove their identity to a low
+  confidence level (P1).
+
+states:
+  # Entry points
+  START:
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  REPROVE_IDENTITY:
+    events:
+      next:
+        targetState: REPROVE_IDENTITY_START
+
+  # Q's:
+  # - No photo id journey doesn't have bav CRI intentional?
+  # - Multiple doc page Nino skip eligibility page?
+  # - StrategicApp placeholder?
+  # - Ticket for new f2f volumes?
+  # - Mitigations?
+  # - "Route to DCMAW" on NINO CRI?
+
+  # Proposal
+  # - New web app journey
+  #   - Can lead to no photo id journey
+  #
+  # - Generally:
+  #   - Don't add any mitigations yet (saves time & allows clearer picture before re-evaluation)
+
+  # talk to joe - he may have an idea with how to extract sub-journeys
+
+  # Parent states
+  CRI_STATE:
+    events:
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+      invalid-request:
+        targetJourney: FAILED
+        targetState: FAILED
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Journey states
+  REPROVE_IDENTITY_START:
+    response:
+      type: page
+      pageId: reprove-identity-start
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  IDENTITY_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-document-start
+    events:
+      appTriage:
+        targetState: CRI_DCMAW
+        checkIfDisabled:
+          dcmaw:
+            targetState: NINO_START_PAGE
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: F2F_START_PAGE
+                checkIfDisabled:
+                  f2f:
+                    targetState: PYI_ESCAPE
+
+      end:
+        targetState: NINO_START_PAGE
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: F2F_START_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: PYI_ESCAPE
+
+  NINO_START_PAGE:
+    response:
+      type: page
+      pageId: prove-identity-no-photo-id
+      context: nino-only
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_NO_PHOTO_ID
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: F2F_START_PAGE
+            checkIfDisabled:
+              f2f:
+                targetState: PYI_ESCAPE
+      end:
+        targetState: F2F_START_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_ESCAPE
+
+  F2F_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-postoffice-start
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: F2F
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_ESCAPE
+      end:
+        targetState: PYI_ESCAPE
+
+  CRI_DCMAW:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      not-found:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      temporarily-unavailable:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      fail-with-no-ci:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+
+  MULTIPLE_DOC_CHECK_PAGE:
+    response:
+      type: page
+      pageId: page-multiple-doc-check # PYIC-7016: Update so can produce nino event
+    events:
+      ukPassport:
+        targetState: CRI_UK_PASSPORT
+      drivingLicence:
+        targetState: CRI_DRIVING_LICENCE
+      nino:
+        targetState: NINO_START_PAGE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  MULTIPLE_DOC_F2F_CHECK_PAGE:
+    response:
+      type: page
+      context: f2f
+      pageId: page-multiple-doc-check # PYIC-7016: Update so can produce nino event
+    events:
+      ukPassport:
+        targetState: CRI_UK_PASSPORT
+      drivingLicence:
+        targetState: CRI_DRIVING_LICENCE
+      nino:
+        targetState: NINO_START_PAGE
+      end:
+        targetState: PYI_POST_OFFICE
+
+  PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: F2F
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_ESCAPE
+      end:
+        targetState: PYI_ESCAPE
+
+  PYI_ESCAPE: # is this right?
+    response:
+      type: page
+      pageId: pyi-escape
+    events:
+      next:
+        targetState: RESET_SESSION_IDENTITY
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  RESET_SESSION_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  # DCMAW journey
+  POST_DCMAW_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-dcmaw-success
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_DCMAW
+
+  ADDRESS_AND_FRAUD_DCMAW:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: EVALUATE_GPG45_SCORES_AND_FINISH
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # No photo id journey
+  CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: claimedIdentity
+      context: hmrc_record_check
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_NINO_NO_PHOTO_ID
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID # ?
+
+  CRI_NINO_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: nino
+      evidenceRequest: # ?
+        scoringPolicy: gpg45
+        strengthScore: 2
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_NO_PHOTO_ID
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NINO
+
+  PYI_ESCAPE_ABANDON_NO_PHOTO_ID:
+    response:
+      type: page
+      context: abandon
+      pageId: no-photo-id-exit-find-another-way
+    events:
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+      next:
+        targetState: RESET_SESSION_IDENTITY
+
+  ADDRESS_AND_FRAUD_NO_PHOTO_ID:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+
+  CRI_DWP_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: dwpKbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: EVALUATE_GPG45_SCORES_AND_FINISH
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID # send to CRI_HMRC_KBV_NO_PHOTO_ID first?
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID # send to CRI_HMRC_KBV_NO_PHOTO_ID first?
+
+  CRI_HMRC_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: hmrcKbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: EVALUATE_GPG45_SCORES_AND_FINISH
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV_NO_PHOTO_ID
+
+  CRI_EXPERIAN_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: kbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: EVALUATE_GPG45_SCORES_AND_FINISH
+      fail-with-no-ci:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: KBV_DROPOUT
+        checkIfDisabled:
+          f2f:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: KBV_DROPOUT_NO_F2F
+
+  # Passport journey
+  CRI_UK_PASSPORT:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: ADDRESS_AND_FRAUD_PASSPORT
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+
+  # Driving licence journey
+  CRI_DRIVING_LICENCE:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: ADDRESS_AND_FRAUD_DRIVING_LICENCE
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -357,7 +357,7 @@ states:
       next:
         targetState: ADDRESS_AND_FRAUD_J2
       access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        targetState: PROVE_ANOTHER_WAY_J2
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
@@ -367,6 +367,20 @@ states:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: invalid-passport
+
+  PROVE_ANOTHER_WAY_J2:
+    response:
+      type: page
+      pageId: prove-identity-another-type-photo-id
+      context: passport
+    events:
+      otherPhotoId:
+        targetState: CRI_DRIVING_LICENCE_J3
+      f2f:
+        targetState: F2F_PYI_POST_OFFICE
+      returnToRp:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
 
   ADDRESS_AND_FRAUD_J2:
     nestedJourney: ADDRESS_AND_FRAUD
@@ -398,7 +412,7 @@ states:
       next:
         targetState: ADDRESS_AND_FRAUD_J3
       access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        targetState: PROVE_ANOTHER_WAY_J3
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
@@ -408,6 +422,20 @@ states:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: invalid-dl
+
+  PROVE_ANOTHER_WAY_J3:
+    response:
+      type: page
+      pageId: prove-identity-another-type-photo-id
+      context: drivingLicence
+    events:
+      otherPhotoId:
+        targetState: CRI_UK_PASSPORT_J2
+      f2f:
+        targetState: F2F_PYI_POST_OFFICE
+      returnToRp:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
 
   ADDRESS_AND_FRAUD_J3:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -303,7 +303,6 @@ states:
     response:
       type: cri
       criId: kbv
-      # requires verification score 1
     parent: CRI_STATE
     events:
       fail-with-no-ci:
@@ -495,7 +494,6 @@ states:
     response:
       type: cri
       criId: hmrcKbv
-      # need verification score 1
     parent: CRI_STATE
     events:
       next:
@@ -523,7 +521,6 @@ states:
     response:
       type: cri
       criId: hmrcKbv
-      # need verification score 1
     parent: CRI_STATE
     events:
       next:
@@ -552,7 +549,6 @@ states:
     response:
       type: cri
       criId: dwpKbv
-      # need verification score 1
     parent: CRI_STATE
     events:
       next:
@@ -580,7 +576,6 @@ states:
     response:
       type: cri
       criId: dwpKbv
-      # need verification score 1
     parent: CRI_STATE
     events:
       next:
@@ -666,7 +661,6 @@ states:
     response:
       type: cri
       criId: kbv
-      # requires verification score 1
     parent: CRI_STATE
     events:
       fail-with-no-ci:
@@ -1140,7 +1134,6 @@ states:
     response:
       type: cri
       criId: kbv
-      # requires verification score 1
     parent: CRI_STATE
     events:
       fail-with-no-ci:
@@ -1157,7 +1150,6 @@ states:
     response:
       type: cri
       criId: hmrcKbv
-      # requires verification score 1
     parent: CRI_STATE
     events:
       next:
@@ -1175,7 +1167,6 @@ states:
     response:
       type: cri
       criId: dwpKbv
-      # requires verification score 1
     parent: CRI_STATE
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -5,23 +5,43 @@ description: >-
 
 states:
   # Entry points
+
   START:
     events:
       next:
         targetState: IDENTITY_START_PAGE
+
+  ENHANCED_VERIFICATION:
+    events:
+      next:
+        targetState: MITIGATION_01_IDENTITY_START_PAGE
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+
+  ALTERNATE_DOC_PASSPORT:
+    events:
+      next:
+        targetState: MITIGATION_04_DL_NO_MATCH_PAGE
+
+  ALTERNATE_DOC_DL:
+    events:
+      next:
+        targetState: MITIGATION_06_PASSPORT_NO_MATCH_PAGE
+
+  ENHANCED_VERIFICATION_F2F_FAIL:
+    events:
+      next:
+        targetState: F2F_FAILED_MITIGATION_PAGE
 
   REPROVE_IDENTITY:
     events:
       next:
         targetState: REPROVE_IDENTITY_START
 
-  # Q's:
-  # - Multiple doc page Nino skip eligibility page?
-  # - StrategicApp placeholder?
-  # - Ticket for new f2f volumes?
-  # - "Route to DCMAW" on NINO CRI?
-
   # Parent states
+
   CRI_STATE:
     events:
       not-found:
@@ -58,11 +78,39 @@ states:
         targetJourney: FAILED
         targetState: FAILED
 
+  CRI_TICF_STATE:
+    events:
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
   # Journey states
-  REPROVE_IDENTITY_START:
+  REPROVE_IDENTITY_START: # do I need this?
     response:
       type: page
       pageId: reprove-identity-start
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
+  RESET_SESSION_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
     events:
       next:
         targetState: IDENTITY_START_PAGE
@@ -107,6 +155,26 @@ states:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
 
+  F2F_START_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-identity-postoffice-start
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetState: PYI_ESCAPE
+
+  F2F_PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      end:
+        targetState: PYI_ESCAPE
+
   NINO_START_PAGE:
     response:
       type: page
@@ -115,31 +183,13 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_NO_PHOTO_ID
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: F2F_START_PAGE
-            checkIfDisabled:
-              f2f:
-                targetState: PYI_ESCAPE
+        auditEvents:
+          - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: F2F_START_PAGE
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-
-  F2F_START_PAGE:
-    response:
-      type: page
-      pageId: page-ipv-identity-postoffice-start
-    events:
-      next:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_ESCAPE
-      end:
-        targetState: PYI_ESCAPE
 
   CRI_DCMAW:
     response:
@@ -176,9 +226,9 @@ states:
       pageId: page-multiple-doc-check # PYIC-7016: Update so can produce nino event
     events:
       ukPassport:
-        targetState: CRI_UK_PASSPORT
+        targetState: CRI_UK_PASSPORT_J2
       drivingLicence:
-        targetState: CRI_DRIVING_LICENCE
+        targetState: CRI_DRIVING_LICENCE_J3
       nino:
         targetState: NINO_START_PAGE
       end:
@@ -192,27 +242,13 @@ states:
       pageId: page-multiple-doc-check # PYIC-7016: Update so can produce nino event
     events:
       ukPassport:
-        targetState: CRI_UK_PASSPORT
+        targetState: CRI_UK_PASSPORT_J2
       drivingLicence:
-        targetState: CRI_DRIVING_LICENCE
+        targetState: CRI_DRIVING_LICENCE_J3
       nino:
         targetState: NINO_START_PAGE
       end:
-        targetState: PYI_POST_OFFICE
-
-  PYI_POST_OFFICE:
-    response:
-      type: page
-      pageId: pyi-post-office
-    events:
-      next:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_ESCAPE
-      end:
-        targetState: PYI_ESCAPE
+        targetState: F2F_PYI_POST_OFFICE
 
   PYI_ESCAPE:
     response:
@@ -224,16 +260,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
-
-  RESET_SESSION_IDENTITY:
-    response:
-      type: process
-      lambda: reset-session-identity
-      lambdaInput:
-        resetType: ALL
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
 
   PYI_CRI_ESCAPE:
     response:
@@ -271,405 +297,12 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  CRI_DCMAW_PYI_ESCAPE:
-    response:
-      type: cri
-      criId: dcmaw
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      not-found:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: FAILED
-            targetState: FAILED
-      access-denied:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      temporarily-unavailable:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      fail-with-no-ci:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      enhanced-verification:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-
-  STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
-    nestedJourney: STRATEGIC_APP_TRIAGE
-    exitEvents:
-      next:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      end:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-
-  # DCMAW journey
-  POST_DCMAW_SUCCESS_PAGE:
-    response:
-      type: page
-      pageId: page-dcmaw-success
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_DCMAW
-
-  ADDRESS_AND_FRAUD_DCMAW:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  # No photo id journey
-  CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: claimedIdentity
-      context: hmrc_record_check
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CRI_NINO_NO_PHOTO_ID
-      enhanced-verification:
-        targetState: CRI_NINO_NO_PHOTO_ID
-
-  CRI_NINO_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: nino
-      evidenceRequest: # Is this still the same ?
-        scoringPolicy: gpg45
-        strengthScore: 2
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_NO_PHOTO_ID
-      access-denied:
-        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID
-      fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NINO
-
-  PYI_ESCAPE_ABANDON_NO_PHOTO_ID:
-    response:
-      type: page
-      context: abandon
-      pageId: no-photo-id-exit-find-another-way
-    events:
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-      next:
-        targetState: RESET_SESSION_IDENTITY
-
-  ADDRESS_AND_FRAUD_NO_PHOTO_ID:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-
-  CRI_DWP_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: dwpKbv
-      # requires verification score 1
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID # send to CRI_HMRC_KBV_NO_PHOTO_ID first?
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID # send to CRI_HMRC_KBV_NO_PHOTO_ID first?
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_KBV_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-      # do we not also want to point people downstream to (surely HMRC) Experian if they get fail-no-ci?
-
-  CRI_HMRC_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: hmrcKbv
-      # requires verification score 1
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_KBV_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-
-  PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: CRI_EXPERIAN_KBV_NO_PHOTO_ID
-
-  CRI_EXPERIAN_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: kbv
-      # requires verification score 1
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      fail-with-no-ci:
-        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
-      enhanced-verification:
-        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_KBV_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-
-  PYI_KBV_DROPOUT_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: no-photo-id-security-questions-find-another-way
-      context: dropout
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-
-  # Passport journey
-  CRI_UK_PASSPORT:
-    response:
-      type: cri
-      criId: ukPassport
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_PASSPORT
-      access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-      alternate-doc-invalid-passport:
-        targetState: MITIGATION_05_OPTIONS
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: invalid-passport
-
-  ADDRESS_AND_FRAUD_PASSPORT:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: CRI_DWP_KBV
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      enhanced-verification:
-        targetState: CRI_DWP_KBV
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  # Driving licence journey
-  CRI_DRIVING_LICENCE:
-    response:
-      type: cri
-      criId: drivingLicence
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_DL
-      access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
-      alternate-doc-invalid-dl:
-        targetState: MITIGATION_03_OPTIONS
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: invalid-dl
-
-  ADDRESS_AND_FRAUD_DL:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: CHECK_FRAUD_SCORE_DL
-      enhanced-verification:
-        targetState: CHECK_FRAUD_SCORE_DL
-
-  CHECK_FRAUD_SCORE_DL:
+  RETURN_TO_RP:
     response:
       type: process
-      lambda: check-gpg45-score
-    events:
-      met:
-        targetState: CRI_DWP_KBV
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      unmet:
-        targetJourney: FAILED
-        targetState: FAILED
+      lambda: build-client-oauth-response
 
-  # DWP KBV journey
-  CRI_DWP_KBV:
-    response:
-      type: cri
-      criId: dwpKbv
-      # requires verification score 1
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_KBV_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-
-  # HMRC KBV journey
-  CRI_NINO:
-    response:
-      type: cri
-      criId: nino
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CRI_HMRC_KBV
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  CRI_HMRC_KBV:
-    response:
-      type: cri
-      criId: hmrcKbv
-      # requires verification score 1
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_KBV_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  # Experian KBV Journey
+  # Common pages
   PRE_EXPERIAN_KBV_TRANSITION_PAGE:
     response:
       type: page
@@ -701,13 +334,406 @@ states:
           mitigationType: enhanced-verification
         checkIfDisabled:
           f2f:
-            targetState: MITIGATION_KBV_OPTIONS
+            targetState: MITIGATION_02_OPTIONS
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: enhanced-verification
 
-  # Mitigation Journeys
+  # DCMAW journey (J1)
+  POST_DCMAW_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-dcmaw-success
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J1
+
+  ADDRESS_AND_FRAUD_J1:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Passport journey (J2)
+  CRI_UK_PASSPORT_J2:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J2
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-passport:
+        targetState: MITIGATION_05_OPTIONS
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-passport
+
+  ADDRESS_AND_FRAUD_J2:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_DWP_KBV_J7
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: CRI_DWP_KBV_J7
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  # Driving licence journey (J3)
+  CRI_DRIVING_LICENCE_J3:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J3
+      access-denied:
+        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-dl:
+        targetState: MITIGATION_03_OPTIONS
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-dl
+
+  ADDRESS_AND_FRAUD_J3:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CHECK_FRAUD_SCORE_J3
+      enhanced-verification:
+        targetState: CHECK_FRAUD_SCORE_J3
+
+  CHECK_FRAUD_SCORE_J3:
+    response:
+      type: process
+      lambda: check-gpg45-score
+    events:
+      met:
+        targetState: CRI_DWP_KBV_J7
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # F2F journey (J4)
+  CRI_CLAIMED_IDENTITY_J4:
+    response:
+      type: cri
+      criId: claimedIdentity
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J4
+      enhanced-verification:
+        targetState: ADDRESS_AND_FRAUD_J4
+
+  ADDRESS_AND_FRAUD_J4:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      enhanced-verification:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+
+  # HMRC KBV journey (J6)
+  CRI_NINO_J6:
+    response:
+      type: cri
+      criId: nino
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_HMRC_KBV_J6
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  CRI_HMRC_KBV_J6:
+    response:
+      type: cri
+      criId: hmrcKbv
+      # need verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  CRI_HMRC_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: hmrcKbv
+      # need verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  # DWP KBV journey (J7)
+  CRI_DWP_KBV_J7:
+    response:
+      type: cri
+      criId: dwpKbv
+      # need verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+
+  CRI_DWP_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: dwpKbv
+      # need verification score 1
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+
+  # No photo id journey
+  CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: claimedIdentity
+      context: hmrc_record_check
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_NINO_NO_PHOTO_ID
+      enhanced-verification:
+        targetState: CRI_NINO_NO_PHOTO_ID
+
+  CRI_NINO_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: nino
+      evidenceRequest:
+        scoringPolicy: gpg45
+        strengthScore: 2
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_NO_PHOTO_ID
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NINO
+
+  ADDRESS_AND_FRAUD_NO_PHOTO_ID:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      enhanced-verification:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV_NO_PHOTO_ID
+
+  CRI_EXPERIAN_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: kbv
+      # requires verification score 1
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_KBV_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+
+  MITIGATION_KBV_FAIL_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  PYI_ESCAPE_ABANDON_NO_PHOTO_ID:
+    response:
+      type: page
+      context: abandon
+      pageId: no-photo-id-exit-find-another-way
+    events:
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+      next:
+        targetState: RESET_SESSION_IDENTITY
+
+  PYI_KBV_DROPOUT_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+      context: dropout
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
 
   # Mitigation journey (01)
   MITIGATION_01_IDENTITY_START_PAGE:
@@ -827,6 +853,59 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
 
+  STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      end:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  CRI_DCMAW_PYI_ESCAPE:
+    response:
+      type: cri
+      criId: dcmaw
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      not-found:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: FAILED
+            targetState: FAILED
+      access-denied:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      temporarily-unavailable:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      fail-with-no-ci:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      enhanced-verification:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
   MITIGATION_02_OPTIONS_WITH_F2F:
     response:
       type: page
@@ -863,6 +942,18 @@ states:
           dcmaw:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
+
+  PYI_POST_OFFICE:
+    response:
+      type: page
+      pageId: pyi-post-office
+    events:
+      next:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
 
   # Mitigation journey (03) same session - invalid-dl
   MITIGATION_03_OPTIONS:
@@ -1097,27 +1188,6 @@ states:
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
-
-  MITIGATION_KBV_FAIL_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: no-photo-id-security-questions-find-another-way
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
 
   F2F_FAILED_MITIGATION_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -604,7 +604,7 @@ states:
     response:
       type: cri
       criId: claimedIdentity
-      context: hmrc_record_check
+      context: hmrc_check
     parent: CRI_STATE
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -128,20 +128,8 @@ states:
         checkIfDisabled:
           dcmaw:
             targetState: NINO_START_PAGE
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: F2F_START_PAGE
-                checkIfDisabled:
-                  f2f:
-                    targetState: PYI_ESCAPE
       end:
         targetState: NINO_START_PAGE
-        checkIfDisabled:
-          hmrcKbv:
-            targetState: F2F_START_PAGE
-            checkIfDisabled:
-              f2f:
-                targetState: PYI_ESCAPE
 
   STRATEGIC_APP_TRIAGE:
     nestedJourney: STRATEGIC_APP_TRIAGE
@@ -388,17 +376,11 @@ states:
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
   # Driving licence journey (J3)
   CRI_DRIVING_LICENCE_J3:
@@ -425,26 +407,15 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CHECK_FRAUD_SCORE_J3
-      enhanced-verification:
-        targetState: CHECK_FRAUD_SCORE_J3
-
-  CHECK_FRAUD_SCORE_J3:
-    response:
-      type: process
-      lambda: check-gpg45-score
-    events:
-      met:
         targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      unmet:
-        targetJourney: FAILED
-        targetState: FAILED
+      enhanced-verification:
+        targetState: CRI_DWP_KBV_J7
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
 
   # F2F journey (J4)
   CRI_CLAIMED_IDENTITY_J4:
@@ -477,6 +448,9 @@ states:
     events:
       next:
         targetState: CRI_HMRC_KBV_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       fail-with-no-ci:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
@@ -1024,9 +998,6 @@ states:
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
@@ -1109,9 +1080,6 @@ states:
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       unmet:
         targetJourney: FAILED
         targetState: FAILED
@@ -1125,6 +1093,9 @@ states:
     events:
       next:
         targetState: MITIGATION_CRI_HMRC_KBV
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       fail-with-no-ci:
         targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -70,15 +70,40 @@ states:
       next:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
-  KBV_DROPOUT:
+  KBV_DROPOUT_NO_PHOTO_ID:
     events:
       next:
         targetState: PYI_KBV_DROPOUT_M2B
 
-  KBV_DROPOUT_NO_F2F:
+  KBV_DROPOUT_NO_PHOTO_ID_NO_F2F:
     events:
       next:
         targetState: PYI_CRI_ESCAPE_NO_F2F
+
+  ALTERNATE_DOC_INVALID_PASSPORT:
+    events:
+      next:
+        targetState: MITIGATION_05_OPTIONS
+
+  ALTERNATE_DOC_INVALID_DL:
+    events:
+      next:
+        targetState: MITIGATION_03_OPTIONS
+
+  MITIGATION_OPTIONS_WITH_F2F_NO_PHOTO_ID:
+    events:
+      next:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+
+  MITIGATION_OPTIONS_NO_PHOTO_ID:
+    events:
+      next:
+        targetState: MITIGATION_02_OPTIONS
+
+  KBV_FAIL_NO_PHOTO_ID:
+    events:
+      next:
+        targetState: MITIGATION_KBV_FAIL_M2B
 
   # Parent states
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -40,6 +40,46 @@ states:
       next:
         targetState: REPROVE_IDENTITY_START
 
+  F2F:
+    events:
+      next:
+        targetState: CRI_F2F
+
+  EVALUATE_GPG45_SCORES_AND_FINISH:
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+
+  ADDRESS_AND_FRAUD_PASSPORT:
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J2
+
+  ADDRESS_AND_FRAUD_DL:
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J3
+
+  HMRC_KBV:
+    events:
+      next:
+        targetState: CRI_NINO_J6
+
+  EXPERIAN_KBV:
+    events:
+      next:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  KBV_DROPOUT:
+    events:
+      next:
+        targetState: PYI_KBV_DROPOUT_M2B
+
+  KBV_DROPOUT_NO_F2F:
+    events:
+      next:
+        targetState: PYI_CRI_ESCAPE_NO_F2F
+
   # Parent states
 
   CRI_STATE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1,6 +1,6 @@
 name: New P2 Identity
 description: >-
-  The routes a user can take to prove their identity to a medium
+  The routes a user so they can prove their identity to a medium
   confidence level (P2).
 
 states:
@@ -39,71 +39,6 @@ states:
     events:
       next:
         targetState: REPROVE_IDENTITY_START
-
-  F2F:
-    events:
-      next:
-        targetState: CRI_F2F
-
-  EVALUATE_GPG45_SCORES_AND_FINISH:
-    events:
-      next:
-        targetState: EVALUATE_GPG45_SCORES
-
-  ADDRESS_AND_FRAUD_PASSPORT:
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_J2
-
-  ADDRESS_AND_FRAUD_DL:
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_J3
-
-  HMRC_KBV:
-    events:
-      next:
-        targetState: CRI_NINO_J6
-
-  EXPERIAN_KBV:
-    events:
-      next:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  KBV_DROPOUT_NO_PHOTO_ID:
-    events:
-      next:
-        targetState: PYI_KBV_DROPOUT_M2B
-
-  KBV_DROPOUT_NO_PHOTO_ID_NO_F2F:
-    events:
-      next:
-        targetState: PYI_CRI_ESCAPE_NO_F2F
-
-  ALTERNATE_DOC_INVALID_PASSPORT:
-    events:
-      next:
-        targetState: MITIGATION_05_OPTIONS
-
-  ALTERNATE_DOC_INVALID_DL:
-    events:
-      next:
-        targetState: MITIGATION_03_OPTIONS
-
-  MITIGATION_OPTIONS_WITH_F2F_NO_PHOTO_ID:
-    events:
-      next:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
-
-  MITIGATION_OPTIONS_NO_PHOTO_ID:
-    events:
-      next:
-        targetState: MITIGATION_02_OPTIONS
-
-  KBV_FAIL_NO_PHOTO_ID:
-    events:
-      next:
-        targetState: MITIGATION_KBV_FAIL_M2B
 
   # Parent states
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.processjourneyevent;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.di.ipv.core.library.domain.IpvJourneyTypes;
@@ -120,6 +121,11 @@ class JourneyMapTest {
                 }
             }
         }
+    }
+
+    @Test
+    void shouldMatchAllJourneyMapEntryPoints() {
+        // Idea being no undefined entry points assumed and no redundancies
     }
 
     @ParameterizedTest

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
@@ -15,7 +15,7 @@ public enum IpvJourneyTypes {
     // Successful journeys
     REUSE_EXISTING_IDENTITY("reuse-existing-identity"),
     // PYIC-6911 decide where the P1 journeys should actually be defined.
-    NEW_P1_IDENTITY("new-p2-identity"),
+    NEW_P1_IDENTITY("new-p1-identity"),
     NEW_P2_IDENTITY("new-p2-identity"),
     REPEAT_FRAUD_CHECK("repeat-fraud-check"),
     EVALUATE_SCORES("evaluate-scores"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
@@ -14,7 +14,6 @@ public enum IpvJourneyTypes {
 
     // Successful journeys
     REUSE_EXISTING_IDENTITY("reuse-existing-identity"),
-    // PYIC-6911 decide where the P1 journeys should actually be defined.
     NEW_P1_IDENTITY("new-p1-identity"),
     NEW_P2_IDENTITY("new-p2-identity"),
     REPEAT_FRAUD_CHECK("repeat-fraud-check"),


### PR DESCRIPTION
## Proposed changes

- Added in P1 journey
[See this for a comparison between p1 & p2!](https://www.diffchecker.com/ikuwxLdI/)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7018](https://govukverify.atlassian.net/browse/PYIC-7018)

## Notes

- Opportunity to add test to JourneyMapTest to check journey maps thread together - i.e. each targetJourney & targetState points to a defined entry point



[PYIC-7018]: https://govukverify.atlassian.net/browse/PYIC-7018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ