### PR TITLE
BAU: Parse CIMIT API errors

### DIFF
--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/domain/CimitApiResponse.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/domain/CimitApiResponse.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.library.cimit.domain;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public record CimitApiResponse(@JsonProperty String result, @JsonProperty String reason) {}
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CimitApiResponse(String result, String reason, String errorMessage) {}

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CimitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CimitService.java
@@ -221,7 +221,11 @@ public class CimitService {
     }
 
     private void logApiRequestError(CimitApiResponse failedResponse) {
-        LOGGER.error(LogHelper.buildErrorMessage(FAILED_API_REQUEST, failedResponse.reason()));
+        LOGGER.error(
+                LogHelper.buildErrorMessage(
+                        FAILED_API_REQUEST,
+                        failedResponse.errorMessage(),
+                        failedResponse.reason()));
     }
 
     private void sendPostHttpRequest(

--- a/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CimitServiceTest.java
+++ b/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CimitServiceTest.java
@@ -56,11 +56,11 @@ class CimitServiceTest {
     private static final String CLIENT_SOURCE_IP = "a-client-source-ip";
     private static final String CIMIT_COMPONENT_ID = "https://identity.staging.account.gov.uk";
     private static final CimitApiResponse SUCCESSFUL_POST_HTTP_RESPONSE =
-            new CimitApiResponse("success", null);
+            new CimitApiResponse("success", null, null);
     private static final ContraIndicatorCredentialDto SUCCESSFUL_GET_CI_HTTP_RESPONSE =
             new ContraIndicatorCredentialDto(SIGNED_CONTRA_INDICATOR_VC);
     private static final CimitApiResponse FAILED_CIMIT_HTTP_RESPONSE =
-            new CimitApiResponse(FAILED_RESPONSE, "Internal Server Error");
+            new CimitApiResponse(FAILED_RESPONSE, "INTERNAL_ERROR", "Internal Server Error");
     private static final String CIMIT_API_BASE_URL = "https://base-url.co.uk";
     private static final String MOCK_CIMIT_API_KEY = "mock-api-key"; // pragma: allowlist secret
 


### PR DESCRIPTION
## Proposed changes

### What changed

Relax parsing rules on CIMIT responses to ignore unknown properties, and handle the known 'errorMessage' property.

### Why did it change

We want to be lenient when parsing error responses, so we don't fail inappropriately.
