### PR TITLE
BAU: Re-migrate EVCS credentials if necessary

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -729,11 +729,9 @@ public class CheckExistingIdentityHandler
         if (configService.enabled(EVCS_WRITE_ENABLED) && !vcBundle.hasEvcsIdentity()) {
             try {
                 evcsMigrationService.migrateExistingIdentity(
-                        auditEventUser.getUserId(),
-                        vcBundle.credentials.stream()
-                                .filter(vc -> vc.getMigrated() == null)
-                                .toList());
-                sendVCsMigratedAuditEvent(auditEventUser, vcBundle.credentials, deviceInformation);
+                        auditEventUser.getUserId(), vcBundle.credentials());
+                sendVCsMigratedAuditEvent(
+                        auditEventUser, vcBundle.credentials(), deviceInformation);
             } catch (EvcsServiceException e) {
                 if (configService.enabled(EVCS_READ_ENABLED)) {
                     throw e;


### PR DESCRIPTION
We're seeing issues in staging when a VC marked as migrated is not present in EVCS.

In that scenario we are already logging a warning ('Failed to find corresponding evcs credential for migrated tactical credential'), but should handle it gracefully by re-migrating the VCs.

In the meantime we should also diagnose the root cause of the issue in EVCS.