### PR TITLE
PYIC-7232: Remove ticfCriBeta feature flag from local

### DIFF
--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -348,7 +348,6 @@ core:
     deleteDetailsEnabled: false
     pendingF2FResetEnabled: false
     strategicAppEnabled: false
-    ticfCriBeta: false
     inheritedIdentity: true
     repeatFraudCheckEnabled: true
     evcsWriteEnabled: true
@@ -418,8 +417,6 @@ core:
       featureFlags:
         pendingF2FResetEnabled: true
     ticfCriBeta:
-      featureFlags:
-        ticfCriBeta: true
       credentialIssuers:
         ticf:
           enabled: true


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove ticfCriBeta feature flag from local

### Why did it change

This flag has already been removed and can be cleaned up from the local running config.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7232](https://govukverify.atlassian.net/browse/PYIC-7232)


[PYIC-7232]: https://govukverify.atlassian.net/browse/PYIC-7232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ