### PR TITLE
PYIC-7198: Make ticf request timeout configurable

### DIFF
--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/service/TicfCriService.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
 import java.util.List;
 
 import static uk.gov.di.ipv.core.library.domain.Cri.TICF;
@@ -40,6 +42,7 @@ public class TicfCriService {
     private final VerifiableCredentialValidator jwtValidator;
     private final SessionCredentialsService sessionCredentialsService;
 
+    @ExcludeFromGeneratedCoverageReport
     public TicfCriService(ConfigService configService) {
         this.configService = configService;
         this.httpClient = HttpClient.newHttpClient();
@@ -47,7 +50,7 @@ public class TicfCriService {
         this.sessionCredentialsService = new SessionCredentialsService(configService);
     }
 
-    @ExcludeFromGeneratedCoverageReport
+    // Used by contract tests
     public TicfCriService(
             ConfigService configService,
             VerifiableCredentialValidator jwtValidator,
@@ -92,9 +95,10 @@ public class TicfCriService {
                                     .map(VerifiableCredential::getVcString)
                                     .toList());
 
-            HttpRequest.Builder httpRequestBuilder =
+            var httpRequestBuilder =
                     HttpRequest.newBuilder()
                             .uri(ticfCriConfig.getCredentialUrl())
+                            .timeout(Duration.ofSeconds(ticfCriConfig.getRequestTimeout()))
                             .POST(
                                     HttpRequest.BodyPublishers.ofString(
                                             OBJECT_MAPPER.writeValueAsString(ticfCriRequest)));
@@ -134,6 +138,10 @@ public class TicfCriService {
             if (e instanceof InterruptedException) {
                 // This should never happen running in Lambda as it's single threaded.
                 Thread.currentThread().interrupt();
+            }
+
+            if (e instanceof HttpTimeoutException) {
+                LOGGER.warn(LogHelper.buildLogMessage("Request to TICF CRI has timed out"));
             }
             // In the case of unavailability, the TICF CRI is deemed optional.
             LOGGER.error(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/dto/RestCriConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/dto/RestCriConfig.java
@@ -12,8 +12,16 @@ import java.net.URI;
 @Getter
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-@JsonIgnoreProperties(ignoreUnknown = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RestCriConfig extends CriConfig {
+    private static final long DEFAULT_REQUEST_TIMEOUT = 30;
+
+    private Long requestTimeout;
     private URI credentialUrl;
     private boolean requiresApiKey;
+
+    public long getRequestTimeout() {
+        // This it to avoid having to define the request timeout in config if not desired
+        return requestTimeout == null ? DEFAULT_REQUEST_TIMEOUT : requestTimeout;
+    }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/dto/RestCriConfigTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/dto/RestCriConfigTest.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.core.library.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RestCriConfigTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void getRequestTimeoutShouldReturnDefaultIfNotSet() throws Exception {
+        var jsonConfigWithNoTimeout =
+                "{\"credentialUrl\":\"http://example.com\",\"requiresApiKey\":\"false\"}";
+        var config = OBJECT_MAPPER.readValue(jsonConfigWithNoTimeout, RestCriConfig.class);
+
+        assertEquals(30, config.getRequestTimeout());
+    }
+
+    @Test
+    void getRequestTimeoutShouldReturnDefinedValue() throws Exception {
+        var jsonConfigWithTimeout =
+                "{\"credentialUrl\":\"http://example.com\",\"requiresApiKey\":\"false\",\"requestTimeout\":5}";
+        var config = OBJECT_MAPPER.readValue(jsonConfigWithTimeout, RestCriConfig.class);
+
+        assertEquals(5, config.getRequestTimeout());
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Make ticf request timeout configurable

### Why did it change

This updates the ticfCriService to allow the request timeout to be configurable. A request should never take longer than 2 seconds to be processed by the TICF CRI, so we can reduce our own timeout.

The config value comes from the RestCriConfig for the TICF CRI. We may not want to explicitly set a timeout on other CRIs, so the value is optional, defaulting to 30 seconds. Currently the TICF CRI is the only CRI that uses the RestCriConfig.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7198](https://govukverify.atlassian.net/browse/PYIC-7198)


[PYIC-7198]: https://govukverify.atlassian.net/browse/PYIC-7198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ