### PR TITLE
PYIC-7219 add evcs and cri api keys to run-tests.sh

### DIFF
--- a/api-tests/secure-pipeline/run-tests.sh
+++ b/api-tests/secure-pipeline/run-tests.sh
@@ -10,6 +10,12 @@ echo "Running API tests against the build environment"
 CORE_BACK_INTERNAL_API_KEY=$(aws secretsmanager get-secret-value --secret-id CoreBackInternalTestingApiKey | jq -r .SecretString)
 export CORE_BACK_INTERNAL_API_KEY
 
+EVCS_STUB_API_KEY=$(aws secretsmanager get-secret-value --secret-id /build/core/evcs/apiKey | jq -r .SecretString)
+export EVCS_STUB_API_KEY
+
+CRI_STUB_GEN_CRED_API_KEY=$(aws secretsmanager get-secret-value --secret-id CriStubGenCredApiKey | jq -r .SecretString)
+export CRI_STUB_GEN_CRED_API_KEY
+
 cd /api-tests
 
 npm run test:build -- --profile codepipeline


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adds env vars for EVCS_STUB_API_KEY and CRI_STUB_GEN_CRED_API_KEY to api test run-tests.sh script

<!-- Describe the changes in detail - the "what"-->

### Why did it change

The current tests in build are failing due to missing env vars

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

https://govukverify.atlassian.net/browse/PYIC-7219

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


