### PR TITLE
PYIC-7380: Reinstate identity for failed COI journeys

### DIFF
--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -24,7 +24,19 @@ Feature: Identity reuse update details failures
         When I submit a 'continue' event
         Then I get an OAuth response
         When I use the OAuth response to get my identity
-        Then I get a 'P0' identity
+        Then I get a 'P2' identity
+        When I start a new 'medium-confidence' journey
+        Then I get a 'page-ipv-reuse' page response
+
+    @FastFollow
+    Scenario: Given name change - fail-with-no-ci from DCMAW
+        Given I activate the 'updateDetailsAccountDeletion' feature set
+        When I submit 'kenneth-passport-verification-zero' details to the CRI stub
+        Then I get an 'update-details-failed' page response
+        When I submit a 'continue' event
+        Then I get an OAuth response
+        When I use the OAuth response to get my identity
+        Then I get a 'P2' identity
         When I start a new 'medium-confidence' journey
         Then I get a 'page-ipv-reuse' page response
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
@@ -9,6 +9,11 @@ states:
       next:
         targetState: EVALUATE_GPG45_SCORES
 
+  START_NO_STORE:
+    events:
+      next:
+        targetState: EVALUATE_GPG45_SCORES_NO_STORE
+
   # Parent states
   CRI_TICF_STATE:
     events:
@@ -43,6 +48,20 @@ states:
         targetJourney: FAILED
         targetState: FAILED
 
+  EVALUATE_GPG45_SCORES_NO_STORE:
+    response:
+      type: process
+      lambda: evaluate-gpg45-scores
+    events:
+      met:
+        targetState: CRI_TICF_BEFORE_RP_RETURN_NO_STORE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+
   CRI_TICF_BEFORE_SUCCESS:
     response:
       type: process
@@ -51,6 +70,15 @@ states:
     events:
       next:
         targetState: STORE_IDENTITY_BEFORE_SUCCESS
+
+  CRI_TICF_BEFORE_RP_RETURN_NO_STORE:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: RETURN_TO_RP
 
   STORE_IDENTITY_BEFORE_SUCCESS:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -251,9 +251,20 @@ states:
       pageId: update-details-failed
     events:
       continue:
-        targetState: RETURN_TO_RP
+        targetState: REINSTATE_EXISTING_IDENTITY
       delete:
         targetState: DELETE_HANDOVER_PAGE
+
+  REINSTATE_EXISTING_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: REINSTATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START_NO_STORE
 
   COULD_NOT_UPDATE_DETAILS_PAGE_RFC:
     response:

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
@@ -4,5 +4,6 @@ public enum SessionCredentialsResetType {
     ALL,
     NAME_ONLY_CHANGE,
     ADDRESS_ONLY_CHANGE,
-    PENDING_F2F_ALL;
+    PENDING_F2F_ALL,
+    REINSTATE
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -102,7 +102,7 @@ public class SessionCredentialsService {
             var sessionCredentialItems = dataStore.getItems(ipvSessionId);
             var vcsToDelete =
                     switch (resetType) {
-                        case ALL, PENDING_F2F_ALL -> sessionCredentialItems;
+                        case ALL, PENDING_F2F_ALL, REINSTATE -> sessionCredentialItems;
                         case ADDRESS_ONLY_CHANGE -> sessionCredentialItems.stream()
                                 .filter(
                                         item ->


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Reinstate identity for failed COI journeys

### Why did it change

If a user fails a COI journey but still has a valid identity, they should be able to still use it.

This adds some logic to the reset-session-identity lambda with a new reset type to delete the current session VCs and restore the old identity from the long term store. This is plumbed in with some routing in the journey maps.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7380](https://govukverify.atlassian.net/browse/PYIC-7380)


[PYIC-7380]: https://govukverify.atlassian.net/browse/PYIC-7380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ