### PR TITLE
BAU: Truncate queue names

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -144,9 +144,10 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Calculate queue name
+        # SQS queue names have a max length of 80 and cannot contain special characters
         run: |
           branch_name=${{ github.head_ref || github.ref_name }}
-          queue_name=`echo $branch_name | sed 's/[^[:alnum:]-]/\_/g'`
+          queue_name=`echo $branch_name | sed 's/[^[:alnum:]-]/\_/g' | cut -c1-60`
           echo "queue_name=stubQueue_branch_$queue_name" >> $GITHUB_OUTPUT
         id: extract_queue_name
 


### PR DESCRIPTION
SQS queue names have a max length of 80 and cannot contain special characters, but dependabot PRs often have very long branch names which takes the generated queue name (for API tests) over the limit.

Use cut to truncate the branch name to 60 chars, so the branch name is within the limit.