### PR TITLE
BAU: Remove generic DynamoDB null warning in favour of explicit checks

### DIFF
--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -31,7 +31,6 @@ import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyState;
 import uk.gov.di.ipv.core.library.enums.Vot;
-import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -42,7 +41,6 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.validation.ValidationResult;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
@@ -94,8 +92,7 @@ class BuildClientOauthResponseHandlerTest {
     }
 
     @Test
-    void shouldReturn200OnSuccessfulOauthRequest()
-            throws URISyntaxException, IpvSessionNotFoundException {
+    void shouldReturn200OnSuccessfulOauthRequest() throws Exception {
         when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
                 .thenReturn(ValidationResult.createValidResult());
         IpvSessionItem ipvSessionItem = spy(generateIpvSessionItem());
@@ -141,8 +138,7 @@ class BuildClientOauthResponseHandlerTest {
     @ParameterizedTest
     @MethodSource("testParamsForSuccessfulOauthRequestForReproveIdentity")
     void shouldReturn200OnSuccessfulOauthRequestForReproveIdentity(
-            Vot vot, String vtr, boolean success)
-            throws URISyntaxException, IpvSessionNotFoundException {
+            Vot vot, String vtr, boolean success) throws Exception {
         when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
                 .thenReturn(ValidationResult.createValidResult());
         IpvSessionItem ipvSessionItem = spy(generateIpvSessionItem());
@@ -198,7 +194,7 @@ class BuildClientOauthResponseHandlerTest {
 
     @Test
     void shouldReturn200OnSuccessfulOauthRequest_withNullIpvSessionAndClientSessionIdInRequest()
-            throws URISyntaxException {
+            throws Exception {
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
                 .thenReturn(getClientOAuthSessionItem());
 
@@ -235,8 +231,7 @@ class BuildClientOauthResponseHandlerTest {
     }
 
     @Test
-    void shouldReturn200WhenStateNotInSession()
-            throws URISyntaxException, IpvSessionNotFoundException {
+    void shouldReturn200WhenStateNotInSession() throws Exception {
         when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
                 .thenReturn(ValidationResult.createValidResult());
         when(mockSessionService.getIpvSession(anyString())).thenReturn(generateIpvSessionItem());
@@ -267,7 +262,7 @@ class BuildClientOauthResponseHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfRequestFailsValidation() throws IpvSessionNotFoundException {
+    void shouldReturn400IfRequestFailsValidation() throws Exception {
         when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
                 .thenReturn(new ValidationResult<>(false, ErrorResponse.MISSING_QUERY_PARAMETERS));
         when(mockSessionService.getIpvSession(anyString())).thenReturn(generateIpvSessionItem());
@@ -294,7 +289,7 @@ class BuildClientOauthResponseHandlerTest {
     @ParameterizedTest
     @ValueSource(strings = {OAuth2RequestParams.CLIENT_ID, OAuth2RequestParams.RESPONSE_TYPE})
     void shouldReturn400IfCanNotParseAuthRequestFromQueryStringParams(String param)
-            throws IpvSessionNotFoundException {
+            throws Exception {
         when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
                 .thenReturn(ValidationResult.createValidResult());
         when(mockSessionService.getIpvSession(anyString())).thenReturn(generateIpvSessionItem());
@@ -381,8 +376,7 @@ class BuildClientOauthResponseHandlerTest {
     }
 
     @Test
-    void shouldReturn200OnSuccessfulOauthRequestForJsonRequest()
-            throws URISyntaxException, IpvSessionNotFoundException {
+    void shouldReturn200OnSuccessfulOauthRequestForJsonRequest() throws Exception {
         when(mockAuthRequestValidator.validateRequest(anyMap(), anyMap()))
                 .thenReturn(ValidationResult.createValidResult());
         IpvSessionItem ipvSessionItem = generateIpvSessionItem();

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/UserIdentityRequestHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/UserIdentityRequestHandler.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.ExpiredAccessTokenException;
 import uk.gov.di.ipv.core.library.exceptions.InvalidScopeException;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
@@ -97,7 +98,7 @@ public abstract class UserIdentityRequestHandler {
     }
 
     protected ClientOAuthSessionItem getClientOAuthSessionItem(String clientOAuthSessionId)
-            throws InvalidScopeException {
+            throws InvalidScopeException, ClientOauthSessionNotFoundException {
         var clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.getClientOAuthSession(clientOAuthSessionId);
 

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.builduseridentity;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
@@ -689,8 +688,7 @@ class BuildUserIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseWhenTokenIsNull()
-            throws JsonProcessingException, VerifiableCredentialException {
+    void shouldReturnErrorResponseWhenTokenIsNull() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> headers = new HashMap<>(Collections.emptyMap());
         headers.put("Authorization", null);
@@ -779,8 +777,7 @@ class BuildUserIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseWhenTokenIsMissingBearerPrefix()
-            throws JsonProcessingException, VerifiableCredentialException {
+    void shouldReturnErrorResponseWhenTokenIsMissingBearerPrefix() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> headers =
                 Map.of("Authorization", "11111111", "ip-address", TEST_IP_ADDRESS);
@@ -802,8 +799,7 @@ class BuildUserIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseWhenTokenIsMissing()
-            throws JsonProcessingException, VerifiableCredentialException {
+    void shouldReturnErrorResponseWhenTokenIsMissing() throws Exception {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         Map<String, String> headers = Map.of("ip-address", TEST_IP_ADDRESS);
         event.setHeaders(headers);
@@ -823,9 +819,7 @@ class BuildUserIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseWhenInvalidAccessTokenProvided()
-            throws JsonProcessingException, VerifiableCredentialException,
-                    IpvSessionNotFoundException {
+    void shouldReturnErrorResponseWhenInvalidAccessTokenProvided() throws Exception {
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
                 .thenThrow(new IpvSessionNotFoundException("error"));
 
@@ -847,9 +841,7 @@ class BuildUserIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseWhenAccessTokenHasBeenRevoked()
-            throws JsonProcessingException, VerifiableCredentialException,
-                    IpvSessionNotFoundException {
+    void shouldReturnErrorResponseWhenAccessTokenHasBeenRevoked() throws Exception {
         AccessTokenMetadata revokedAccessTokenMetadata = new AccessTokenMetadata();
         revokedAccessTokenMetadata.setRevokedAtDateTime(Instant.now().toString());
         ipvSessionItem.setAccessTokenMetadata(revokedAccessTokenMetadata);
@@ -872,9 +864,7 @@ class BuildUserIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturn403ErrorResponseWhenAccessTokenHasExpired()
-            throws JsonProcessingException, VerifiableCredentialException,
-                    IpvSessionNotFoundException {
+    void shouldReturn403ErrorResponseWhenAccessTokenHasExpired() throws Exception {
         AccessTokenMetadata expiredAccessTokenMetadata = new AccessTokenMetadata();
         expiredAccessTokenMetadata.setExpiryDateTime(Instant.now().minusSeconds(5).toString());
         ipvSessionItem.setAccessTokenMetadata(expiredAccessTokenMetadata);
@@ -897,9 +887,7 @@ class BuildUserIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturn403ErrorResponseWhenIpvSessionNotFoundExceptionThrown()
-            throws JsonProcessingException, VerifiableCredentialException,
-                    IpvSessionNotFoundException {
+    void shouldReturn403ErrorResponseWhenIpvSessionNotFoundExceptionThrown() throws Exception {
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
                 .thenThrow(new IpvSessionNotFoundException("err", new Exception()));
 

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
@@ -140,7 +141,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
     private Map<String, Object> callTicfCri(IpvSessionItem ipvSessionItem, ProcessRequest request)
             throws TicfCriServiceException, CiRetrievalException, VerifiableCredentialException,
                     CiPostMitigationsException, CiPutException, ConfigException,
-                    UnrecognisedVotException {
+                    UnrecognisedVotException, ClientOauthSessionNotFoundException {
         configService.setFeatureSet(RequestHelper.getFeatureSet(request));
         var clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.getClientOAuthSession(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -45,7 +45,6 @@ import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
-import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45ProfileEvaluator;
@@ -287,7 +286,7 @@ class CheckExistingIdentityHandlerTest {
     @DisplayName("reuse journeys")
     class ReuseJourneys {
         @BeforeEach
-        public void reuseSetup() throws IpvSessionNotFoundException {
+        public void reuseSetup() throws Exception {
             when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID))
                     .thenReturn(ipvSessionItem);
             when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -841,7 +840,7 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfSessionIdNotInHeader() {
+    void shouldReturn400IfSessionIdNotInHeader() throws Exception {
         JourneyRequest eventWithoutHeaders = JourneyRequest.builder().build();
 
         JourneyErrorResponse journeyResponse =
@@ -864,8 +863,7 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnPendingResponseIfFaceToFaceVerificationIsPending()
-            throws IpvSessionNotFoundException {
+    void shouldReturnPendingResponseIfFaceToFaceVerificationIsPending() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         CriResponseItem criResponseItem = createCriResponseStoreItem();
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
@@ -886,7 +884,7 @@ class CheckExistingIdentityHandlerTest {
 
     @Test
     void shouldReturnPendingResponseIfFaceToFaceVerificationIsPendingAndBreachingCi()
-            throws ConfigException, IpvSessionNotFoundException {
+            throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         CriResponseItem criResponseItem = createCriResponseStoreItem();
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
@@ -908,8 +906,7 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnFailResponseIfFaceToFaceVerificationIsError()
-            throws IpvSessionNotFoundException {
+    void shouldReturnFailResponseIfFaceToFaceVerificationIsError() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         CriResponseItem criResponseItem = createCriErrorResponseStoreItem(Instant.now());
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
@@ -982,8 +979,7 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnJourneyIpvGpg45MediumIfDataDoesNotCorrelateAndNotF2F()
-            throws CredentialParseException, IpvSessionNotFoundException {
+    void shouldReturnJourneyIpvGpg45MediumIfDataDoesNotCorrelateAndNotF2F() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(null);

--- a/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
+++ b/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
+import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -126,7 +127,7 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
 
     private int getScore(String ipvSessionId, String scoreType)
             throws UnknownScoreTypeException, VerifiableCredentialException,
-                    IpvSessionNotFoundException {
+                    IpvSessionNotFoundException, ClientOauthSessionNotFoundException {
         var vcs = getParsedCredentials(ipvSessionId);
         var gpg45Scores = gpg45ProfileEvaluator.buildScore(vcs);
         return switch (scoreType) {
@@ -138,7 +139,8 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
     }
 
     private List<VerifiableCredential> getParsedCredentials(String ipvSessionId)
-            throws VerifiableCredentialException, IpvSessionNotFoundException {
+            throws VerifiableCredentialException, IpvSessionNotFoundException,
+                    ClientOauthSessionNotFoundException {
         IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
         ClientOAuthSessionItem clientOAuthSessionItem =
                 clientOAuthSessionDetailsService.getClientOAuthSession(

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -288,7 +288,7 @@ class EvaluateGpg45ScoresHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfSessionIdNotInRequest() {
+    void shouldReturn400IfSessionIdNotInRequest() throws Exception {
         JourneyRequest requestWithoutSessionId =
                 JourneyRequest.builder().ipAddress(TEST_CLIENT_SOURCE_IP).build();
 

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -27,6 +27,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
+import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -212,7 +213,7 @@ public class IssueClientAccessTokenHandler
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     error.getHTTPStatusCode(), error.toJSONObject());
-        } catch (IpvSessionNotFoundException e) {
+        } catch (IpvSessionNotFoundException | ClientOauthSessionNotFoundException e) {
             ErrorObject error = OAuth2Error.INVALID_GRANT.setDescription(e.getMessage());
 
             LOGGER.error(

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/service/ClientAuthJwtIdService.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/service/ClientAuthJwtIdService.java
@@ -26,7 +26,7 @@ public class ClientAuthJwtIdService {
     }
 
     public ClientAuthJwtIdItem getClientAuthJwtIdItem(String jwtId) {
-        return dataStore.getItem(jwtId, false);
+        return dataStore.getItem(jwtId);
     }
 
     public void persistClientAuthJwtId(String jwtId) {

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/service/ClientAuthJwtIdServiceTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/service/ClientAuthJwtIdServiceTest.java
@@ -28,7 +28,7 @@ class ClientAuthJwtIdServiceTest {
         String testJwtId = "test-jwt-id";
         String testTimestamp = Instant.now().toString();
         ClientAuthJwtIdItem clientAuthJwtIdItem = new ClientAuthJwtIdItem(testJwtId, testTimestamp);
-        when(mockDataStore.getItem(testJwtId, false)).thenReturn(clientAuthJwtIdItem);
+        when(mockDataStore.getItem(testJwtId)).thenReturn(clientAuthJwtIdItem);
 
         ClientAuthJwtIdItem result = clientAuthJwtIdService.getClientAuthJwtIdItem(testJwtId);
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -180,8 +180,7 @@ class ProcessJourneyEventHandlerTest {
     }
 
     @Test
-    void shouldReturn500IfNoStateMachineMatchingJourneyType()
-            throws IOException, IpvSessionNotFoundException {
+    void shouldReturn500IfNoStateMachineMatchingJourneyType() throws Exception {
         var input =
                 JourneyRequest.builder()
                         .ipAddress(TEST_IP)
@@ -223,7 +222,7 @@ class ProcessJourneyEventHandlerTest {
     }
 
     @Test
-    void shouldReturnCurrentStateIfPageOutOfSync() throws IOException, IpvSessionNotFoundException {
+    void shouldReturnCurrentStateIfPageOutOfSync() throws Exception {
         var input =
                 JourneyRequest.builder()
                         .ipAddress(TEST_IP)
@@ -248,7 +247,7 @@ class ProcessJourneyEventHandlerTest {
     }
 
     @Test
-    void shouldReturnNextStateIfInSync() throws IOException, IpvSessionNotFoundException {
+    void shouldReturnNextStateIfInSync() throws Exception {
         var input =
                 JourneyRequest.builder()
                         .ipAddress(TEST_IP)
@@ -278,8 +277,7 @@ class ProcessJourneyEventHandlerTest {
     @ParameterizedTest()
     @MethodSource("journeyUrisWithCurrentPageForCri")
     void shouldTransitionCriStateIfCurrentPageMatchesCriId(
-            String journeyUri, String expectedNewJourneyState)
-            throws IOException, IpvSessionNotFoundException {
+            String journeyUri, String expectedNewJourneyState) throws Exception {
         var input =
                 JourneyRequest.builder()
                         .ipAddress(TEST_IP)
@@ -320,8 +318,7 @@ class ProcessJourneyEventHandlerTest {
     }
 
     @Test
-    void shouldThrowErrorIfJourneyEventDuringProcess()
-            throws IOException, IpvSessionNotFoundException {
+    void shouldThrowErrorIfJourneyEventDuringProcess() throws Exception {
         var input =
                 JourneyRequest.builder()
                         .ipAddress(TEST_IP)
@@ -950,7 +947,7 @@ class ProcessJourneyEventHandlerTest {
         assertEquals(ErrorResponse.FAILED_JOURNEY_ENGINE_STEP.getMessage(), response.get(MESSAGE));
     }
 
-    private void mockIpvSessionItemAndTimeout(String userState) throws IpvSessionNotFoundException {
+    private void mockIpvSessionItemAndTimeout(String userState) throws Exception {
         IpvSessionItem ipvSessionItem = spy(IpvSessionItem.class);
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());

--- a/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
+++ b/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
-import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
@@ -287,7 +286,7 @@ class ResetSessionIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorJourneyIfUnknownResetType() throws IpvSessionNotFoundException {
+    void shouldReturnErrorJourneyIfUnknownResetType() throws Exception {
         // Arrange
         when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))

--- a/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
+++ b/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.core.builduseridentity.UserIdentityRequestHandler;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.ReverificationResponse;
 import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
+import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.ExpiredAccessTokenException;
 import uk.gov.di.ipv.core.library.exceptions.InvalidScopeException;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
@@ -91,7 +92,7 @@ public class UserReverificationHandler extends UserIdentityRequestHandler
             return getExpiredAccessTokenApiGatewayProxyResponseEvent(e.getExpiredAt());
         } catch (InvalidScopeException e) {
             return getAccessDeniedApiGatewayProxyResponseEvent();
-        } catch (IpvSessionNotFoundException e) {
+        } catch (IpvSessionNotFoundException | ClientOauthSessionNotFoundException e) {
             return getUnknownAccessTokenApiGatewayProxyResponseEvent();
         }
     }

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.userreverification;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
@@ -19,7 +18,6 @@ import uk.gov.di.ipv.core.library.domain.ReverificationResponse;
 import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
-import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -131,9 +129,7 @@ class UserReverificationHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseWhenAccessTokenHasExpired()
-            throws JsonProcessingException, VerifiableCredentialException,
-                    IpvSessionNotFoundException {
+    void shouldReturnErrorResponseWhenAccessTokenHasExpired() throws Exception {
         AccessTokenMetadata expiredAccessTokenMetadata = new AccessTokenMetadata();
         expiredAccessTokenMetadata.setExpiryDateTime(Instant.now().minusSeconds(5).toString());
         ipvSessionItem.setAccessTokenMetadata(expiredAccessTokenMetadata);
@@ -157,9 +153,7 @@ class UserReverificationHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseWhenIpvSessionNotFoundExceptionThrown()
-            throws JsonProcessingException, VerifiableCredentialException,
-                    IpvSessionNotFoundException {
+    void shouldReturnErrorResponseWhenIpvSessionNotFoundExceptionThrown() throws Exception {
         AccessTokenMetadata expiredAccessTokenMetadata = new AccessTokenMetadata();
         expiredAccessTokenMetadata.setExpiryDateTime(Instant.now().minusSeconds(5).toString());
         ipvSessionItem.setAccessTokenMetadata(expiredAccessTokenMetadata);
@@ -178,9 +172,7 @@ class UserReverificationHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseWhenAccessTokenHasBeenRevoked()
-            throws JsonProcessingException, VerifiableCredentialException,
-                    IpvSessionNotFoundException {
+    void shouldReturnErrorResponseWhenAccessTokenHasBeenRevoked() throws Exception {
         AccessTokenMetadata revokedAccessTokenMetadata = new AccessTokenMetadata();
         revokedAccessTokenMetadata.setRevokedAtDateTime(Instant.now().toString());
         ipvSessionItem.setAccessTokenMetadata(revokedAccessTokenMetadata);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -105,7 +105,8 @@ public enum ErrorResponse {
     INVALID_SIGNING_KEY_TYPE(1091, "Signing key is invalid type. Must be EC or RSA"),
     UNEXPECTED_CREDENTIAL_TYPE(1092, "Unexpected credential type"),
     IPV_SESSION_NOT_FOUND(
-            1093, "Invalid IPV session id provided, corresponding session not found in db");
+            1093, "Invalid IPV session id provided, corresponding session not found in db"),
+    CLIENT_OAUTH_SESSION_NOT_FOUND(1093, "Client OAuth session not found");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/ClientOauthSessionNotFoundException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/ClientOauthSessionNotFoundException.java
@@ -1,0 +1,12 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+import software.amazon.awssdk.http.HttpStatusCode;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+
+public class ClientOauthSessionNotFoundException extends HttpResponseExceptionWithErrorBody {
+    public ClientOauthSessionNotFoundException() {
+        // Client OAuth sessions are read using an ID from the IPV Session and
+        // have a longer expiry time, so this is an internal server error
+        super(HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.CLIENT_OAUTH_SESSION_NOT_FOUND);
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DataStore.java
@@ -32,8 +32,6 @@ public interface DataStore<T extends PersistenceItem> {
 
     T getItem(String partitionValue);
 
-    T getItem(String partitionValue, boolean warnOnNull);
-
     T getItemByIndex(String indexName, String value);
 
     List<T> getItems(String partitionValue);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStore.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.library.persistence;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -96,18 +95,13 @@ public class DynamoDataStore<T extends PersistenceItem> implements DataStore<T> 
     @Override
     public T getItem(String partitionValue, String sortValue) {
         var key = Key.builder().partitionValue(partitionValue).sortValue(sortValue).build();
-        return getItemByKey(key, true);
+        return getItemByKey(key);
     }
 
     @Override
     public T getItem(String partitionValue) {
-        return getItem(partitionValue, true);
-    }
-
-    @Override
-    public T getItem(String partitionValue, boolean warnOnNull) {
         var key = Key.builder().partitionValue(partitionValue).build();
-        return getItemByKey(key, warnOnNull);
+        return getItemByKey(key);
     }
 
     @Override
@@ -219,15 +213,7 @@ public class DynamoDataStore<T extends PersistenceItem> implements DataStore<T> 
         delete(getItems(partitionValue));
     }
 
-    private T getItemByKey(Key key, boolean warnOnNull) {
-        T result = table.getItem(key);
-        if (warnOnNull && result == null) {
-            var message =
-                    new StringMapMessage()
-                            .with("datastore", "Null result retrieved from DynamoDB")
-                            .with("table", table.describeTable().table().tableName());
-            LOGGER.warn(message);
-        }
-        return result;
+    private T getItemByKey(Key key) {
+        return table.getItem(key);
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/InMemoryDataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/InMemoryDataStore.java
@@ -79,11 +79,6 @@ public class InMemoryDataStore<T extends PersistenceItem> implements DataStore<T
     }
 
     @Override
-    public T getItem(String partitionValue, boolean warnOnNull) {
-        return getItem(partitionValue);
-    }
-
-    @Override
     public T getItemByIndex(String indexName, String value) {
         Method indexMethod = null;
         for (var method : klass.getMethods()) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 
@@ -26,8 +27,13 @@ public class ClientOAuthSessionDetailsService {
                         configService);
     }
 
-    public ClientOAuthSessionItem getClientOAuthSession(String clientOAuthSessionId) {
-        return dataStore.getItem(clientOAuthSessionId);
+    public ClientOAuthSessionItem getClientOAuthSession(String clientOAuthSessionId)
+            throws ClientOauthSessionNotFoundException {
+        var clientOauthSession = dataStore.getItem(clientOAuthSessionId);
+        if (clientOauthSession == null) {
+            throw new ClientOauthSessionNotFoundException();
+        }
+        return clientOauthSession;
     }
 
     public ClientOAuthSessionItem generateClientSessionDetails(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.Cri;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 
@@ -30,7 +31,11 @@ public class CriOAuthSessionService {
     }
 
     public CriOAuthSessionItem getCriOauthSessionItem(String criOAuthSessionId) {
-        return dataStore.getItem(criOAuthSessionId);
+        var criOauthSessionItem = dataStore.getItem(criOAuthSessionId);
+        if (criOauthSessionItem == null) {
+            LOGGER.warn(LogHelper.buildLogMessage("CRI OAuth session not found"));
+        }
+        return criOauthSessionItem;
     }
 
     public CriOAuthSessionItem persistCriOAuthSession(

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStoreTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStoreTest.java
@@ -16,8 +16,6 @@ import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.internal.conditional.BeginsWithConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.*;
-import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
-import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import uk.gov.di.ipv.core.library.persistence.item.AuthorizationCodeItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
@@ -114,16 +112,6 @@ class DynamoDataStoreTest {
 
     @Test
     void shouldGetItemFromDynamoDbTableViaPartitionKeyAndSortKey() {
-        TableDescription tableDescription =
-                TableDescription.builder().tableName(TEST_TABLE_NAME).build();
-        DescribeTableResponse describeTableResponse =
-                DescribeTableResponse.builder().table(tableDescription).build();
-        when(mockDynamoDbTable.describeTable())
-                .thenReturn(
-                        new DescribeTableEnhancedResponse.Builder()
-                                .response(describeTableResponse)
-                                .build());
-
         dataStore.getItem(PARTITION_VALUE, SORT_KEY_VALUE);
 
         ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);
@@ -139,16 +127,6 @@ class DynamoDataStoreTest {
 
     @Test
     void shouldGetItemFromDynamoDbTableViaPartitionKey() {
-        TableDescription tableDescription =
-                TableDescription.builder().tableName(TEST_TABLE_NAME).build();
-        DescribeTableResponse describeTableResponse =
-                DescribeTableResponse.builder().table(tableDescription).build();
-        when(mockDynamoDbTable.describeTable())
-                .thenReturn(
-                        new DescribeTableEnhancedResponse.Builder()
-                                .response(describeTableResponse)
-                                .build());
-
         dataStore.getItem(PARTITION_VALUE);
 
         ArgumentCaptor<Key> keyCaptor = ArgumentCaptor.forClass(Key.class);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,7 +32,7 @@ class ClientOAuthSessionDetailsServiceTest {
     @InjectMocks private ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
 
     @Test
-    void shouldReturnClientOAuthSessionItem() {
+    void shouldReturnClientOAuthSessionItem() throws Exception {
         String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
 
         ClientOAuthSessionItem clientOAuthSessionItem = new ClientOAuthSessionItem();
@@ -62,6 +64,16 @@ class ClientOAuthSessionDetailsServiceTest {
         assertEquals(
                 clientOAuthSessionItem.getGovukSigninJourneyId(), result.getGovukSigninJourneyId());
         assertEquals(clientOAuthSessionItem.getReproveIdentity(), result.getReproveIdentity());
+    }
+
+    @Test
+    void shouldThrowIfNoClientOauthSessionItem() {
+        String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();
+        when(mockDataStore.getItem(clientOAuthSessionId)).thenReturn(null);
+
+        assertThrows(
+                ClientOauthSessionNotFoundException.class,
+                () -> clientOAuthSessionDetailsService.getClientOAuthSession(clientOAuthSessionId));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

- Removed generic 'null record' warning in DynamoDB
- Added specific error for `ClientOauthSessionNotFound`

### Why did it change

The generic 'null record' warnings form a large proportion of the current warn/error logs in live, but are nearly always harmless, obscuring cases where this might be a real issue.

There are generally two categories here:
- The record is not necessarily expected to exist (e.g. a pending F2F record), and the calling code already has null-checks to handle the case that it's missing
  - These cases can just drop the warning, and rely on existing checks
- The record is always expected to exist, and will cause a `NullPointerException` if it does not (despite the warning) - i.e. the IpvSession and ClientOauthSession
  - These cases should throw a relevant exception from the service, rather than causing a NPE
  - (IpvSession was recently updated to do this)
