### PR TITLE
PYIC-7018: Remove old journey states

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -188,43 +188,6 @@ states:
       end:
         targetState: PYI_ESCAPE_M2B
 
-  CRI_F2F: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: cri
-      criId: f2f
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-      enhanced-verification:
-        targetState: STORE_IDENTITY_BEFORE_F2F_HANDOFF
-      access-denied:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_NO_TICF
-      not-found:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      fail-with-no-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      vcs-not-correlated:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-      temporarily-unavailable:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-
-  F2F_HANDOFF_PAGE: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: page
-      pageId: page-face-to-face-handoff
-
   CRI_DCMAW:
     response:
       type: cri
@@ -327,93 +290,10 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  EVALUATE_GPG45_SCORES: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: process
-      lambda: evaluate-gpg45-scores
-    events:
-      met:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_SUCCESS
-      unmet:
-        targetJourney: FAILED
-        targetState: FAILED
-      vcs-not-correlated:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  STORE_IDENTITY_BEFORE_SUCCESS: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: process
-      lambda: store-identity
-      lambdaInput:
-        identityType: NEW
-    events:
-      identity-stored:
-        targetState: IPV_SUCCESS_PAGE
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
-  STORE_IDENTITY_BEFORE_F2F_HANDOFF: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: process
-      lambda: store-identity
-      lambdaInput:
-        identityType: PENDING
-    events:
-      identity-stored:
-        targetState: RESET_SESSION_BEFORE_F2F_HANDOFF
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
-  RESET_SESSION_BEFORE_F2F_HANDOFF: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: process
-      lambda: reset-session-identity
-      lambdaInput:
-        resetType: ALL
-    events:
-      next:
-        targetState: F2F_HANDOFF_PAGE
-      error:
-        targetState: F2F_HANDOFF_PAGE
-
-  IPV_SUCCESS_PAGE: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: page
-      pageId: page-ipv-success
-    events:
-      next:
-        targetState: RETURN_TO_RP
-
   RETURN_TO_RP:
     response:
       type: process
       lambda: build-client-oauth-response
-
-  CRI_TICF_BEFORE_SUCCESS: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: process
-      lambda: call-ticf-cri
-    parent: CRI_TICF_STATE
-    events:
-      next:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-
-  CRI_TICF_BEFORE_F2F: # PYIC-7018: Remove after period of redirecting users
-    response:
-      type: process
-      lambda: call-ticf-cri
-    parent: CRI_TICF_STATE
-    events:
-      next:
-        targetState: CRI_F2F
-      enhanced-verification:
-        targetState: CRI_F2F
 
   # Common pages
   PRE_EXPERIAN_KBV_TRANSITION_PAGE:


### PR DESCRIPTION
DO NOT MERGE UNTIL A WHILE AFTER pyic-7018-separate-common-journeys merged in for a while.
It was merged in on Tue 23/07/24 morning. Will merge this one from Wed 24/07/24 morning, giving users a day to complete a f2f hand off/ evaluate scores flow

## Proposed changes

### What changed

- Remove old journey states after all journeys likely moved over to use common f2f/ evaluate journeys

### Why did it change

- To remove redundancy once users have moved off old states

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7018](https://govukverify.atlassian.net/browse/PYIC-7018)

[PYIC-7018]: https://govukverify.atlassian.net/browse/PYIC-7018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ