### PR TITLE
PYIC-7016: add nino only context for the p1 journey multiple doc page

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -138,7 +138,7 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       end:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        targetState: MULTIPLE_DOC_F2F_NINO_CHECK_PAGE
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
@@ -167,7 +167,7 @@ states:
     response:
       type: page
       pageId: prove-identity-no-photo-id
-      context: nino-only
+      context: nino
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_NO_PHOTO_ID
@@ -188,22 +188,22 @@ states:
       next:
         targetState: POST_DCMAW_SUCCESS_PAGE
       not-found:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        targetState: MULTIPLE_DOC_F2F_NINO_CHECK_PAGE
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
       access-denied:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        targetState: MULTIPLE_DOC_F2F_NINO_CHECK_PAGE
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
       temporarily-unavailable:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        targetState: MULTIPLE_DOC_F2F_NINO_CHECK_PAGE
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
       fail-with-no-ci:
-        targetState: MULTIPLE_DOC_F2F_CHECK_PAGE
+        targetState: MULTIPLE_DOC_F2F_NINO_CHECK_PAGE
         checkIfDisabled:
           f2f:
             targetState: MULTIPLE_DOC_CHECK_PAGE
@@ -211,7 +211,7 @@ states:
   MULTIPLE_DOC_CHECK_PAGE:
     response:
       type: page
-      pageId: page-multiple-doc-check # PYIC-7016: Update so can produce nino event
+      pageId: page-multiple-doc-check
     events:
       ukPassport:
         targetState: CRI_UK_PASSPORT_J2
@@ -223,11 +223,11 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  MULTIPLE_DOC_F2F_CHECK_PAGE:
+  MULTIPLE_DOC_F2F_NINO_CHECK_PAGE:
     response:
       type: page
-      context: f2f
-      pageId: page-multiple-doc-check # PYIC-7016: Update so can produce nino event
+      context: nino
+      pageId: page-multiple-doc-check
     events:
       ukPassport:
         targetState: CRI_UK_PASSPORT_J2


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Add nino only context for the p1 journey multiple doc page

### What changed

- Updated P1 journey map

<!-- Describe the changes in detail - the "what"-->


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7016](https://govukverify.atlassian.net/browse/PYIC-7016)


[PYIC-7016]: https://govukverify.atlassian.net/browse/PYIC-7016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ