### PR TITLE
PYIC-7482 Add nested journey for KBVs

### DIFF
--- a/journey-map/public/index.mjs
+++ b/journey-map/public/index.mjs
@@ -397,7 +397,7 @@ const setupSearchHandler = () => {
 const initialize = async () => {
     setupHeader();
     await loadJourneyMaps();
-    const { disabledOptions, featureFlagOptions } = getOptions(journeyMaps);
+    const { disabledOptions, featureFlagOptions } = getOptions(journeyMaps, nestedJourneys);
     setupOptions('disabledCri', disabledOptions, disabledInput, CRI_NAMES);
     setupOptions('featureFlag', featureFlagOptions, featureFlagInput);
     setupOtherOptions();

--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -18,16 +18,27 @@ const addDefinitionOptions = (definition, disabledOptions, featureFlagOptions) =
 };
 
 // Traverse the journey map to collect the available 'disabled' and 'featureFlag' options
-export const getOptions = (journeyMaps) => {
+export const getOptions = (journeyMaps, nestedJourneys) => {
     const disabledOptions = ['ticf'];
     const featureFlagOptions = [];
 
-    Object.values(journeyMaps).forEach((journeyMap) => {
-        Object.values(journeyMap.states).forEach((definition) => {
-            const events = definition.events || definition.exitEvents || {};
-            Object.values(events).forEach((def) => {
-                addDefinitionOptions(def, disabledOptions, featureFlagOptions);
-            });
+    const states = [
+        ...Object.values(journeyMaps)
+            .flatMap(journeyMap => Object.values(journeyMap.states)),
+        ...Object.values(nestedJourneys)
+            .flatMap(nestedJourney => Object.values(nestedJourney.nestedJourneyStates)),
+    ];
+
+    states.forEach((definition) => {
+        const events = definition.events || definition.exitEvents || {};
+        Object.values(events).forEach((def) => {
+            addDefinitionOptions(def, disabledOptions, featureFlagOptions);
+        });
+    });
+
+    Object.values(nestedJourneys).forEach(nestedJourney => {
+        Object.values(nestedJourney.entryEvents).forEach((def) => {
+            addDefinitionOptions(def, disabledOptions, featureFlagOptions);
         });
     });
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -375,3 +375,83 @@ WEB_DL_OR_PASSPORT:
           targetState: MITIGATION_PP_CRI_UK_PASSPORT
         returnToRp:
           exitEventToEmit: return-to-rp
+
+KBVS:
+  name: KBV challenge routing
+  description: >-
+    The combined journey for enabled KBV CRIs.
+  entryEvents:
+    next:
+      targetState: CRI_DWP_KBV
+      checkIfDisabled:
+        dwpKbv:
+          targetState: CRI_NINO
+          checkIfDisabled:
+            hmrcKbv:
+              targetState: PRE_EXPERIAN_PAGE
+    next-with-nino:
+      targetState: CRI_DWP_KBV
+      checkIfDisabled:
+        dwpKbv:
+          targetState: CRI_HMRC_KBV
+          checkIfDisabled:
+            hmrcKbv:
+              targetState: PRE_EXPERIAN_PAGE
+  nestedJourneyStates:
+    CRI_NINO:
+      response:
+        type: cri
+        criId: nino
+      parent: CRI_STATE
+      events:
+        next:
+          targetState: CRI_HMRC_KBV
+        fail-with-no-ci:
+          targetState: PRE_EXPERIAN_PAGE
+    CRI_DWP_KBV:
+      response:
+        type: cri
+        criId: dwpKbv
+      parent: CRI_STATE
+      events:
+        next:
+          exitEventToEmit: next
+        enhanced-verification:
+          exitEventToEmit: enhanced-verification
+        invalid-request:
+          targetState: PRE_EXPERIAN_PAGE
+        access-denied:
+          targetState: PRE_EXPERIAN_PAGE
+    CRI_HMRC_KBV:
+      response:
+        type: cri
+        criId: hmrcKbv
+      parent: CRI_STATE
+      events:
+        next:
+          exitEventToEmit: next
+        enhanced-verification:
+          exitEventToEmit: enhanced-verification
+        invalid-request:
+          targetState: PRE_EXPERIAN_PAGE
+        access-denied:
+          targetState: PRE_EXPERIAN_PAGE
+    PRE_EXPERIAN_PAGE:
+      response:
+        type: page
+        pageId: page-pre-experian-kbv-transition
+      events:
+        next:
+          targetState: CRI_EXPERIAN_KBV
+    CRI_EXPERIAN_KBV:
+      response:
+        type: cri
+        criId: kbv
+      parent: CRI_STATE
+      events:
+        fail-with-no-ci:
+          exitEventToEmit: fail-with-no-ci
+        next:
+          exitEventToEmit: next
+        enhanced-verification:
+          exitEventToEmit: enhanced-verification

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -220,37 +220,15 @@ states:
     nestedJourney: WEB_DL_OR_PASSPORT
     exitEvents:
       next-dl:
-        targetState: CRI_DWP_KBV_J7
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_NINO_J6
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: KBV_PHOTO_ID
+        targetEntryEvent: next
       next-passport:
-        targetState: CRI_DWP_KBV_J7
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_NINO_J6
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: KBV_PHOTO_ID
+        targetEntryEvent: next
       alternate-doc-next-dl:
-        targetState: MITIGATION_CRI_DWP_KBV
-        checkIfDisabled:
-          dwpKbv:
-            targetState: MITIGATION_PP_CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: MITIGATION_KBVS
       alternate-doc-next-passport:
-        targetState: MITIGATION_CRI_DWP_KBV
-        checkIfDisabled:
-          dwpKbv:
-            targetState: MITIGATION_PP_CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: MITIGATION_KBVS
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:
@@ -331,20 +309,9 @@ states:
       lambda: build-client-oauth-response
 
   # Common pages
-  PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: CRI_EXPERIAN_KBV
-
-  CRI_EXPERIAN_KBV:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
+  KBV_PHOTO_ID:
+    nestedJourney: KBVS
+    exitEvents:
       fail-with-no-ci:
         targetState: PYI_CRI_ESCAPE
         checkIfDisabled:
@@ -408,127 +375,6 @@ states:
         targetJourney: F2F_HAND_OFF
         targetState: START
 
-  # HMRC KBV journey (J6)
-  CRI_NINO_J6:
-    response:
-      type: cri
-      criId: nino
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CRI_HMRC_KBV_J6
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  CRI_HMRC_KBV_J6:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  CRI_HMRC_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      enhanced-verification:
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-
-  # DWP KBV journey (J7)
-  CRI_DWP_KBV_J7:
-    response:
-      type: cri
-      criId: dwpKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-
-  CRI_DWP_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: dwpKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-      enhanced-verification:
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-
   # No photo id journey
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
     response:
@@ -563,36 +409,15 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+        targetState: KBV_NO_PHOTO_ID
+        targetEntryEvent: next-with-nino
       enhanced-verification:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+        targetState: KBV_NO_PHOTO_ID
+        targetEntryEvent: next-with-nino
 
-  PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: CRI_EXPERIAN_KBV_NO_PHOTO_ID
-
-  CRI_EXPERIAN_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
+  KBV_NO_PHOTO_ID:
+    nestedJourney: KBVS
+    exitEvents:
       fail-with-no-ci:
         targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
         checkIfDisabled:
@@ -883,71 +708,15 @@ states:
         targetState: INELIGIBLE
 
   # Common Mitigation states - invalid-dl/invalid-passport
-  MITIGATION_PP_CRI_NINO:
-    response:
-      type: cri
-      criId: nino
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: MITIGATION_CRI_HMRC_KBV
-      fail-with-no-ci:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: MITIGATION_CRI_EXPERIAN_KBV
-
-  MITIGATION_CRI_EXPERIAN_KBV:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
+  MITIGATION_KBVS:
+    nestedJourney: KBVS
+    exitEvents:
       fail-with-no-ci:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  MITIGATION_CRI_HMRC_KBV:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-      invalid-request:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  MITIGATION_CRI_DWP_KBV:
-    response:
-      type: cri
-      criId: dwpKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -776,3 +776,65 @@ states:
           mitigationType: enhanced-verification
       end:
         targetState: RETURN_TO_RP
+
+## Temporary inclusion of KBV states to avoid breaking existing journeys
+
+  PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: CRI_EXPERIAN_KBV
+
+  CRI_EXPERIAN_KBV:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetState: PYI_CRI_ESCAPE
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        auditEvents:
+          - IPV_MITIGATION_START
+        auditContext:
+          mitigationType: enhanced-verification
+        checkIfDisabled:
+          f2f:
+            targetState: MITIGATION_02_OPTIONS
+            auditEvents:
+              - IPV_MITIGATION_START
+            auditContext:
+              mitigationType: enhanced-verification
+
+  MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: MITIGATION_CRI_EXPERIAN_KBV
+
+  MITIGATION_CRI_EXPERIAN_KBV:
+    response:
+      type: cri
+      criId: kbv
+    parent: CRI_STATE
+    events:
+      fail-with-no-ci:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -224,23 +224,11 @@ states:
       next-dl:
         targetState: CHECK_FRAUD_AFTER_DL
       next-passport:
-        targetState: CRI_DWP_KBV_J7
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_NINO_J6
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: KBV_PHOTO_ID
       alternate-doc-next-dl:
         targetState: MITIGATION_CHECK_FRAUD_AFTER_DL
       alternate-doc-next-passport:
-        targetState: MITIGATION_CRI_DWP_KBV
-        checkIfDisabled:
-          dwpKbv:
-            targetState: MITIGATION_PP_CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: MITIGATION_KBVS
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:
@@ -262,13 +250,8 @@ states:
         scoreThreshold: 2
     events:
       met:
-        targetState: CRI_DWP_KBV_J7
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_NINO_J6
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: KBV_PHOTO_ID
+        targetEntryEvent: next
       unmet:
         targetJourney: FAILED
         targetState: FAILED
@@ -282,13 +265,8 @@ states:
         scoreThreshold: 2
     events:
       met:
-        targetState: MITIGATION_CRI_DWP_KBV
-        checkIfDisabled:
-          dwpKbv:
-            targetState: MITIGATION_PP_CRI_NINO
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
+        targetState: MITIGATION_KBVS
+        targetEntryEvent: next
       unmet:
         targetJourney: FAILED
         targetState: FAILED
@@ -346,20 +324,9 @@ states:
       lambda: build-client-oauth-response
 
   # Common pages
-  PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: CRI_EXPERIAN_KBV
-
-  CRI_EXPERIAN_KBV:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
+  KBV_PHOTO_ID:
+    nestedJourney: KBVS
+    exitEvents:
       fail-with-no-ci:
         targetState: PYI_CRI_ESCAPE
         checkIfDisabled:
@@ -423,127 +390,6 @@ states:
         targetJourney: F2F_HAND_OFF
         targetState: START
 
-  # HMRC KBV journey (J6)
-  CRI_NINO_J6:
-    response:
-      type: cri
-      criId: nino
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CRI_HMRC_KBV_J6
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  CRI_HMRC_KBV_J6:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  CRI_HMRC_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      enhanced-verification:
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-
-  # DWP KBV journey (J7)
-  CRI_DWP_KBV_J7:
-    response:
-      type: cri
-      criId: dwpKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-
-  CRI_DWP_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: dwpKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-      access-denied:
-        targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
-      enhanced-verification:
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-        targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
-
   # No photo id journey (M2B)
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
     response:
@@ -592,36 +438,15 @@ states:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+        targetState: KBV_NO_PHOTO_ID
+        targetEntryEvent: next-with-nino
       enhanced-verification:
-        targetState: CRI_DWP_KBV_NO_PHOTO_ID
-        checkIfDisabled:
-          dwpKbv:
-            targetState: CRI_HMRC_KBV_NO_PHOTO_ID
-            checkIfDisabled:
-              hmrcKbv:
-                targetState: PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID
+        targetState: KBV_NO_PHOTO_ID
+        targetEntryEvent: next-with-nino
 
-  PRE_EXPERIAN_KBV_TRANSITION_PAGE_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: CRI_EXPERIAN_KBV_NO_PHOTO_ID
-
-  CRI_EXPERIAN_KBV_NO_PHOTO_ID:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
+  KBV_NO_PHOTO_ID:
+    nestedJourney: KBVS
+    exitEvents:
       fail-with-no-ci:
         targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
         checkIfDisabled:
@@ -925,71 +750,15 @@ states:
         targetState: INELIGIBLE
 
   # Common Mitigation states - invalid-dl/invalid-passport
-  MITIGATION_PP_CRI_NINO:
-    response:
-      type: cri
-      criId: nino
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: MITIGATION_CRI_HMRC_KBV
-      fail-with-no-ci:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE:
-    response:
-      type: page
-      pageId: page-pre-experian-kbv-transition
-    events:
-      next:
-        targetState: MITIGATION_CRI_EXPERIAN_KBV
-
-  MITIGATION_CRI_EXPERIAN_KBV:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
+  MITIGATION_KBVS:
+    nestedJourney: KBVS
+    exitEvents:
       fail-with-no-ci:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  MITIGATION_CRI_HMRC_KBV:
-    response:
-      type: cri
-      criId: hmrcKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED
-      invalid-request:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-
-  MITIGATION_CRI_DWP_KBV:
-    response:
-      type: cri
-      criId: dwpKbv
-    parent: CRI_STATE
-    events:
-      next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START
-      invalid-request:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
-      access-denied:
-        targetState: MITIGATION_PRE_EXPERIAN_KBV_TRANSITION_PAGE
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED


### PR DESCRIPTION
## Proposed changes

### What changed

Pull all KBV journeys into a nested journey

### Why did it change

The KBVs are highly duplicated, with 6 different copies - making it quite well-suited to pulling out into a nested journey.

One consideration is that this ties our KBV priority together - we'll have to add duplication back in if we want different priorities depending on the route.

### Screenshots

KBV routing with HMRC/DWP disabled:
![image](https://github.com/user-attachments/assets/037b416d-3110-4c60-8f60-de0d020eca3a)

KBV routing with HMRC enabled:
![image](https://github.com/user-attachments/assets/8e3019e4-31bd-441b-af50-5a7a0d8e3a62)

KBV routing with DWP enabled:
![image](https://github.com/user-attachments/assets/33933ffc-07c0-4aff-ab28-b33173765c52)

P2 identity:
![image](https://github.com/user-attachments/assets/db8f0d39-c0d9-4a29-b197-131f66e9e630)

P1 identity:
![image](https://github.com/user-attachments/assets/723cdd2b-302c-4438-88d4-8b3a103942e9)
