### PR TITLE
PYIC-7160 fast follow update name dob

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -172,6 +172,9 @@ states:
           updateSupported: true
       dob:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -179,6 +182,9 @@ states:
           updateSupported: false
       dob-given:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -186,6 +192,9 @@ states:
           updateSupported: false
       dob-family:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -193,6 +202,9 @@ states:
           updateSupported: false
       address-dob:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -200,6 +212,9 @@ states:
           updateSupported: false
       dob-family-given:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -207,6 +222,9 @@ states:
           updateSupported: false
       address-dob-given:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -214,6 +232,9 @@ states:
           updateSupported: false
       address-dob-family:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -221,6 +242,9 @@ states:
           updateSupported: false
       address-dob-family-given:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -228,6 +252,9 @@ states:
           updateSupported: false
       family-given:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -235,6 +262,9 @@ states:
           updateSupported: false
       address-family-given:
         targetState: UPDATE_NAME_DOB_PAGE
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_REUSE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -265,6 +295,22 @@ states:
     events:
       end:
         targetState: UPDATE_DETAILS_PAGE
+
+  UPDATE_NAME_DOB_REUSE:
+    response:
+      type: page
+      pageId: update-name-date-birth
+      context: reuse
+    events:
+      continue:
+        targetState: RETURN_TO_RP
+      end:
+        targetState: DELETE_IDENTITY_PAGE
+
+  DELETE_IDENTITY_PAGE:
+    response:
+      type: page
+      pageId: delete-handover
 
   RETURN_TO_RP:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -174,7 +174,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -184,7 +184,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -194,7 +194,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -204,7 +204,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -214,7 +214,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -224,7 +224,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -234,7 +234,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -244,7 +244,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -254,7 +254,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -264,7 +264,7 @@ states:
         targetState: UPDATE_NAME_DOB_PAGE
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: UPDATE_NAME_DOB_REUSE
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -296,7 +296,7 @@ states:
       end:
         targetState: UPDATE_DETAILS_PAGE
 
-  UPDATE_NAME_DOB_REUSE:
+  UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION:
     response:
       type: page
       pageId: update-name-date-birth

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -304,6 +304,8 @@ states:
     events:
       continue:
         targetState: RETURN_TO_RP
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_ABORTED
       end:
         targetState: DELETE_IDENTITY_PAGE
 
@@ -311,9 +313,6 @@ states:
     response:
       type: page
       pageId: delete-handover
-    events:
-      back:
-        targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
 
   RETURN_TO_RP:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -311,6 +311,9 @@ states:
     response:
       type: page
       pageId: delete-handover
+    events:
+      back:
+        targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
 
   RETURN_TO_RP:
     response:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -359,7 +359,6 @@ core:
     p1JourneysEnabled: false
     sqsAsync: true
     cimitApiGatewayEnabled: true
-    updateDetailsAccountDeletion: false
   features:
     mfaReset:
       featureFlags:
@@ -377,9 +376,6 @@ core:
     evcsRead:
       featureFlags:
         evcsReadEnabled: true
-    updateDetailsAccountDeletion:
-      featureFlags:
-        updateDetailsAccountDeletion: true
     hmrcKbvBeta:
       credentialIssuers:
         hmrcKbv:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -359,6 +359,7 @@ core:
     p1JourneysEnabled: false
     sqsAsync: true
     cimitApiGatewayEnabled: true
+    updateDetailsAccountDeletion: false
   features:
     mfaReset:
       featureFlags:
@@ -376,6 +377,9 @@ core:
     evcsRead:
       featureFlags:
         evcsReadEnabled: true
+    updateDetailsAccountDeletion:
+      featureFlags:
+        updateDetailsAccountDeletion: true
     hmrcKbvBeta:
       credentialIssuers:
         hmrcKbv:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Adds new steps to handle routing from update-name-date-birth when account deletion is enabled.

### Why did it change
We want to reduce the number of people contacting the call centre for help by allowing users to delete their account themselves.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7160](https://govukverify.atlassian.net/browse/PYIC-7160)

Corresponding core-front PR: https://github.com/govuk-one-login/ipv-core-front/pull/1534


[PYIC-7160]: https://govukverify.atlassian.net/browse/PYIC-7160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ