### PR TITLE
PYIC-7018: Add identityCheck scope to Nino

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -484,6 +484,7 @@ states:
     response:
       type: cri
       criId: nino
+      scope: identityCheck
     parent: CRI_STATE
     events:
       next:


### PR DESCRIPTION
## Proposed changes

### What changed

- Add "identityCheck" scope for Nino CRI in P1 journey

### Why did it change

- Because required to provide us with the strength & validity scores

### Issue tracking

- [PYIC-7018](https://govukverify.atlassian.net/browse/PYIC-7018)

[PYIC-7018]: https://govukverify.atlassian.net/browse/PYIC-7018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ