### PR TITLE
PYIC-7130: remove checks for null api key in public methods

### DIFF
--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -126,8 +126,7 @@ public class CiMitService {
 
         LOGGER.info(LogHelper.buildLogMessage("Sending VC to CIMIT."));
         try {
-            if (configService.enabled(CIMIT_API_GATEWAY_ENABLED)
-                    && configService.getSecret(CIMIT_API_KEY) != null) {
+            if (configService.enabled(CIMIT_API_GATEWAY_ENABLED)) {
                 var payload =
                         OBJECT_MAPPER.writeValueAsString(new PostCiApiRequest(vc.getVcString()));
 
@@ -169,8 +168,7 @@ public class CiMitService {
 
         LOGGER.info(LogHelper.buildLogMessage("Sending mitigating VCs to CIMIT."));
         try {
-            if (configService.enabled(CIMIT_API_GATEWAY_ENABLED)
-                    && configService.getSecret(CIMIT_API_KEY) != null) {
+            if (configService.enabled(CIMIT_API_GATEWAY_ENABLED)) {
                 var payload =
                         OBJECT_MAPPER.writeValueAsString(
                                 new PostMitigationsApiRequest(
@@ -256,8 +254,7 @@ public class CiMitService {
             throws CiRetrievalException {
         LOGGER.info(LogHelper.buildLogMessage("Retrieving CIs from CIMIT system"));
         try {
-            if (configService.enabled(CIMIT_API_GATEWAY_ENABLED)
-                    && configService.getSecret(CIMIT_API_KEY) != null) {
+            if (configService.enabled(CIMIT_API_GATEWAY_ENABLED)) {
                 var response = sendGetHttpRequest(userId, govukSigninJourneyId, ipAddress);
 
                 if (response.statusCode() != SC_OK) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- remove null checks in public methods and let private method for building request handle null api keys

### Why did it change

The CIMIT interface is being updated to use a private API Gateway. The stub requires an api key as it is a public api gateway but the real cimit api does not require one.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7130](https://govukverify.atlassian.net/browse/PYIC-7130)


[PYIC-7130]: https://govukverify.atlassian.net/browse/PYIC-7130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ