### PR TITLE
PYIC-7069: repeat fraud check api tests

### DIFF
--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-first-name-only-passport-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-first-name-only-passport-valid/credentialSubject.json
@@ -1,0 +1,28 @@
+{
+  "passport": [
+    {
+      "expiryDate": "2030-01-01",
+      "icaoIssuerCode": "GBR",
+      "documentNumber": "321654987"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "Michael"
+        },
+        {
+          "type": "FamilyName",
+          "value": "Decerqueira"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-first-name-only-passport-valid/evidence.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-first-name-only-passport-valid/evidence.json
@@ -1,0 +1,15 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "checkMethod": "vri"
+    },
+    {
+      "biometricVerificationProcessLevel": 3,
+      "checkMethod": "bvr"
+    }
+  ],
+  "validityScore": 2,
+  "strengthScore": 3,
+  "type": "IdentityCheck"
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-changed-first-name-only-score-2/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-changed-first-name-only-score-2/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "Michael"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-changed-first-name-only-score-2/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-changed-first-name-only-score-2/evidence.json
@@ -1,0 +1,31 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "none",
+      "activityFrom": "1963-01-01",
+      "checkMethod": "data"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "mortality_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "identity_theft_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "synthetic_identity_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "impersonation_risk_check",
+      "txn": "RB000117397035"
+    }
+  ],
+  "ci": [],
+  "txn": "RB000117420948",
+  "identityFraudScore": 2,
+  "type": "IdentityCheck"
+}

--- a/api-tests/features/repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check.feature
@@ -18,9 +18,21 @@ Feature: Repeat fraud check journeys
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
-#    When I return using 'P2' identity
-#    Then I see 'confirm-your-details' with my details
-#    When I select update
-#    Then I see 'update-details' page response
-#    When I select Name change
-#    Then I should be successful in changing my name
+
+    # Repeat fraud check with update name
+    When I start a new 'medium-confidence' journey
+    Then I get a 'confirm-your-details' page response
+    When I submit a 'given-names-only' event
+    Then I get a 'page-update-name' page response
+    When I submit a 'update-name' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-changed-first-name-only-passport-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-changed-first-name-only-score-2-with-expiry' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity

--- a/api-tests/features/repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check.feature
@@ -1,0 +1,26 @@
+Feature: Repeat fraud check journeys
+
+  @Build
+  Scenario: Fraud 6 Months Expiry + Name Update
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2-with-expiry' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+#    When I return using 'P2' identity
+#    Then I see 'confirm-your-details' with my details
+#    When I select update
+#    Then I see 'update-details' page response
+#    When I select Name change
+#    Then I should be successful in changing my name

--- a/api-tests/features/repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check.feature
@@ -1,7 +1,6 @@
 Feature: Repeat fraud check journeys
 
-  @Build
-  Scenario: Fraud 6 Months Expiry + Name Update
+  Background:
     Given I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -19,6 +18,8 @@ Feature: Repeat fraud check journeys
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
 
+  @Build
+  Scenario: Fraud 6 Months Expiry + Name Update
     # Repeat fraud check with update name
     When I start a new 'medium-confidence' journey
     Then I get a 'confirm-your-details' page response
@@ -39,23 +40,6 @@ Feature: Repeat fraud check journeys
 
   @Build
   Scenario: Fraud 6 Months Expiry + No Update
-    Given I start a new 'medium-confidence' journey
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2-with-expiry' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P2' identity
-
     # Repeat fraud check with no update
     When I start a new 'medium-confidence' journey
     Then I get a 'confirm-your-details' page response

--- a/api-tests/features/repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check.feature
@@ -36,3 +36,34 @@ Feature: Repeat fraud check journeys
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
+
+  @Build
+  Scenario: Fraud 6 Months Expiry + No Update
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2-with-expiry' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    # Repeat fraud check with no update
+    When I start a new 'medium-confidence' journey
+    Then I get a 'confirm-your-details' page response
+    When I submit a 'next' event
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity

--- a/api-tests/features/repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check.feature
@@ -11,7 +11,21 @@ Feature: Repeat fraud check journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2-with-expiry' details to the CRI stub
+    When I submit expired 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+  @Build
+  Scenario: Fraud 6 Months Expiry + No Update
+    # Repeat fraud check with no update
+    When I start a new 'medium-confidence' journey
+    Then I get a 'confirm-your-details' page response
+    When I submit a 'next' event
+    Then I get a 'fraud' CRI response
+    When I submit expired 'kenneth-score-2' details to the CRI stub
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -31,21 +45,7 @@ Feature: Repeat fraud check journeys
     Then I get a 'page-dcmaw-success' page response
     When I submit a 'next' event
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-changed-first-name-only-score-2-with-expiry' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P2' identity
-
-  @Build
-  Scenario: Fraud 6 Months Expiry + No Update
-    # Repeat fraud check with no update
-    When I start a new 'medium-confidence' journey
-    Then I get a 'confirm-your-details' page response
-    When I submit a 'next' event
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit expired 'kenneth-changed-first-name-only-score-2' details to the CRI stub
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -14,7 +14,7 @@ import {
 } from "../types/internal-api.js";
 import { CriStubRequest } from "../types/cri-stub.js";
 
-const EXPIRED_NBF = 1658829758;
+const EXPIRED_NBF = 1658829758; // 26/07/2022 in epoch seconds
 
 const submitAndProcessCriAction = async (
   world: World,
@@ -44,24 +44,23 @@ const submitAndProcessCriAction = async (
 };
 
 When(
-  "I submit {string} details to the CRI stub",
-  async function (this: World, scenario: string): Promise<void> {
+  /I submit (expired )?'([\w-]+)' details to the CRI stub/,
+  async function (
+    this: World,
+    expired: string,
+    scenario: string,
+  ): Promise<void> {
     if (!isCriResponse(this.lastJourneyEngineResponse)) {
       throw new Error("Last journey engine response was not a CRI response");
     }
-
-    const matchedRegex = /^(.*)-with-expiry$/.exec(scenario);
-    const nbf = matchedRegex === null ? undefined : EXPIRED_NBF;
-    const extractedScenario =
-      matchedRegex === null ? scenario : matchedRegex[1];
 
     await submitAndProcessCriAction(
       this,
       await generateCriStubBody(
         this.lastJourneyEngineResponse.cri.id,
-        extractedScenario,
+        scenario,
         this.lastJourneyEngineResponse.cri.redirectUrl,
-        nbf,
+        expired ? EXPIRED_NBF : undefined,
       ),
     );
   },

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -14,6 +14,8 @@ import {
 } from "../types/internal-api.js";
 import { CriStubRequest } from "../types/cri-stub.js";
 
+const EXPIRED_NBF = 1658829758;
+
 const submitAndProcessCriAction = async (
   world: World,
   criStubRequest: CriStubRequest,
@@ -48,12 +50,18 @@ When(
       throw new Error("Last journey engine response was not a CRI response");
     }
 
+    const matchedRegex = /^(.*)-with-expiry$/.exec(scenario);
+    const nbf = matchedRegex === null ? undefined : EXPIRED_NBF;
+    const extractedScenario =
+      matchedRegex === null ? scenario : matchedRegex[1];
+
     await submitAndProcessCriAction(
       this,
       await generateCriStubBody(
         this.lastJourneyEngineResponse.cri.id,
-        scenario,
+        extractedScenario,
         this.lastJourneyEngineResponse.cri.redirectUrl,
+        nbf,
       ),
     );
   },

--- a/api-tests/src/utils/request-body-generators.ts
+++ b/api-tests/src/utils/request-body-generators.ts
@@ -58,6 +58,7 @@ export const generateCriStubBody = async (
   criId: string,
   scenario: string,
   redirectUrl: string,
+  nbf?: number,
 ): Promise<CriStubRequest> => {
   const urlParams = new URL(redirectUrl).searchParams;
   return {
@@ -69,6 +70,7 @@ export const generateCriStubBody = async (
       "credentialSubject",
     ),
     evidenceJson: await readJsonFile(criId, scenario, "evidence"),
+    nbf,
   };
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add api tests for repeat fraud check

### Why did it change
Increase coverage of api tests to cover key journeys

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7069](https://govukverify.atlassian.net/browse/PYIC-7069)


[PYIC-7069]: https://govukverify.atlassian.net/browse/PYIC-7069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ