### PR TITLE
Improve journey map test to also check target states for ifDisabled sections

### DIFF
--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -228,26 +228,23 @@ class JourneyMapTest {
         }
     }
 
-    private void checkTargetStatesExist(Event event, Set<String> stateMachineKeys) throws IOException {
+    private void checkTargetStatesExist(Event event, Set<String> stateMachineKeys)
+            throws IOException {
         if (event instanceof BasicEvent basicEvent) {
             if (basicEvent.getTargetJourney() != null) {
                 var basicEventStateMachine =
                         new StateMachineInitializer(
-                                IpvJourneyTypes.valueOf(
-                                        basicEvent.getTargetJourney()))
+                                        IpvJourneyTypes.valueOf(basicEvent.getTargetJourney()))
                                 .initialize();
                 var basicEventStateMachineKeys = basicEventStateMachine.keySet();
                 assertTrue(
-                        basicEventStateMachineKeys.contains(
-                                basicEvent.getTargetState()),
-                        "Unknown target state %s"
-                                .formatted(basicEvent.getTargetState()));
+                        basicEventStateMachineKeys.contains(basicEvent.getTargetState()),
+                        "Unknown target state %s".formatted(basicEvent.getTargetState()));
 
             } else if (basicEvent.getTargetState() != null) {
                 assertTrue(
                         stateMachineKeys.contains(basicEvent.getTargetState()),
-                        "Unknown target state %s"
-                                .formatted(basicEvent.getTargetState()));
+                        "Unknown target state %s".formatted(basicEvent.getTargetState()));
             }
 
             var eventsIfDisabled = basicEvent.getCheckIfDisabled();

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -198,27 +198,7 @@ class JourneyMapTest {
             if (targetState instanceof BasicState basicState) {
                 var events = basicState.getEvents();
                 for (var event : events.values()) {
-                    if (event instanceof BasicEvent basicEvent) {
-                        if (basicEvent.getTargetJourney() != null) {
-                            var basicEventStateMachine =
-                                    new StateMachineInitializer(
-                                                    IpvJourneyTypes.valueOf(
-                                                            basicEvent.getTargetJourney()))
-                                            .initialize();
-                            var basicEventStateMachineKeys = basicEventStateMachine.keySet();
-                            assertTrue(
-                                    basicEventStateMachineKeys.contains(
-                                            basicEvent.getTargetState()),
-                                    "Unknown target state %s"
-                                            .formatted(basicEvent.getTargetState()));
-
-                        } else if (basicEvent.getTargetState() != null) {
-                            assertTrue(
-                                    stateMachineKeys.contains(basicEvent.getTargetState()),
-                                    "Unknown target state %s"
-                                            .formatted(basicEvent.getTargetState()));
-                        }
-                    }
+                    checkTargetStatesExist(event, stateMachineKeys);
                 }
             }
         }
@@ -244,6 +224,37 @@ class JourneyMapTest {
                         actualExitEvents,
                         String.format(
                                 "%s doesn't have matching exit states to nested journey", state));
+            }
+        }
+    }
+
+    private void checkTargetStatesExist(Event event, Set<String> stateMachineKeys) throws IOException {
+        if (event instanceof BasicEvent basicEvent) {
+            if (basicEvent.getTargetJourney() != null) {
+                var basicEventStateMachine =
+                        new StateMachineInitializer(
+                                IpvJourneyTypes.valueOf(
+                                        basicEvent.getTargetJourney()))
+                                .initialize();
+                var basicEventStateMachineKeys = basicEventStateMachine.keySet();
+                assertTrue(
+                        basicEventStateMachineKeys.contains(
+                                basicEvent.getTargetState()),
+                        "Unknown target state %s"
+                                .formatted(basicEvent.getTargetState()));
+
+            } else if (basicEvent.getTargetState() != null) {
+                assertTrue(
+                        stateMachineKeys.contains(basicEvent.getTargetState()),
+                        "Unknown target state %s"
+                                .formatted(basicEvent.getTargetState()));
+            }
+
+            var eventsIfDisabled = basicEvent.getCheckIfDisabled();
+            if (eventsIfDisabled != null) {
+                for (var eventIfDisabled : eventsIfDisabled.values()) {
+                    checkTargetStatesExist(eventIfDisabled, stateMachineKeys);
+                }
             }
         }
     }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The `basicEventTargetStatesShouldExist` test

### Why did it change

It currently doesn't check target states under `ifDisabled` conditions but it should
