### PR TITLE
BAU: Bump API test step timeout to 30s

### DIFF
--- a/api-tests/src/config/cucumber.ts
+++ b/api-tests/src/config/cucumber.ts
@@ -1,3 +1,3 @@
 import { setDefaultTimeout } from "@cucumber/cucumber";
 
-setDefaultTimeout(15 * 1000); // 15 seconds
+setDefaultTimeout(30 * 1000); // 30 seconds


### PR DESCRIPTION
## Proposed changes

### What changed

Increase the default step timeout to 30s

### Why did it change

Occasionally the first few tests time out, usually on overnight dependabot PRs - suspect this is because all the stub lambdas are cold-starting.

Increasing to 30s will widen to just larger than the API GW timeout (29s), so we should see which request failed.