### PR TITLE
BAU update AWS X-Ray tracing

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -277,7 +277,6 @@ public class BuildClientOauthResponseHandler
         return new ClientResponse(new ClientDetails(uriBuilder.build().toString()));
     }
 
-    @Tracing
     private Map<String, List<String>> getAuthParamsAsMap(
             ClientOAuthSessionItem clientOAuthSessionItem) {
         if (clientOAuthSessionItem != null) {

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -384,7 +384,6 @@ public class BuildCriOauthRequestHandler
         return new EvidenceRequest(SCORING_POLICY_GPG45, null, verificationScoreRequired);
     }
 
-    @Tracing
     private SharedClaimsResponse getSharedAttributesForUser(
             IpvSessionItem ipvSessionItem, List<VerifiableCredential> vcs, Cri cri)
             throws HttpResponseExceptionWithErrorBody {
@@ -473,13 +472,11 @@ public class BuildCriOauthRequestHandler
                 : Arrays.asList(allowedSharedAttributes.split(REGEX_COMMA_SEPARATION));
     }
 
-    @Tracing
     private void persistOauthState(IpvSessionItem ipvSessionItem, String oauthState) {
         ipvSessionItem.setCriOAuthSessionId(oauthState);
         ipvSessionService.updateIpvSession(ipvSessionItem);
     }
 
-    @Tracing
     private void persistCriOauthState(
             String oauthState, Cri cri, String clientOAuthSessionId, String connection) {
         criOAuthSessionService.persistCriOAuthSession(

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -132,7 +132,6 @@ public class BuildProvenUserIdentityDetailsHandler
         return ApiGatewayResponseGenerator.proxyJsonResponse(statusCode, errorResponse);
     }
 
-    @Tracing
     private IdentityClaim getProvenIdentity(List<VerifiableCredential> vcs)
             throws ProvenUserIdentityDetailsException, CredentialParseException {
         try {
@@ -156,7 +155,6 @@ public class BuildProvenUserIdentityDetailsHandler
         }
     }
 
-    @Tracing
     private List<PostalAddress> getProvenIdentityAddresses(List<VerifiableCredential> vcs)
             throws HttpResponseExceptionWithErrorBody, ProvenUserIdentityDetailsException {
         var addressClaim = userIdentityService.generateAddressClaim(vcs);

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -137,7 +137,6 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
         }
     }
 
-    @Tracing
     private Map<String, Object> callTicfCri(IpvSessionItem ipvSessionItem, ProcessRequest request)
             throws TicfCriServiceException, CiRetrievalException, VerifiableCredentialException,
                     CiPostMitigationsException, CiPutException, ConfigException,

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -69,6 +69,7 @@ public class TicfCriService {
         this.sessionCredentialsService = sessionCredentialsService;
     }
 
+    @Tracing
     public List<VerifiableCredential> getTicfVc(
             ClientOAuthSessionItem clientOAuthSessionItem, IpvSessionItem ipvSessionItem)
             throws TicfCriServiceException {

--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -17,6 +17,7 @@ import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialValidator;
 
@@ -42,7 +43,7 @@ public class TicfCriService {
 
     public TicfCriService(ConfigService configService) {
         this.configService = configService;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = TracingHttpClient.newHttpClient();
         this.jwtValidator = new VerifiableCredentialValidator(configService);
         this.sessionCredentialsService = new SessionCredentialsService(configService);
     }
@@ -53,7 +54,7 @@ public class TicfCriService {
             VerifiableCredentialValidator jwtValidator,
             SessionCredentialsService sessionCredentialsService) {
         this.configService = configService;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = TracingHttpClient.newHttpClient();
         this.jwtValidator = jwtValidator;
         this.sessionCredentialsService = sessionCredentialsService;
     }
@@ -161,7 +162,6 @@ public class TicfCriService {
         LOGGER.info(LogHelper.buildLogMessage("Successful HTTP response from TICF CRI"));
     }
 
-    @Tracing
     private HttpResponse<String> sendHttpRequest(HttpRequest ticfCriHttpRequest)
             throws IOException, InterruptedException {
         LOGGER.info(LogHelper.buildLogMessage("Sending HTTP request to TICF CRI"));

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -220,7 +220,6 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
         ipvSessionService.updateIpvSession(ipvSessionItem);
     }
 
-    @Tracing
     private void sendAuditEvent(
             AuditEventTypes auditEventType,
             CoiCheckType coiCheckType,
@@ -261,7 +260,6 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
                 new DeviceInformation(deviceInformation));
     }
 
-    @Tracing
     private List<VerifiableCredential> getOldIdentity(
             String userId, String ipvSessionId, String evcsAccessToken)
             throws CredentialParseException, EvcsServiceException {

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -114,7 +114,7 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
         try {
             var ipAddress = request.getIpAddress();
             var deviceInformation = request.getDeviceInformation();
-            String ipvSessionId = RequestHelper.getIpvSessionId(request);
+            var ipvSessionId = RequestHelper.getIpvSessionId(request);
             var ipvSession = ipvSessionService.getIpvSession(ipvSessionId);
             var clientOAuthSession =
                     clientOAuthSessionDetailsService.getClientOAuthSession(
@@ -135,8 +135,7 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
                     null,
                     deviceInformation);
 
-            var oldVcs =
-                    getOldIdentity(userId, ipvSessionId, clientOAuthSession.getEvcsAccessToken());
+            var oldVcs = getOldIdentity(userId, clientOAuthSession.getEvcsAccessToken());
 
             var sessionVcs = sessionCredentialsService.getCredentials(ipvSessionId, userId);
             var combinedCredentials = Stream.concat(oldVcs.stream(), sessionVcs.stream()).toList();
@@ -260,8 +259,7 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
                 new DeviceInformation(deviceInformation));
     }
 
-    private List<VerifiableCredential> getOldIdentity(
-            String userId, String ipvSessionId, String evcsAccessToken)
+    private List<VerifiableCredential> getOldIdentity(String userId, String evcsAccessToken)
             throws CredentialParseException, EvcsServiceException {
 
         List<VerifiableCredential> credentials = null;

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -241,7 +241,6 @@ public class CheckExistingIdentityHandler
         "java:S3776", // Cognitive Complexity of methods should not be too high
         "java:S6541" // "Brain method" PYIC-6901 should refactor this method
     })
-    @Tracing
     private JourneyResponse getJourneyResponse(
             IpvSessionItem ipvSessionItem,
             ClientOAuthSessionItem clientOAuthSessionItem,
@@ -364,7 +363,6 @@ public class CheckExistingIdentityHandler
         }
     }
 
-    @Tracing
     private VerifiableCredentialBundle getVerifiableCredentials(
             String userId, String evcsAccessToken)
             throws CredentialParseException, EvcsServiceException {
@@ -564,7 +562,6 @@ public class CheckExistingIdentityHandler
         return vcs.stream().map(vc -> vc.getCri().getId()).collect(Collectors.joining(","));
     }
 
-    @Tracing
     private JourneyResponse buildF2FIncompleteResponse(CriResponseItem faceToFaceRequest) {
         switch (faceToFaceRequest.getStatus()) {
             case CriResponseService.STATUS_PENDING -> {
@@ -584,7 +581,6 @@ public class CheckExistingIdentityHandler
         }
     }
 
-    @Tracing
     private Optional<JourneyResponse> checkForProfileMatch(
             IpvSessionItem ipvSessionItem,
             ClientOAuthSessionItem clientOAuthSessionItem,
@@ -774,7 +770,6 @@ public class CheckExistingIdentityHandler
                         new AuditRestrictedDeviceInformation(deviceInformation)));
     }
 
-    @Tracing
     private void sendVCsMigratedAuditEvent(
             AuditEventUser auditEventUser,
             List<VerifiableCredential> credentials,
@@ -799,7 +794,6 @@ public class CheckExistingIdentityHandler
                 JOURNEY_ERROR_PATH, HttpStatus.SC_INTERNAL_SERVER_ERROR, errorResponse);
     }
 
-    @Tracing
     private Optional<Vot> getStrongestAttainedVotForVtr(
             List<Vot> requestedVotsByStrength,
             List<VerifiableCredential> vcs,
@@ -897,7 +891,6 @@ public class CheckExistingIdentityHandler
         return false;
     }
 
-    @Tracing
     private void sendProfileMatchedAuditEvent(
             Gpg45Profile gpg45Profile,
             Gpg45Scores gpg45Scores,

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -195,7 +195,6 @@ public class EvaluateGpg45ScoresHandler
                 .toObjectMap();
     }
 
-    @Tracing
     private Optional<Gpg45Profile> findMatchingGpg45Profile(
             List<VerifiableCredential> vcs,
             IpvSessionItem ipvSessionItem,
@@ -251,7 +250,6 @@ public class EvaluateGpg45ScoresHandler
         LOGGER.info(message);
     }
 
-    @Tracing
     private AuditEvent buildProfileMatchedAuditEvent(
             IpvSessionItem ipvSessionItem,
             ClientOAuthSessionItem clientOAuthSessionItem,

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -363,7 +363,6 @@ public class InitialiseIpvSessionHandler
         }
     }
 
-    @Tracing
     private void storeInheritedIdentity(
             String userId,
             IpvSessionItem ipvSessionItem,
@@ -427,7 +426,6 @@ public class InitialiseIpvSessionHandler
         return true;
     }
 
-    @Tracing
     private String getEvcsAccessToken(JWTClaimsSet claimsSet)
             throws RecoverableJarValidationException, ParseException {
         try {
@@ -443,7 +441,6 @@ public class InitialiseIpvSessionHandler
         }
     }
 
-    @Tracing
     private String validateEvcsAccessToken(
             Optional<StringListClaim> evcsAccessTokenClaim, JWTClaimsSet claimsSet)
             throws RecoverableJarValidationException, ParseException {
@@ -560,7 +557,6 @@ public class InitialiseIpvSessionHandler
         }
     }
 
-    @Tracing
     private Optional<ErrorResponse> validateSessionParams(Map<String, String> sessionParams) {
         boolean isInvalid = false;
 

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -224,14 +224,12 @@ public class IssueClientAccessTokenHandler
         }
     }
 
-    @Tracing
     private int getHttpStatusCodeForErrorResponse(ErrorObject errorObject) {
         return errorObject.getHTTPStatusCode() > 0
                 ? errorObject.getHTTPStatusCode()
                 : HttpStatus.SC_BAD_REQUEST;
     }
 
-    @Tracing
     private boolean redirectUrlsDoNotMatch(
             AuthorizationCodeMetadata authorizationCodeMetadata,
             AuthorizationCodeGrant authorizationGrant) {

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -175,7 +175,6 @@ public class ProcessAsyncCriCredentialHandler
         sendIpvVcErrorAuditEvent(errorAsyncCriResponse);
     }
 
-    @Tracing
     private void processSuccessAsyncCriResponse(SuccessAsyncCriResponse successAsyncCriResponse)
             throws ParseException, CiPutException, AsyncVerifiableCredentialException,
                     CiPostMitigationsException, VerifiableCredentialException,
@@ -247,7 +246,6 @@ public class ProcessAsyncCriCredentialHandler
         }
     }
 
-    @Tracing
     private void sendIpvVcReceivedAuditEvent(
             AuditEventUser auditEventUser,
             VerifiableCredential verifiableCredential,
@@ -262,7 +260,6 @@ public class ProcessAsyncCriCredentialHandler
         auditService.sendAuditEvent(auditEvent);
     }
 
-    @Tracing
     void sendIpvVcConsumedAuditEvent(AuditEventUser auditEventUser, VerifiableCredential vc) {
         AuditEvent auditEvent =
                 AuditEvent.createWithoutDeviceInformation(
@@ -274,7 +271,6 @@ public class ProcessAsyncCriCredentialHandler
         auditService.sendAuditEvent(auditEvent);
     }
 
-    @Tracing
     private void sendIpvVcErrorAuditEvent(ErrorAsyncCriResponse errorAsyncCriResponse) {
         AuditEventUser auditEventUser =
                 new AuditEventUser(errorAsyncCriResponse.getUserId(), null, null, null);
@@ -295,12 +291,10 @@ public class ProcessAsyncCriCredentialHandler
         auditService.sendAuditEvent(auditEvent);
     }
 
-    @Tracing
     private void submitVcToCiStorage(VerifiableCredential vc) throws CiPutException {
         ciMitService.submitVC(vc, null, null);
     }
 
-    @Tracing
     private void postMitigatingVc(VerifiableCredential vc) throws CiPostMitigationsException {
         ciMitService.submitMitigatingVcList(List.of(vc), null, null);
     }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -170,7 +170,6 @@ public class ProcessJourneyEventHandler
         }
     }
 
-    @Tracing
     private StepResponse executeJourneyEvent(
             String journeyEvent,
             IpvSessionItem ipvSessionItem,
@@ -251,7 +250,6 @@ public class ProcessJourneyEventHandler
         }
     }
 
-    @Tracing
     private State executeStateTransition(
             JourneyState initialJourneyState,
             IpvSessionItem ipvSessionItem,
@@ -309,7 +307,6 @@ public class ProcessJourneyEventHandler
         return result.state();
     }
 
-    @Tracing
     private void logStateChange(
             JourneyState oldJourneyState, String journeyEvent, IpvSessionItem ipvSessionItem) {
         var newJourneyState = ipvSessionItem.getState();
@@ -324,14 +321,12 @@ public class ProcessJourneyEventHandler
         LOGGER.info(message);
     }
 
-    @Tracing
     private void clearOauthSessionIfExists(IpvSessionItem ipvSessionItem) {
         if (ipvSessionItem.getCriOAuthSessionId() != null) {
             ipvSessionItem.setCriOAuthSessionId(null);
         }
     }
 
-    @Tracing
     private void updateUserSessionForTimeout(
             IpvSessionItem ipvSessionItem,
             AuditEventUser auditEventUser,
@@ -346,7 +341,6 @@ public class ProcessJourneyEventHandler
         sendSubJourneyStartAuditEvent(auditEventUser, SESSION_TIMEOUT, deviceInformation);
     }
 
-    @Tracing
     private boolean sessionIsNewlyExpired(IpvSessionItem ipvSessionItem) {
         return (!SESSION_TIMEOUT.equals(ipvSessionItem.getState().subJourney()))
                 && Instant.parse(ipvSessionItem.getCreationDateTime())
@@ -357,7 +351,6 @@ public class ProcessJourneyEventHandler
                                                         BACKEND_SESSION_TIMEOUT)));
     }
 
-    @Tracing
     private Map<IpvJourneyTypes, StateMachine> loadStateMachines(
             List<IpvJourneyTypes> journeyTypes,
             StateMachineInitializerMode stateMachineInitializerMode)

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -214,7 +214,6 @@ public class CiMitService {
         }
     }
 
-    @Tracing
     public ContraIndicators getContraIndicators(
             String userId, String govukSigninJourneyId, String ipAddress)
             throws CiRetrievalException {
@@ -223,7 +222,6 @@ public class CiMitService {
         return getContraIndicators(vc);
     }
 
-    @Tracing
     public ContraIndicators getContraIndicators(VerifiableCredential vc)
             throws CiRetrievalException {
         var evidenceItem = parseContraIndicatorEvidence(vc);
@@ -432,6 +430,7 @@ public class CiMitService {
         return requestBuilder;
     }
 
+    @Tracing
     private HttpResponse<String> sendHttpRequest(HttpRequest cimitHttpRequest)
             throws CimitHttpRequestException {
         try {

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CiMitService.java
@@ -36,6 +36,7 @@ import uk.gov.di.ipv.core.library.domain.cimitvc.CiMitVc;
 import uk.gov.di.ipv.core.library.domain.cimitvc.EvidenceItem;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialValidator;
 
 import java.io.IOException;
@@ -96,7 +97,7 @@ public class CiMitService {
                         .build();
         this.configService = configService;
         this.verifiableCredentialValidator = new VerifiableCredentialValidator(configService);
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = TracingHttpClient.newHttpClient();
     }
 
     public CiMitService(
@@ -106,7 +107,7 @@ public class CiMitService {
         this.lambdaClient = lambdaClient;
         this.configService = configService;
         this.verifiableCredentialValidator = verifiableCredentialValidator;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = TracingHttpClient.newHttpClient();
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -430,7 +431,6 @@ public class CiMitService {
         return requestBuilder;
     }
 
-    @Tracing
     private HttpResponse<String> sendHttpRequest(HttpRequest cimitHttpRequest)
             throws CimitHttpRequestException {
         try {

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 			libs.jacksonDataformatYaml,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
+			libs.powertoolsTracing,
 			project(":libs:journey-uris")
 
 	compileOnly libs.lombok

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java
@@ -1,0 +1,132 @@
+package uk.gov.di.ipv.core.library.tracing;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorder;
+import com.amazonaws.xray.entities.Namespace;
+import com.amazonaws.xray.entities.Subsegment;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+// Implementation of java.net.HttpClient that includes AWS X-Ray tracing
+@ExcludeFromGeneratedCoverageReport
+public class TracingHttpClient extends HttpClient {
+    private final HttpClient baseClient;
+    private final AWSXRayRecorder recorder;
+
+    private TracingHttpClient(HttpClient baseClient) {
+        this.baseClient = baseClient;
+        this.recorder = AWSXRay.getGlobalRecorder();
+    }
+
+    public static HttpClient newHttpClient() {
+        return new TracingHttpClient(HttpClient.newHttpClient());
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return baseClient.cookieHandler();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return baseClient.connectTimeout();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return baseClient.followRedirects();
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return baseClient.proxy();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return baseClient.sslContext();
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return baseClient.sslParameters();
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return baseClient.authenticator();
+    }
+
+    @Override
+    public Version version() {
+        return baseClient.version();
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return baseClient.executor();
+    }
+
+    @Override
+    public <T> HttpResponse<T> send(
+            HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+            throws IOException, InterruptedException {
+        var subsegment = recorder.beginSubsegment(request.uri().getHost());
+        addRequestInformation(subsegment, request);
+        try {
+            return baseClient.send(
+                    request, new TracingResponseHandler<>(subsegment, responseBodyHandler));
+        } catch (Exception e) {
+            subsegment.addException(e);
+            throw e;
+        } finally {
+            recorder.endSubsegment();
+        }
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+        throw new UnsupportedOperationException(
+                "TracingHttpClient does not support async requests yet");
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+            HttpRequest request,
+            HttpResponse.BodyHandler<T> responseBodyHandler,
+            HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        throw new UnsupportedOperationException(
+                "TracingHttpClient does not support async requests yet");
+    }
+
+    // Adapted from
+    // https://github.com/aws/aws-xray-sdk-java/blob/master/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java#L103
+    private static void addRequestInformation(Subsegment subsegment, HttpRequest request) {
+        subsegment.setNamespace(Namespace.REMOTE.toString());
+
+        Map<String, Object> requestInformation = new HashMap<>();
+
+        // Resolve against `/` to strip any sensitive data from the path
+        requestInformation.put("url", request.uri().resolve("/").toString());
+        requestInformation.put("method", request.method());
+
+        subsegment.putHttp("request", requestInformation);
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingResponseHandler.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingResponseHandler.java
@@ -1,0 +1,53 @@
+package uk.gov.di.ipv.core.library.tracing;
+
+import com.amazonaws.xray.entities.Subsegment;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+@ExcludeFromGeneratedCoverageReport
+public class TracingResponseHandler<T> implements HttpResponse.BodyHandler<T> {
+    private final Subsegment subsegment;
+    private final HttpResponse.BodyHandler<T> inner;
+
+    public TracingResponseHandler(Subsegment subsegment, HttpResponse.BodyHandler<T> inner) {
+        this.inner = inner;
+        this.subsegment = subsegment;
+    }
+
+    @Override
+    public HttpResponse.BodySubscriber<T> apply(HttpResponse.ResponseInfo responseInfo) {
+        addResponseInformation(subsegment, responseInfo);
+        return inner.apply(responseInfo);
+    }
+
+    // Adapted from
+    // https://github.com/aws/aws-xray-sdk-java/blob/master/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedResponseHandler.java#L39
+    private static void addResponseInformation(
+            Subsegment subsegment, HttpResponse.ResponseInfo response) {
+        if (null == subsegment) {
+            return;
+        }
+
+        Map<String, Object> responseInformation = new HashMap<>();
+
+        int responseCode = response.statusCode();
+        switch (responseCode / 100) {
+            case 4:
+                subsegment.setError(true);
+                if (429 == responseCode) {
+                    subsegment.setThrottle(true);
+                }
+                break;
+            case 5:
+                subsegment.setFault(true);
+                break;
+            default:
+        }
+        responseInformation.put("status", responseCode);
+
+        subsegment.putHttp("response", responseInformation);
+    }
+}

--- a/libs/cri-api-service/build.gradle
+++ b/libs/cri-api-service/build.gradle
@@ -2,17 +2,23 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	alias libs.plugins.postCompileWeaving
 }
 
 dependencies {
 	implementation libs.bundles.log4j,
 			libs.jacksonDatabind,
+			libs.powertoolsTracing,
 			project(":libs:common-services"),
 			project(":libs:kms-es256-signer"),
 			project(":libs:verifiable-credentials")
 
 	compileOnly libs.lombok
 	annotationProcessor libs.lombok
+
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
@@ -41,6 +47,8 @@ tasks.named('jar') {
 }
 
 test {
+	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
+	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -24,6 +24,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
+import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.criapiservice.dto.AsyncCredentialRequestBodyDto;
@@ -113,6 +114,7 @@ public class CriApiService {
         return fetchAccessToken(criOAuthSessionItem.getCriId(), criOAuthSessionItem, httpRequest);
     }
 
+    @Tracing
     private BearerAccessToken fetchAccessToken(
             String criId, CriOAuthSessionItem criOAuthSessionItem, HTTPRequest accessTokenRequest)
             throws CriApiException {
@@ -252,6 +254,7 @@ public class CriApiService {
         return fetchVerifiableCredential(cri, request);
     }
 
+    @Tracing
     private VerifiableCredentialResponse fetchVerifiableCredential(
             Cri cri, HTTPRequest credentialRequest) throws CriApiException {
         try {

--- a/libs/evcs-service/build.gradle
+++ b/libs/evcs-service/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	alias libs.plugins.postCompileWeaving
 }
 
 dependencies {
@@ -15,6 +16,10 @@ dependencies {
 
 	compileOnly libs.lombok
 	annotationProcessor libs.lombok
+
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
@@ -42,6 +47,8 @@ tasks.named('jar') {
 }
 
 test {
+	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
+	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java
@@ -24,6 +24,7 @@ import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.retry.Retry;
 import uk.gov.di.ipv.core.library.retry.Sleeper;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
 
 import java.io.IOException;
 import java.net.URI;
@@ -60,7 +61,7 @@ public class EvcsClient {
     @ExcludeFromGeneratedCoverageReport
     public EvcsClient(ConfigService configService) {
         this.configService = configService;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = TracingHttpClient.newHttpClient();
         this.sleeper = new Sleeper();
     }
 
@@ -218,7 +219,6 @@ public class EvcsClient {
         LOGGER.info(LogHelper.buildLogMessage("Successful HTTP response from EVCS Api"));
     }
 
-    @Tracing
     private HttpResponse<String> sendHttpRequest(HttpRequest evcsHttpRequest)
             throws EvcsServiceException {
 

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/service/EvcsService.java
@@ -110,7 +110,6 @@ public class EvcsService {
                                 EXTERNAL)));
     }
 
-    @Tracing
     public List<VerifiableCredential> getVerifiableCredentials(
             String userId, String evcsAccessToken, EvcsVCState... states)
             throws CredentialParseException, EvcsServiceException {

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'java-library'
 	id "idea"
 	id "jacoco"
+	alias libs.plugins.postCompileWeaving
 }
 
 dependencies {
@@ -12,11 +13,16 @@ dependencies {
 			libs.diVocab,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
+			libs.powertoolsTracing,
 			project(":libs:common-services"),
 			project(":libs:gpg45-evaluator")
 
 	compileOnly libs.lombok
 	annotationProcessor libs.lombok
+
+	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
+			libs.aspectj
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
@@ -44,6 +50,8 @@ tasks.named('jar') {
 }
 
 test {
+	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
+	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.library.verifiablecredential.service;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.Cri;
@@ -46,6 +47,7 @@ public class SessionCredentialsService {
         return getCredentials(ipvSessionId, userId, null);
     }
 
+    @Tracing
     public List<VerifiableCredential> getCredentials(
             String ipvSessionId, String userId, Boolean receivedThisSession)
             throws VerifiableCredentialException {
@@ -73,6 +75,7 @@ public class SessionCredentialsService {
         }
     }
 
+    @Tracing
     public void persistCredentials(
             List<VerifiableCredential> credentials,
             String ipvSessionId,
@@ -91,6 +94,7 @@ public class SessionCredentialsService {
         }
     }
 
+    @Tracing
     public void deleteSessionCredentialsForResetType(
             String ipvSessionId, SessionCredentialsResetType resetType)
             throws VerifiableCredentialException {
@@ -123,6 +127,7 @@ public class SessionCredentialsService {
         }
     }
 
+    @Tracing
     public void deleteSessionCredentials(String ipvSessionId) throws VerifiableCredentialException {
         LOGGER.info(
                 LogHelper.buildLogMessage(
@@ -136,6 +141,7 @@ public class SessionCredentialsService {
         }
     }
 
+    @Tracing
     public void deleteSessionCredentialsForCri(String ipvSessionId, Cri cri)
             throws VerifiableCredentialException {
         var criId = cri.getId();

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/VerifiableCredentialService.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.library.verifiablecredential.service;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -39,6 +40,7 @@ public class VerifiableCredentialService {
                         configService);
     }
 
+    @Tracing
     public void persistUserCredentials(VerifiableCredential vc)
             throws VerifiableCredentialException {
         try {
@@ -50,6 +52,7 @@ public class VerifiableCredentialService {
         }
     }
 
+    @Tracing
     public List<VerifiableCredential> getVcs(String userId) throws CredentialParseException {
         var vcs = new ArrayList<VerifiableCredential>();
         for (var vcStoreItem : dataStore.getItems(userId)) {
@@ -58,10 +61,12 @@ public class VerifiableCredentialService {
         return vcs;
     }
 
+    @Tracing
     public VerifiableCredential getVc(String userId, String criId) throws CredentialParseException {
         return VerifiableCredential.fromVcStoreItem(dataStore.getItem(userId, criId));
     }
 
+    @Tracing
     public void deleteVCs(String userId) throws VerifiableCredentialException {
         try {
             dataStore.deleteAllByPartition(userId);
@@ -70,6 +75,7 @@ public class VerifiableCredentialService {
         }
     }
 
+    @Tracing
     public void storeIdentity(List<VerifiableCredential> vcs, String userId)
             throws VerifiableCredentialException {
         try {
@@ -83,6 +89,7 @@ public class VerifiableCredentialService {
         }
     }
 
+    @Tracing
     public void updateIdentity(List<VerifiableCredential> vcs)
             throws VerifiableCredentialException {
         try {


### PR DESCRIPTION
## Proposed changes

### What changed

- Include AspectJ on libs that use tracing
- Remove Tracing from fast in-memory operations
- Add Tracing to external service calls
- Add TracingHttpClient to include more detailed information on external HTTP requests

### Why did it change

Missing AspectJ meant that the `@Tracing` annotations in libs were ignored. Moreover, tracing was applied inconsistently, often tracing useless information while leaving gaps where it would be useful.
