### PR TITLE
PYIC-7324: Write VCs directly to EVCS for reuse tests

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -163,6 +163,8 @@ jobs:
         env:
           ASYNC_QUEUE_NAME: ${{ steps.extract_queue_name.outputs.queue_name }}
           MANAGEMENT_CIMIT_STUB_API_KEY: ${{ secrets.MANAGEMENT_CIMIT_STUB_API_KEY }}
+          EVCS_STUB_API_KEY: ${{ secrets.API_KEY_EVCS }}
+          CRI_STUB_GEN_CRED_API_KEY: ${{ secrets.CRI_STUB_GEN_CRED_API_KEY }}
         run: npm run test:ci
 
       - name: Upload API test report

--- a/api-tests/.env.build
+++ b/api-tests/.env.build
@@ -3,14 +3,19 @@ CORE_BACK_COMPONENT_ID="https://identity.build.account.gov.uk"
 CORE_BACK_INTERNAL_API_URL="https://internal-test-api.identity.build.account.gov.uk"
 CORE_BACK_EXTERNAL_API_URL="https://api.identity.build.account.gov.uk"
 CORE_BACK_PUBLIC_ENCRYPTION_KEY='{"kty":"RSA","e":"AQAB","n":"nel7ibmSTaXWhwEAdqKTiEVcxsYgv6CdXaz90aVN7IorlaCeNj0j06OsA4zdmWEjj21wEZULsxPoZo5N_tsQ7NtOnOkcnDc-g_Nbpt0jelzJSbFRkx3kwXy8YIYKR_myNbiHNTTc7S6GkQRg0N1MPWtzoEKYJs41AN4onrsvUzgpCypWwPy2-ppsaDvms_11YA7A7x3zHj9oKCPJ_uk_0MV3vZAxCxbiPb9ABGWcoGQ5QKGfv40ylBsEdOhE3w-3SAAQIrrHyMRGGiPxcNO161XVL-lOnYt93FgEe16LgpfE22UdENfHnG0UQaTgph1Dm24oqn7qpPTY2DfER5HCKQ"}' # pragma: allowlist secret
+CORE_BACK_CRI_CLIENT_ID="ipv-core-build"
 ORCHESTRATOR_REDIRECT_URL="https://orch.stubs.account.gov.uk/callback"
 # The below private key is a test key that is already in the public domain. It is not used for anything sensitive.
 JAR_SIGNING_KEY='{"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}' # pragma: allowlist secret
 ASYNC_QUEUE_NAME="stubQueue_F2FQueue_build"
 ASYNC_QUEUE_DELAY=5
+EVCS_STUB_BASE_URL="https://evcs.stubs.account.gov.uk"
 
 # These aren't needed for build but are required to have a value for config
 CIMIT_STUB_BASE_URL="https://cimit.stubs.account.gov.uk"
 MANAGEMENT_CIMIT_STUB_API_KEY="some-value" # pragma: allowlist secret
 
-# Also requires CORE_BACK_INTERNAL_API_KEY to be specified in .env or as an environment variable
+# Also requires the following to be specified in .env or as an env variable
+# CORE_BACK_INTERNAL_API_KEY
+# CRI_STUB_GEN_CRED_API_KEY
+# EVCS_STUB_API_KEY

--- a/api-tests/.env.local
+++ b/api-tests/.env.local
@@ -4,11 +4,16 @@ CORE_BACK_INTERNAL_API_URL="http://localhost:4502"
 CORE_BACK_INTERNAL_API_KEY=
 CORE_BACK_EXTERNAL_API_URL="http://localhost:4502"
 CORE_BACK_PUBLIC_ENCRYPTION_KEY='{"kty": "RSA","n": "0465qJwo8nCkC2tvV4niuWF6IM6pNjmeYszhTwHPY609-HVAtO8PoRLUyA86rzQ-QzbT7XxbzCjfyRXoRFOGleZqTuwlc25ezDxV58bhecPiWFMaFYOS1W7zIDsVFo37gjjvtkcD6OqK8PKAv6n5tUphjDCcnnmpTMIyGAnzmQCbSkJWu6V_gc3tirAugXoZukMCohxw3_-c6prhMN0smDNv0qWmva3oqokabePwe1OS72DXyXR-TPd_Dtz4-tRr9jvZwHulX4Zcs1BBbjBpIim3WNY8asv9yjlBxkdt-nckhCMZekPuT7xWSTrvccB_fnnSUgEQW_5irLNdnr5MWQ","e": "AQAB","alg": "RS256"}' # pragma: allowlist secret
+CORE_BACK_CRI_CLIENT_ID="ipv-core-local"
 ORCHESTRATOR_REDIRECT_URL="http://localhost:4500/callback"
 JAR_SIGNING_KEY='{"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}' # pragma: allowlist secret
 LOCAL_AUDIT_EVENTS=true
 ASYNC_QUEUE_DELAY=2
 CIMIT_STUB_BASE_URL="https://cimit.stubs.account.gov.uk"
+EVCS_STUB_BASE_URL="https://evcs.stubs.account.gov.uk"
 
-# Also requires ASYNC_QUEUE_NAME to be specified in .env or as an environment variable
-# Also requires MANAGEMENT_CIMIT_STUB_API_KEY to be specified in .env or as an environment variable
+# Also requires the following to be specified in .env or as an env variable
+# ASYNC_QUEUE_NAME
+# MANAGEMENT_CIMIT_STUB_API_KEY
+# CRI_STUB_GEN_CRED_API_KEY
+# EVCS_STUB_API_KEY

--- a/api-tests/.env.template
+++ b/api-tests/.env.template
@@ -6,3 +6,9 @@
 
 # Required for CiMit journeys in local, found in API Gateway for Cimit External API
 # MANAGEMENT_CIMIT_STUB_API_KEY=
+
+# Required for generating VCs directly with the CRI stubs
+# CRI_STUB_GEN_CRED_API_KEY=
+
+# Required for sending VCs directly to the EVCS stub
+# EVCS_STUB_API_KEY=

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -2,22 +2,11 @@
 Feature: MFA reset journey
 
   Scenario: MFA reset journey
-    Given I start a new 'medium-confidence' journey
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P2' identity
+    Given the subject already has the following credentials
+      | CRI     | scenario                     |
+      | dcmaw   | kenneth-driving-permit-valid |
+      | address | kenneth-current              |
+      | fraud   | kenneth-score-2              |
 
     # Start MFA Reset journey for existing user
     When I start a new 'reverification' journey

--- a/api-tests/features/p2-coi-update-details.feature
+++ b/api-tests/features/p2-coi-update-details.feature
@@ -2,25 +2,13 @@
 Feature: Update details
 
     Background:
-        Given I start a new 'medium-confidence' journey
-        Then I get a 'page-ipv-identity-document-start' page response
-        When I submit an 'appTriage' event
-        Then I get a 'dcmaw' CRI response
-        When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
-        When I submit a 'next' event
-        Then I get an 'address' CRI response
-        When I submit 'kenneth-current' details to the CRI stub
-        Then I get a 'fraud' CRI response
-        When I submit 'kenneth-score-2' details to the CRI stub
-        Then I get a 'page-ipv-success' page response
-        When I submit a 'next' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P2' identity
+        Given the subject already has the following credentials
+            | CRI     | scenario                     |
+            | dcmaw   | kenneth-driving-permit-valid |
+            | address | kenneth-current              |
+            | fraud   | kenneth-score-2              |
         When I start a new 'medium-confidence' journey
         Then I get a 'page-ipv-reuse' page response
-        And my proven user details match
         When I submit a 'update-details' event
         Then I get a 'update-details' page response
 

--- a/api-tests/features/p2-reprove-identity.feature
+++ b/api-tests/features/p2-reprove-identity.feature
@@ -2,22 +2,11 @@
 Feature: Reprove Identity Journey
 
     Scenario: User needs to reprove their identity
-        Given I start a new 'medium-confidence' journey
-        Then I get a 'page-ipv-identity-document-start' page response
-        When I submit an 'appTriage' event
-        Then I get a 'dcmaw' CRI response
-        When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
-        When I submit a 'next' event
-        Then I get an 'address' CRI response
-        When I submit 'kenneth-current' details to the CRI stub
-        Then I get a 'fraud' CRI response
-        When I submit 'kenneth-score-2' details to the CRI stub
-        Then I get a 'page-ipv-success' page response
-        When I submit a 'next' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P2' identity
+        Given the subject already has the following credentials
+            | CRI     | scenario                     |
+            | dcmaw   | kenneth-driving-permit-valid |
+            | address | kenneth-current              |
+            | fraud   | kenneth-score-2              |
         When I start a new 'medium-confidence' journey with reprove identity
         Then I get a 'reprove-identity-start' page response
         When I submit a 'next' event

--- a/api-tests/features/repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check.feature
@@ -2,22 +2,13 @@
 Feature: Repeat fraud check journeys
 
   Background:
-    Given I start a new 'medium-confidence' journey
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit expired 'kenneth-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P2' identity
+    Given the subject already has the following credentials
+      | CRI     | scenario                     |
+      | dcmaw   | kenneth-driving-permit-valid |
+      | address | kenneth-current              |
+    And the subject already has the following expired credentials
+      | CRI   | scenario        |
+      | fraud | kenneth-score-2 |
 
   Scenario: Fraud 6 Months Expiry + No Update
     # Repeat fraud check with no update

--- a/api-tests/src/clients/cri-stub-client.ts
+++ b/api-tests/src/clients/cri-stub-client.ts
@@ -1,4 +1,9 @@
-import { CriStubRequest, CriStubResponse } from "../types/cri-stub.js";
+import {
+  CriStubGenerateVcRequest,
+  CriStubRequest,
+  CriStubResponse,
+} from "../types/cri-stub.js";
+import config from "../config/config.js";
 
 export const callHeadlessApi = async (
   redirectUrl: string,
@@ -20,4 +25,26 @@ export const callHeadlessApi = async (
   }
 
   return criStubResponse.json();
+};
+
+export const generateVc = async (
+  criId: string,
+  body: CriStubGenerateVcRequest,
+): Promise<string> => {
+  const response = await fetch(
+    `https://${criId}-cri.stubs.account.gov.uk/credentials/generate`,
+    {
+      headers: {
+        "x-api-key": config.credentialIssuers.generateCredentialApiKey,
+      },
+      method: "POST",
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`generateVc request failed: ${response.statusText}`);
+  }
+
+  return response.text();
 };

--- a/api-tests/src/clients/evcs-stub-client.ts
+++ b/api-tests/src/clients/evcs-stub-client.ts
@@ -1,0 +1,19 @@
+import config from "../config/config.js";
+import { EvcsStubPostVcsRequest } from "../types/evcs-stub.js";
+
+export const postCredentials = async (
+  userId: string,
+  body: EvcsStubPostVcsRequest,
+): Promise<void> => {
+  const response = await fetch(`${config.evcs.baseUrl}/vcs/${userId}`, {
+    headers: {
+      "x-api-key": config.evcs.apiKey,
+    },
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`generateVc request failed: ${response.statusText}`);
+  }
+};

--- a/api-tests/src/config/config.ts
+++ b/api-tests/src/config/config.ts
@@ -27,7 +27,8 @@ const config = {
     internalApiUrl: getMandatoryConfig("CORE_BACK_INTERNAL_API_URL"),
     internalApiKey: getOptionalConfig("CORE_BACK_INTERNAL_API_KEY"),
     externalApiUrl: getMandatoryConfig("CORE_BACK_EXTERNAL_API_URL"),
-    encryptionkey: getMandatoryConfig("CORE_BACK_PUBLIC_ENCRYPTION_KEY"),
+    encryptionKey: getMandatoryConfig("CORE_BACK_PUBLIC_ENCRYPTION_KEY"),
+    criClientId: getMandatoryConfig("CORE_BACK_CRI_CLIENT_ID"),
   },
   orch: {
     redirectUrl: getMandatoryConfig("ORCHESTRATOR_REDIRECT_URL"),
@@ -41,6 +42,13 @@ const config = {
   cimit: {
     managementCimitUrl: getMandatoryConfig("CIMIT_STUB_BASE_URL"),
     managementCimitApiKey: getMandatoryConfig("MANAGEMENT_CIMIT_STUB_API_KEY"),
+  },
+  credentialIssuers: {
+    generateCredentialApiKey: getMandatoryConfig("CRI_STUB_GEN_CRED_API_KEY"),
+  },
+  evcs: {
+    baseUrl: getMandatoryConfig("EVCS_STUB_BASE_URL"),
+    apiKey: getMandatoryConfig("EVCS_STUB_API_KEY"),
   },
 };
 

--- a/api-tests/src/types/cri-stub.ts
+++ b/api-tests/src/types/cri-stub.ts
@@ -30,3 +30,11 @@ export interface CriStubResponse {
     evidence_requested?: { strength?: number; validity?: number };
   };
 }
+
+export interface CriStubGenerateVcRequest {
+  userId: string;
+  clientId: string;
+  credentialSubjectJson: string;
+  evidenceJson: string;
+  nbf?: number;
+}

--- a/api-tests/src/types/evcs-stub.ts
+++ b/api-tests/src/types/evcs-stub.ts
@@ -1,0 +1,8 @@
+export type EvcsStubPostVcsRequest = EvcsStubPostVcsCredential[];
+
+export interface EvcsStubPostVcsCredential {
+  vc: string;
+  state: "CURRENT" | "PENDING" | "PENDING_RETURN" | "VERIFICATION";
+  metadata: object;
+  provenance: "ONLINE" | "OFFLINE" | "EXTERNAL" | "MIGRATED" | "OTHER";
+}

--- a/api-tests/src/utils/jar-generator.ts
+++ b/api-tests/src/utils/jar-generator.ts
@@ -11,7 +11,7 @@ import { JarRequest } from "../types/jar-request.js";
 const encAlg = "RSA-OAEP-256";
 const encMethod = "A256GCM";
 const encKey = await jose.importJWK(
-  JSON.parse(config.core.encryptionkey) as jose.JWK,
+  JSON.parse(config.core.encryptionKey) as jose.JWK,
   encAlg,
 );
 

--- a/api-tests/src/utils/request-body-generators.ts
+++ b/api-tests/src/utils/request-body-generators.ts
@@ -4,12 +4,17 @@ import path from "path";
 import { fileURLToPath } from "url";
 import fs from "node:fs/promises";
 import { createSignedJwt } from "./jwt-signer.js";
-import { CriStubRequest, CriStubResponse } from "../types/cri-stub.js";
+import {
+  CriStubGenerateVcRequest,
+  CriStubRequest,
+  CriStubResponse,
+} from "../types/cri-stub.js";
 import { IpvSessionDetails } from "./ipv-session.js";
 import {
   AuthRequestBody,
   ProcessCriCallbackRequest,
 } from "../types/internal-api.js";
+import { EvcsStubPostVcsRequest } from "../types/evcs-stub.js";
 
 const ORCHESTRATOR_CLIENT_ID = "orchestrator";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -134,6 +139,36 @@ export const generateTokenExchangeBody = async (
   );
 
   return params.toString();
+};
+
+export const generateVcRequestBody = async (
+  userId: string,
+  criId: string,
+  scenario: string,
+  nbf?: number,
+): Promise<CriStubGenerateVcRequest> => {
+  return {
+    userId: userId,
+    clientId: config.core.criClientId,
+    credentialSubjectJson: await readJsonFile(
+      criId,
+      scenario,
+      "credentialSubject",
+    ),
+    evidenceJson: await readJsonFile(criId, scenario, "evidence"),
+    nbf: nbf ?? Math.floor(Date.now() / 1000),
+  };
+};
+
+export const generatePostVcsBody = (
+  credentialsToPost: string[],
+): EvcsStubPostVcsRequest => {
+  return credentialsToPost.map((cred) => ({
+    vc: cred,
+    state: "CURRENT",
+    metadata: {},
+    provenance: "ONLINE",
+  }));
 };
 
 const readJsonFile = async (


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Write VCs directly to EVCS for reuse tests

### Why did it change

API tests that required an existing identity would have to run a full journey through the system to generate it. This change allows for VCs generated by the CRI stubs to be written directly to EVCS for a user.

This should mean less boilerplate as well as a faster running test suite.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7324](https://govukverify.atlassian.net/browse/PYIC-7324)


[PYIC-7324]: https://govukverify.atlassian.net/browse/PYIC-7324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ