### PR TITLE
BAU: Add permissions for cimit API secret to evaluate GP45

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1699,6 +1699,8 @@ Resources:
             QueueName: !ImportValue AuditEventQueueName
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/self/ciConfig-*
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/cimitApi/apiKey-*
         - Statement:
             - Sid: invokeGetContraIndicatorCredentialFunction
               Effect: Allow


### PR DESCRIPTION
## Proposed changes

EvaluateGPG45 needs permissions to read the CIMIT API secret, so it can check for CIs.

This only occurs when multiple VTRs are sent, which is being exposed by our inherited id tests.
