### PR TITLE
PYIC-7162 rfc update name date birth

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -239,9 +239,6 @@ states:
     response:
       type: page
       pageId: delete-handover
-    events:
-      back:
-        targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
 
   FRAUD_CHECK_RFC:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -100,6 +100,9 @@ states:
           updateSupported: true
       dob:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -108,6 +111,9 @@ states:
           updateSupported: false
       dob-given:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -116,6 +122,9 @@ states:
           updateSupported: false
       dob-family:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -124,6 +133,9 @@ states:
           updateSupported: false
       address-dob:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -132,6 +144,9 @@ states:
           updateSupported: false
       dob-family-given:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -140,6 +155,9 @@ states:
           updateSupported: false
       address-dob-given:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -148,6 +166,9 @@ states:
           updateSupported: false
       address-dob-family:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -156,6 +177,9 @@ states:
           updateSupported: false
       address-dob-family-given:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -164,6 +188,9 @@ states:
           updateSupported: false
       family-given:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -172,6 +199,9 @@ states:
           updateSupported: false
       address-family-given:
         targetState: UPDATE_NAME_DOB
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -191,6 +221,27 @@ states:
        targetState: CONFIRM_DETAILS
        auditEvents:
          - IPV_USER_DETAILS_UPDATE_ABORTED
+
+  UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION:
+    response:
+      type: page
+      pageId: update-name-date-birth
+      context: rfcAccountDeletion
+    events:
+      continue:
+        targetState: DELETE_HANDOVER_PAGE
+      end:
+        targetState: CONFIRM_DETAILS
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_ABORTED
+
+  DELETE_HANDOVER_PAGE:
+    response:
+      type: page
+      pageId: delete-handover
+    events:
+      back:
+        targetState: UPDATE_NAME_DOB_ALLOW_ACCOUNT_DELETION
 
   FRAUD_CHECK_RFC:
     response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update repeat fraud check journey map to use updated `update-name-birth-date` page when `updateDetailsAccountDeletion` is enabled and to route to `delete-handover`

### Why did it change

We want to reduce the number of people contacting the call centre for help by allowing users to delete their account themselves.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7162](https://govukverify.atlassian.net/browse/PYIC-7162)
Associated core-front PR: https://github.com/govuk-one-login/ipv-core-front/pull/1536

[PYIC-7162]: https://govukverify.atlassian.net/browse/PYIC-7162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ