### PR TITLE
Pyic 7051 update no photo id kbv fail page

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -528,11 +528,11 @@ states:
         targetJourney: EVALUATE_SCORES
         targetState: START
       enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: enhanced-verification
+        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
@@ -587,11 +587,11 @@ states:
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: enhanced-verification
+        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
@@ -916,25 +916,6 @@ states:
     response:
       type: page
       pageId: pyi-suggest-other-options
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-
-  MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options
-      context: no-photo-id
     events:
       f2f:
         targetJourney: F2F_HAND_OFF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -930,26 +930,6 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
-  # PYIC-7051 Remove once route changes have been live some time.
-  MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options
-      context: no-photo-id
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-
   PYI_POST_OFFICE:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -541,9 +541,9 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
 
   # DWP KBV journey (J7)
   CRI_DWP_KBV_J7:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -930,6 +930,26 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
+  # PYIC-7051 Remove once route changes have been live some time.
+  MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+      context: no-photo-id
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
   PYI_POST_OFFICE:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -969,26 +969,6 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
-  # PYIC-7051 Remove once route changes have been live some time.
-  MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options
-      context: no-photo-id
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-
   PYI_POST_OFFICE:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -969,6 +969,26 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
+  # PYIC-7051 Remove once route changes have been live some time.
+  MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+      context: no-photo-id
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: CRI_DCMAW_PYI_ESCAPE
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
   PYI_POST_OFFICE:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -540,11 +540,11 @@ states:
         targetJourney: EVALUATE_SCORES
         targetState: START
       enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: enhanced-verification
+        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
@@ -599,11 +599,11 @@ states:
       access-denied:
         targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: enhanced-verification
+        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
             targetState: MITIGATION_02_OPTIONS
@@ -955,25 +955,6 @@ states:
     response:
       type: page
       pageId: pyi-suggest-other-options
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-      appTriage:
-        targetState: CRI_DCMAW_PYI_ESCAPE
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-
-  MITIGATION_02_OPTIONS_WITH_F2F_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options
-      context: no-photo-id
     events:
       f2f:
         targetJourney: F2F_HAND_OFF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -553,9 +553,9 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
 
   # DWP KBV journey (J7)
   CRI_DWP_KBV_J7:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update routing to make enhanced verification route consistent between Experian, HMRC, and DWP KBV CRIs.

Also fix bug where no-photo-id HRMC KBV CRI failures jumped out of the no-photo-id path

### Why did it change

The Experian route is more up to date and better for users.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7051](https://govukverify.atlassian.net/browse/PYIC-7051)


[PYIC-7051]: https://govukverify.atlassian.net/browse/PYIC-7051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ