### PR TITLE
PYIC-6021: add check for dummy api key

### DIFF
--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -77,6 +77,7 @@ public class CiMitService {
     private static final String POST_CI_ENDPOINT = "/contra-indicators/detect";
     private static final String POST_MITIGATIONS_ENDPOINT = "/contra-indicators/mitigate";
     private static final String GET_VCS_ENDPOINT = "/contra-indicators";
+    private static final String DUMMY_CIMIT_API_KEY = "dummyApiKey";
 
     public static final String FAILED_RESPONSE = "fail";
 
@@ -418,7 +419,7 @@ public class CiMitService {
                         .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 
         var apiKey = configService.getSecret(CIMIT_API_KEY);
-        if (apiKey != null) {
+        if (apiKey != null && !apiKey.equals(DUMMY_CIMIT_API_KEY)) {
             requestBuilder.header(X_API_KEY_HEADER, configService.getSecret(CIMIT_API_KEY));
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- add check for dummy api key

### Why did it change

The stub requires an api key when making requests to cimit stub api but now when sending requests to real cimit. We don't want to log an error when the cimit api key doesn't exist for staging+ envs so we add a dummy api key instead.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6021](https://govukverify.atlassian.net/browse/PYIC-6021)


[PYIC-6021]: https://govukverify.atlassian.net/browse/PYIC-6021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ