### PR TITLE
PYIC-6914: Add lng parameter to CRI redirectUri

### DIFF
--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -39,7 +39,11 @@ export const sendJourneyEvent = async (
   const url = `${config.core.internalApiUrl}${event.startsWith(JOURNEY_PREFIX) ? event : JOURNEY_PREFIX + event}`;
   const response = await fetch(url, {
     method: POST,
-    headers: { ...internalApiHeaders, ...{ "ipv-session-id": ipvSessionId } },
+    headers: {
+      ...internalApiHeaders,
+      "ipv-session-id": ipvSessionId,
+      language: "en",
+    },
   });
 
   if (!response.ok) {

--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -111,7 +111,8 @@
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "clientOAuthSessionId.$": "$$.Execution.Input.clientOAuthSessionId",
         "featureSet.$": "$$.Execution.Input.featureSet",
-        "deviceInformation.$": "$$.Execution.Input.deviceInformation"
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation",
+        "language.$": "$$.Execution.Input.language"
       },
       "Next": "ProcessNextJourney"
     },

--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -9,7 +9,6 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "featureSet.$": "$$.Execution.Input.featureSet",
-        "language.$": "$$.Execution.Input.language",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessJourneyStepResult"

--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -9,6 +9,7 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "featureSet.$": "$$.Execution.Input.featureSet",
+        "language.$": "$$.Execution.Input.language",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
       "Next": "ProcessJourneyStepResult"

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -26,10 +26,10 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.Cri;
+import uk.gov.di.ipv.core.library.domain.CriJourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.EvidenceRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
-import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.SharedClaims;
 import uk.gov.di.ipv.core.library.domain.SharedClaimsResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
@@ -88,7 +88,7 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getLanguage;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 
 public class BuildCriOauthRequestHandler
-        implements RequestHandler<JourneyRequest, Map<String, Object>> {
+        implements RequestHandler<CriJourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     public static final String SHARED_CLAIM_ATTR_NAME = "name";
@@ -148,7 +148,7 @@ public class BuildCriOauthRequestHandler
     @Override
     @Tracing
     @Logging(clearState = true)
-    public Map<String, Object> handleRequest(JourneyRequest input, Context context) {
+    public Map<String, Object> handleRequest(CriJourneyRequest input, Context context) {
         LogHelper.attachComponentId(configService);
         try {
             String ipvSessionId = getIpvSessionId(input);

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -280,7 +280,7 @@ class BuildCriOauthRequestHandlerTest {
     void shouldReceive400ResponseCodeIfCredentialIssuerNotPresent() throws JsonProcessingException {
         // Arrange
         var input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId("aSessionId")
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -300,7 +300,7 @@ class BuildCriOauthRequestHandlerTest {
             throws JsonProcessingException {
         // Arrange
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId("aSessionId")
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -347,7 +347,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -433,7 +433,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -515,7 +515,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -598,7 +598,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -680,7 +680,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -763,7 +763,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -788,8 +788,7 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldReturn400IfSessionIdIsNull() throws JsonProcessingException {
         // Arrange
-        CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder().journey(PASSPORT.getId()).build();
+        CriJourneyRequest input = CriJourneyRequest.builder().journey(PASSPORT.getId()).build();
 
         // Act
         var responseJson = handleRequest(input, context);
@@ -907,7 +906,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -973,7 +972,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1037,7 +1036,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1125,7 +1124,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1191,7 +1190,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1264,7 +1263,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1337,7 +1336,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1412,7 +1411,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1474,7 +1473,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1531,7 +1530,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1598,7 +1597,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)
@@ -1651,7 +1650,7 @@ class BuildCriOauthRequestHandlerTest {
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
         CriJourneyRequest input =
-                CriJourneyRequest.criJourneyRequestBuilder()
+                CriJourneyRequest.builder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
                         .language(TEST_LANGUAGE)

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -34,10 +34,10 @@ import uk.gov.di.ipv.core.buildcrioauthrequest.domain.CriResponse;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.domain.Address;
+import uk.gov.di.ipv.core.library.domain.CriJourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.EvidenceRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
-import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
 import uk.gov.di.ipv.core.library.enums.Vot;
@@ -119,6 +119,7 @@ class BuildCriOauthRequestHandlerTest {
     private static final String SESSION_ID = "the-session-id";
     private static final String TEST_USER_ID = "test-user-id";
     private static final String TEST_IP_ADDRESS = "192.168.1.100";
+    private static final String TEST_LANGUAGE = "en";
     private static final String TEST_SHARED_CLAIMS = "shared_claims";
     private static final String JOURNEY_BASE_URL = "/journey/cri/build-oauth-request/%s";
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
@@ -278,9 +279,10 @@ class BuildCriOauthRequestHandlerTest {
     void shouldReceive400ResponseCodeIfCredentialIssuerNotPresent() throws JsonProcessingException {
         // Arrange
         var input =
-                JourneyRequest.builder()
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId("aSessionId")
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey("nope")
                         .build();
 
@@ -296,10 +298,11 @@ class BuildCriOauthRequestHandlerTest {
     void shouldReceive400ResponseCodeIfCredentialIssuerNotInPermittedSet()
             throws JsonProcessingException {
         // Arrange
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId("aSessionId")
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, "bad"))
                         .build();
 
@@ -342,10 +345,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -427,10 +431,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -508,10 +513,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -590,10 +596,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -671,10 +678,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, DCMAW.getId()))
                         .build();
 
@@ -726,7 +734,8 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldReturn400IfSessionIdIsNull() throws JsonProcessingException {
         // Arrange
-        JourneyRequest input = JourneyRequest.builder().journey(PASSPORT.getId()).build();
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder().journey(PASSPORT.getId()).build();
 
         // Act
         var responseJson = handleRequest(input, context);
@@ -843,10 +852,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -908,10 +918,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -971,10 +982,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -1058,10 +1070,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -1123,10 +1136,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -1195,10 +1209,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, PASSPORT.getId()))
                         .build();
 
@@ -1267,10 +1282,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(new Gpg45Scores(1, 1, 3, 3, 3));
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, F2F.getId()))
                         .build();
 
@@ -1341,10 +1357,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(new Gpg45Scores(1, 1, 3, 3, 3));
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, F2F.getId()))
                         .build();
 
@@ -1402,10 +1419,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, HMRC_KBV.getId()))
                         .build();
 
@@ -1458,10 +1476,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, HMRC_KBV.getId()))
                         .build();
 
@@ -1524,10 +1543,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, HMRC_KBV.getId()))
                         .build();
 
@@ -1576,10 +1596,11 @@ class BuildCriOauthRequestHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockSignerFactory.getSigner()).thenReturn(new ECDSASigner(getSigningPrivateKey()));
 
-        JourneyRequest input =
-                JourneyRequest.builder()
+        CriJourneyRequest input =
+                CriJourneyRequest.criJourneyRequestBuilder()
                         .ipvSessionId(SESSION_ID)
                         .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
                         .journey(String.format(JOURNEY_BASE_URL, journeyUri))
                         .build();
 
@@ -1663,7 +1684,7 @@ class BuildCriOauthRequestHandlerTest {
         return OBJECT_MAPPER.writeValueAsString(response);
     }
 
-    private String handleRequest(JourneyRequest event, Context context)
+    private String handleRequest(CriJourneyRequest event, Context context)
             throws JsonProcessingException {
         final var response = buildCriOauthRequestHandler.handleRequest(event, context);
         return getJsonResponse(OBJECT_MAPPER.convertValue(response, new TypeReference<>() {}));

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
@@ -1,19 +1,21 @@
 package uk.gov.di.ipv.core.library.domain;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @ExcludeFromGeneratedCoverageReport
 @EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
 @NoArgsConstructor
 @Data
+@SuperBuilder
 public class CriJourneyRequest extends JourneyRequest {
     private String language;
 
-    @Builder()
     public CriJourneyRequest(
             String ipvSessionId,
             String ipAddress,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
@@ -13,7 +13,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 public class CriJourneyRequest extends JourneyRequest {
     private String language;
 
-    @Builder(builderMethodName = "criJourneyRequestBuilder")
+    @Builder()
     public CriJourneyRequest(
             String ipvSessionId,
             String ipAddress,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
@@ -15,22 +15,4 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @SuperBuilder
 public class CriJourneyRequest extends JourneyRequest {
     private String language;
-
-    public CriJourneyRequest(
-            String ipvSessionId,
-            String ipAddress,
-            String deviceInformation,
-            String clientOAuthSessionId,
-            String journey,
-            String featureSet,
-            String language) {
-        super(
-                ipvSessionId,
-                ipAddress,
-                deviceInformation,
-                clientOAuthSessionId,
-                journey,
-                featureSet);
-        this.language = language;
-    }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
@@ -5,23 +5,21 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import java.util.Map;
-
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @Data
-public class ProcessRequest extends JourneyRequest {
-    private Map<String, Object> lambdaInput;
+public class CriJourneyRequest extends JourneyRequest {
+    private String language;
 
-    @Builder(builderMethodName = "processRequestBuilder")
-    public ProcessRequest(
+    @Builder(builderMethodName = "criJourneyRequestBuilder")
+    public CriJourneyRequest(
             String ipvSessionId,
             String ipAddress,
             String deviceInformation,
             String clientOAuthSessionId,
             String journey,
             String featureSet,
-            Map<String, Object> lambdaInput) {
+            String language) {
         super(
                 ipvSessionId,
                 ipAddress,
@@ -29,6 +27,6 @@ public class ProcessRequest extends JourneyRequest {
                 clientOAuthSessionId,
                 journey,
                 featureSet);
-        this.lambdaInput = lambdaInput;
+        this.language = language;
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/CriJourneyRequest.java
@@ -4,7 +4,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+@ExcludeFromGeneratedCoverageReport
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @Data

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -62,8 +62,6 @@ public enum ErrorResponse {
     FAILED_UNHANDLED_EXCEPTION(1049, "Unhandled exception"),
     UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL(1050, "Unexpected async verifiable credential"),
     PENDING_VERIFICATION_EXCEPTION(1051, "Pending face to face verification exception"),
-    FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE(
-            1051, "Failed to validate verifiable credential response"),
     FAILED_TO_FIND_VISITED_CRI(1052, "Failed to find a visited CRI"),
     FAILED_TO_PARSE_CIMIT_SIGNING_KEY(1053, "Failed to parse CIMIT signing key"),
     UNRECOGNISED_CI_CODE(1054, "Unrecognised CI code"),
@@ -106,8 +104,10 @@ public enum ErrorResponse {
     UNEXPECTED_CREDENTIAL_TYPE(1092, "Unexpected credential type"),
     IPV_SESSION_NOT_FOUND(
             1093, "Invalid IPV session id provided, corresponding session not found in db"),
-    CLIENT_OAUTH_SESSION_NOT_FOUND(1093, "Client OAuth session not found"),
-    MISSING_LANGUAGE(1093, "Missing language choice from the frontend");
+    CLIENT_OAUTH_SESSION_NOT_FOUND(1094, "Client OAuth session not found"),
+    MISSING_LANGUAGE(1095, "Missing language choice from the frontend"),
+    FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE(
+            1096, "Failed to validate verifiable credential response");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -106,7 +106,8 @@ public enum ErrorResponse {
     UNEXPECTED_CREDENTIAL_TYPE(1092, "Unexpected credential type"),
     IPV_SESSION_NOT_FOUND(
             1093, "Invalid IPV session id provided, corresponding session not found in db"),
-    CLIENT_OAUTH_SESSION_NOT_FOUND(1093, "Client OAuth session not found");
+    CLIENT_OAUTH_SESSION_NOT_FOUND(1093, "Client OAuth session not found"),
+    MISSING_COOKIES(1093, "Missing cookies from the frontend");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -107,7 +107,7 @@ public enum ErrorResponse {
     IPV_SESSION_NOT_FOUND(
             1093, "Invalid IPV session id provided, corresponding session not found in db"),
     CLIENT_OAUTH_SESSION_NOT_FOUND(1093, "Client OAuth session not found"),
-    MISSING_COOKIES(1093, "Missing cookies from the frontend");
+    MISSING_LANGUAGE(1093, "Missing language choice from the frontend");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -1,9 +1,9 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 import java.net.URI;
@@ -14,7 +14,7 @@ import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_BAD_REQUEST;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@Builder
+@SuperBuilder
 public class JourneyRequest {
     private String ipvSessionId;
     private String ipAddress;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -22,6 +22,7 @@ public class JourneyRequest {
     private String clientOAuthSessionId;
     private String journey;
     private String featureSet;
+    private String language;
 
     public URI getJourneyUri() throws HttpResponseExceptionWithErrorBody {
         if (journey == null) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -22,6 +22,22 @@ public class JourneyRequest {
     private String clientOAuthSessionId;
     private String journey;
     private String featureSet;
+    private String language;
+
+    public JourneyRequest(
+            String ipvSessionId,
+            String ipAddress,
+            String deviceInformation,
+            String clientOAuthSessionId,
+            String journey,
+            String featureSet) {
+        this.ipvSessionId = ipvSessionId;
+        this.ipAddress = ipAddress;
+        this.deviceInformation = deviceInformation;
+        this.clientOAuthSessionId = clientOAuthSessionId;
+        this.journey = journey;
+        this.featureSet = featureSet;
+    }
 
     public URI getJourneyUri() throws HttpResponseExceptionWithErrorBody {
         if (journey == null) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -22,7 +22,6 @@ public class JourneyRequest {
     private String clientOAuthSessionId;
     private String journey;
     private String featureSet;
-    private String language;
 
     public URI getJourneyUri() throws HttpResponseExceptionWithErrorBody {
         if (journey == null) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/JourneyRequest.java
@@ -22,22 +22,6 @@ public class JourneyRequest {
     private String clientOAuthSessionId;
     private String journey;
     private String featureSet;
-    private String language;
-
-    public JourneyRequest(
-            String ipvSessionId,
-            String ipAddress,
-            String deviceInformation,
-            String clientOAuthSessionId,
-            String journey,
-            String featureSet) {
-        this.ipvSessionId = ipvSessionId;
-        this.ipAddress = ipAddress;
-        this.deviceInformation = deviceInformation;
-        this.clientOAuthSessionId = clientOAuthSessionId;
-        this.journey = journey;
-        this.featureSet = featureSet;
-    }
 
     public URI getJourneyUri() throws HttpResponseExceptionWithErrorBody {
         if (journey == null) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 @Data
 public class ProcessRequest extends JourneyRequest {
     private Map<String, Object> lambdaInput;
-    private String language;
 
     @Builder(builderMethodName = "processRequestBuilder")
     public ProcessRequest(
@@ -30,8 +29,8 @@ public class ProcessRequest extends JourneyRequest {
                 deviceInformation,
                 clientOAuthSessionId,
                 journey,
-                featureSet);
+                featureSet,
+                language);
         this.lambdaInput = lambdaInput;
-        this.language = language;
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ProcessRequest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 @Data
 public class ProcessRequest extends JourneyRequest {
     private Map<String, Object> lambdaInput;
+    private String language;
 
     @Builder(builderMethodName = "processRequestBuilder")
     public ProcessRequest(
@@ -21,6 +22,7 @@ public class ProcessRequest extends JourneyRequest {
             String clientOAuthSessionId,
             String journey,
             String featureSet,
+            String language,
             Map<String, Object> lambdaInput) {
         super(
                 ipvSessionId,
@@ -30,5 +32,6 @@ public class ProcessRequest extends JourneyRequest {
                 journey,
                 featureSet);
         this.lambdaInput = lambdaInput;
+        this.language = language;
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -87,6 +88,21 @@ public class RequestHelper {
         String ipAddress = request.getIpAddress();
         validateIpAddress(ipAddress, "ipAddress not present in request.");
         return ipAddress;
+    }
+
+    public static String getLanguage(JourneyRequest request)
+            throws HttpResponseExceptionWithErrorBody, JsonProcessingException {
+        String language = request.getLanguage();
+
+        if (language == null) {
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "cookies is missing from this request", IP_ADDRESS_HEADER));
+            throw new HttpResponseExceptionWithErrorBody(
+                    SC_BAD_REQUEST, ErrorResponse.MISSING_COOKIES);
+        }
+
+        return language;
     }
 
     public static String getClientOAuthSessionId(JourneyRequest event) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.library.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -91,7 +90,7 @@ public class RequestHelper {
     }
 
     public static String getLanguage(JourneyRequest request)
-            throws HttpResponseExceptionWithErrorBody, JsonProcessingException {
+            throws HttpResponseExceptionWithErrorBody {
         String language = request.getLanguage();
 
         if (language == null) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
+import uk.gov.di.ipv.core.library.domain.CriJourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
@@ -89,14 +90,15 @@ public class RequestHelper {
         return ipAddress;
     }
 
-    public static String getLanguage(JourneyRequest request)
+    public static String getLanguage(CriJourneyRequest request)
             throws HttpResponseExceptionWithErrorBody {
         String language = request.getLanguage();
 
         if (language == null) {
             LOGGER.error(
                     LogHelper.buildErrorMessage(
-                            "Language choice is missing from this request", IP_ADDRESS_HEADER));
+                            "Language choice is missing from this frontend request",
+                            IP_ADDRESS_HEADER));
             throw new HttpResponseExceptionWithErrorBody(
                     SC_BAD_REQUEST, ErrorResponse.MISSING_LANGUAGE);
         }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/RequestHelper.java
@@ -97,9 +97,9 @@ public class RequestHelper {
         if (language == null) {
             LOGGER.error(
                     LogHelper.buildErrorMessage(
-                            "cookies is missing from this request", IP_ADDRESS_HEADER));
+                            "Language choice is missing from this request", IP_ADDRESS_HEADER));
             throw new HttpResponseExceptionWithErrorBody(
-                    SC_BAD_REQUEST, ErrorResponse.MISSING_COOKIES);
+                    SC_BAD_REQUEST, ErrorResponse.MISSING_LANGUAGE);
         }
 
         return language;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ErrorResponseTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/ErrorResponseTest.java
@@ -1,0 +1,27 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class ErrorResponseTest {
+    @Test
+    void errorCodesShouldIncreaseForErrorResponses() {
+        // Arrange
+        var errorResponses = ErrorResponse.values();
+        var previousCode = 0;
+
+        // Act & Assert
+        for (var errorResponse : errorResponses) {
+            assertTrue(
+                    errorResponse.getCode() > previousCode,
+                    String.format(
+                            "Error response with code %s is not an increase from the previous code %s",
+                            errorResponse.getCode(), previousCode));
+            previousCode = errorResponse.getCode();
+        }
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.ipv.core.library.domain.CriJourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
@@ -42,6 +43,7 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getHeaderByKey;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionIdAllowBlank;
+import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getLanguage;
 
 class RequestHelperTest {
     private final String TEST_IPV_SESSION_ID = "a-session-id";
@@ -236,6 +238,34 @@ class RequestHelperTest {
         event.setClientOAuthSessionId(null);
 
         assertNull(getClientOAuthSessionId(event));
+    }
+
+    @Test
+    void getLanguageInCriRequestShouldReturnLanguage() throws HttpResponseExceptionWithErrorBody {
+        // Arrange
+        var event = new CriJourneyRequest();
+        String language = "some-language";
+        event.setLanguage(language);
+
+        // Act & Assert
+        assertEquals(language, getLanguage(event));
+    }
+
+    @Test
+    void getLanguageInCriRequestShouldThrowIfLanguageIsNull() {
+        // Arrange
+        var event = new CriJourneyRequest();
+        event.setLanguage(null);
+
+        // Act
+        HttpResponseExceptionWithErrorBody exception =
+                assertThrows(
+                        HttpResponseExceptionWithErrorBody.class,
+                        () -> {
+                            getLanguage(event);
+                        });
+        // Assert
+        assertEquals(ErrorResponse.MISSING_LANGUAGE, exception.getErrorResponse());
     }
 
     @Test

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -9,6 +9,7 @@ import uk.gov.di.ipv.core.checkcoi.CheckCoiHandler;
 import uk.gov.di.ipv.core.checkexistingidentity.CheckExistingIdentityHandler;
 import uk.gov.di.ipv.core.checkgpg45score.CheckGpg45ScoreHandler;
 import uk.gov.di.ipv.core.evaluategpg45scores.EvaluateGpg45ScoresHandler;
+import uk.gov.di.ipv.core.library.domain.CriJourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.processjourneyevent.ProcessJourneyEventHandler;
@@ -112,7 +113,7 @@ public class JourneyEngineHandler {
             default -> {
                 if (journeyStep.matches("/journey/cri/build-oauth-request/.*")) {
                     yield buildCriOauthRequestHandler.handleRequest(
-                            buildJourneyRequest(ctx, journeyStep), EMPTY_CONTEXT);
+                            buildFrontendJourneyRequest(ctx, journeyStep), EMPTY_CONTEXT);
                 } else {
                     throw new UnrecognisedJourneyException(
                             String.format("Journey not configured: %s", journeyStep));
@@ -122,7 +123,18 @@ public class JourneyEngineHandler {
     }
 
     private JourneyRequest buildJourneyRequest(Context ctx, String journey) {
-        return JourneyRequest.builder()
+        return CriJourneyRequest.builder()
+                .ipvSessionId(ctx.header(IPV_SESSION_ID))
+                .ipAddress(ctx.header(IP_ADDRESS))
+                .deviceInformation(ctx.header(ENCODED_DEVICE_INFORMATION))
+                .clientOAuthSessionId(ctx.header(CLIENT_SESSION_ID))
+                .featureSet(ctx.header(FEATURE_SET))
+                .journey(journey)
+                .build();
+    }
+
+    private CriJourneyRequest buildFrontendJourneyRequest(Context ctx, String journey) {
+        return CriJourneyRequest.criJourneyRequestBuilder()
                 .ipvSessionId(ctx.header(IPV_SESSION_ID))
                 .ipAddress(ctx.header(IP_ADDRESS))
                 .deviceInformation(ctx.header(ENCODED_DEVICE_INFORMATION))
@@ -141,7 +153,6 @@ public class JourneyEngineHandler {
                 .deviceInformation(ctx.header(ENCODED_DEVICE_INFORMATION))
                 .clientOAuthSessionId(ctx.header(CLIENT_SESSION_ID))
                 .featureSet(ctx.header(FEATURE_SET))
-                .language(ctx.header(LANGUAGE))
                 .journey((String) processJourneyEventOutput.get(JOURNEY))
                 .lambdaInput((Map<String, Object>) processJourneyEventOutput.get("lambdaInput"))
                 .build();

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -123,7 +123,7 @@ public class JourneyEngineHandler {
     }
 
     private JourneyRequest buildJourneyRequest(Context ctx, String journey) {
-        return CriJourneyRequest.builder()
+        return JourneyRequest.builder()
                 .ipvSessionId(ctx.header(IPV_SESSION_ID))
                 .ipAddress(ctx.header(IP_ADDRESS))
                 .deviceInformation(ctx.header(ENCODED_DEVICE_INFORMATION))

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -134,7 +134,7 @@ public class JourneyEngineHandler {
     }
 
     private CriJourneyRequest buildCriJourneyRequest(Context ctx, String journey) {
-        return CriJourneyRequest.criJourneyRequestBuilder()
+        return CriJourneyRequest.builder()
                 .ipvSessionId(ctx.header(IPV_SESSION_ID))
                 .ipAddress(ctx.header(IP_ADDRESS))
                 .deviceInformation(ctx.header(ENCODED_DEVICE_INFORMATION))

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -29,6 +29,7 @@ public class JourneyEngineHandler {
     public static final String ENCODED_DEVICE_INFORMATION = "txma-audit-encoded";
     public static final String CLIENT_SESSION_ID = "client-session-id";
     public static final String FEATURE_SET = "feature-set";
+    public static final String LANGUAGE = "language";
 
     private final ProcessJourneyEventHandler processJourneyEventHandler;
     private final CheckExistingIdentityHandler checkExistingIdentityHandler;
@@ -139,6 +140,7 @@ public class JourneyEngineHandler {
                 .deviceInformation(ctx.header(ENCODED_DEVICE_INFORMATION))
                 .clientOAuthSessionId(ctx.header(CLIENT_SESSION_ID))
                 .featureSet(ctx.header(FEATURE_SET))
+                .language(ctx.header(LANGUAGE))
                 .journey((String) processJourneyEventOutput.get(JOURNEY))
                 .lambdaInput((Map<String, Object>) processJourneyEventOutput.get("lambdaInput"))
                 .build();

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -128,6 +128,7 @@ public class JourneyEngineHandler {
                 .deviceInformation(ctx.header(ENCODED_DEVICE_INFORMATION))
                 .clientOAuthSessionId(ctx.header(CLIENT_SESSION_ID))
                 .featureSet(ctx.header(FEATURE_SET))
+                .language(ctx.header(LANGUAGE))
                 .journey(journey)
                 .build();
     }

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -113,7 +113,7 @@ public class JourneyEngineHandler {
             default -> {
                 if (journeyStep.matches("/journey/cri/build-oauth-request/.*")) {
                     yield buildCriOauthRequestHandler.handleRequest(
-                            buildFrontendJourneyRequest(ctx, journeyStep), EMPTY_CONTEXT);
+                            buildCriJourneyRequest(ctx, journeyStep), EMPTY_CONTEXT);
                 } else {
                     throw new UnrecognisedJourneyException(
                             String.format("Journey not configured: %s", journeyStep));
@@ -133,7 +133,7 @@ public class JourneyEngineHandler {
                 .build();
     }
 
-    private CriJourneyRequest buildFrontendJourneyRequest(Context ctx, String journey) {
+    private CriJourneyRequest buildCriJourneyRequest(Context ctx, String journey) {
         return CriJourneyRequest.criJourneyRequestBuilder()
                 .ipvSessionId(ctx.header(IPV_SESSION_ID))
                 .ipAddress(ctx.header(IP_ADDRESS))

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -73,7 +73,7 @@ paths:
               \"featureSet\":\"$util.escapeJavaScript($input.params('feature-set'))\",
               \"ipvSessionId\":\"$util.escapeJavaScript($input.params('ipv-session-id'))\",
               \"clientOAuthSessionId\":\"$util.escapeJavaScript($input.params('client-session-id'))\",
-              \"lng\":\"$util.escapeJavaScript($input.params('lng'))\"
+              \"language\":\"$util.escapeJavaScript($input.params('language'))\"
               }",
               "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${JourneyEngineStepFunction.Name}"
               }

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -72,7 +72,8 @@ paths:
               \"deviceInformation\":\"$util.escapeJavaScript($input.params('txma-audit-encoded'))\",
               \"featureSet\":\"$util.escapeJavaScript($input.params('feature-set'))\",
               \"ipvSessionId\":\"$util.escapeJavaScript($input.params('ipv-session-id'))\",
-              \"clientOAuthSessionId\":\"$util.escapeJavaScript($input.params('client-session-id'))\"
+              \"clientOAuthSessionId\":\"$util.escapeJavaScript($input.params('client-session-id'))\",
+              \"lng\":\"$util.escapeJavaScript($input.params('lng'))\"
               }",
               "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${JourneyEngineStepFunction.Name}"
               }


### PR DESCRIPTION
## Proposed changes

### What changed

- Add lng parameter to cri redirect uri created in BuildCriOauthRequest
- Add language to step function, and referenced as CriJourneyRequest dto for BuildCriOauthRequest, so it can be passed from the frontend

### Why did it change

- DWP want the language choice of the user to be passed through from the frontend

### Issue tracking

- [PYIC-6914](https://govukverify.atlassian.net/browse/PYIC-6914)

[PYIC-6914]: https://govukverify.atlassian.net/browse/PYIC-6914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ