### PR TITLE
PYIC-7360 Remove padding in request jwt

### DIFF
--- a/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256Signer.java
+++ b/libs/kms-es256-signer/src/main/java/uk/gov/di/ipv/core/library/kmses256signer/KmsEs256Signer.java
@@ -14,7 +14,6 @@ import software.amazon.awssdk.services.kms.model.SignRequest;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 import java.util.Set;
 
 import static software.amazon.awssdk.services.kms.model.MessageType.DIGEST;
@@ -23,8 +22,6 @@ import static software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec.ECD
 public class KmsEs256Signer implements JWSSigner {
 
     private final KmsClient kmsClient;
-
-    private static final Base64.Encoder B64_URL_ENCODER = Base64.getUrlEncoder();
     private final JCAContext jcaContext = new JCAContext();
     private final String keyId;
 
@@ -59,7 +56,7 @@ public class KmsEs256Signer implements JWSSigner {
                         signResponse.signature().asByteArray(),
                         ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256));
 
-        return new Base64URL(B64_URL_ENCODER.encodeToString(concatSignature));
+        return Base64URL.encode(concatSignature);
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

### What changed

Use `Base64URL.encode` which should correctly encode the signature without trailing padding.

### Why did it change

DWP have reported that they are seeing == padding in our request JWT which according to the JWS RFC should be omitted (https://datatracker.ietf.org/doc/html/rfc7515#page-54). This might be causing their signature verification to fail.

### Issue tracking
- [PYIC-7360](https://govukverify.atlassian.net/browse/PYIC-7360)



[PYIC-7360]: https://govukverify.atlassian.net/browse/PYIC-7360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ