### PR TITLE
PYIC-7209: remove unused context for p1 journey dropout

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -689,7 +689,6 @@ states:
     response:
       type: page
       pageId: no-photo-id-security-questions-find-another-way
-      context: p1
     events:
       f2f:
         targetJourney: F2F_HAND_OFF
@@ -723,7 +722,7 @@ states:
     response:
       type: page
       pageId: no-photo-id-security-questions-find-another-way
-      context: p1Dropout
+      context: dropout
     events:
       f2f:
         targetJourney: F2F_HAND_OFF


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- remove unused context for p1 journey dropout

### What changed

- removed p1 context for the dropout journey

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- Not in use anymore

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7209](https://govukverify.atlassian.net/browse/PYIC-7209)


Front PR : https://github.com/govuk-one-login/ipv-core-front/pull/1540


[PYIC-7209]: https://govukverify.atlassian.net/browse/PYIC-7209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ