### PR TITLE
PYIC-7450: update journey map to route to the two variants of the sorry-could-not-confirm-details page

### DIFF
--- a/api-tests/data/cri-stub-requests/fraud/alice-score-2/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/alice-score-2/credentialSubject.json
@@ -1,0 +1,34 @@
+{
+  "name": [
+    {
+      "nameParts": [
+        {
+          "value": "Alice",
+          "type": "GivenName"
+        },
+        {
+          "value": "Jane",
+          "type": "GivenName"
+        },
+        {
+          "value": "Par-ker",
+          "type": "FamilyName"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1970-01-01"
+    }
+  ],
+  "address": [
+    {
+      "buildingName": "80T",
+      "streetName": "YEOMAN WAY",
+      "postalCode": "BA14 0QP",
+      "addressLocality": "TROWBRIDGE",
+      "validFrom": "1952-01-01"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/alice-score-2/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/alice-score-2/evidence.json
@@ -1,0 +1,31 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "none",
+      "activityFrom": "1963-01-01",
+      "checkMethod": "data"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "mortality_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "identity_theft_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "synthetic_identity_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "impersonation_risk_check",
+      "txn": "RB000117397035"
+    }
+  ],
+  "ci": [],
+  "txn": "RB000117420948",
+  "identityFraudScore": 2,
+  "type": "IdentityCheck"
+}

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -19,17 +19,26 @@ Feature: Repeat fraud check failures
       Then I get a 'dcmaw' CRI response
 
     @FastFollow
-    Scenario: Given name change - DCMAW access denied OAuth error
+    Scenario: DCMAW access denied OAuth error
+      Given I activate the 'updateDetailsAccountDeletion' feature set
       When I get an 'access_denied' OAuth error from the CRI stub
-      Then I get an 'sorry-could-not-confirm-details' page response
-      When I submit a 'end' event
+      Then I get an 'update-details-failed' page response
+      When I submit a 'return-to-service' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
 
-    Scenario: Given name change - breaching CI received from DCMAW
+    @FastFollow
+    Scenario: User is able to delete details from update-details-failed screen
+      Given I activate the 'updateDetailsAccountDeletion' feature set
+      When I get an 'access_denied' OAuth error from the CRI stub
+      Then I get an 'update-details-failed' page response
+      When I submit a 'delete' event
+      Then I get a 'delete-handover' page response
+
+    Scenario: Breaching CI received from DCMAW
       When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
       Then I get a 'sorry-could-not-confirm-details' page response
       When I submit a 'end' event
@@ -39,7 +48,27 @@ Feature: Repeat fraud check failures
       When I start a new 'medium-confidence' journey
       Then I get a 'pyi-no-match' page response
 
-    Scenario: Given name change - zero score in fraud CRI
+    @FastFollow
+    Scenario: Breaching CI received from DCMAW
+      Given I activate the 'updateDetailsAccountDeletion' feature set
+      When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'pyi-no-match' page response
+
+    @FastFollow
+    Scenario: Users able to delete account from sorry-could-not-confirm-details screen
+      Given I activate the 'updateDetailsAccountDeletion' feature set
+      When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit a 'delete' event
+      Then I get a 'delete-handover' page response
+
+    Scenario: Zero score in fraud CRI
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response
       When I submit a 'next' event
@@ -53,7 +82,23 @@ Feature: Repeat fraud check failures
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
 
-    Scenario: Given name change - breaching CI received from fraud CRI
+    @FastFollow
+    Scenario: Zero score in fraud CRI
+      Given I activate the 'updateDetailsAccountDeletion' feature set
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+
+    Scenario: Breaching CI received from fraud CRI
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response
       When I submit a 'next' event
@@ -67,7 +112,23 @@ Feature: Repeat fraud check failures
       When I start a new 'medium-confidence' journey
       Then I get a 'pyi-no-match' page response
 
-    Scenario: Given name change - family name changed
+    @FastFollow
+    Scenario: Breaching CI received from fraud CRI
+      Given I activate the 'updateDetailsAccountDeletion' feature set
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-ci' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'pyi-no-match' page response
+
+    Scenario: Failed COI check
       When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response
       When I submit a 'next' event
@@ -75,20 +136,30 @@ Feature: Repeat fraud check failures
       When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
       Then I get a 'sorry-could-not-confirm-details' page response
 
-    Scenario: Given name change - breaching CI received from TICF CRI
+    @FastFollow
+    Scenario: Failed COI check
+      Given I activate the 'updateDetailsAccountDeletion' feature set
+      When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+
+    Scenario: Breaching CI received from TICF CRI
+      Given TICF CRI will respond with default parameters and
+        | cis | BREACHING |
       When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
-      Then I get a 'page-ipv-success' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P2' identity
-      Given TICF CRI will respond with default parameters and
-        | cis | BREACHING |
-      When I start a new 'medium-confidence' journey
       Then I get a 'pyi-no-match' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -98,19 +169,7 @@ Feature: Repeat fraud check failures
         | cis  | BREACHING      |
         | type | RiskAssessment |
 
-    Scenario: Given name change - failed COI check
-      When I submit 'alice-passport-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
-      When I submit a 'next' event
-      Then I get a 'fraud' CRI response
-      When I submit 'alice-score-2' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response
-      When I submit an 'end' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-
-    Scenario: Given name change - Fraud access denied OAuth error
+    Scenario: Fraud access denied OAuth error
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response
       When I submit a 'next' event
@@ -124,9 +183,24 @@ Feature: Repeat fraud check failures
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
 
-  Rule: Update address only
+    @FastFollow
+    Scenario: Fraud access denied OAuth error
+      Given I activate the 'updateDetailsAccountDeletion' feature set
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I get an 'access_denied' OAuth error from the CRI stub
+      Then I get an 'sorry-could-not-confirm-details' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
 
-    Scenario: Given name change - Address access denied OAuth error
+  Rule: Update address only
+    Background:
       Given the subject already has the following credentials
         | CRI     | scenario                     |
         | dcmaw   | kenneth-driving-permit-valid |
@@ -138,9 +212,23 @@ Feature: Repeat fraud check failures
       Then I get a 'confirm-your-details' page response
       When I submit a 'address-only' event
       Then I get an 'address' CRI response
+
+    Scenario: Address access denied OAuth error
       When I get an 'access_denied' OAuth error from the CRI stub
       Then I get an 'sorry-could-not-confirm-details' page response
       When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+
+    @FastFollow
+    Scenario: Address access denied OAuth error
+      Given I activate the 'updateDetailsAccountDeletion' feature set
+      When I get an 'access_denied' OAuth error from the CRI stub
+      Then I get an 'sorry-could-not-confirm-details' page response
+      When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -122,7 +122,7 @@ Feature: Repeat fraud check failures
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
       When I start a new 'medium-confidence' journey
-      Then I get a 'page-ipv-reuse' page response
+      Then I get a 'confirm-your-details' page response
 
   Rule: Update address only
 

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -31,7 +31,7 @@ Feature: Repeat fraud check failures
       Then I get a 'confirm-your-details' page response
 
     @FastFollow
-    Scenario: User is able to delete details from update-details-failed screen
+    Scenario: User is able to delete account from update-details-failed screen
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I get an 'access_denied' OAuth error from the CRI stub
       Then I get an 'update-details-failed' page response
@@ -61,7 +61,7 @@ Feature: Repeat fraud check failures
       Then I get a 'pyi-no-match' page response
 
     @FastFollow
-    Scenario: Users able to delete account from sorry-could-not-confirm-details screen
+    Scenario: User is able to delete account from sorry-could-not-confirm-details screen
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
       Then I get a 'sorry-could-not-confirm-details' page response

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -1,97 +1,148 @@
 @Build
 Feature: Repeat fraud check failures
 
-  Background:
-    Given the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-    And the subject already has the following expired credentials
-      | CRI   | scenario        |
-      | fraud | kenneth-score-2 |
-    When I start a new 'medium-confidence' journey
-    Then I get a 'confirm-your-details' page response
-    When I submit a 'given-names-only' event
-    Then I get a 'page-update-name' page response
-    When I submit an 'update-name' event
-    Then I get a 'dcmaw' CRI response
+  Rule: Given name change only
 
-  @FastFollow
-  Scenario: Given name change - DCMAW access denied OAuth error
-    When I get an 'access_denied' OAuth error from the CRI stub
-    Then I get an 'sorry-could-not-confirm-details' page response
-    When I submit a 'end' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P0' identity
-    When I start a new 'medium-confidence' journey
-    Then I get a 'confirm-your-details' page response
+    Background:
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+      And the subject already has the following expired credentials
+        | CRI   | scenario        |
+        | fraud | kenneth-score-2 |
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response
+      When I submit an 'update-name' event
+      Then I get a 'dcmaw' CRI response
 
-  Scenario: Given name change - breaching CI received from DCMAW
-    When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-    Then I get a 'sorry-could-not-confirm-details' page response
-    When I submit a 'end' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P0' identity
-    When I start a new 'medium-confidence' journey
-    Then I get a 'pyi-no-match' page response
+    @FastFollow
+    Scenario: Given name change - DCMAW access denied OAuth error
+      When I get an 'access_denied' OAuth error from the CRI stub
+      Then I get an 'sorry-could-not-confirm-details' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
 
-  Scenario: Given name change - zero score in fraud CRI
-    When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
-    Then I get a 'sorry-could-not-confirm-details' page response
-    When I submit a 'end' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P0' identity
-    When I start a new 'medium-confidence' journey
-    Then I get a 'confirm-your-details' page response
+    Scenario: Given name change - breaching CI received from DCMAW
+      When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'pyi-no-match' page response
 
-  Scenario: Given name change - breaching CI received from fraud CRI
-    When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-breaching-ci' details to the CRI stub
-    Then I get a 'sorry-could-not-confirm-details' page response
-    When I submit a 'end' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P0' identity
-    When I start a new 'medium-confidence' journey
-    Then I get a 'pyi-no-match' page response
+    Scenario: Given name change - zero score in fraud CRI
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
 
-  Scenario: Given name change - family name changed
-    When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
-    Then I get a 'sorry-could-not-confirm-details' page response
+    Scenario: Given name change - breaching CI received from fraud CRI
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-ci' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'pyi-no-match' page response
 
-  Scenario: Given name change - breaching CI received from TICF CRI
-    When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P2' identity
-    Given TICF CRI will respond with default parameters and
-      | cis | BREACHING |
-    When I start a new 'medium-confidence' journey
-    Then I get a 'pyi-no-match' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P0' identity
-    And the TICF VC has properties
-      | cis  | BREACHING      |
-      | type | RiskAssessment |
+    Scenario: Given name change - family name changed
+      When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+
+    Scenario: Given name change - breaching CI received from TICF CRI
+      When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+      Given TICF CRI will respond with default parameters and
+        | cis | BREACHING |
+      When I start a new 'medium-confidence' journey
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      And the TICF VC has properties
+        | cis  | BREACHING      |
+        | type | RiskAssessment |
+
+    Scenario: Given name change - failed COI check
+      When I submit 'alice-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'alice-score-2' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response
+      When I submit an 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
+    Scenario: Given name change - Fraud access denied OAuth error
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I get an 'access_denied' OAuth error from the CRI stub
+      Then I get an 'sorry-could-not-confirm-details' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response
+
+  Rule: Update address only
+
+    Scenario: Given name change - Address access denied OAuth error
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+      And the subject already has the following expired credentials
+        | CRI   | scenario        |
+        | fraud | kenneth-score-2 |
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+      When I submit a 'address-only' event
+      Then I get an 'address' CRI response
+      When I get an 'access_denied' OAuth error from the CRI stub
+      Then I get an 'sorry-could-not-confirm-details' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -31,6 +31,14 @@ Feature: Identity reuse update details failures
             Then I get a 'page-ipv-reuse' page response
 
         @FastFollow
+        Scenario: User is able to delete account from update-details-failed page
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I get an 'access_denied' OAuth error from the CRI stub
+            Then I get an 'update-details-failed' page response
+            When I submit a 'delete' event
+            Then I get a 'delete-handover' page response
+
+        @FastFollow
         Scenario: fail-with-no-ci from DCMAW
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I submit 'kenneth-passport-verification-zero' details to the CRI stub
@@ -63,6 +71,14 @@ Feature: Identity reuse update details failures
             Then I get a 'P0' identity
             When I start a new 'medium-confidence' journey
             Then I get a 'pyi-no-match' page response
+
+        @FastFollow
+        Scenario: User is able to delete account from sorry-could-not-confirm-details page
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit a 'delete' event
+            Then I get a 'delete-handover' page response
 
         Scenario: Zero score in fraud CRI
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -1,102 +1,153 @@
 @Build
 Feature: Identity reuse update details failures
 
-    Background:
-        Given the subject already has the following credentials
-            | CRI     | scenario                     |
-            | dcmaw   | kenneth-driving-permit-valid |
-            | address | kenneth-current              |
-            | fraud   | kenneth-score-2              |
-        When I start a new 'medium-confidence' journey
-        Then I get a 'page-ipv-reuse' page response
-        When I submit an 'update-details' event
-        Then I get an 'update-details' page response
-        When I submit a 'given-names-only' event
-        Then I get a 'page-update-name' page response
-        When I submit an 'update-name' event
-        Then I get a 'dcmaw' CRI response
+    Rule: Update given name only
 
-    @FastFollow
-    Scenario: Given name change - DCMAW access denied OAuth error
-        Given I activate the 'updateDetailsAccountDeletion' feature set
-        When I get an 'access_denied' OAuth error from the CRI stub
-        Then I get an 'update-details-failed' page response
-        When I submit a 'continue' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P2' identity
-        When I start a new 'medium-confidence' journey
-        Then I get a 'page-ipv-reuse' page response
+        Background:
+            Given the subject already has the following credentials
+                | CRI     | scenario                     |
+                | dcmaw   | kenneth-driving-permit-valid |
+                | address | kenneth-current              |
+                | fraud   | kenneth-score-2              |
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
+            When I submit an 'update-details' event
+            Then I get an 'update-details' page response
+            When I submit a 'given-names-only' event
+            Then I get a 'page-update-name' page response
+            When I submit an 'update-name' event
+            Then I get a 'dcmaw' CRI response
 
-    @FastFollow
-    Scenario: Given name change - fail-with-no-ci from DCMAW
-        Given I activate the 'updateDetailsAccountDeletion' feature set
-        When I submit 'kenneth-passport-verification-zero' details to the CRI stub
-        Then I get an 'update-details-failed' page response
-        When I submit a 'continue' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P2' identity
-        When I start a new 'medium-confidence' journey
-        Then I get a 'page-ipv-reuse' page response
+        @FastFollow
+        Scenario: Given name change - DCMAW access denied OAuth error
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I get an 'access_denied' OAuth error from the CRI stub
+            Then I get an 'update-details-failed' page response
+            When I submit a 'continue' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P2' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
 
-    Scenario: Given name change - breaching CI received from DCMAW
-        When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-        Then I get a 'sorry-could-not-confirm-details' page response
-        When I submit a 'end' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P0' identity
-        When I start a new 'medium-confidence' journey
-        Then I get a 'pyi-no-match' page response
+        @FastFollow
+        Scenario: Given name change - fail-with-no-ci from DCMAW
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I submit 'kenneth-passport-verification-zero' details to the CRI stub
+            Then I get an 'update-details-failed' page response
+            When I submit a 'continue' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P2' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
 
-    Scenario: Given name change - zero score in fraud CRI
-        When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
-        When I submit a 'next' event
-        Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
-        Then I get a 'sorry-could-not-confirm-details' page response
-        When I submit a 'end' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P0' identity
-        When I start a new 'medium-confidence' journey
-        Then I get a 'page-ipv-reuse' page response
+        Scenario: Given name change - breaching CI received from DCMAW
+            When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit a 'end' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'pyi-no-match' page response
 
-    Scenario: Given name change - breaching CI received from fraud CRI
-        When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
-        When I submit a 'next' event
-        Then I get a 'fraud' CRI response
-        When I submit 'kenneth-breaching-ci' details to the CRI stub
-        Then I get a 'sorry-could-not-confirm-details' page response
-        When I submit a 'end' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P0' identity
-        When I start a new 'medium-confidence' journey
-        Then I get a 'pyi-no-match' page response
+        Scenario: Given name change - zero score in fraud CRI
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit a 'end' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
 
-    Scenario: Given name change - breaching CI received from TICF CRI
-        When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
-        When I submit a 'next' event
-        Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
-        Then I get a 'page-ipv-success' page response
-        When I submit a 'next' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P2' identity
-        Given TICF CRI will respond with default parameters and
-            | cis | BREACHING |
-        When I start a new 'medium-confidence' journey
-        Then I get a 'pyi-no-match' page response
-        When I submit a 'next' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P0' identity
-        And the TICF VC has properties
-            | cis  | BREACHING      |
-            | type | RiskAssessment |
+        Scenario: Given name change - breaching CI received from fraud CRI
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I submit 'kenneth-breaching-ci' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit a 'end' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'pyi-no-match' page response
+
+        Scenario: Given name change - breaching CI received from TICF CRI
+            When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
+            Then I get a 'page-ipv-success' page response
+            When I submit a 'next' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P2' identity
+            Given TICF CRI will respond with default parameters and
+                | cis | BREACHING |
+            When I start a new 'medium-confidence' journey
+            Then I get a 'pyi-no-match' page response
+            When I submit a 'next' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+            And the TICF VC has properties
+                | cis  | BREACHING      |
+                | type | RiskAssessment |
+
+        Scenario: Given name change - failed COI check
+            When I submit 'alice-passport-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I submit 'alice-score-2' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit an 'end' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+
+        Scenario: Given name change - Fraud access denied OAuth error
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I get an 'access_denied' OAuth error from the CRI stub
+            Then I get an 'sorry-could-not-confirm-details' page response
+            When I submit a 'end' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
+
+    Rule: Update address only
+
+        Scenario: Given name change - Address access denied OAuth error
+            Given the subject already has the following credentials
+                | CRI     | scenario                     |
+                | dcmaw   | kenneth-driving-permit-valid |
+                | address | kenneth-current              |
+                | fraud   | kenneth-score-2              |
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
+            When I submit an 'update-details' event
+            Then I get an 'update-details' page response
+            When I submit a 'address-only' event
+            Then I get an 'address' CRI response
+            When I get an 'access_denied' OAuth error from the CRI stub
+            Then I get an 'sorry-could-not-confirm-details' page response
+            When I submit a 'end' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -19,7 +19,7 @@ Feature: Identity reuse update details failures
             Then I get a 'dcmaw' CRI response
 
         @FastFollow
-        Scenario: Given name change - DCMAW access denied OAuth error
+        Scenario: DCMAW access denied OAuth error
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I get an 'access_denied' OAuth error from the CRI stub
             Then I get an 'update-details-failed' page response
@@ -31,7 +31,7 @@ Feature: Identity reuse update details failures
             Then I get a 'page-ipv-reuse' page response
 
         @FastFollow
-        Scenario: Given name change - fail-with-no-ci from DCMAW
+        Scenario: fail-with-no-ci from DCMAW
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I submit 'kenneth-passport-verification-zero' details to the CRI stub
             Then I get an 'update-details-failed' page response
@@ -42,7 +42,7 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
 
-        Scenario: Given name change - breaching CI received from DCMAW
+        Scenario: Breaching CI received from DCMAW
             When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
             Then I get a 'sorry-could-not-confirm-details' page response
             When I submit a 'end' event
@@ -52,7 +52,19 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'pyi-no-match' page response
 
-        Scenario: Given name change - zero score in fraud CRI
+        @FastFollow
+        Scenario: Breaching CI received from DCMAW
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit a 'returnToRp' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'pyi-no-match' page response
+
+        Scenario: Zero score in fraud CRI
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
             Then I get a 'page-dcmaw-success' page response
             When I submit a 'next' event
@@ -66,7 +78,23 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
 
-        Scenario: Given name change - breaching CI received from fraud CRI
+        @FastFollow
+        Scenario: Zero score in fraud CRI
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit a 'returnToRp' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P2' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
+
+        Scenario: Breaching CI received from fraud CRI
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
             Then I get a 'page-dcmaw-success' page response
             When I submit a 'next' event
@@ -80,20 +108,30 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'pyi-no-match' page response
 
-        Scenario: Given name change - breaching CI received from TICF CRI
+        @FastFollow
+        Scenario: Breaching CI received from fraud CRI
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I submit 'kenneth-breaching-ci' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit a 'returnToRp' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'pyi-no-match' page response
+
+        Scenario: Breaching CI received from TICF CRI
+            Given TICF CRI will respond with default parameters and
+                | cis | BREACHING |
             When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
             Then I get a 'page-dcmaw-success' page response
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
-            Then I get a 'page-ipv-success' page response
-            When I submit a 'next' event
-            Then I get an OAuth response
-            When I use the OAuth response to get my identity
-            Then I get a 'P2' identity
-            Given TICF CRI will respond with default parameters and
-                | cis | BREACHING |
-            When I start a new 'medium-confidence' journey
             Then I get a 'pyi-no-match' page response
             When I submit a 'next' event
             Then I get an OAuth response
@@ -103,7 +141,8 @@ Feature: Identity reuse update details failures
                 | cis  | BREACHING      |
                 | type | RiskAssessment |
 
-        Scenario: Given name change - failed COI check
+
+        Scenario: Failed COI check
             When I submit 'alice-passport-valid' details to the CRI stub
             Then I get a 'page-dcmaw-success' page response
             When I submit a 'next' event
@@ -115,7 +154,23 @@ Feature: Identity reuse update details failures
             When I use the OAuth response to get my identity
             Then I get a 'P0' identity
 
-        Scenario: Given name change - Fraud access denied OAuth error
+        @FastFollow
+        Scenario: Failed COI check
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I submit 'alice-passport-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I submit 'alice-score-2' details to the CRI stub
+            Then I get a 'sorry-could-not-confirm-details' page response
+            When I submit an 'returnToRp' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P2' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
+
+        Scenario: Fraud access denied OAuth error
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
             Then I get a 'page-dcmaw-success' page response
             When I submit a 'next' event
@@ -129,9 +184,25 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
 
+        @FastFollow
+        Scenario: Fraud access denied OAuth error
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            Then I get a 'page-dcmaw-success' page response
+            When I submit a 'next' event
+            Then I get a 'fraud' CRI response
+            When I get an 'access_denied' OAuth error from the CRI stub
+            Then I get an 'sorry-could-not-confirm-details' page response
+            When I submit a 'returnToRp' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P2' identity
+            When I start a new 'medium-confidence' journey
+            Then I get a 'page-ipv-reuse' page response
+
     Rule: Update address only
 
-        Scenario: Given name change - Address access denied OAuth error
+        Background:
             Given the subject already has the following credentials
                 | CRI     | scenario                     |
                 | dcmaw   | kenneth-driving-permit-valid |
@@ -143,6 +214,8 @@ Feature: Identity reuse update details failures
             Then I get an 'update-details' page response
             When I submit a 'address-only' event
             Then I get an 'address' CRI response
+
+        Scenario: Address access denied OAuth error - receives P0
             When I get an 'access_denied' OAuth error from the CRI stub
             Then I get an 'sorry-could-not-confirm-details' page response
             When I submit a 'end' event
@@ -151,3 +224,13 @@ Feature: Identity reuse update details failures
             Then I get a 'P0' identity
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
+
+        @FastFollow
+        Scenario: Address access denied OAuth error - receives old identity (P2) when continuing to service
+            Given I activate the 'updateDetailsAccountDeletion' feature set
+            When I get an 'access_denied' OAuth error from the CRI stub
+            Then I get an 'sorry-could-not-confirm-details' page response
+            When I submit a 'returnToRp' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P2' identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -276,7 +276,7 @@ states:
       context: existingIdentityValid
     events:
       returnToRp:
-        targetState: RETURN_TO_RP
+        targetState: REINSTATE_EXISTING_IDENTITY
       delete:
         targetState: DELETE_HANDOVER_PAGE
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -161,7 +161,7 @@ states:
       alternate-doc-invalid-passport:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
       fail-with-ci:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -199,7 +199,7 @@ states:
       alternate-doc-invalid-passport:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE
       fail-with-ci:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -67,7 +67,7 @@ states:
               successful: false
             checkJourneyContext:
               rfc:
-                targetState: CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS_RFC
+                targetState: CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS_INVALID_IDENTITY
                 auditEvents:
                   - IPV_USER_DETAILS_UPDATE_END
                 auditContext:
@@ -204,21 +204,21 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
-  CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS_RFC:
+  CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS_INVALID_IDENTITY:
     response:
       type: process
       lambda: call-ticf-cri
     events:
       next:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_RFC
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       enhanced-verification:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_RFC
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       alternate-doc-invalid-dl:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_RFC
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       alternate-doc-invalid-passport:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_RFC
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       fail-with-ci:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_RFC
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -301,6 +301,19 @@ states:
       delete:
         targetState: DELETE_HANDOVER_PAGE
 
+  COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY:
+    response:
+      type: page
+      pageId: update-details-failed
+      context: existingIdentityInvalid
+    events:
+      delete:
+        targetState: DELETE_HANDOVER_PAGE
+      return-to-service:
+        targetState: RETURN_TO_RP
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_ABORTED
+
   REINSTATE_EXISTING_IDENTITY:
     response:
       type: process
@@ -311,19 +324,6 @@ states:
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START_NO_STORE
-
-  COULD_NOT_UPDATE_DETAILS_PAGE_RFC:
-    response:
-      type: page
-      pageId: update-details-failed
-      context: repeatFraudCheck
-    events:
-      delete:
-        targetState: DELETE_HANDOVER_PAGE
-      return-to-service:
-        targetState: RETURN_TO_RP
-        auditEvents:
-          - IPV_USER_DETAILS_UPDATE_ABORTED
 
   DELETE_HANDOVER_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -28,18 +28,27 @@ states:
           successful: false
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_REUSE
+            targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_VALID_ID
             auditEvents:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
               successful: false
             checkJourneyContext:
               rfc:
-                targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_RFC
+                targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_INVALID_ID
                 auditEvents:
                   - IPV_USER_DETAILS_UPDATE_END
                 auditContext:
                   successful: false
+
+  FAILED_CONFIRM_DETAILS_INVALID_ID:
+    events:
+      next:
+        targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_INVALID_ID
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_END
+        auditContext:
+          successful: false
 
   FAILED_UPDATE_DETAILS:
     events:
@@ -138,40 +147,40 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
-  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_REUSE:
+  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_VALID_ID:
     response:
       type: process
       lambda: call-ticf-cri
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
       enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
       alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
       alternate-doc-invalid-passport:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
       fail-with-ci:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
-  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_RFC:
+  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_INVALID_ID:
     response:
       type: process
       lambda: call-ticf-cri
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
       enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
       alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
       alternate-doc-invalid-passport:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
       fail-with-ci:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -260,22 +269,22 @@ states:
       end:
         targetState: RETURN_TO_RP
 
-  COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE:
+  COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID:
     response:
       type: page
       pageId: sorry-could-not-confirm-details
-      context: deleteDetailsReuse
+      context: existingIdentityValid
     events:
       returnToRp:
         targetState: RETURN_TO_RP
       delete:
         targetState: DELETE_HANDOVER_PAGE
 
-  COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC:
+  COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID:
     response:
       type: page
       pageId: sorry-could-not-confirm-details
-      context: deleteDetailsRfc
+      context: existingIdentityInvalid
     events:
       returnToRp:
         targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -28,7 +28,7 @@ states:
           successful: false
         checkFeatureFlag:
           updateDetailsAccountDeletion:
-            targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION
+            targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_REUSE
             auditEvents:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
@@ -138,21 +138,21 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
-  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION:
+  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_REUSE:
     response:
       type: process
       lambda: call-ticf-cri
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
       enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
       alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
       alternate-doc-invalid-passport:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
       fail-with-ci:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -260,7 +260,7 @@ states:
       end:
         targetState: RETURN_TO_RP
 
-  COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION:
+  COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_REUSE:
     response:
       type: page
       pageId: sorry-could-not-confirm-details

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -33,6 +33,13 @@ states:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
               successful: false
+            checkJourneyContext:
+              rfc:
+                targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_RFC
+                auditEvents:
+                  - IPV_USER_DETAILS_UPDATE_END
+                auditContext:
+                  successful: false
 
   FAILED_UPDATE_DETAILS:
     events:
@@ -150,6 +157,25 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
+  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_RFC:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+      enhanced-verification:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+      alternate-doc-invalid-dl:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+      alternate-doc-invalid-passport:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+      fail-with-ci:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
   CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS:
     response:
       type: process
@@ -240,7 +266,18 @@ states:
       pageId: sorry-could-not-confirm-details
       context: deleteDetailsReuse
     events:
-      end:
+      returnToRp:
+        targetState: RETURN_TO_RP
+      delete:
+        targetState: DELETE_HANDOVER_PAGE
+
+  COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_RFC:
+    response:
+      type: page
+      pageId: sorry-could-not-confirm-details
+      context: deleteDetailsRfc
+    events:
+      returnToRp:
         targetState: RETURN_TO_RP
       delete:
         targetState: DELETE_HANDOVER_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -33,21 +33,37 @@ states:
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
       alternate-doc-invalid-passport:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -69,21 +69,38 @@ states:
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
       alternate-doc-invalid-passport:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          updateDetailsAccountDeletion:
+            targetJourney: FAILED
+            targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+
 
   # Journey States
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Updated route to the two variants of the `sorry-could-not-confirm-details` page depending on the journeyContext and when `updateDetailsAccountDeletion` feature flag is enabled

### Why did it change
The `sorry-could-not-confirm-details` has two variants depending on the initial journey (rfc or reuse) which show different content so the routing needed to be updated to allow for this.

Corresponding FE PR: https://github.com/govuk-one-login/ipv-core-front/pull/1573

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7450](https://govukverify.atlassian.net/browse/PYIC-7450)


[PYIC-7450]: https://govukverify.atlassian.net/browse/PYIC-7450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ