### PR TITLE
PYIC-7018: Separate common journeys

### DIFF
--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -16,6 +16,7 @@ const JOURNEY_TYPES = {
     TECHNICAL_ERROR: 'Technical error',
     REPEAT_FRAUD_CHECK: 'Repeat fraud check',
     SESSION_TIMEOUT: 'Session timeout',
+    F2F_HAND_OFF: 'F2F hand off',
     F2F_PENDING: 'F2F pending',
     F2F_FAILED: 'F2F failed',
     OPERATIONAL_PROFILE_MIGRATION: 'Operational profile migration',

--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -8,6 +8,7 @@ const DEFAULT_JOURNEY_TYPE = 'INITIAL_JOURNEY_SELECTION';
 const JOURNEY_TYPES = {
     INITIAL_JOURNEY_SELECTION: 'Initial journey selection',
     NEW_P2_IDENTITY: 'New P2 identity',
+    EVALUATE_SCORES: 'Evaluate scores',
     REUSE_EXISTING_IDENTITY: 'Reuse existing identity',
     UPDATE_NAME: 'Update name',
     UPDATE_ADDRESS: 'Update address',

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
@@ -1,0 +1,82 @@
+name: Evaluate Scores
+description: >-
+  The routes evaluates the success of a user's identity proving and returns them to the RP.
+
+states:
+  # Entry points
+  START:
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES
+
+  # Parent states
+  CRI_TICF_STATE:
+    events:
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  # Journey states
+  EVALUATE_GPG45_SCORES:
+    response:
+      type: process
+      lambda: evaluate-gpg45-scores
+    events:
+      met:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_SUCCESS
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  CRI_TICF_BEFORE_SUCCESS:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+
+  STORE_IDENTITY_BEFORE_SUCCESS:
+    response:
+      type: process
+      lambda: store-identity
+      lambdaInput:
+        identityType: NEW
+    events:
+      identity-stored:
+        targetState: IPV_SUCCESS_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  IPV_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-success
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -1,0 +1,142 @@
+name: F2F Hand Off
+description: >-
+  The routes a user to proving their identity with f2f.
+
+states:
+  # Entry points
+  START:
+    events:
+      next:
+        targetState: CRI_F2F
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_F2F
+
+  # Parent states
+  CRI_STATE:
+    events:
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+      invalid-request:
+        targetJourney: FAILED
+        targetState: FAILED
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  CRI_TICF_STATE:
+    events:
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  # Journey states
+  CRI_TICF_BEFORE_F2F:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: CRI_F2F
+      enhanced-verification:
+        targetState: CRI_F2F
+
+  CRI_F2F:
+    response:
+      type: cri
+      criId: f2f
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      enhanced-verification:
+        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      access-denied:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_NO_TICF
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  STORE_IDENTITY_BEFORE_F2F_HANDOFF:
+    response:
+      type: process
+      lambda: store-identity
+      lambdaInput:
+        identityType: PENDING
+    events:
+      identity-stored:
+        targetState: RESET_SESSION_BEFORE_F2F_HANDOFF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  RESET_SESSION_BEFORE_F2F_HANDOFF:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        targetState: F2F_HANDOFF_PAGE
+      error:
+        targetState: F2F_HANDOFF_PAGE
+
+  F2F_HANDOFF_PAGE:
+    response:
+      type: page
+      pageId: page-face-to-face-handoff

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -290,57 +290,10 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  EVALUATE_GPG45_SCORES:
-    response:
-      type: process
-      lambda: evaluate-gpg45-scores
-    events:
-      met:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_SUCCESS
-      unmet:
-        targetJourney: FAILED
-        targetState: FAILED
-      vcs-not-correlated:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  STORE_IDENTITY_BEFORE_SUCCESS:
-    response:
-      type: process
-      lambda: store-identity
-      lambdaInput:
-        identityType: NEW
-    events:
-      identity-stored:
-        targetState: IPV_SUCCESS_PAGE
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
-  IPV_SUCCESS_PAGE:
-    response:
-      type: page
-      pageId: page-ipv-success
-    events:
-      next:
-        targetState: RETURN_TO_RP
-
   RETURN_TO_RP:
     response:
       type: process
       lambda: build-client-oauth-response
-
-  CRI_TICF_BEFORE_SUCCESS:
-    response:
-      type: process
-      lambda: call-ticf-cri
-    parent: CRI_TICF_STATE
-    events:
-      next:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
 
   # Common pages
   PRE_EXPERIAN_KBV_TRANSITION_PAGE:
@@ -363,7 +316,8 @@ states:
           f2f:
             targetState: PYI_CRI_ESCAPE_NO_F2F
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       enhanced-verification:
         targetState: MITIGATION_02_OPTIONS_WITH_F2F
         auditEvents:
@@ -391,7 +345,8 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
@@ -555,7 +510,8 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       enhanced-verification:
         targetState: MITIGATION_02_OPTIONS_WITH_F2F
         auditEvents:
@@ -581,7 +537,8 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       enhanced-verification:
         targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
         auditEvents:
@@ -608,7 +565,8 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       invalid-request:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       access-denied:
@@ -634,7 +592,8 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       invalid-request:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
       access-denied:
@@ -737,7 +696,8 @@ states:
           f2f:
             targetState: PYI_CRI_ESCAPE_NO_F2F
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       enhanced-verification:
         targetState: MITIGATION_KBV_FAIL_M2B
         checkIfDisabled:
@@ -958,7 +918,8 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       not-found:
         targetState: PYI_POST_OFFICE
         checkIfDisabled:
@@ -1233,7 +1194,8 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
@@ -1245,7 +1207,8 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED
@@ -1261,7 +1224,8 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: EVALUATE_GPG45_SCORES
+        targetJourney: EVALUATE_SCORES
+        targetState: START
       invalid-request:
         targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       access-denied:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -188,6 +188,43 @@ states:
       end:
         targetState: PYI_ESCAPE_M2B
 
+  CRI_F2F: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: cri
+      criId: f2f
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      enhanced-verification:
+        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
+      access-denied:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_NO_TICF
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  F2F_HANDOFF_PAGE: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: page
+      pageId: page-face-to-face-handoff
+
   CRI_DCMAW:
     response:
       type: cri
@@ -290,10 +327,93 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
+  EVALUATE_GPG45_SCORES: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: process
+      lambda: evaluate-gpg45-scores
+    events:
+      met:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+        checkFeatureFlag:
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_SUCCESS
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  STORE_IDENTITY_BEFORE_SUCCESS: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: process
+      lambda: store-identity
+      lambdaInput:
+        identityType: NEW
+    events:
+      identity-stored:
+        targetState: IPV_SUCCESS_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  STORE_IDENTITY_BEFORE_F2F_HANDOFF: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: process
+      lambda: store-identity
+      lambdaInput:
+        identityType: PENDING
+    events:
+      identity-stored:
+        targetState: RESET_SESSION_BEFORE_F2F_HANDOFF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  RESET_SESSION_BEFORE_F2F_HANDOFF: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        targetState: F2F_HANDOFF_PAGE
+      error:
+        targetState: F2F_HANDOFF_PAGE
+
+  IPV_SUCCESS_PAGE: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: page
+      pageId: page-ipv-success
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
   RETURN_TO_RP:
     response:
       type: process
       lambda: build-client-oauth-response
+
+  CRI_TICF_BEFORE_SUCCESS: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: STORE_IDENTITY_BEFORE_SUCCESS
+
+  CRI_TICF_BEFORE_F2F: # PYIC-7018: Remove after period of redirecting users
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: CRI_F2F
+      enhanced-verification:
+        targetState: CRI_F2F
 
   # Common pages
   PRE_EXPERIAN_KBV_TRANSITION_PAGE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -188,43 +188,6 @@ states:
       end:
         targetState: PYI_ESCAPE_M2B
 
-  CRI_F2F:
-    response:
-      type: cri
-      criId: f2f
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-      enhanced-verification:
-        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-      access-denied:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_NO_TICF
-      not-found:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      fail-with-no-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      vcs-not-correlated:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-      temporarily-unavailable:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-
-  F2F_HANDOFF_PAGE:
-    response:
-      type: page
-      pageId: page-face-to-face-handoff
-
   CRI_DCMAW:
     response:
       type: cri
@@ -306,10 +269,8 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
 
   PYI_CRI_ESCAPE_NO_F2F:
     response:
@@ -359,31 +320,6 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
 
-  STORE_IDENTITY_BEFORE_F2F_HANDOFF:
-    response:
-      type: process
-      lambda: store-identity
-      lambdaInput:
-        identityType: PENDING
-    events:
-      identity-stored:
-        targetState: RESET_SESSION_BEFORE_F2F_HANDOFF
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
-  RESET_SESSION_BEFORE_F2F_HANDOFF:
-    response:
-      type: process
-      lambda: reset-session-identity
-      lambdaInput:
-        resetType: ALL
-    events:
-      next:
-        targetState: F2F_HANDOFF_PAGE
-      error:
-        targetState: F2F_HANDOFF_PAGE
-
   IPV_SUCCESS_PAGE:
     response:
       type: page
@@ -405,17 +341,6 @@ states:
     events:
       next:
         targetState: STORE_IDENTITY_BEFORE_SUCCESS
-
-  CRI_TICF_BEFORE_F2F:
-    response:
-      type: process
-      lambda: call-ticf-cri
-    parent: CRI_TICF_STATE
-    events:
-      next:
-        targetState: CRI_F2F
-      enhanced-verification:
-        targetState: CRI_F2F
 
   # Common pages
   PRE_EXPERIAN_KBV_TRANSITION_PAGE:
@@ -605,15 +530,11 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
       enhanced-verification:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
 
   # HMRC KBV journey (J6)
   CRI_NINO_J6:
@@ -837,10 +758,8 @@ states:
       pageId: no-photo-id-security-questions-find-another-way
     events:
       f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
       appTriage:
         targetState: CRI_DCMAW_PYI_ESCAPE
         checkFeatureFlag:
@@ -886,10 +805,8 @@ states:
       context: dropout
     events:
       f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
       appTriage:
         targetState: CRI_DCMAW_PYI_ESCAPE
         checkFeatureFlag:
@@ -1079,10 +996,8 @@ states:
       pageId: pyi-suggest-other-options
     events:
       f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
       appTriage:
         targetState: CRI_DCMAW_PYI_ESCAPE
         checkFeatureFlag:
@@ -1100,10 +1015,8 @@ states:
       context: no-photo-id
     events:
       f2f:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
       appTriage:
         targetState: CRI_DCMAW_PYI_ESCAPE
         checkFeatureFlag:
@@ -1120,10 +1033,8 @@ states:
       pageId: pyi-post-office
     events:
       next:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetJourney: F2F_HAND_OFF
+        targetState: START
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
@@ -25,7 +25,8 @@ public enum IpvJourneyTypes {
     TECHNICAL_ERROR("technical-error"),
     SESSION_TIMEOUT("session-timeout"),
 
-    // F2F return journeys
+    // F2F journeys
+    F2F_HAND_OFF("f2f-hand-off"),
     F2F_PENDING("f2f-pending"),
     F2F_FAILED("f2f-failed"),
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
@@ -18,6 +18,7 @@ public enum IpvJourneyTypes {
     NEW_P1_IDENTITY("new-p2-identity"),
     NEW_P2_IDENTITY("new-p2-identity"),
     REPEAT_FRAUD_CHECK("repeat-fraud-check"),
+    EVALUATE_SCORES("evaluate-scores"),
 
     // Unsuccessful journeys
     INELIGIBLE("ineligible"),


### PR DESCRIPTION
## Proposed changes

### What changed

- Separated out 2 journeys from new p2 identity because will be used in P1 and simplifies 

new-p2-identity:
<img width="776" alt="Screenshot 2024-07-19 at 11 50 36" src="https://github.com/user-attachments/assets/f7fb7cdd-3aad-4fa7-b1d6-ad7d3ca6b638">

f2f-hand-off:
<img width="1609" alt="Screenshot 2024-07-19 at 11 52 58" src="https://github.com/user-attachments/assets/8a91fcf8-9a7f-4c6c-98eb-2cd9568f84b0">

evaluate-scores:
<img width="1606" alt="Screenshot 2024-07-19 at 11 53 17" src="https://github.com/user-attachments/assets/51dcfa3a-4973-43ca-95a3-d8b9b3b7d26e">

### Why did it change

- P1 will use these as well and they are identical in both. It will reduce code and could make the functionality simpler to understand

### Issue tracking

- [PYIC-7018](https://govukverify.atlassian.net/browse/PYIC-7018)

### Notes

- Apart from redundancy, this will be easily checked with e2e tests

[PYIC-7018]: https://govukverify.atlassian.net/browse/PYIC-7018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ