### PR TITLE
PYIC-7163: allow coi failure users to delete account

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -43,20 +43,14 @@ states:
   FAILED_UPDATE_DETAILS:
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
         checkFeatureFlag:
-          updateDetailsAccountDeletion:
-            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
-            auditEvents:
-              - IPV_USER_DETAILS_UPDATE_END
-            auditContext:
-              successful: false
           ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_COULD_UPDATE_CONFIRM_DETAILS
+            targetState: CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS
             auditEvents:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
@@ -221,9 +215,6 @@ states:
     response:
       type: page
       pageId: delete-handover
-    events:
-      back:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
 
   NO_MATCH_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -40,6 +40,28 @@ states:
             auditContext:
               successful: false
 
+  FAILED_UPDATE_DETAILS:
+    events:
+      next:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_END
+        auditContext:
+          successful: false
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+            auditEvents:
+              - IPV_USER_DETAILS_UPDATE_END
+            auditContext:
+              successful: false
+          ticfCriBeta:
+            targetState: CRI_TICF_BEFORE_COULD_UPDATE_CONFIRM_DETAILS
+            auditEvents:
+              - IPV_USER_DETAILS_UPDATE_END
+            auditContext:
+              successful: false
+
   FAILED_BAV:
     events:
       next:
@@ -120,6 +142,25 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
+  CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      enhanced-verification:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      alternate-doc-invalid-dl:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      alternate-doc-invalid-passport:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      fail-with-ci:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
   CRI_TICF_BEFORE_NO_MATCH_BAV:
     response:
       type: process
@@ -165,6 +206,24 @@ states:
     events:
       end:
         targetState: RETURN_TO_RP
+
+  COULD_NOT_UPDATE_DETAILS_PAGE:
+    response:
+      type: page
+      pageId: update-details-failed
+    events:
+      continue:
+        targetState: RETURN_TO_RP
+      delete:
+        targetState: DELETE_HANDOVER_PAGE
+
+  DELETE_HANDOVER_PAGE:
+    response:
+      type: page
+      pageId: delete-handover
+    events:
+      back:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
 
   NO_MATCH_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -179,13 +179,13 @@ states:
         targetState: FAILED_CONFIRM_DETAILS
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
+        targetState: FAILED_UPDATE_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
+        targetState: FAILED_UPDATE_DETAILS
 
   DCMAW_FAMILY_ONLY:
     response:
@@ -200,13 +200,13 @@ states:
         targetState: FAILED_CONFIRM_DETAILS
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
+        targetState: FAILED_UPDATE_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
+        targetState: FAILED_UPDATE_DETAILS
 
   POST_DCMAW_SUCCESS_PAGE_GIVEN_ONLY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -360,12 +360,20 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS
 
   DCMAW_FAMILY_WITH_ADDRESS:
     response:
@@ -381,12 +389,20 @@ states:
       access-denied:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS
 
   POST_DCMAW_SUCCESS_PAGE_GIVEN_WITH_ADDRESS:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -179,13 +179,21 @@ states:
         targetState: FAILED_CONFIRM_DETAILS
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
+        targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
+        targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS
 
   DCMAW_FAMILY_ONLY:
     response:
@@ -200,13 +208,19 @@ states:
         targetState: FAILED_CONFIRM_DETAILS
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
+        targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: FAILED_UPDATE_DETAILS
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
+        targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetState: FAILED_UPDATE_DETAILS
 
   POST_DCMAW_SUCCESS_PAGE_GIVEN_ONLY:
     response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Changes to the update-name journey to route users to the new `update-details-failed` page (where they have the option to delete their account) if we get `fail-with-no-ci` or `access-denied` events from dcmaw (and the `updateDetailsAccountDeletion` is set)

<!-- Describe the changes in detail - the "what"-->

### Why did it change
This change aims to provide users with clear information and options when they are unable to use the live/likeness application to prove their identity. By offering self-service options, users can either proceed to the service they intended to access or delete their account, improving user experience and reducing the need for call centre support.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-7163

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

