### PR TITLE
PYIC-5095: Add routing for PIP & Security routing

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -220,7 +220,7 @@ states:
     nestedJourney: WEB_DL_OR_PASSPORT
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_J7
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
@@ -370,6 +370,116 @@ states:
         targetJourney: FAILED
         targetState: FAILED
 
+  # Passport journey (J2)
+  CRI_UK_PASSPORT_J2:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J2
+      access-denied:
+        targetState: PROVE_ANOTHER_WAY_J2
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-passport:
+        targetState: MITIGATION_05_OPTIONS
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-passport
+
+  PROVE_ANOTHER_WAY_J2:
+    response:
+      type: page
+      pageId: prove-identity-another-type-photo-id
+      context: passport
+    events:
+      otherPhotoId:
+        targetState: CRI_DRIVING_LICENCE_J3
+      f2f:
+        targetState: F2F_PYI_POST_OFFICE
+      returnToRp:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  ADDRESS_AND_FRAUD_J2:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  # Driving licence journey (J3)
+  CRI_DRIVING_LICENCE_J3:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J3
+      access-denied:
+        targetState: PROVE_ANOTHER_WAY_J3
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-dl:
+        targetState: MITIGATION_03_OPTIONS
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-dl
+
+  PROVE_ANOTHER_WAY_J3:
+    response:
+      type: page
+      pageId: prove-identity-another-type-photo-id
+      context: drivingLicence
+    events:
+      otherPhotoId:
+        targetState: CRI_UK_PASSPORT_J2
+      f2f:
+        targetState: F2F_PYI_POST_OFFICE
+      returnToRp:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  ADDRESS_AND_FRAUD_J3:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
   # F2F journey (J4)
   CRI_CLAIMED_IDENTITY_J4:
     response:
@@ -513,6 +623,52 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
+  PERSONAL_INDEPENDENCE_PAYMENT_PAGE:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: PRE_DWP_KBV_TRANSITION_PAGE
+      end:
+        targetState: CRI_HMRC_KBV_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  PRE_DWP_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: CRI_DWP_KBV_J7
+      end:
+        targetState: PYI_CRI_ESCAPE
+
+  PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: PRE_DWP_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      end:
+        targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+
+  PRE_DWP_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+      end:
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+
   # No photo id journey
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
     response:
@@ -547,7 +703,7 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_HMRC_KBV_NO_PHOTO_ID
@@ -555,7 +711,7 @@ states:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       enhanced-verification:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_HMRC_KBV_NO_PHOTO_ID

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -228,7 +228,7 @@ states:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       alternate-doc-next:
-        targetState: MITIGATION_CRI_DWP_KBV
+        targetState: MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
@@ -1041,6 +1041,29 @@ states:
     events:
       next:
         targetState: MITIGATION_CRI_EXPERIAN_KBV
+
+  MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: MITIGATION_PRE_DWP_KBV_TRANSITION_PAGE
+      end:
+        targetState: MITIGATION_CRI_HMRC_KBV
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PRE_DWP_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: MITIGATION_CRI_DWP_KBV
+      end:
+        targetState: PYI_CRI_ESCAPE
 
   MITIGATION_CRI_EXPERIAN_KBV:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -230,7 +230,7 @@ states:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       alternate-doc-next:
-        targetState: MITIGATION_CRI_DWP_KBV
+        targetState: MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
@@ -1064,6 +1064,29 @@ states:
     events:
       next:
         targetState: MITIGATION_CRI_EXPERIAN_KBV
+
+  MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: MITIGATION_PRE_DWP_KBV_TRANSITION_PAGE
+      end:
+        targetState: MITIGATION_CRI_HMRC_KBV
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PRE_DWP_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: MITIGATION_CRI_DWP_KBV
+      end:
+        targetState: PYI_CRI_ESCAPE
 
   MITIGATION_CRI_EXPERIAN_KBV:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -222,7 +222,7 @@ states:
     nestedJourney: WEB_DL_OR_PASSPORT
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_J7
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
@@ -354,6 +354,124 @@ states:
         targetJourney: EVALUATE_SCORES
         targetState: START
       enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  # Passport journey (J2)
+  CRI_UK_PASSPORT_J2:
+    response:
+      type: cri
+      criId: ukPassport
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J2
+      access-denied:
+        targetState: PROVE_ANOTHER_WAY_J2
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-passport:
+        targetState: MITIGATION_05_OPTIONS
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-passport
+
+  PROVE_ANOTHER_WAY_J2:
+    response:
+      type: page
+      pageId: prove-identity-another-type-photo-id
+      context: passport
+    events:
+      otherPhotoId:
+        targetState: CRI_DRIVING_LICENCE_J3
+      f2f:
+        targetState: F2F_PYI_POST_OFFICE
+      returnToRp:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  ADDRESS_AND_FRAUD_J2:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      enhanced-verification:
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  # Driving licence journey (J3)
+  CRI_DRIVING_LICENCE_J3:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J3
+      access-denied:
+        targetState: PROVE_ANOTHER_WAY_J3
+        checkIfDisabled:
+          f2f:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+      alternate-doc-invalid-dl:
+        targetState: MITIGATION_03_OPTIONS
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: invalid-dl
+
+  PROVE_ANOTHER_WAY_J3:
+    response:
+      type: page
+      pageId: prove-identity-another-type-photo-id
+      context: drivingLicence
+    events:
+      otherPhotoId:
+        targetState: CRI_UK_PASSPORT_J2
+      f2f:
+        targetState: F2F_PYI_POST_OFFICE
+      returnToRp:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  ADDRESS_AND_FRAUD_J3:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: CHECK_FRAUD_SCORE_J3
+      enhanced-verification:
+        targetState: CHECK_FRAUD_SCORE_J3
+
+  CHECK_FRAUD_SCORE_J3:
+    response:
+      type: process
+      lambda: check-gpg45-score
+      lambdaInput:
+        scoreType: fraud
+        scoreThreshold: 2
+    events:
+      met:
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
         targetJourney: FAILED
         targetState: FAILED
 
@@ -500,6 +618,53 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
+  PERSONAL_INDEPENDENCE_PAYMENT_PAGE:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: PRE_DWP_KBV_TRANSITION_PAGE
+      end:
+        targetState: CRI_HMRC_KBV_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  PRE_DWP_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: CRI_DWP_KBV_J7
+      end:
+        targetState: PYI_CRI_ESCAPE
+
+  PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: PRE_DWP_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      end:
+        targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+
+  PRE_DWP_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+      end:
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+
+
   # No photo id journey (M2B)
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
     response:
@@ -548,7 +713,7 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_HMRC_KBV_NO_PHOTO_ID
@@ -556,7 +721,7 @@ states:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       enhanced-verification:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_HMRC_KBV_NO_PHOTO_ID

--- a/libs/common-services/bin/test/AdditionalPropertyCredential.json
+++ b/libs/common-services/bin/test/AdditionalPropertyCredential.json
@@ -1,0 +1,14 @@
+{
+  "credentialSubject": {
+    "address": [{
+      "buildingNumber": "35",
+      "streetName": "IDSWORTH ROAD",
+      "addressLocality": "SHEFFIELD",
+      "postalCode": "S5 6UN",
+      "addressCountry": "GB",
+      "validFrom": "2000-01-01"
+    }],
+    "additionalProperty": true
+  },
+  "type": ["VerifiableCredential", "AddressCredential"]
+}

--- a/libs/common-services/bin/test/AddressCredential.json
+++ b/libs/common-services/bin/test/AddressCredential.json
@@ -1,0 +1,14 @@
+{
+  "credentialSubject": {
+    "address": [{
+      "uprn": "100120012077",
+      "buildingNumber": "35",
+      "streetName": "IDSWORTH ROAD",
+      "addressLocality": "SHEFFIELD",
+      "postalCode": "S5 6UN",
+      "addressCountry": "GB",
+      "validFrom": "2000-01-01"
+    }]
+  },
+  "type": ["VerifiableCredential", "AddressCredential"]
+}

--- a/libs/common-services/bin/test/IdentityAssertionCredential.json
+++ b/libs/common-services/bin/test/IdentityAssertionCredential.json
@@ -1,0 +1,24 @@
+{
+  "credentialSubject": {
+    "name": [{
+      "nameParts": [
+        {
+          "value": "Alice",
+          "type": "GivenName"
+        },
+        {
+          "value": "Jane",
+          "type": "GivenName"
+        },
+        {
+          "value": "Doe",
+          "type": "FamilyName"
+        }
+      ]
+    }],
+    "birthDate": [{
+      "value": "1970-01-01"
+    }]
+  },
+  "type": ["VerifiableCredential", "IdentityAssertionCredential"]
+}

--- a/libs/common-services/bin/test/IdentityCheckCredential.json
+++ b/libs/common-services/bin/test/IdentityCheckCredential.json
@@ -1,0 +1,47 @@
+{
+  "credentialSubject": {
+    "name": [
+      {
+        "nameParts": [
+          {
+            "value": "Alice",
+            "type": "GivenName"
+          },
+          {
+            "value": "Jane",
+            "type": "GivenName"
+          },
+          {
+            "value": "Doe",
+            "type": "FamilyName"
+          }
+        ]
+      }
+    ],
+    "birthDate": [{
+      "value": "1970-01-01"
+    }],
+    "passport": [{
+      "documentNumber": "122345678",
+      "expiryDate": "2022-02-02",
+      "icaoIssuerCode": "GBR"
+    }]
+  },
+  "evidence": [{
+    "type": "IdentityCheck",
+    "txn": "example-txn",
+    "strengthScore": 4,
+    "validityScore": 2,
+    "checkDetails": [
+      {
+        "checkMethod": "data",
+        "dataCheck": "record_check"
+      },
+      {
+        "checkMethod": "data",
+        "dataCheck": "cancelled_check"
+      }
+    ]
+  }],
+  "type": ["VerifiableCredential", "IdentityCheckCredential"]
+}

--- a/libs/common-services/bin/test/InvalidPropertyCredential.json
+++ b/libs/common-services/bin/test/InvalidPropertyCredential.json
@@ -1,0 +1,4 @@
+{
+  "credentialSubject": "potato",
+  "type": ["VerifiableCredential", "AddressCredential"]
+}

--- a/libs/common-services/bin/test/InvalidTypeCredential.json
+++ b/libs/common-services/bin/test/InvalidTypeCredential.json
@@ -1,0 +1,14 @@
+{
+  "credentialSubject": {
+    "address": [{
+      "uprn": "100120012077",
+      "buildingNumber": "35",
+      "streetName": "IDSWORTH ROAD",
+      "addressLocality": "SHEFFIELD",
+      "postalCode": "S5 6UN",
+      "addressCountry": "GB",
+      "validFrom": "2000-01-01"
+    }]
+  },
+  "type": ["VerifiableCredential", "NotAnAddressCredential"]
+}

--- a/libs/common-services/bin/test/MissingTypeCredential.json
+++ b/libs/common-services/bin/test/MissingTypeCredential.json
@@ -1,0 +1,13 @@
+{
+  "credentialSubject": {
+    "address": [{
+      "uprn": "100120012077",
+      "buildingNumber": "35",
+      "streetName": "IDSWORTH ROAD",
+      "addressLocality": "SHEFFIELD",
+      "postalCode": "S5 6UN",
+      "addressCountry": "GB",
+      "validFrom": "2000-01-01"
+    }]
+  }
+}

--- a/libs/common-services/bin/test/RiskAssessmentCredential.json
+++ b/libs/common-services/bin/test/RiskAssessmentCredential.json
@@ -1,0 +1,8 @@
+{
+  "evidence": [{
+    "txn": "example-txn",
+    "ci": [],
+    "type": "RiskAssessment"
+  }],
+  "type": ["VerifiableCredential", "RiskAssessmentCredential"]
+}

--- a/libs/common-services/bin/test/SecurityCheckCredential.json
+++ b/libs/common-services/bin/test/SecurityCheckCredential.json
@@ -1,0 +1,12 @@
+{
+  "evidence": [{
+    "contraIndicator": [{
+      "code": "XX",
+      "issuanceDate": "",
+      "issuers": ["https://example-issuer"],
+      "document": "example-document"
+    }],
+    "type": "SecurityCheck"
+  }],
+  "type": ["VerifiableCredential", "SecurityCheckCredential"]
+}

--- a/libs/common-services/bin/test/test-parameters.yaml
+++ b/libs/common-services/bin/test/test-parameters.yaml
@@ -1,0 +1,19 @@
+---
+core:
+  self:
+    componentId: "test-component-id"
+  credentialIssuers:
+    address:
+      connections:
+        test: '{
+          "componentId":"test-issuer"
+        }'
+    dcmaw:
+      connections:
+        test: '{
+          "componentId":"alternate-issuer"
+        }'
+  features:
+    testFeature:
+      self:
+        componentId: "alternate-component-id"

--- a/libs/common-services/bin/test/test-secrets.yaml
+++ b/libs/common-services/bin/test/test-secrets.yaml
@@ -1,0 +1,4 @@
+---
+core:
+  govUkNotify:
+      apiKey: "test-api-key" # pragma: allowlist secret


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The first page that a user will land on when they begin the DWP KBV journey will consist of a 2 pages. This will qualify the user being routed down the DWP KBV journey or other KBV journeys respective of their answers.

If DWP KBV enabled, route to this ‘eligibility’ page. ‘Yes’ continues to DWP KBV CRI (via the start page). ‘No’/'prefer not to say' continues to HMRC KBV if enabled, otherwise Experian KBV (via the start page).

If the user clicks ‘I need to prove my identity another way’ should go to pyi-cri-escape (photo id) or no-photo-id-security-questions-find-another-way/en?context=dropout (no photo id)

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5095](https://govukverify.atlassian.net/browse/PYIC-5095)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-5095]: https://govukverify.atlassian.net/browse/PYIC-5095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ