### PR TITLE
PYIC-6611: provider test for reverification endpoint

### DIFF
--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -65,3 +65,9 @@ jobs:
         with:
           name: issue-client-access-token provider pact test report
           path: /home/runner/work/ipv-core-back/ipv-core-back/lambdas/issue-client-access-token/build/reports/tests/pactProviderTests/
+      - name: Upload user-reverification provider pact test report
+        if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: user-reverification provider pact test report
+          path: /home/runner/work/ipv-core-back/ipv-core-back/lambdas/user-reverification/build/reports/tests/pactProviderTests/

--- a/lambdas/user-reverification/build.gradle
+++ b/lambdas/user-reverification/build.gradle
@@ -20,7 +20,8 @@ dependencies {
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
 			libs.pactProviderJunit,
-			project(path: ':libs:common-services', configuration: 'tests')
+			project(path: ':libs:common-services', configuration: 'tests'),
+			project(path: ':libs:pact-test-helpers')
 
 	testRuntimeOnly libs.junitPlatform
 }
@@ -35,6 +36,14 @@ test {
 	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
+}
+
+task pactProviderTests (type: Test) {
+	useJUnitPlatform()
+	include 'uk/gov/di/ipv/core/userreverification/pact/**'
+	systemProperties['pact.verifier.publishResults'] = "true"
+	systemProperties['pact.provider.branch'] = "${System.env.GIT_BRANCH}"
+	systemProperties['pact.provider.version'] = "${System.env.GIT_SHA}"
 }
 
 jacocoTestReport {

--- a/lambdas/user-reverification/build.gradle
+++ b/lambdas/user-reverification/build.gradle
@@ -36,6 +36,7 @@ test {
 	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
+	exclude 'uk/gov/di/ipv/core/userreverification/pact/**'
 }
 
 task pactProviderTests (type: Test) {

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
@@ -115,10 +115,11 @@ public class UserReverificationHandlerTest {
     }
 
     @State("accessToken is a invalid access token")
-    /*
-    This method is empty as it doesn't set an access token in order to invoke a 403
-     */
-    public void dontSetAccessToken() {}
+    public void dontSetAccessToken() {
+        /*
+            This method is empty as it doesn't set an access token in order to invoke a 403
+        */
+    }
 
     @TestTemplate
     @ExtendWith(PactVerificationInvocationContextProvider.class)

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
@@ -117,7 +117,7 @@ public class UserReverificationHandlerTest {
     @State("accessToken is a invalid access token")
     public void dontSetAccessToken() {
         /*
-            This method is empty as it doesn't set an access token in order to invoke a 403
+            This method is empty - access tokens are invalid by default
         */
     }
 

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
@@ -1,0 +1,126 @@
+package uk.gov.di.ipv.core.userreverification.pact;
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import au.com.dius.pact.provider.junitsupport.loader.SelectorBuilder;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
+import uk.gov.di.ipv.core.library.pacttesthelpers.LambdaHttpServer;
+import uk.gov.di.ipv.core.library.persistence.DataStore;
+import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
+import uk.gov.di.ipv.core.library.retry.Sleeper;
+import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.service.IpvSessionService;
+import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
+import uk.gov.di.ipv.core.userreverification.UserReverificationHandler;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.when;
+
+// To run these tests locally you need to:
+// - Obtain the relevant pact file (from the pact broker or another team) and put it in
+//   /lambdas/build-user-identity/pacts. See the `Running provider pact tests locally` section of
+//   the README for details on how to get the pact file
+// - Comment out the @PactBroker annotation below
+// - Uncomment @PactFolder annotation below
+@Provider("IpvCoreBackReverificationProvider")
+// @PactBroker(
+//        url = "${PACT_URL}?testSource=${PACT_BROKER_SOURCE_SECRET_DEV}",
+//        authentication = @PactBrokerAuth(username = "${PACT_USER}", password =
+// "${PACT_PASSWORD}"))
+@PactFolder("pacts")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UserReverificationHandlerTest {
+    private static final String IPV_SESSION_ID = "mockIpvSessionId";
+
+    private LambdaHttpServer httpServer;
+
+    @Mock private Sleeper mockSleeper;
+    @Mock private DataStore<IpvSessionItem> mockIpvSessionDataStore;
+    @Mock private ConfigService mockConfigService;
+    @Mock private DataStore<ClientOAuthSessionItem> mockOAuthSessionStore;
+    @Mock private DataStore<SessionCredentialItem> mockSessionCredentialItemStore;
+
+    @PactBrokerConsumerVersionSelectors
+    public static SelectorBuilder consumerVersionSelectors() {
+        return new SelectorBuilder().mainBranch();
+    }
+
+    @BeforeAll
+    static void setupServer() {
+        System.setProperty("pact.content_type.override.application/jwt", "text");
+    }
+
+    @BeforeEach
+    void pactSetup(PactVerificationContext context) throws IOException {
+        var ipvSessionService = new IpvSessionService(mockIpvSessionDataStore, mockSleeper);
+        var clientOAuthSessionDetailsService =
+                new ClientOAuthSessionDetailsService(mockOAuthSessionStore);
+        var sessionCredentialService =
+                new SessionCredentialsService(mockSessionCredentialItemStore);
+
+        var handler =
+                new UserReverificationHandler(
+                        ipvSessionService,
+                        mockConfigService,
+                        clientOAuthSessionDetailsService,
+                        sessionCredentialService);
+
+        httpServer = new LambdaHttpServer(handler, "/reverification");
+        httpServer.startServer();
+
+        context.setTarget(new HttpTestTarget("localhost", httpServer.getPort()));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        httpServer.stopServer();
+    }
+
+    @State("accessToken is a valid access token")
+    public void setAccessToken() {
+        var ipvSession = new IpvSessionItem();
+        ipvSession.setIpvSessionId(IPV_SESSION_ID);
+        ipvSession.setClientOAuthSessionId("mockClientOAuthSessionId");
+        ipvSession.setAccessTokenMetadata(new AccessTokenMetadata());
+
+        var oAuthSession = new ClientOAuthSessionItem();
+        oAuthSession.setUserId("mockUserId");
+        oAuthSession.setClientId("mockClientId");
+        oAuthSession.setGovukSigninJourneyId("mockGovukSigninJourneyId");
+        oAuthSession.setScope("reverification");
+
+        when(mockOAuthSessionStore.getItem("mockClientOAuthSessionId")).thenReturn(oAuthSession);
+        when(mockIpvSessionDataStore.getItemByIndex(
+                        "accessToken", DigestUtils.sha256Hex("accessToken")))
+                .thenReturn(ipvSession);
+    }
+
+    @State("accessToken is a invalid access token")
+    public void dontSetAccessToken() {}
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void testMethod(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+}

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
@@ -115,7 +115,9 @@ public class UserReverificationHandlerTest {
     }
 
     @State("accessToken is a invalid access token")
-    // This method is empty as it doesn't set an access token in order to invoke a 403
+    /*
+    This method is empty as it doesn't set an access token in order to invoke a 403
+     */
     public void dontSetAccessToken() {}
 
     @TestTemplate

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
@@ -114,8 +114,8 @@ public class UserReverificationHandlerTest {
                 .thenReturn(ipvSession);
     }
 
-    // This method is empty as it doesn't set an access token in order to invoke a 403
     @State("accessToken is a invalid access token")
+    // This method is empty as it doesn't set an access token in order to invoke a 403
     public void dontSetAccessToken() {}
 
     @TestTemplate

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
@@ -114,6 +114,7 @@ public class UserReverificationHandlerTest {
                 .thenReturn(ipvSession);
     }
 
+    // This method is empty as it doesn't set an access token in order to invoke a 403
     @State("accessToken is a invalid access token")
     public void dontSetAccessToken() {}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Adds provider test for reverification endpoint.

### Why did it change
The Auth consumer test has been added for the reverification endpoint so the provider tests need to be added to check it aligns with the pact produced from the consumer test.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6611](https://govukverify.atlassian.net/browse/PYIC-6611)


[PYIC-6611]: https://govukverify.atlassian.net/browse/PYIC-6611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ