### PR TITLE
BAU: Handle missing journey id in cimit service

### DIFF
--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -415,12 +415,15 @@ public class CiMitService {
         var requestBuilder =
                 HttpRequest.newBuilder()
                         .uri(uri)
-                        .header(GOVUK_SIGNIN_JOURNEY_ID_HEADER, govukSigninJourneyId)
                         .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 
         var apiKey = configService.getSecret(CIMIT_API_KEY);
         if (apiKey != null && !apiKey.equals(NOT_REQUIRED)) {
             requestBuilder.header(X_API_KEY_HEADER, configService.getSecret(CIMIT_API_KEY));
+        }
+
+        if (govukSigninJourneyId != null) {
+            requestBuilder.header(GOVUK_SIGNIN_JOURNEY_ID_HEADER, govukSigninJourneyId);
         }
 
         if (ipAddress != null) {


### PR DESCRIPTION
## Proposed changes

### What changed

Handle null govuk_signin_journey_id when sending requests to CIMIT.

### Why did it change

When processing async VCs, there is no journey id (or ip address) and we need to handle appropriately.
