### PR TITLE
PYIC-7018-temporary-fix: Remove hmrc_check context from CIC cri to al…

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -605,7 +605,6 @@ states:
     response:
       type: cri
       criId: claimedIdentity
-      context: hmrc_check
     parent: CRI_STATE
     events:
       next:


### PR DESCRIPTION
…low staging tests to pass

## Proposed changes

### What changed

- Removed context for no photo id P1 journey

### Why did it change

- Suspect Kiwi/ CIC Cri don't expect it and causes journey to fail

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7018](https://govukverify.atlassian.net/browse/PYIC-7018)

[PYIC-7018]: https://govukverify.atlassian.net/browse/PYIC-7018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ