### PR TITLE
PYIC-7342: Add Account Deletion API tests

### DIFF
--- a/api-tests/features/account-deletion.feature
+++ b/api-tests/features/account-deletion.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: Account Deletion
 
-  Scenario: Successfully delete an account
+  Background:
     Given the subject already has the following credentials
       | CRI     | scenario                     |
       | dcmaw   | kenneth-driving-permit-valid |
@@ -11,6 +11,8 @@ Feature: Account Deletion
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'next' event
     Then I get a 'pyi-new-details' page response
+
+  Scenario: Successfully delete an account
     When I submit a 'next' event
     Then I get a 'pyi-confirm-delete-details' page response
     When I submit a 'next' event
@@ -18,29 +20,11 @@ Feature: Account Deletion
     When I submit a 'next' event
     Then I get a 'page-ipv-identity-document-start' page response
 
-    Scenario: Choose not to delete account
-      Given the subject already has the following credentials
-        | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
-        | address | kenneth-current              |
-        | fraud   | kenneth-score-2              |
-      When I start a new 'medium-confidence' journey with feature set 'deleteDetailsTestJourney'
-      Then I get a 'page-ipv-reuse' page response
-      When I submit a 'next' event
-      Then I get a 'pyi-new-details' page response
-      When I submit a 'end' event
-      Then I get a 'page-ipv-reuse' page response
+  Scenario: Choose not to delete account
+    When I submit a 'end' event
+    Then I get a 'page-ipv-reuse' page response
 
   Scenario: Dropout of account deletion
-    Given the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-      | fraud   | kenneth-score-2              |
-    When I start a new 'medium-confidence' journey with feature set 'deleteDetailsTestJourney'
-    Then I get a 'page-ipv-reuse' page response
-    When I submit a 'next' event
-    Then I get a 'pyi-new-details' page response
     When I submit a 'next' event
     Then I get a 'pyi-confirm-delete-details' page response
     When I submit a 'end' event

--- a/api-tests/features/account-deletion.feature
+++ b/api-tests/features/account-deletion.feature
@@ -1,0 +1,47 @@
+@Build
+Feature: Account Deletion
+
+  Scenario: Successfully delete an account
+    Given the subject already has the following credentials
+      | CRI     | scenario                     |
+      | dcmaw   | kenneth-driving-permit-valid |
+      | address | kenneth-current              |
+      | fraud   | kenneth-score-2              |
+    When I start a new 'medium-confidence' journey with feature set 'deleteDetailsTestJourney'
+    Then I get a 'page-ipv-reuse' page response
+    When I submit a 'next' event
+    Then I get a 'pyi-new-details' page response
+    When I submit a 'next' event
+    Then I get a 'pyi-confirm-delete-details' page response
+    When I submit a 'next' event
+    Then I get a 'pyi-details-deleted' page response
+    When I submit a 'next' event
+    Then I get a 'page-ipv-identity-document-start' page response
+
+    Scenario: Choose not to delete account
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      When I start a new 'medium-confidence' journey with feature set 'deleteDetailsTestJourney'
+      Then I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get a 'pyi-new-details' page response
+      When I submit a 'end' event
+      Then I get a 'page-ipv-reuse' page response
+
+  Scenario: Dropout of account deletion
+    Given the subject already has the following credentials
+      | CRI     | scenario                     |
+      | dcmaw   | kenneth-driving-permit-valid |
+      | address | kenneth-current              |
+      | fraud   | kenneth-score-2              |
+    When I start a new 'medium-confidence' journey with feature set 'deleteDetailsTestJourney'
+    Then I get a 'page-ipv-reuse' page response
+    When I submit a 'next' event
+    Then I get a 'pyi-new-details' page response
+    When I submit a 'next' event
+    Then I get a 'pyi-confirm-delete-details' page response
+    When I submit a 'end' event
+    Then I get a 'page-ipv-reuse' page response


### PR DESCRIPTION
## Proposed changes

### What changed

- Add Account Deletion API tests

### Why did it change

- To move E2E tests to API tests

### Issue tracking

- [PYIC-7342](https://govukverify.atlassian.net/browse/PYIC-7342)

## Still to do

- Remove two of the deletion journeys from core-tests

[PYIC-7342]: https://govukverify.atlassian.net/browse/PYIC-7342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ