### PR TITLE
PYIC-7035 Pull fraud score check out of web doc nested journey

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -206,9 +206,9 @@ WEB_DL_OR_PASSPORT:
       nestedJourney: ADDRESS_AND_FRAUD
       exitEvents:
         next:
-          exitEventToEmit: next
+          exitEventToEmit: next-passport
         enhanced-verification:
-          exitEventToEmit: next
+          exitEventToEmit: next-passport
     PROVE_ANOTHER_WAY_AFTER_PASSPORT:
       response:
         type: page
@@ -244,21 +244,9 @@ WEB_DL_OR_PASSPORT:
       nestedJourney: ADDRESS_AND_FRAUD
       exitEvents:
         next:
-          targetState: CHECK_FRAUD_SCORE_DL
+          exitEventToEmit: next-dl
         enhanced-verification:
-          targetState: CHECK_FRAUD_SCORE_DL
-    CHECK_FRAUD_SCORE_DL:
-      response:
-        type: process
-        lambda: check-gpg45-score
-        lambdaInput:
-          scoreType: fraud
-          scoreThreshold: 2
-      events:
-        met:
-          exitEventToEmit: next
-        unmet:
-          exitEventToEmit: failed
+          exitEventToEmit: next-dl
     PROVE_ANOTHER_WAY_AFTER_DL:
       response:
         type: page
@@ -326,20 +314,8 @@ WEB_DL_OR_PASSPORT:
       nestedJourney: ADDRESS_AND_FRAUD
       exitEvents:
         next:
-          targetState: MITIGATION_CHECK_FRAUD_SCORE
+          exitEventToEmit: alternate-doc-next-dl
         enhanced-verification:
-          exitEventToEmit: failed
-    MITIGATION_CHECK_FRAUD_SCORE:
-      response:
-        type: process
-        lambda: check-gpg45-score
-        lambdaInput:
-          scoreType: fraud
-          scoreThreshold: 2
-      events:
-        met:
-          exitEventToEmit: alternate-doc-next
-        unmet:
           exitEventToEmit: failed
 
     # Invalid DL mitigation routes
@@ -386,7 +362,7 @@ WEB_DL_OR_PASSPORT:
       nestedJourney: ADDRESS_AND_FRAUD
       exitEvents:
         next:
-          exitEventToEmit: alternate-doc-next
+          exitEventToEmit: alternate-doc-next-passport
         enhanced-verification:
           exitEventToEmit: failed
     MITIGATION_PP_PROVE_ANOTHER_WAY:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -219,7 +219,7 @@ states:
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
     exitEvents:
-      next:
+      next-dl:
         targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
           dwpKbv:
@@ -227,7 +227,23 @@ states:
             checkIfDisabled:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      alternate-doc-next:
+      next-passport:
+        targetState: CRI_DWP_KBV_J7
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      alternate-doc-next-dl:
+        targetState: MITIGATION_CRI_DWP_KBV
+        checkIfDisabled:
+          dwpKbv:
+            targetState: MITIGATION_PP_CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      alternate-doc-next-passport:
         targetState: MITIGATION_CRI_DWP_KBV
         checkIfDisabled:
           dwpKbv:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -221,7 +221,9 @@ states:
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
     exitEvents:
-      next:
+      next-dl:
+        targetState: CHECK_FRAUD_AFTER_DL
+      next-passport:
         targetState: CRI_DWP_KBV_J7
         checkIfDisabled:
           dwpKbv:
@@ -229,7 +231,9 @@ states:
             checkIfDisabled:
               hmrcKbv:
                 targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      alternate-doc-next:
+      alternate-doc-next-dl:
+        targetState: MITIGATION_CHECK_FRAUD_AFTER_DL
+      alternate-doc-next-passport:
         targetState: MITIGATION_CRI_DWP_KBV
         checkIfDisabled:
           dwpKbv:
@@ -246,6 +250,46 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
       failed:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  CHECK_FRAUD_AFTER_DL:
+    response:
+      type: process
+      lambda: check-gpg45-score
+      lambdaInput:
+        scoreType: fraud
+        scoreThreshold: 2
+    events:
+      met:
+        targetState: CRI_DWP_KBV_J7
+        checkIfDisabled:
+          dwpKbv:
+            targetState: CRI_NINO_J6
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  MITIGATION_CHECK_FRAUD_AFTER_DL:
+    response:
+      type: process
+      lambda: check-gpg45-score
+      lambdaInput:
+        scoreType: fraud
+        scoreThreshold: 2
+    events:
+      met:
+        targetState: MITIGATION_CRI_DWP_KBV
+        checkIfDisabled:
+          dwpKbv:
+            targetState: MITIGATION_PP_CRI_NINO
+            checkIfDisabled:
+              hmrcKbv:
+                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+      unmet:
         targetJourney: FAILED
         targetState: FAILED
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -290,6 +290,13 @@ class JourneyMapTest {
                     }
                 }
             }
+            if (nestedState instanceof NestedJourneyInvokeState nestedNestedState) {
+                for (var event : nestedNestedState.getExitEvents().values()) {
+                    if (event instanceof ExitNestedJourneyEvent exitNestedJourneyEvent) {
+                        actualExitEvents.add(exitNestedJourneyEvent.getExitEventToEmit());
+                    }
+                }
+            }
         }
         return actualExitEvents;
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Included the fraud score check in the nested web doc journey, which meant it inadvertently got added to the P1 journey.

Instead, we can emit different exit events, and allow the main journey to determine how to handle different events. This should be more flexible if (for example) in future we wish to allow users to follow other routes with DL + fraud score 1.