### PR TITLE
PYIC-7383 TICF special routing

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
@@ -36,9 +36,6 @@ states:
     events:
       met:
         targetState: CRI_TICF_BEFORE_SUCCESS
-        checkIfDisabled:
-          ticf:
-            targetState: STORE_IDENTITY_BEFORE_SUCCESS
       unmet:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -8,9 +8,6 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_F2F
-        checkIfDisabled:
-          ticf:
-            targetState: CRI_F2F
 
   # Parent states
   CRI_STATE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -12,17 +12,11 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_NO_MATCH
-        checkIfDisabled:
-          ticf:
-            targetState: NO_MATCH_PAGE
 
   FAILED_SKIP_MESSAGE:
     events:
       next:
         targetState: CRI_TICF_BEFORE_RETURN_TO_RP
-        checkIfDisabled:
-          ticf:
-            targetState: RETURN_TO_RP
 
   FAILED_CONFIRM_DETAILS:
     events:
@@ -32,20 +26,6 @@ states:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
-        checkIfDisabled:
-          ticf:
-            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE
-            auditEvents:
-              - IPV_USER_DETAILS_UPDATE_END
-            auditContext:
-              successful: false
-            checkFeatureFlag:
-              updateDetailsAccountDeletion:
-                targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION
-                auditEvents:
-                  - IPV_USER_DETAILS_UPDATE_END
-                auditContext:
-                  successful: false
         checkFeatureFlag:
           updateDetailsAccountDeletion:
             targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION
@@ -62,27 +42,6 @@ states:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
-        checkIfDisabled:
-          ticf:
-            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE
-            auditEvents:
-              - IPV_USER_DETAILS_UPDATE_END
-            auditContext:
-              successful: false
-            checkFeatureFlag:
-              updateDetailsAccountDeletion:
-                targetState: COULD_NOT_UPDATE_DETAILS_PAGE
-                auditEvents:
-                  - IPV_USER_DETAILS_UPDATE_END
-                auditContext:
-                  successful: false
-                checkJourneyContext:
-                  rfc:
-                    targetState: COULD_NOT_UPDATE_DETAILS_PAGE_RFC
-                    auditEvents:
-                      - IPV_USER_DETAILS_UPDATE_END
-                    auditContext:
-                      successful: false
         checkFeatureFlag:
           updateDetailsAccountDeletion:
             targetState: CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS
@@ -102,17 +61,11 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
-        checkIfDisabled:
-          ticf:
-            targetState: NO_MATCH_PAGE_BAV
 
   FAILED_NINO:
     events:
       next:
         targetState: CRI_TICF_BEFORE_NO_MATCH_NINO
-        checkIfDisabled:
-          ticf:
-            targetState: NO_MATCH_PAGE_NINO
 
   FAILED_NO_TICF:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -11,9 +11,6 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_ANOTHER_WAY
-        checkIfDisabled:
-          ticf:
-            targetState: ANOTHER_WAY_PAGE
 
   INELIGIBLE_NO_TICF:
     events:
@@ -24,9 +21,6 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_RETURN_TO_RP
-        checkIfDisabled:
-          ticf:
-            targetState: RETURN_TO_RP
 
   # Journey states
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
@@ -10,9 +10,6 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_RETURN_TO_RP
-        checkIfDisabled:
-          ticf:
-            targetState: RETURN_TO_RP
 
   # Journey states
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -10,9 +10,6 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_RETURN_TO_RP
-        checkIfDisabled:
-          ticf:
-            targetState: RETURN_TO_RP
 
   # Journey states
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -269,9 +269,6 @@ states:
     events:
       met:
         targetState: CRI_TICF_BEFORE_SUCCESS_RFC
-        checkIfDisabled:
-          ticf:
-            targetState: STORE_IDENTITY_BEFORE_SUCCESS
       unmet:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -10,12 +10,6 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_REUSE
-        checkIfDisabled:
-          ticf:
-            targetState: IDENTITY_REUSE_PAGE
-            checkFeatureFlag:
-              deleteDetailsEnabled:
-                targetState: IDENTITY_REUSE_PAGE_TEST
 
   UPDATE_DETAILS_START:
     events:
@@ -41,12 +35,6 @@ states:
         targetState: ERROR
       identity-stored:
         targetState: CRI_TICF_BEFORE_REUSE
-        checkIfDisabled:
-          ticf:
-            targetState: IDENTITY_REUSE_PAGE
-            checkFeatureFlag:
-              deleteDetailsEnabled:
-                targetState: IDENTITY_REUSE_PAGE_TEST
 
   CRI_TICF_BEFORE_REUSE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -121,9 +121,6 @@ states:
     events:
       coi-check-passed:
         targetState: CRI_TICF
-        checkIfDisabled:
-          ticf:
-            targetState: RETURN_TO_RP
       coi-check-failed:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -11,9 +11,6 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_ERROR
-        checkIfDisabled:
-          ticf:
-            targetState: ERROR_PAGE
 
   ERROR_NO_TICF:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -74,9 +74,6 @@ states:
     events:
       met:
         targetState: CRI_TICF_BEFORE_SUCCESS_UPDATE_ADDRESS
-        checkIfDisabled:
-          ticf:
-            targetState: STORE_IDENTITY_BEFORE_SUCCESS
       unmet:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -451,9 +451,6 @@ states:
     events:
       met:
         targetState: CRI_TICF_BEFORE_SUCCESS
-        checkIfDisabled:
-          ticf:
-            targetState: STORE_IDENTITY_BEFORE_SUCCESS
       unmet:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -26,6 +26,8 @@ states:
         targetState: PAGE_STATE_AT_START_OF_NO_PHOTO_ID
       eventFive:
         targetState: PAGE_STATE_WITH_BACK_EVENT
+      eventSix:
+        targetState: TICF_CRI_STATE
 
   CRI_STATE:
     response:
@@ -145,3 +147,11 @@ states:
     response:
       type: page
       pageId: page-id-for-another-page-state
+
+  TICF_CRI_STATE:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: ANOTHER_PAGE_STATE


### PR DESCRIPTION
## Proposed changes

### What changed

Added a special case to the journey engine to skip TICF CRI steps if the CRI is disabled.

### Why did it change

Easier to manage than manually defining fallback states which just skip a state

### Issue tracking

- [PYIC-7383](https://govukverify.atlassian.net/browse/PYIC-7383)


[PYIC-7383]: https://govukverify.atlassian.net/browse/PYIC-7383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ