### PR TITLE
PYIC-5095: Add routing for PIP & Security

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -236,7 +236,7 @@ states:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       alternate-doc-next-dl:
-        targetState: MITIGATION_CRI_DWP_KBV
+        targetState: MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
@@ -244,7 +244,7 @@ states:
               hmrcKbv:
                 targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       alternate-doc-next-passport:
-        targetState: MITIGATION_CRI_DWP_KBV
+        targetState: MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
@@ -980,6 +980,29 @@ states:
         targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       access-denied:
         targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: MITIGATION_PRE_DWP_KBV_TRANSITION_PAGE
+      end:
+        targetState: MITIGATION_CRI_HMRC_KBV
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PRE_DWP_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: MITIGATION_CRI_DWP_KBV
+      end:
+        targetState: PYI_CRI_ESCAPE
 
   MITIGATION_CRI_DWP_KBV:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -220,7 +220,7 @@ states:
     nestedJourney: WEB_DL_OR_PASSPORT
     exitEvents:
       next-dl:
-        targetState: CRI_DWP_KBV_J7
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
@@ -228,7 +228,7 @@ states:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
       next-passport:
-        targetState: CRI_DWP_KBV_J7
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
@@ -529,6 +529,52 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
+  PERSONAL_INDEPENDENCE_PAYMENT_PAGE:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: PRE_DWP_KBV_TRANSITION_PAGE
+      end:
+        targetState: CRI_HMRC_KBV_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  PRE_DWP_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: CRI_DWP_KBV_J7
+      end:
+        targetState: PYI_CRI_ESCAPE
+
+  PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: PRE_DWP_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      end:
+        targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+
+  PRE_DWP_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+      end:
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+
   # No photo id journey
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
     response:
@@ -563,7 +609,7 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_HMRC_KBV_NO_PHOTO_ID
@@ -571,7 +617,7 @@ states:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       enhanced-verification:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_HMRC_KBV_NO_PHOTO_ID

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -224,7 +224,7 @@ states:
       next-dl:
         targetState: CHECK_FRAUD_AFTER_DL
       next-passport:
-        targetState: CRI_DWP_KBV_J7
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_NINO_J6
@@ -544,6 +544,52 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
+  PERSONAL_INDEPENDENCE_PAYMENT_PAGE:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: PRE_DWP_KBV_TRANSITION_PAGE
+      end:
+        targetState: CRI_HMRC_KBV_J6
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  PRE_DWP_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: CRI_DWP_KBV_J7
+      end:
+        targetState: PYI_CRI_ESCAPE
+
+  PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: PRE_DWP_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+      end:
+        targetState: CRI_HMRC_KBV_NO_PHOTO_ID
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+
+  PRE_DWP_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+      end:
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+
   # No photo id journey (M2B)
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
     response:
@@ -592,7 +638,7 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_HMRC_KBV_NO_PHOTO_ID
@@ -600,7 +646,7 @@ states:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
       enhanced-verification:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
+        targetState: PERSONAL_INDEPENDENCE_PAYMENT_PAGE_NO_PHOTO_ID
         checkIfDisabled:
           dwpKbv:
             targetState: CRI_HMRC_KBV_NO_PHOTO_ID

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -234,7 +234,7 @@ states:
       alternate-doc-next-dl:
         targetState: MITIGATION_CHECK_FRAUD_AFTER_DL
       alternate-doc-next-passport:
-        targetState: MITIGATION_CRI_DWP_KBV
+        targetState: MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE
         checkIfDisabled:
           dwpKbv:
             targetState: MITIGATION_PP_CRI_NINO
@@ -1022,6 +1022,29 @@ states:
         targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       access-denied:
         targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PERSONAL_INDEPENDENCE_PAYMENT_PAGE:
+    response:
+      type: page
+      pageId: personal-independence-payment
+    events:
+      next:
+        targetState: MITIGATION_PRE_DWP_KBV_TRANSITION_PAGE
+      end:
+        targetState: MITIGATION_CRI_HMRC_KBV
+        checkIfDisabled:
+          hmrcKbv:
+            targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+
+  MITIGATION_PRE_DWP_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-dwp-kbv-transition
+    events:
+      next:
+        targetState: MITIGATION_CRI_DWP_KBV
+      end:
+        targetState: PYI_CRI_ESCAPE
 
   MITIGATION_CRI_DWP_KBV:
     response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The first page that a user will land on when they begin the DWP KBV journey will consist of a 2 pages. This will qualify the user being routed down the DWP KBV journey or other KBV journeys respective of their answers.

If DWP KBV enabled, route to this ‘eligibility’ page. ‘Yes’ continues to DWP KBV CRI (via the start page). ‘No’/'prefer not to say' continues to HMRC KBV if enabled, otherwise Experian KBV (via the start page).

If the user clicks ‘I need to prove my identity another way’ should go to pyi-cri-escape (photo id) or no-photo-id-security-questions-find-another-way/en?context=dropout (no photo id)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5095](https://govukverify.atlassian.net/browse/PYIC-5095)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-5095]: https://govukverify.atlassian.net/browse/PYIC-5095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ