### PR TITLE
PYIC-7011: Add context to post office page when it's the last option …

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -146,6 +146,7 @@ states:
   F2F_START_PAGE:
     response:
       type: page
+      context: lastChoice
       pageId: page-ipv-identity-postoffice-start
     events:
       next:


### PR DESCRIPTION
…in a P1 journey

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add a context to the post office start page for P1 journeys

### Why did it change

To try to indicate to the user that this is the last option for proving their identity

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7011](https://govukverify.atlassian.net/browse/PYIC-7011)

P1 journey:
![image](https://github.com/user-attachments/assets/fad69d74-3701-41c3-b95d-bd9016f38613)

P2 journey:
![image](https://github.com/user-attachments/assets/fc911743-2563-43a9-964b-4dedaaf06df6)


[PYIC-7011]: https://govukverify.atlassian.net/browse/PYIC-7011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ