### PR TITLE
PYIC-7340 Add API tests for healthcheck

### DIFF
--- a/api-tests/features/healthcheck.feature
+++ b/api-tests/features/healthcheck.feature
@@ -1,0 +1,5 @@
+@Build
+Feature: Healthcheck API
+  Scenario: Healthcheck passes
+    Given I call the healthcheck endpoint
+    Then the healthcheck is successful

--- a/api-tests/src/clients/core-back-external-client.ts
+++ b/api-tests/src/clients/core-back-external-client.ts
@@ -60,3 +60,11 @@ export const getMfaResetResult = async (
 
   return (await response.json()) as MfaResetResult;
 };
+
+export const healthcheck = async (): Promise<boolean> => {
+  const response = await fetch(`${config.core.externalApiUrl}/healthcheck`, {
+    method: "GET",
+  });
+
+  return response.ok;
+};

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -374,3 +374,11 @@ Then(
     );
   },
 );
+
+When("I call the healthcheck endpoint", async function (this: World) {
+  this.healthCheckResult = await externalClient.healthcheck();
+});
+
+Then("the healthcheck is successful", async function (this: World) {
+  assert.ok(this.healthCheckResult);
+});

--- a/api-tests/src/types/world.ts
+++ b/api-tests/src/types/world.ts
@@ -4,12 +4,20 @@ import { World as CucumberWorld } from "@cucumber/cucumber";
 import { VcJwtPayload } from "./external-api.js";
 
 export interface World extends CucumberWorld {
+  // Journey properties
   userId: string;
   ipvSessionId: string;
   journeyId: string;
   featureSet: string | undefined;
   lastJourneyEngineResponse?: JourneyEngineResponse;
+
+  // Identity proving results
   identity?: UserIdentity;
-  mfaResetResult?: MfaResetResult;
   vcs?: Record<string, VcJwtPayload>;
+
+  // MFA reset results
+  mfaResetResult?: MfaResetResult;
+
+  // Healthcheck results
+  healthCheckResult?: boolean;
 }

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/CoreBack.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/CoreBack.java
@@ -11,6 +11,7 @@ import uk.gov.di.ipv.coreback.services.AsyncCredentialPoller;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 public class CoreBack {
     private static final int DEFAULT_PORT = 4502;
@@ -38,6 +39,7 @@ public class CoreBack {
         app.post("/token", lambdaHandler::getToken);
         app.get("/user-identity", lambdaHandler::getUserIdentity);
         app.get("/reverification", lambdaHandler::getUserReverification);
+        app.get("/healthcheck", (ctx) -> ctx.json(Map.of("healthcheck", "ok")));
 
         // Poll for async credentials
         startAsyncPoller();


### PR DESCRIPTION
## Proposed changes

### What changed

Add API tests for healthcheck

### Why did it change

The healthcheck is used by service monitoring in AWS to ensure the core-back service is deployed and running

### Issue tracking

- [PYIC-7340](https://govukverify.atlassian.net/browse/PYIC-7340)


[PYIC-7340]: https://govukverify.atlassian.net/browse/PYIC-7340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ