### PR TITLE
PYIC-7017: Add contexts to P1 journey map

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -690,6 +690,7 @@ states:
     response:
       type: page
       pageId: no-photo-id-security-questions-find-another-way
+      context: p1
     events:
       f2f:
         targetJourney: F2F_HAND_OFF
@@ -723,7 +724,7 @@ states:
     response:
       type: page
       pageId: no-photo-id-security-questions-find-another-way
-      context: dropout
+      context: p1Dropout
     events:
       f2f:
         targetJourney: F2F_HAND_OFF


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add contexts for no-photo-id-security-questions-find-another-way page for P1

### Why did it change

So the P1 pages can look different to P2

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7017](https://govukverify.atlassian.net/browse/PYIC-7017)


[PYIC-7017]: https://govukverify.atlassian.net/browse/PYIC-7017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ