### PR TITLE
DCMAW-9911: Update consumer contract test for DCMAW async cri

### DIFF
--- a/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/pact/dcmawasynccri/ContractTest.java
+++ b/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/pact/dcmawasynccri/ContractTest.java
@@ -54,6 +54,7 @@ class ContractTest {
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private SecureTokenHelper mockSecureTokenHelper;
+    @Mock private BearerAccessToken mockBearerAccessToken;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String SUBJECT_ID = "dummySubjectId";
     private static final String CALLBACK_URL =
@@ -293,6 +294,7 @@ class ContractTest {
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         when(mockConfigService.getOauthCriConfig(CRI_OAUTH_SESSION_ITEM))
                 .thenReturn(credentialIssuerConfig);
+        when(mockBearerAccessToken.toAuthorizationHeader()).thenReturn(null);
 
         var underTest =
                 new CriApiService(
@@ -304,7 +306,7 @@ class ContractTest {
                         CriApiException.class,
                         () ->
                                 underTest.fetchVerifiableCredential(
-                                        new BearerAccessToken("missingAccessToken"),
+                                        mockBearerAccessToken,
                                         DCMAW_ASYNC,
                                         CRI_OAUTH_SESSION_ITEM,
                                         getCredentialRequestBody(SUBJECT_ID)));


### PR DESCRIPTION
### What changed
- Updates expected status code to 400 when request to `async/token` contains invalid client secrets
- Adds a scenario to the `async/credential` endpoint when the access token is missing (401 status code) 

### Why did it change
Aligns to the latest DCMAW architecture

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-9911](https://govukverify.atlassian.net/browse/DCMAW-991)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[DCMAW-9911]: https://govukverify.atlassian.net/browse/DCMAW-9911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ