### PR TITLE
PYIC-7320: additional inherited identity api tests

### DIFF
--- a/api-tests/data/inherited-identities/kenneth-vot-pcl200-no-evidence.json
+++ b/api-tests/data/inherited-identities/kenneth-vot-pcl200-no-evidence.json
@@ -1,0 +1,29 @@
+{
+  "iss": "https://orch.stubs.account.gov.uk/migration/v1",
+  "vot": "PCL200",
+  "vc": {
+    "type": ["VerifiableCredential", "IdentityCheckCredential"],
+    "credentialSubject": {
+      "name": [
+        {
+          "nameParts": [
+            {
+              "value": "Kenneth",
+              "type": "GivenName"
+            },
+            {
+              "value": "Decerqueira",
+              "type": "FamilyName"
+            }
+          ]
+        }
+      ],
+      "birthDate": [
+        {
+          "value": "1970-01-01"
+        }
+      ]
+    },
+    "evidence": []
+  }
+}

--- a/api-tests/features/inherited-identity.feature
+++ b/api-tests/features/inherited-identity.feature
@@ -19,34 +19,22 @@ Feature: Inherited Identity
       | medium-confidence-pcl250        | kenneth-vot-pcl250-passport       | PCL250            |
       | medium-confidence-pcl250        | kenneth-vot-pcl250-driving-permit | PCL250            |
 
-  Scenario: Migrate PCL 200 HMRC profile successfully with no evidence and returns with P2
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+  Scenario Outline: Migrate <expected-identity> HMRC profile successfully with no evidence and returns with <vtr> - requires identity to be proved for stronger profile
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<inherited-identity>'
     Then I get an OAuth response
     And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
-    Then I get a 'PCL200' identity
-    When I start a new 'medium-confidence' journey
+    Then I get a '<expected-identity>' identity
+    When I start a new '<return-journey-type>' journey
     Then I get a 'page-ipv-identity-document-start' page response
 
-  Scenario: Migrate PCL 200 HMRC profile successfully with no evidence and returns with P2/PCL250
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL200' identity
-    When I start a new 'medium-confidence-pcl250' journey
-    Then I get a 'page-ipv-identity-document-start' page response
+    Examples:
+    | inherited-identity            | expected-identity | return-journey-type      | vtr       |
+    |  alice-vot-pcl200-no-evidence | PCL200            | medium-confidence        | P2        |
+    |  alice-vot-pcl200-no-evidence | PCL200            | medium-confidence-pcl250 | P2/PCL250 |
+    | alice-vot-pcl250-no-evidence  | PCL250            | medium-confidence        | P2        |
 
-  Scenario: Migrate PCL 250 HRMC profile successfully with no evidence and returns with P2
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL250' identity
-    When I start a new 'medium-confidence' journey
-    Then I get a 'page-ipv-identity-document-start' page response
-
-  Scenario: Migrate PCL 250 HRMC profile successfully with no evidence and returns with P2/PCL250
+  Scenario: Migrate PCL250 HRMC profile successfully with no evidence and returns with P2/PCL250
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
     Then I get an OAuth response
     And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
@@ -87,82 +75,26 @@ Feature: Inherited Identity
     | alice-vot-pcl200-no-evidence      | with no evidence |
     | kenneth-vot-pcl250-driving-permit | with evidence    |
 
-  Scenario: Previous PCL 200 is replaced by new PCL 200 for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl200-no-evidence'
+  Scenario Outline: Previous <old-identity> is <is-replaced> with new <new-identity> for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<old-details>'
     Then I get an OAuth response
     And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
-    Then I get a 'PCL200' identity
-    And my identity 'GivenName' is 'Kenneth'
+    Then I get a '<old-expected-vot>' identity
+    And my identity 'GivenName' is '<old-expected-name>'
 
-    # New journey with new PCL200 inherited identity for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+    # New journey with new inherited identity for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<new-details>'
     Then I get an OAuth response
     And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
-    Then I get a 'PCL200' identity
-    And my identity 'GivenName' is 'Alice'
+    Then I get a '<new-expected-vot>' identity
+    And my identity 'GivenName' is '<new-expected-name>'
 
-  Scenario: Previous PCL 200 is replaced by new PCL 250 for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl200-no-evidence'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL200' identity
-    And my identity 'GivenName' is 'Kenneth'
-
-    # New journey with new PCL200 inherited identity for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL250' identity
-    And my identity 'GivenName' is 'Alice'
-
-  Scenario: Previous PCL 200 is replaced by new PCL 250 with DL evidence for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL200' identity
-    And my identity 'GivenName' is 'Alice'
-
-    # New journey with new PCL200 inherited identity for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl250-driving-permit'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL250' identity
-    And my identity 'GivenName' is 'Kenneth'
-
-  Scenario: Previous PCL 200 is replaced by new PCL 250 with passport evidence for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL200' identity
-    And my identity 'GivenName' is 'Alice'
-
-    # New journey with new PCL200 inherited identity for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl250-passport'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL250' identity
-    And my identity 'GivenName' is 'Kenneth'
-
-  Scenario: Previous PCL 250 is not replaced by new PCL 200 for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL250' identity
-    And my identity 'GivenName' is 'Alice'
-
-    # New journey with new PCL200 inherited identity for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl200-no-evidence'
-    Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
-    When I use the OAuth response to get my identity
-    Then I get a 'PCL250' identity
-    And my identity 'GivenName' is 'Alice'
+    Examples:
+    | old-identity | old-details                    | old-expected-name | old-expected-vot | new-identity | new-details                          | new-expected-name | new-expected-vot | is-replaced  |
+    | PCL200       | kenneth-vot-pcl200-no-evidence | Kenneth           | PCL200           | PCL200       | alice-vot-pcl200-no-evidence         | Alice             | PCL200           | replaced     |
+    | PCL200       | kenneth-vot-pcl200-no-evidence | Kenneth           | PCL200           | PCL250       | alice-vot-pcl250-no-evidence         | Alice             | PCL250           | replaced     |
+    | PCL200       | alice-vot-pcl200-no-evidence   | Alice             | PCL200           | PCL250       | kenneth-vot-pcl250-driving-permit    | Kenneth           | PCL250           | replaced     |
+    | PCL200       | alice-vot-pcl200-no-evidence   | Alice             | PCL200           | PCL250       | kenneth-vot-pcl250-passport          | Kenneth           | PCL250           | replaced     |
+    | PCL250       | alice-vot-pcl250-no-evidence   | Alice             | PCL250           | PCL200       | kenneth-vot-pcl200-no-evidence       | Alice             | PCL250           | not replaced |

--- a/api-tests/features/inherited-identity.feature
+++ b/api-tests/features/inherited-identity.feature
@@ -36,3 +36,133 @@ Feature: Inherited Identity
     Then I get a 'PCL200' identity
     When I start a new 'medium-confidence-pcl250' journey
     Then I get a 'page-ipv-identity-document-start' page response
+
+  Scenario: Migrate PCL 250 HRMC profile successfully with no evidence and returns with P2
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+
+  Scenario: Migrate PCL 250 HRMC profile successfully with no evidence and returns with P2/PCL250
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    When I start a new 'medium-confidence-pcl250' journey
+    Then I get an OAuth response
+
+  Scenario Outline: P2 identity takes priority over successfully migrated PCL200 <evidence-state>
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    # New journey with inherited identity
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<inherited-identity>'
+    Then I get a 'page-ipv-reuse' page response
+    When I submit an 'next' event
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+    | inherited-identity                | evidence-state   |
+    | alice-vot-pcl200-no-evidence      | with no evidence |
+    | kenneth-vot-pcl250-driving-permit | with evidence    |
+
+  Scenario: Previous PCL 200 is replaced by new PCL 200 for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL200' identity
+    And my identity 'GivenName' is 'Kenneth'
+
+    # New journey with new PCL200 inherited identity for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL200' identity
+    And my identity 'GivenName' is 'Alice'
+
+  Scenario: Previous PCL 200 is replaced by new PCL 250 for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL200' identity
+    And my identity 'GivenName' is 'Kenneth'
+
+    # New journey with new PCL200 inherited identity for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    And my identity 'GivenName' is 'Alice'
+
+  Scenario: Previous PCL 200 is replaced by new PCL 250 with DL evidence for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL200' identity
+    And my identity 'GivenName' is 'Alice'
+
+    # New journey with new PCL200 inherited identity for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl250-driving-permit'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    And my identity 'GivenName' is 'Kenneth'
+
+  Scenario: Previous PCL 200 is replaced by new PCL 250 with passport evidence for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL200' identity
+    And my identity 'GivenName' is 'Alice'
+
+    # New journey with new PCL200 inherited identity for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl250-passport'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    And my identity 'GivenName' is 'Kenneth'
+
+  Scenario: Previous PCL 250 is not replaced by new PCL 200 for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    And my identity 'GivenName' is 'Alice'
+
+    # New journey with new PCL200 inherited identity for the same user
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    And my identity 'GivenName' is 'Alice'

--- a/api-tests/features/inherited-identity.feature
+++ b/api-tests/features/inherited-identity.feature
@@ -19,7 +19,7 @@ Feature: Inherited Identity
       | medium-confidence-pcl250        | kenneth-vot-pcl250-passport       | PCL250            |
       | medium-confidence-pcl250        | kenneth-vot-pcl250-driving-permit | PCL250            |
 
-  Scenario Outline: Migrate <expected-identity> HMRC profile successfully with no evidence and returns with <vtr> - requires identity to be proved for stronger profile
+  Scenario Outline: Migrating a <expected-identity> HMRC profile successfully and returning with <vtr> VTR requires a P2 identity to be proved
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<inherited-identity>'
     Then I get an OAuth response
     And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
@@ -43,8 +43,10 @@ Feature: Inherited Identity
     Then I get a 'PCL250' identity
     When I start a new 'medium-confidence-pcl250' journey
     Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
 
-  Scenario Outline: P2 identity takes priority over successfully migrated PCL200 <evidence-state>
+  Scenario Outline: P2 identity takes priority over successfully migrated PCL200
     Given I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -72,10 +74,10 @@ Feature: Inherited Identity
     Then I get a 'P2' identity
 
     Examples:
-    | inherited-identity                | evidence-state   |
-    | alice-vot-pcl200-no-evidence      | with no evidence |
-    | kenneth-vot-pcl250-driving-permit | with evidence    |
-
+    | inherited-identity                |
+    | alice-vot-pcl200-no-evidence      |
+    | kenneth-vot-pcl250-driving-permit |
+#
   Scenario Outline: Previous <old-identity> is <is-replaced> with new <new-identity> for the same user
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<old-details>'
     Then I get an OAuth response

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -114,7 +114,7 @@ When(
 );
 
 When(
-  /^I start a new ?'([\w-]+)' journey( with reprove identity)?(?: with inherited identity '([\w-]+)')?(?: with feature set '([\w-,]+)')?$/,
+  /^I start a new ?'([<>\w-]+)' journey( with reprove identity)?(?: with inherited identity '([<>\w-]+)')?(?: with feature set '([<>\w-,]+)')?$/,
   async function (
     this: World,
     journeyType: string,
@@ -271,7 +271,7 @@ When(
 );
 
 Then(
-  /^I get a '([\w-]+)' identity( without a TICF VC)?$/,
+  /^I get a '([<>\w-]+)' identity( without a TICF VC)?$/,
   function (
     this: World,
     vot: string,

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -25,6 +25,8 @@ import {
 } from "../types/internal-api.js";
 import { getProvenIdentityDetails } from "../clients/core-back-internal-client.js";
 import {
+  IdentityCheckCredentialClass,
+  IdentityCheckSubjectClass,
   NamePartType,
   PostalAddressClass,
 } from "@govuk-one-login/data-vocab/credentials.js";
@@ -355,11 +357,24 @@ Then(
       throw new Error("No identity found.");
     }
 
-    const namePart = this.identity[identityCredential].name?.[0].nameParts.find(
-      (np) => {
-        return field === np.type;
-      },
-    );
+    if (!this.vcs) {
+      throw new Error("No credentials found.");
+    }
+
+    const inheritedIdentity = this.vcs[
+      "https://orch.stubs.account.gov.uk/migration/v1"
+    ]
+      ? (this.vcs["https://orch.stubs.account.gov.uk/migration/v1"]
+          .vc as IdentityCheckCredentialClass)
+      : undefined;
+
+    const namePart = (
+      inheritedIdentity
+        ? (inheritedIdentity.credentialSubject as IdentityCheckSubjectClass)
+        : this.identity[identityCredential]
+    ).name?.[0].nameParts.find((np) => {
+      return field === np.type;
+    });
     assert.equal(value.toLowerCase(), namePart?.value.toLowerCase());
   },
 );

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -25,8 +25,6 @@ import {
 } from "../types/internal-api.js";
 import { getProvenIdentityDetails } from "../clients/core-back-internal-client.js";
 import {
-  IdentityCheckCredentialClass,
-  IdentityCheckSubjectClass,
   NamePartType,
   PostalAddressClass,
 } from "@govuk-one-login/data-vocab/credentials.js";
@@ -361,20 +359,11 @@ Then(
       throw new Error("No credentials found.");
     }
 
-    const inheritedIdentity = this.vcs[
-      "https://orch.stubs.account.gov.uk/migration/v1"
-    ]
-      ? (this.vcs["https://orch.stubs.account.gov.uk/migration/v1"]
-          .vc as IdentityCheckCredentialClass)
-      : undefined;
-
-    const namePart = (
-      inheritedIdentity
-        ? (inheritedIdentity.credentialSubject as IdentityCheckSubjectClass)
-        : this.identity[identityCredential]
-    ).name?.[0].nameParts.find((np) => {
-      return field === np.type;
-    });
+    const namePart = this.identity[identityCredential].name?.[0].nameParts.find(
+      (np) => {
+        return field === np.type;
+      },
+    );
     assert.equal(value.toLowerCase(), namePart?.value.toLowerCase());
   },
 );

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.verifiablecredential.helpers;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ProfileType;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.Vot;
@@ -50,7 +51,8 @@ public class VcHelper {
     }
 
     public static boolean isSuccessfulVc(VerifiableCredential vc) {
-        if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
+        if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential
+                && vc.getCri() != Cri.HMRC_MIGRATION) {
             var evidence = identityCheckCredential.getEvidence();
             if (isNullOrEmpty(evidence)) {
                 LOGGER.warn(

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -42,6 +42,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudNotExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL200;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL200NoEvidence;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL250;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL250NoEvidence;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcInvalidVot;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcNinoSuccessful;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcNullVot;
@@ -57,7 +58,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcVerificationM1a;
 class VcHelperTest {
     @Mock private ConfigService configService;
 
-    private static Stream<Arguments> SuccessfulTestCases() {
+    private static Stream<Arguments> SuccessfulTestCases() throws Exception {
         return Stream.of(
                 Arguments.of("Non-evidence VC", M1A_ADDRESS_VC),
                 Arguments.of("Evidence VC", PASSPORT_NON_DCMAW_SUCCESSFUL_VC),
@@ -66,7 +67,9 @@ class VcHelperTest {
                 Arguments.of("Verification VC", vcVerificationM1a()),
                 Arguments.of("Verification DCMAW VC", M1B_DCMAW_VC),
                 Arguments.of("Verification F2F VC", vcF2fM1a()),
-                Arguments.of("Verification Nino VC", vcNinoSuccessful()));
+                Arguments.of("Verification Nino VC", vcNinoSuccessful()),
+                Arguments.of("PCL250 no evidence VC", vcHmrcMigrationPCL250NoEvidence()),
+                Arguments.of("PCL200 no evidence VC", vcHmrcMigrationPCL200NoEvidence()));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Adds additional inherited identity api tests

### Why did it change
Increase coverage of api tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7320](https://govukverify.atlassian.net/browse/PYIC-7320)


[PYIC-7320]: https://govukverify.atlassian.net/browse/PYIC-7320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ