### PR TITLE
PYIC-7179: Use TICF CRI enabled setting

### DIFF
--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -44,7 +44,8 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredential
 
 import java.util.Map;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.TICF_CRI_BETA;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CREDENTIAL_ISSUER_ENABLED;
+import static uk.gov.di.ipv.core.library.domain.Cri.TICF;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.OPENID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_VOT;
@@ -123,7 +124,8 @@ public class BuildUserIdentityHandler extends UserIdentityRequestHandler
                     userIdentityService.generateUserIdentity(
                             vcs, userId, achievedVot, targetVot, contraIndicators);
             userIdentity.getVcs().add(contraIndicatorsVc.getVcString());
-            if (configService.enabled(TICF_CRI_BETA)
+
+            if (configService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, TICF.getId())
                     && (ipvSessionItem.getRiskAssessmentCredential() != null)) {
                 userIdentity.getVcs().add(ipvSessionItem.getRiskAssessmentCredential());
             }

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -79,9 +79,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CREDENTIAL_ISSUER_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.TICF_CRI_BETA;
 import static uk.gov.di.ipv.core.library.domain.Cri.CIMIT;
+import static uk.gov.di.ipv.core.library.domain.Cri.TICF;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.ADDRESS_JSON_1;
@@ -218,7 +219,6 @@ class BuildUserIdentityHandlerTest {
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
         when(mockContraIndicators.hasMitigations()).thenReturn(true);
-        when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(false);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(VC_ADDRESS));
@@ -285,7 +285,6 @@ class BuildUserIdentityHandlerTest {
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
         when(mockContraIndicators.hasMitigations()).thenReturn(true);
-        when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(false);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(VC_ADDRESS));
@@ -352,7 +351,6 @@ class BuildUserIdentityHandlerTest {
         ContraIndicators mockContraIndicators = mock(ContraIndicators.class);
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
         when(mockContraIndicators.hasMitigations()).thenReturn(true);
-        when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(false);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(VC_ADDRESS));
@@ -505,7 +503,8 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
-        when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(true);
+        when(mockConfigService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, TICF.getId()))
+                .thenReturn(true);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         // Act
         APIGatewayProxyResponseEvent response =
@@ -581,7 +580,6 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(
                         VerifiableCredential.fromValidJwt(
                                 TEST_USER_ID, CIMIT, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC)));
-        when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(true);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         // Act
         APIGatewayProxyResponseEvent response =
@@ -762,7 +760,6 @@ class BuildUserIdentityHandlerTest {
         when(mockCiMitService.getContraIndicators(any())).thenReturn(mockContraIndicators);
 
         when(mockContraIndicators.hasMitigations()).thenReturn(true);
-        when(mockConfigService.enabled(TICF_CRI_BETA)).thenReturn(false);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
 
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
@@ -35,10 +35,10 @@ states:
       lambda: evaluate-gpg45-scores
     events:
       met:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_SUCCESS
+        targetState: CRI_TICF_BEFORE_SUCCESS
+        checkIfDisabled:
+          ticf:
+            targetState: STORE_IDENTITY_BEFORE_SUCCESS
       unmet:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -7,10 +7,10 @@ states:
   START:
     events:
       next:
-        targetState: CRI_F2F
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_F2F
+        targetState: CRI_TICF_BEFORE_F2F
+        checkIfDisabled:
+          ticf:
+            targetState: CRI_F2F
 
   # Parent states
   CRI_STATE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -11,30 +11,30 @@ states:
   FAILED:
     events:
       next:
-        targetState: NO_MATCH_PAGE
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_NO_MATCH
+        targetState: CRI_TICF_BEFORE_NO_MATCH
+        checkIfDisabled:
+          ticf:
+            targetState: NO_MATCH_PAGE
 
   FAILED_SKIP_MESSAGE:
     events:
       next:
-        targetState: RETURN_TO_RP
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        checkIfDisabled:
+          ticf:
+            targetState: RETURN_TO_RP
 
   FAILED_CONFIRM_DETAILS:
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE
+        targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS
+        checkIfDisabled:
+          ticf:
+            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE
             auditEvents:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
@@ -43,14 +43,14 @@ states:
   FAILED_UPDATE_DETAILS:
     events:
       next:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+        targetState: CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS
+        checkIfDisabled:
+          ticf:
+            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
             auditEvents:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
@@ -59,18 +59,18 @@ states:
   FAILED_BAV:
     events:
       next:
-        targetState: NO_MATCH_PAGE_BAV
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
+        targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
+        checkIfDisabled:
+          ticf:
+            targetState: NO_MATCH_PAGE_BAV
 
   FAILED_NINO:
     events:
       next:
-        targetState: NO_MATCH_PAGE_NINO
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_NO_MATCH_NINO
+        targetState: CRI_TICF_BEFORE_NO_MATCH_NINO
+        checkIfDisabled:
+          ticf:
+            targetState: NO_MATCH_PAGE_NINO
 
   FAILED_NO_TICF:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -10,10 +10,10 @@ states:
   INELIGIBLE:
     events:
       next:
-        targetState: ANOTHER_WAY_PAGE
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_ANOTHER_WAY
+        targetState: CRI_TICF_BEFORE_ANOTHER_WAY
+        checkIfDisabled:
+          ticf:
+            targetState: ANOTHER_WAY_PAGE
 
   INELIGIBLE_NO_TICF:
     events:
@@ -23,10 +23,10 @@ states:
   INELIGIBLE_SKIP_MESSAGE:
     events:
       next:
-        targetState: RETURN_TO_RP
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        checkIfDisabled:
+          ticf:
+            targetState: RETURN_TO_RP
 
   # Journey states
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -819,9 +819,6 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
@@ -833,9 +830,6 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -858,9 +858,6 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
@@ -872,9 +869,6 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
@@ -9,10 +9,10 @@ states:
   START:
     events:
       next:
-        targetState: RETURN_TO_RP
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        checkIfDisabled:
+          ticf:
+            targetState: RETURN_TO_RP
 
   # Journey states
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -9,10 +9,10 @@ states:
   START:
     events:
       next:
-        targetState: RETURN_TO_RP
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        checkIfDisabled:
+          ticf:
+            targetState: RETURN_TO_RP
 
   # Journey states
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -267,10 +267,10 @@ states:
       lambda: evaluate-gpg45-scores
     events:
       met:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_SUCCESS_RFC
+        targetState: CRI_TICF_BEFORE_SUCCESS_RFC
+        checkIfDisabled:
+          ticf:
+            targetState: STORE_IDENTITY_BEFORE_SUCCESS
       unmet:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -9,12 +9,13 @@ states:
   START:
     events:
       next:
-        targetState: IDENTITY_REUSE_PAGE
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_REUSE
-          deleteDetailsEnabled:
-            targetState: IDENTITY_REUSE_PAGE_TEST
+        targetState: CRI_TICF_BEFORE_REUSE
+        checkIfDisabled:
+          ticf:
+            targetState: IDENTITY_REUSE_PAGE
+            checkFeatureFlag:
+              deleteDetailsEnabled:
+                targetState: IDENTITY_REUSE_PAGE_TEST
 
   UPDATE_DETAILS_START:
     events:
@@ -39,12 +40,13 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       identity-stored:
-        targetState: IDENTITY_REUSE_PAGE
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_REUSE
-          deleteDetailsEnabled:
-            targetState: IDENTITY_REUSE_PAGE_TEST
+        targetState: CRI_TICF_BEFORE_REUSE
+        checkIfDisabled:
+          ticf:
+            targetState: IDENTITY_REUSE_PAGE
+            checkFeatureFlag:
+              deleteDetailsEnabled:
+                targetState: IDENTITY_REUSE_PAGE_TEST
 
   CRI_TICF_BEFORE_REUSE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -120,10 +120,10 @@ states:
         checkType: FULL_NAME_AND_DOB
     events:
       coi-check-passed:
-        targetState: RETURN_TO_RP
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF
+        targetState: CRI_TICF
+        checkIfDisabled:
+          ticf:
+            targetState: RETURN_TO_RP
       coi-check-failed:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -10,10 +10,10 @@ states:
   ERROR:
     events:
       next:
-        targetState: ERROR_PAGE
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_ERROR
+        targetState: CRI_TICF_BEFORE_ERROR
+        checkIfDisabled:
+          ticf:
+            targetState: ERROR_PAGE
 
   ERROR_NO_TICF:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -73,10 +73,10 @@ states:
       lambda: evaluate-gpg45-scores
     events:
       met:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS
+        targetState: CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS
+        checkIfDisabled:
+          ticf:
+            targetState: STORE_IDENTITY_BEFORE_SUCCESS
       unmet:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -480,10 +480,10 @@ states:
       lambda: evaluate-gpg45-scores
     events:
       met:
-        targetState: STORE_IDENTITY_BEFORE_SUCCESS
-        checkFeatureFlag:
-          ticfCriBeta:
-            targetState: CRI_TICF_BEFORE_SUCCESS
+        targetState: CRI_TICF_BEFORE_SUCCESS
+        checkIfDisabled:
+          ticf:
+            targetState: STORE_IDENTITY_BEFORE_SUCCESS
       unmet:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -5,7 +5,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     RESET_IDENTITY("resetIdentity"),
     INHERITED_IDENTITY("inheritedIdentity"),
     REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
-    TICF_CRI_BETA("ticfCriBeta"),
     EVCS_WRITE_ENABLED("evcsWriteEnabled"),
     EVCS_ASYNC_WRITE_ENABLED("evcsAsyncWriteEnabled"),
     EVCS_READ_ENABLED("evcsReadEnabled"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use TICF CRI enabled setting

### Why did it change

[PYIC-7179: Use TICF CRI enabled setting](https://github.com/govuk-one-login/ipv-core-back/commit/99567c64fba72eb6cd04ccbef3d9fd0ce12f6c41)

We're currently using a feature flag to determine if we should be
calling the TICF CRI or not. The CRI config for TICF includes an
"enabled" value, similarly to other CRIs. We can use this rather than a
flag to route journeys. This means we can remove that flag.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7179](https://govukverify.atlassian.net/browse/PYIC-7179)


[PYIC-7179]: https://govukverify.atlassian.net/browse/PYIC-7179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ