### PR TITLE
BAU: Fix MITIGATION_KBV_OPTIONS to MITIGATION_02_OPTIONS

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -675,7 +675,7 @@ states:
         targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
-            targetState: MITIGATION_KBV_OPTIONS
+            targetState: MITIGATION_02_OPTIONS
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:


### PR DESCRIPTION
## Proposed changes

### What changed

- MITIGATION_KBV_OPTIONS => MITIGATION_02_OPTIONS

### Why did it change

- MITIGATION_02_OPTIONS was the intended state to be referenced