### PR TITLE
PYIC-7018: Add in *_NO_PHOTO_ID states to replace *_M2B into P2

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -182,11 +182,11 @@ states:
       pageId: prove-identity-no-photo-id
     events:
       next:
-        targetState: CRI_CLAIMED_IDENTITY_M2B
+        targetState: CRI_CLAIMED_IDENTITY_NO_PHOTO_ID
         auditEvents:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
-        targetState: PYI_ESCAPE_M2B
+        targetState: PYI_ESCAPE_NO_PHOTO_ID
 
   CRI_F2F: # PYIC-7018: Remove after period of redirecting users
     response:
@@ -650,7 +650,7 @@ states:
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
-  CRI_HMRC_KBV_M2B:
+  CRI_HMRC_KBV_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: cri
       criId: hmrcKbv
@@ -660,7 +660,7 @@ states:
         targetJourney: EVALUATE_SCORES
         targetState: START
       enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
@@ -676,6 +676,33 @@ states:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+        CRI_HMRC_KBV_NO_PHOTO_ID:
+          response:
+            type: cri
+            criId: hmrcKbv
+          parent: CRI_STATE
+          events:
+            next:
+              targetJourney: EVALUATE_SCORES
+              targetState: START
+            enhanced-verification:
+              targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
+              auditEvents:
+                - IPV_MITIGATION_START
+              auditContext:
+                mitigationType: enhanced-verification
+              checkIfDisabled:
+                f2f:
+                  targetState: MITIGATION_02_OPTIONS
+                  auditEvents:
+                    - IPV_MITIGATION_START
+                  auditContext:
+                    mitigationType: enhanced-verification
+            invalid-request:
+              targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+            access-denied:
+              targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
   # DWP KBV journey (J7)
   CRI_DWP_KBV_J7:
@@ -705,7 +732,7 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
-  CRI_DWP_KBV_M2B:
+  CRI_DWP_KBV_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: cri
       criId: dwpKbv
@@ -715,11 +742,38 @@ states:
         targetJourney: EVALUATE_SCORES
         targetState: START
       invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_M2B
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+
+  CRI_DWP_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: dwpKbv
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
@@ -733,7 +787,7 @@ states:
               mitigationType: enhanced-verification
 
   # No photo id journey (M2B)
-  CRI_CLAIMED_IDENTITY_M2B:
+  CRI_CLAIMED_IDENTITY_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: cri
       criId: claimedIdentity
@@ -741,25 +795,51 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: CRI_BANK_ACCOUNT_M2B
+        targetState: CRI_BANK_ACCOUNT_NO_PHOTO_ID
       enhanced-verification:
-        targetState: CRI_BANK_ACCOUNT_M2B
+        targetState: CRI_BANK_ACCOUNT_NO_PHOTO_ID
 
-  CRI_BANK_ACCOUNT_M2B:
+  CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: claimedIdentity
+      context: bank_account
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_BANK_ACCOUNT_NO_PHOTO_ID
+      enhanced-verification:
+        targetState: CRI_BANK_ACCOUNT_NO_PHOTO_ID
+
+  CRI_BANK_ACCOUNT_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: cri
       criId: bav
     parent: CRI_STATE
     events:
       next:
-        targetState: CRI_NINO_WITH_SCOPE_M2B
+        targetState: CRI_NINO_WITH_SCOPE_NO_PHOTO_ID
       access-denied:
-        targetState: PYI_ESCAPE_ABANDON_M2B
+        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_BAV
 
-  CRI_NINO_WITH_SCOPE_M2B:
+  CRI_BANK_ACCOUNT_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: bav
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_NINO_WITH_SCOPE_NO_PHOTO_ID
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_BAV
+
+  CRI_NINO_WITH_SCOPE_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: cri
       criId: nino
@@ -769,49 +849,94 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: ADDRESS_AND_FRAUD_M2B
+        targetState: ADDRESS_AND_FRAUD_NO_PHOTO_ID
       access-denied:
-        targetState: PYI_ESCAPE_ABANDON_M2B
+        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NINO
 
-  ADDRESS_AND_FRAUD_M2B:
+  CRI_NINO_WITH_SCOPE_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: nino
+      evidenceRequest:
+        scoringPolicy: gpg45
+        strengthScore: 2
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_NO_PHOTO_ID
+      access-denied:
+        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NINO
+
+  ADDRESS_AND_FRAUD_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_M2B
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
-            targetState: CRI_HMRC_KBV_M2B
+            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
             checkIfDisabled:
               hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       enhanced-verification:
-        targetState: CRI_DWP_KBV_M2B
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
-            targetState: CRI_HMRC_KBV_M2B
+            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
             checkIfDisabled:
               hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
 
-  PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B:
+  ADDRESS_AND_FRAUD_NO_PHOTO_ID:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      enhanced-verification:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: page
       pageId: page-pre-experian-kbv-transition
     events:
       next:
-        targetState: CRI_EXPERIAN_KBV_M2B
+        targetState: CRI_EXPERIAN_KBV_NO_PHOTO_ID
 
-  CRI_EXPERIAN_KBV_M2B:
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV_NO_PHOTO_ID
+
+  CRI_EXPERIAN_KBV_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: cri
       criId: kbv
     parent: CRI_STATE
     events:
       fail-with-no-ci:
-        targetState: PYI_KBV_DROPOUT_M2B
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
             targetState: PYI_CRI_ESCAPE_NO_F2F
@@ -819,7 +944,7 @@ states:
         targetJourney: EVALUATE_SCORES
         targetState: START
       enhanced-verification:
-        targetState: MITIGATION_KBV_FAIL_M2B
+        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
@@ -832,7 +957,35 @@ states:
         auditContext:
           mitigationType: enhanced-verification
 
-  MITIGATION_KBV_FAIL_M2B:
+  CRI_EXPERIAN_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+
+  MITIGATION_KBV_FAIL_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: page
       pageId: no-photo-id-security-questions-find-another-way
@@ -853,7 +1006,28 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
 
-  PYI_ESCAPE_M2B:
+  MITIGATION_KBV_FAIL_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  PYI_ESCAPE_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: page
       pageId: no-photo-id-exit-find-another-way
@@ -866,7 +1040,20 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  PYI_ESCAPE_ABANDON_M2B:
+  PYI_ESCAPE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: no-photo-id-exit-find-another-way
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+      bankAccount:
+        targetState: BANK_ACCOUNT_START_PAGE
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  PYI_ESCAPE_ABANDON_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
     response:
       type: page
       context: abandon
@@ -878,7 +1065,41 @@ states:
       next:
         targetState: RESET_SESSION_IDENTITY
 
-  PYI_KBV_DROPOUT_M2B:
+  PYI_ESCAPE_ABANDON_NO_PHOTO_ID:
+    response:
+      type: page
+      context: abandon
+      pageId: no-photo-id-exit-find-another-way
+    events:
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+      next:
+        targetState: RESET_SESSION_IDENTITY
+
+  PYI_KBV_DROPOUT_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
+    response:
+      type: page
+      pageId: no-photo-id-security-questions-find-another-way
+      context: dropout
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  PYI_KBV_DROPOUT_NO_PHOTO_ID:
     response:
       type: page
       pageId: no-photo-id-security-questions-find-another-way
@@ -1089,7 +1310,26 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
-  MITIGATION_02_OPTIONS_WITH_F2F_M2B:
+  MITIGATION_02_OPTIONS_WITH_F2F_M2B: # PYIC-7018: Cleanup after while of redirecting users to _NO_PHOTO_ID
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+      context: no-photo-id
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID:
     response:
       type: page
       pageId: pyi-suggest-other-options

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -677,32 +677,32 @@ states:
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
-        CRI_HMRC_KBV_NO_PHOTO_ID:
-          response:
-            type: cri
-            criId: hmrcKbv
-          parent: CRI_STATE
-          events:
-            next:
-              targetJourney: EVALUATE_SCORES
-              targetState: START
-            enhanced-verification:
-              targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
-              auditEvents:
-                - IPV_MITIGATION_START
-              auditContext:
-                mitigationType: enhanced-verification
-              checkIfDisabled:
-                f2f:
-                  targetState: MITIGATION_02_OPTIONS
-                  auditEvents:
-                    - IPV_MITIGATION_START
-                  auditContext:
-                    mitigationType: enhanced-verification
-            invalid-request:
-              targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-            access-denied:
-              targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+  CRI_HMRC_KBV_NO_PHOTO_ID:
+    response:
+      type: cri
+      criId: hmrcKbv
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+      invalid-request:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      access-denied:
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
 
   # DWP KBV journey (J7)
   CRI_DWP_KBV_J7:


### PR DESCRIPTION
## Proposed changes

### What changed

- Add in *_NO_PHOTO_ID states to replace *_M2B into P2

### Why did it change

- To rename the states in a way which won't break user journeys

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7018](https://govukverify.atlassian.net/browse/PYIC-7018)

### Clean-up PR

https://github.com/govuk-one-login/ipv-core-back/pull/2198

[PYIC-7018]: https://govukverify.atlassian.net/browse/PYIC-7018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ