### PR TITLE
PYIC-7277: Enable CRI api authorize to take both old and new stub response formats

### DIFF
--- a/api-tests/src/clients/cri-stub-client.ts
+++ b/api-tests/src/clients/cri-stub-client.ts
@@ -13,13 +13,17 @@ export const callHeadlessApi = async (
     },
   );
 
-  if (!(criStubResponse.status === 302)) {
-    throw new Error(
-      `callHeadlessApi request failed: ${criStubResponse.statusText}`,
-    );
+  if (criStubResponse.status === 200) {
+    return criStubResponse.json();
   }
 
-  return {
-    redirectUri: criStubResponse.headers.get("location") as string,
-  };
+  if (criStubResponse.status === 302) {
+    return {
+      redirectUri: criStubResponse.headers.get("location") as string,
+    };
+  }
+
+  throw new Error(
+    `callHeadlessApi request failed: ${criStubResponse.statusText}`,
+  );
 };

--- a/api-tests/src/types/cri-stub.ts
+++ b/api-tests/src/types/cri-stub.ts
@@ -25,4 +25,5 @@ export interface CriStubRequest {
 
 export interface CriStubResponse {
   redirectUri: string;
+  jarPayload?: object;
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Enable CRI api authorize to return 200 & body as well as the redirect without breaking

### Why did it change

- So we can merge in the new stub api responses which includes a jarPayload and 200 status code instead of 302

### Issue tracking

- [PYIC-7277](https://govukverify.atlassian.net/browse/PYIC-7277)

[PYIC-7277]: https://govukverify.atlassian.net/browse/PYIC-7277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ