### PR TITLE
PYIC-6857 configurable parallelism and logging

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -78,6 +78,7 @@ import static uk.gov.di.ipv.core.library.domain.ProfileType.OPERATIONAL_HMRC;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.VOT_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.enums.EvcsVCState.CURRENT;
 import static uk.gov.di.ipv.core.library.enums.EvcsVCState.PENDING_RETURN;
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_GPG45_PROFILE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_VOT;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpAddress;
@@ -851,6 +852,11 @@ public class CheckExistingIdentityHandler
                     gpg45Credentials.add(vc);
                 }
             }
+            LOGGER.info(
+                    LogHelper.buildLogMessage("GPG45 profile has been met.")
+                            .with(
+                                    LOG_GPG45_PROFILE.getFieldName(),
+                                    matchedGpg45Profile.get().getLabel()));
             sendProfileMatchedAuditEvent(
                     matchedGpg45Profile.get(),
                     gpg45Scores,

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_GPG45_PROFILE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_JOURNEY_RESPONSE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
@@ -225,6 +226,11 @@ public class EvaluateGpg45ScoresHandler
                                         contraIndicators, requestedVot);
 
                 if (matchedProfile.isPresent() && !isBreaching) {
+                    LOGGER.info(
+                            LogHelper.buildLogMessage("GPG45 profile has been met.")
+                                    .with(
+                                            LOG_GPG45_PROFILE.getFieldName(),
+                                            matchedProfile.get().getLabel()));
                     auditService.sendAuditEvent(
                             buildProfileMatchedAuditEvent(
                                     ipvSessionItem,

--- a/lambdas/report-user-identity/src/main/java/uk/gov/di/ipv/core/reportuseridentity/domain/ReportProcessingRequest.java
+++ b/lambdas/report-user-identity/src/main/java/uk/gov/di/ipv/core/reportuseridentity/domain/ReportProcessingRequest.java
@@ -12,4 +12,5 @@ public record ReportProcessingRequest(
         Map<String, Object> tacticalStoreLastEvaluatedKey,
         Map<String, Object> userIdentitylastEvaluatedKey,
         Map<String, Object> buildReportLastEvaluatedKey,
-        Integer pageSize) {}
+        Integer pageSize,
+        Integer parallelism) {}

--- a/lambdas/report-user-identity/src/main/java/uk/gov/di/ipv/core/reportuseridentity/service/ReportUserIdentityService.java
+++ b/lambdas/report-user-identity/src/main/java/uk/gov/di/ipv/core/reportuseridentity/service/ReportUserIdentityService.java
@@ -1,15 +1,11 @@
 package uk.gov.di.ipv.core.reportuseridentity.service;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45Scores;
-import uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.model.PersonWithDocuments;
 
@@ -19,12 +15,8 @@ import java.util.Optional;
 import static com.nimbusds.oauth2.sdk.util.CollectionUtils.isNotEmpty;
 import static uk.gov.di.ipv.core.library.domain.ProfileType.GPG45;
 import static uk.gov.di.ipv.core.library.enums.Vot.SUPPORTED_VOTS_BY_DESCENDING_STRENGTH;
-import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
-import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_VOT;
 
 public class ReportUserIdentityService {
-    private static final Logger LOGGER = LogManager.getLogger();
-
     private final Gpg45ProfileEvaluator gpg45ProfileEvaluator;
 
     @ExcludeFromGeneratedCoverageReport
@@ -82,18 +74,8 @@ public class ReportUserIdentityService {
     }
 
     private boolean achievedWithGpg45Profile(Vot votToCheck, Gpg45Scores gpg45Scores) {
-        Optional<Gpg45Profile> matchedGpg45Profile =
-                gpg45ProfileEvaluator.getFirstMatchingProfile(
-                        gpg45Scores, votToCheck.getSupportedGpg45Profiles());
-
-        // Successful match
-        if (matchedGpg45Profile.isPresent()) {
-            LOGGER.info(
-                    new StringMapMessage()
-                            .with(LOG_MESSAGE_DESCRIPTION.getFieldName(), "GPG45 profile matched")
-                            .with(LOG_VOT.getFieldName(), votToCheck));
-            return true;
-        }
-        return false;
+        return gpg45ProfileEvaluator
+                .getFirstMatchingProfile(gpg45Scores, votToCheck.getSupportedGpg45Profiles())
+                .isPresent();
     }
 }

--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/Gpg45ProfileEvaluator.java
@@ -1,8 +1,5 @@
 package uk.gov.di.ipv.core.library.gpg45;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile;
 import uk.gov.di.model.CheckDetails;
@@ -22,33 +19,13 @@ import java.util.stream.Stream;
 import static java.util.Objects.requireNonNullElse;
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import static software.amazon.awssdk.utils.StringUtils.isEmpty;
-import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_GPG45_PROFILE;
-import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 
 public class Gpg45ProfileEvaluator {
-    private static final Logger LOGGER = LogManager.getLogger();
     private static final int NO_SCORE = 0;
 
     public Optional<Gpg45Profile> getFirstMatchingProfile(
             Gpg45Scores gpg45Scores, List<Gpg45Profile> profiles) {
-        return profiles.stream()
-                .filter(
-                        profile -> {
-                            boolean profileMet = profile.isSatisfiedBy(gpg45Scores);
-                            if (profileMet) {
-                                var message =
-                                        new StringMapMessage()
-                                                .with(
-                                                        LOG_MESSAGE_DESCRIPTION.getFieldName(),
-                                                        "GPG45 profile has been met.")
-                                                .with(
-                                                        LOG_GPG45_PROFILE.getFieldName(),
-                                                        profile.getLabel());
-                                LOGGER.info(message);
-                            }
-                            return profileMet;
-                        })
-                .findFirst();
+        return profiles.stream().filter(profile -> profile.isSatisfiedBy(gpg45Scores)).findFirst();
     }
 
     public Gpg45Scores buildScore(List<VerifiableCredential> vcs) {

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -7,6 +7,7 @@ import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.gpg45.validators.Gpg45IdentityCheckValidator;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.model.BirthDate;
 import uk.gov.di.model.DrivingPermitDetails;
@@ -34,6 +35,7 @@ import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.FRAUD_CHECK_EXPIRY_PERIOD_HOURS;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.VOT_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.helpers.ListHelper.extractFromFirstElementOfList;
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ISSUER;
 
 public class VcHelper {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -52,8 +54,10 @@ public class VcHelper {
             var evidence = identityCheckCredential.getEvidence();
             if (isNullOrEmpty(evidence)) {
                 LOGGER.warn(
-                        "Unexpected missing evidence on VC from issuer: {}",
-                        vc.getClaimsSet().getIssuer());
+                        LogHelper.buildLogMessage("Unexpected missing evidence on VC")
+                                .with(
+                                        LOG_CRI_ISSUER.getFieldName(),
+                                        vc.getClaimsSet().getIssuer()));
                 return false;
             }
             return evidence.stream()


### PR DESCRIPTION
## Proposed changes

### What changed

- Ability to supply a 'parallelism' to the script, to control degree of parallelism
- Added logs to step 1, so activity is visible
- Removed profile matching logs from step 2

### Why did it change

- The parallelism makes a big difference to the speed of the lambda, and can be tuned to speed up the process.
- The existing logs for step 1 don't indicate it doing anything
- The existing logs for step 2 are very noisy - logging two GPG45 profile matched messages for every match
