### PR TITLE
BAU: Add world debugging info and upload test report

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -152,6 +152,14 @@ jobs:
       - name: Local API tests
         run: npm run test:ci
 
+      - name: Upload API test report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: API test report
+          path: api-tests/reports/
+          retention-days: 7
+
   sam-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -1,5 +1,11 @@
 import * as assert from "assert";
-import { Then, When } from "@cucumber/cucumber";
+import {
+  After,
+  ITestCaseHookParameter,
+  Then,
+  When,
+  Status,
+} from "@cucumber/cucumber";
 import { World } from "../types/world.js";
 import * as internalClient from "../clients/core-back-internal-client.js";
 import * as externalClient from "../clients/core-back-external-client.js";
@@ -19,6 +25,16 @@ import {
   isJourneyResponse,
   isPageResponse,
 } from "../types/internal-api.js";
+
+After(function (this: World, options: ITestCaseHookParameter) {
+  if (options.result?.status === Status.FAILED) {
+    // Log world details if the test fails
+    this.attach(JSON.stringify(this, undefined, 2), {
+      fileName: "world.json",
+      mediaType: "application/json",
+    });
+  }
+});
 
 When(
   "I start a new {string} journey",

--- a/api-tests/src/types/world.ts
+++ b/api-tests/src/types/world.ts
@@ -1,7 +1,8 @@
 import { JourneyEngineResponse } from "./internal-api.js";
 import { UserIdentity } from "./external-api.js";
+import { World as CucumberWorld } from "@cucumber/cucumber";
 
-export interface World {
+export interface World extends CucumberWorld {
   userId: string;
   ipvSessionId: string;
   journeyId: string;


### PR DESCRIPTION
## Proposed changes

### What changed

- Add the current world info as an attachment for failed tests
- Upload test reports when running pre-merge

This uploads the test report as a job artifact, visible on the job summary page, e.g.: https://github.com/govuk-one-login/ipv-core-back/actions/runs/10252001134?pr=2262

### Why did it change

Include useful debug info like the journey id and user id when a test fails
