### PR TITLE
PYIC-7470: Add bulk migration batchIds to tactical store VCs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2488,6 +2488,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub bulk-migrate-vcs-${Environment}
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           REPORT_USER_IDENTITY_TABLE_NAME: !Ref ReportUserIdentityTable
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2518,6 +2519,16 @@ Resources:
             ParameterName: !Sub ${Environment}/core/*
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/evcs/apiKey-*
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
+        - Statement:
+            - Sid: kmsAuditEventQueueEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
       AutoPublishAlias: live
 
   BulkMigrateVcsFunctionLogGroup:

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -141,7 +141,7 @@ public class BuildProvenUserIdentityDetailsHandler
             if (identityClaim.isEmpty()) {
                 LOGGER.error(LogHelper.buildLogMessage("Failed to generate identity claim"));
                 throw new HttpResponseExceptionWithErrorBody(
-                        500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
+                        500, ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM);
             }
 
             return identityClaim.get();

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -642,7 +642,7 @@ class BuildUserIdentityHandlerTest {
         when(mockUserIdentityService.generateUserIdentity(any(), any(), any(), any(), any()))
                 .thenThrow(
                         new HttpResponseExceptionWithErrorBody(
-                                500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM));
+                                500, ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM));
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -653,10 +653,10 @@ class BuildUserIdentityHandlerTest {
 
         assertEquals(500, response.getStatusCode());
         assertEquals(
-                valueOf(ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM.getCode()),
+                valueOf(ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM.getCode()),
                 responseBody.get("error"));
         assertEquals(
-                ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM.getMessage(),
+                ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM.getMessage(),
                 responseBody.get("error_description"));
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
         verify(mockSessionCredentialsService, never()).deleteSessionCredentials(any());

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/BatchReport.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/BatchReport.java
@@ -19,9 +19,11 @@ public class BatchReport {
     private int totalFailedTacticalRead;
     private int totalFailedTacticalWrite;
     private int totalFailedEvcsWrite;
+    private int totalFailedTooManyBatchIds;
     private final List<String> allFailedTacticalReadHashUserIds;
     private final List<String> allFailedTacticalWriteHashUserIds;
     private final List<String> allFailedEvcsWriteHashUserIds;
+    private final List<String> allFailedTooManyBatchIdsHashUserIds;
     @Setter private String nextBatchExclusiveStartKey;
     @Setter private String exitReason;
 
@@ -31,6 +33,7 @@ public class BatchReport {
         this.allFailedTacticalReadHashUserIds = new ArrayList<>();
         this.allFailedTacticalWriteHashUserIds = new ArrayList<>();
         this.allFailedEvcsWriteHashUserIds = new ArrayList<>();
+        this.allFailedTooManyBatchIdsHashUserIds = new ArrayList<>();
     }
 
     public void addPageSummary(PageSummary summary) {
@@ -42,11 +45,13 @@ public class BatchReport {
         totalFailedTacticalRead += summary.getFailedTacticalRead();
         totalFailedTacticalWrite += summary.getFailedTacticalWrite();
         totalFailedEvcsWrite += summary.getFailedEvcsWrite();
+        totalFailedTooManyBatchIds += summary.getFailedTooManyBatchIds();
         totalEvaluated += summary.getTotal();
 
         allFailedTacticalReadHashUserIds.addAll(summary.getFailedTacticalReadHashUserIds());
         allFailedTacticalWriteHashUserIds.addAll(summary.getFailedTacticalWriteHashUserIds());
         allFailedEvcsWriteHashUserIds.addAll(summary.getFailedEvcsWriteHashUserIds());
+        allFailedTooManyBatchIdsHashUserIds.addAll(summary.getFailedTooManyBatchIdsHashUserIds());
 
         this.pageSummaries.add(summary);
     }

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/PageSummary.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/PageSummary.java
@@ -17,10 +17,12 @@ public class PageSummary {
     private int failedEvcsWrite;
     private int failedTacticalRead;
     private int failedTacticalWrite;
+    private int failedTooManyBatchIds;
     private int total;
     private final List<String> failedEvcsWriteHashUserIds;
     private final List<String> failedTacticalReadHashUserIds;
     private final List<String> failedTacticalWriteHashUserIds;
+    private final List<String> failedTooManyBatchIdsHashUserIds;
 
     public PageSummary(String exclusiveStartKey, int count) {
         this.exclusiveStartKey = exclusiveStartKey;
@@ -28,6 +30,7 @@ public class PageSummary {
         this.failedEvcsWriteHashUserIds = new ArrayList<>();
         this.failedTacticalReadHashUserIds = new ArrayList<>();
         this.failedTacticalWriteHashUserIds = new ArrayList<>();
+        this.failedTooManyBatchIdsHashUserIds = new ArrayList<>();
     }
 
     public String getExclusiveStartKey() {
@@ -75,5 +78,11 @@ public class PageSummary {
         failedTacticalWrite++;
         total++;
         failedTacticalWriteHashUserIds.add(hashUserId);
+    }
+
+    public synchronized void incrementFailedTooManyBatchIds(String hashUserId) {
+        failedTooManyBatchIds++;
+        total++;
+        failedTooManyBatchIdsHashUserIds.add(hashUserId);
     }
 }

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/exceptions/TooManyBatchIdsException.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/exceptions/TooManyBatchIdsException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.bulkmigratevcs.exceptions;
+
+public class TooManyBatchIdsException extends Exception {
+    public TooManyBatchIdsException(String message) {
+        super(message);
+    }
+}

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -62,7 +62,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.quality.Strictness.LENIENT;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_READ_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_NAME_CORRELATION;
-import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_CHECK_TYPE;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_IPV_SESSION_ID;
@@ -711,7 +711,7 @@ class CheckCoiHandlerTest {
             when(mockUserIdentityService.findIdentityClaim(any()))
                     .thenThrow(
                             new HttpResponseExceptionWithErrorBody(
-                                    500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM));
+                                    500, ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM));
 
             var request =
                     ProcessRequest.processRequestBuilder()
@@ -722,7 +722,8 @@ class CheckCoiHandlerTest {
             var responseMap = checkCoiHandler.handleRequest(request, mockContext);
 
             assertEquals(JOURNEY_ERROR_PATH, responseMap.get("journey"));
-            assertEquals(FAILED_TO_GENERATE_IDENTIY_CLAIM.getMessage(), responseMap.get("message"));
+            assertEquals(
+                    FAILED_TO_GENERATE_IDENTITY_CLAIM.getMessage(), responseMap.get("message"));
             verify(mockAuditService, times(1)).sendAuditEvent(auditEventCaptor.capture());
         }
     }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -373,13 +373,12 @@ public class CheckExistingIdentityHandler
 
     private VerifiableCredentialBundle getVerifiableCredentials(
             String userId, String evcsAccessToken)
-            throws CredentialParseException, EvcsServiceException, VerifiableCredentialException {
+            throws CredentialParseException, EvcsServiceException {
 
         var tacticalVcs = verifiableCredentialService.getVcs(userId);
 
         if (vcsAreFromEvcsMigrationRollbackBatch(tacticalVcs)) {
             tacticalVcs.forEach(vc -> vc.setBatchId(null));
-            verifiableCredentialService.updateIdentity(tacticalVcs);
             return new VerifiableCredentialBundle(tacticalVcs, false, false);
         }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -5,6 +5,7 @@ public enum ConfigurationVariable {
     BACKEND_SESSION_TIMEOUT("self/backendSessionTimeout"),
     BACKEND_SESSION_TTL("self/backendSessionTtl"),
     BEARER_TOKEN_TTL("self/bearerTokenTtl"),
+    BULK_MIGRATION_ROLLBACK_BATCHES("bulkMigration/rolledBackBatchIds"),
     CIMIT_COMPONENT_ID("cimit/componentId"),
     CIMIT_CONFIG("cimit/config"),
     CIMIT_SIGNING_KEY("cimit/signingKey"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -43,7 +43,7 @@ public enum ErrorResponse {
     MISSING_OAUTH_STATE(1030, "Missing OAuth state in callback request"),
     INVALID_OAUTH_STATE(1031, "Invalid OAuth State"),
     UNRECOVERABLE_OAUTH_STATE(1033, "Unable to resolve OAuth State"),
-    FAILED_TO_GENERATE_IDENTIY_CLAIM(1034, "Failed to generate the identity claim"),
+    FAILED_TO_GENERATE_IDENTITY_CLAIM(1034, "Failed to generate the identity claim"),
     FAILED_TO_GENERATE_ADDRESS_CLAIM(1035, "Failed to generate the address claim"),
     FAILED_TO_GENERATE_PASSPORT_CLAIM(1036, "Failed to generate the passport claim"),
     FAILED_TO_GENERATE_DRIVING_PERMIT_CLAIM(1037, "Failed to generate the driving permit claim"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredential.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/VerifiableCredential.java
@@ -23,8 +23,10 @@ public class VerifiableCredential {
     private final SignedJWT signedJwt;
     private Instant migrated;
     private final uk.gov.di.model.VerifiableCredential credential;
+    private String batchId;
 
-    private VerifiableCredential(String userId, Cri cri, SignedJWT signedJwt, Instant migrated)
+    private VerifiableCredential(
+            String userId, Cri cri, SignedJWT signedJwt, Instant migrated, String batchId)
             throws CredentialParseException {
         try {
             this.userId = userId;
@@ -34,6 +36,7 @@ public class VerifiableCredential {
             this.signedJwt = signedJwt;
             this.migrated = migrated;
             this.credential = VerifiableCredentialParser.parseCredential(this.claimsSet);
+            this.batchId = batchId;
         } catch (ParseException e) {
             throw new CredentialParseException(
                     "Failed to get jwt claims to construct verifiable credential", e);
@@ -42,7 +45,7 @@ public class VerifiableCredential {
 
     public static VerifiableCredential fromValidJwt(String userId, Cri cri, SignedJWT jwt)
             throws CredentialParseException {
-        return new VerifiableCredential(userId, cri, jwt, null);
+        return new VerifiableCredential(userId, cri, jwt, null, null);
     }
 
     public static VerifiableCredential fromVcStoreItem(VcStoreItem vcStoreItem)
@@ -58,7 +61,8 @@ public class VerifiableCredential {
                     vcStoreItem.getUserId(),
                     Cri.fromId(vcStoreItem.getCredentialIssuer()),
                     jwt,
-                    vcStoreItem.getMigrated());
+                    vcStoreItem.getMigrated(),
+                    vcStoreItem.getBatchId());
         } catch (ParseException e) {
             throw new CredentialParseException("Failed to parse VcStoreItem credential", e);
         }
@@ -72,6 +76,7 @@ public class VerifiableCredential {
                         .dateCreated(Instant.now())
                         .credential(vcString)
                         .migrated(migrated)
+                        .batchId(batchId)
                         .build();
 
         Date expirationTime = claimsSet.getExpirationTime();
@@ -89,7 +94,8 @@ public class VerifiableCredential {
                     userId,
                     Cri.fromId(sessionCredentialItem.getCriId()),
                     SignedJWT.parse(sessionCredentialItem.getCredential()),
-                    sessionCredentialItem.getMigrated());
+                    sessionCredentialItem.getMigrated(),
+                    null);
         } catch (ParseException e) {
             throw new CredentialParseException(
                     "Failed to parse SessionCredentialItem credential", e);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/VcStoreItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/VcStoreItem.java
@@ -25,6 +25,7 @@ public class VcStoreItem implements PersistenceItem {
     private Instant dateCreated;
     private Instant expirationTime;
     private Instant migrated;
+    private String batchId;
 
     @DynamoDbPartitionKey
     public String getUserId() {

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -145,7 +145,7 @@ public class UserIdentityService {
         if (claimWithName.isEmpty() || claimWithBirthDate.isEmpty()) {
             LOGGER.error(LogHelper.buildLogMessage("Failed to generate identity claim"));
             throw new HttpResponseExceptionWithErrorBody(
-                    500, ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM);
+                    500, ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM);
         }
         IdentityClaim identityClaim =
                 new IdentityClaim(

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -1053,7 +1053,7 @@ class UserIdentityServiceTest {
 
         assertEquals(500, thrownError.getResponseCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM, thrownError.getErrorResponse());
+                ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM, thrownError.getErrorResponse());
     }
 
     @Test
@@ -1077,7 +1077,7 @@ class UserIdentityServiceTest {
 
         assertEquals(500, thrownError.getResponseCode());
         assertEquals(
-                ErrorResponse.FAILED_TO_GENERATE_IDENTIY_CLAIM, thrownError.getErrorResponse());
+                ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM, thrownError.getErrorResponse());
     }
 
     @Test

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -33,7 +33,7 @@ core:
       # Test COI config
       familyNameChars: 5
   bulkMigration:
-    rolledBackBatchIds: ""
+    rolledBackBatchIds: "noneConfigured"
   clients:
     orchestrator:
       id: orchestrator

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -32,6 +32,8 @@ core:
     coi:
       # Test COI config
       familyNameChars: 5
+  bulkMigration:
+    rolledBackBatchIds: ""
   clients:
     orchestrator:
       id: orchestrator


### PR DESCRIPTION
**Not to be merged before https://github.com/govuk-one-login/ipv-core-common-infra/pull/1064**
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add bulk migration batchIds to tactical store VCs

### Why did it change

This adds the batch ID from the bulk migration to the VCs in the tactical store. This allows for us to more easily deal with having to roll back a batch.

The Bravo team will be responsible for deleting VCs from EVCS. We can then run the script again and remigrate the VCs whos batch IDs match a value in config.

And for on-demand migrations in the check-existing-identity lambda we can follow similar logic - check if the users tactical VCs have a matching batch ID, and remigrate if they do.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ