### PR TITLE
BAU: use sha to run api tests post-merge

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Calculate queue name
         # SQS queue names have a max length of 80 and cannot contain special characters
         run: |
-          branch_name=${{ github.head_ref || github.ref_name }}
+          branch_name=${{ github.head_ref || github.sha }}
           queue_name=`echo $branch_name | sed 's/[^[:alnum:]-]/\_/g' | cut -c1-60`
           echo "queue_name=stubQueue_branch_$queue_name" >> $GITHUB_OUTPUT
         id: extract_queue_name


### PR DESCRIPTION
Currently when you merge multiple changes at the same time, the API tests will use the same `main` F2F queue, and this causes them to occasionally fail.

Using the branch name is nice for PRs, as it avoids creating new queues for every commit, but for main it'll be safer to use the SHA. (They are cleaned up overnight anyway)