### PR TITLE
PYIC-7159: Add context = "hmrc_check" to No PID P1 & API test

### DIFF
--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -8,9 +8,9 @@ Feature: P1 No Photo Id Journey
     Then I get a 'prove-identity-no-photo-id' page response
     When I submit an 'next' event
     Then I get a 'claimedIdentity' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-#      | Attribute | Values         |
-#      | context   | "hmrc_check"   |
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "hmrc_check"   |
     Then I get a 'nino' CRI response
     When I submit 'kenneth' details with attributes to the CRI stub
       | Attribute          | Values                                      |

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -605,6 +605,7 @@ states:
     response:
       type: cri
       criId: claimedIdentity
+      context: hmrc_check
     parent: CRI_STATE
     events:
       next:


### PR DESCRIPTION
## Proposed changes

### What changed

- Add context = "hmrc_check" to CIC in P1 No Photo Id journey
- Add context = "hmrc_check" assertion to  API tests

### Why did it change

- Kiwi have updated their CIC CRI to take the context
- Add we can now test this as now included in journey map

### Issue tracking

- [PYIC-7237](https://govukverify.atlassian.net/browse/PYIC-7237)

[PYIC-7237]: https://govukverify.atlassian.net/browse/PYIC-7237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ