### PR TITLE
PYIC-7454 Add missing CRI events

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -45,6 +45,9 @@ states:
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -45,6 +45,9 @@ states:
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -81,6 +81,9 @@ states:
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -30,15 +30,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JourneyMapTest {
 
-    @ParameterizedTest
-    @EnumSource
-    void shouldHandleSameEventsForAllCris(IpvJourneyTypes journeyType) throws IOException {
-        var stateMachineInitializer = new StateMachineInitializer(journeyType);
-        var stateMachine = stateMachineInitializer.initialize();
-
+    @Test
+    void shouldHandleSameEventsForAllCris() throws IOException {
         var criStatesAndEvents = new ArrayList<StateAndEvents>();
         var allCriEvents = new HashSet<String>();
-        findCriStatesAndEvents(stateMachine, criStatesAndEvents, allCriEvents);
+
+        for (var journeyType : IpvJourneyTypes.values()) {
+            var stateMachineInitializer = new StateMachineInitializer(journeyType);
+            var stateMachine = stateMachineInitializer.initialize();
+
+            findCriStatesAndEvents(stateMachine, criStatesAndEvents, allCriEvents);
+        }
 
         for (var stateAndEvents : criStatesAndEvents) {
             var missingCriEvents = new HashSet<>(allCriEvents);
@@ -53,14 +55,16 @@ class JourneyMapTest {
         }
     }
 
-    @ParameterizedTest
-    @EnumSource
-    void shouldHandleSameEventsForSamePage(IpvJourneyTypes journeyType) throws IOException {
-        var stateMachineInitializer = new StateMachineInitializer(journeyType);
-        var stateMachine = stateMachineInitializer.initialize();
-
+    @Test
+    void shouldHandleSameEventsForSamePage() throws IOException {
         var pageMap = new HashMap<String, List<StateAndEvents>>();
-        findPageSpecificStatesAndEvents(stateMachine, pageMap);
+
+        for (var journeyType : IpvJourneyTypes.values()) {
+            var stateMachineInitializer = new StateMachineInitializer(journeyType);
+            var stateMachine = stateMachineInitializer.initialize();
+
+            findPageSpecificStatesAndEvents(stateMachine, pageMap);
+        }
 
         for (var statesAndEvents : pageMap.values()) {
             var pageEvents = new HashSet<String>();


### PR DESCRIPTION
## Proposed changes

### What changed

Add missing `alternate-doc-invalid-passport` event to CRI states that were missing it

### Why did it change

Although we don't expect to receive that event in those scenarios, we should still define handling for it.

### Issue tracking

- [PYIC-7454](https://govukverify.atlassian.net/browse/PYIC-7454)


[PYIC-7454]: https://govukverify.atlassian.net/browse/PYIC-7454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ