### PR TITLE
PYIC-7482 Fix targetEntryEvent override from an exitEvent

### DIFF
--- a/api-tests/data/cri-stub-requests/hmrcKbv/kenneth-score-2/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/hmrcKbv/kenneth-score-2/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/hmrcKbv/kenneth-score-2/evidence.json
+++ b/api-tests/data/cri-stub-requests/hmrcKbv/kenneth-score-2/evidence.json
@@ -1,0 +1,21 @@
+{
+  "type": "IdentityCheck",
+  "verificationScore": 2,
+  "checkDetails": [
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 3,
+      "checkMethod": "kbv"
+    },
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 3,
+      "checkMethod": "kbv"
+    },
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 2,
+      "checkMethod": "kbv"
+    }
+  ]
+}

--- a/api-tests/features/p2-m2b.feature
+++ b/api-tests/features/p2-m2b.feature
@@ -32,3 +32,33 @@ Feature: M2B No Photo Id Journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
+
+  Scenario: M2B Journey with HMRC KBV
+    Given I start a new 'medium-confidence' journey with feature set 'm2bBetaHmrcKbv'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'page-ipv-identity-postoffice-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response
+    When I submit an 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "bank_account" |
+    Then I get a 'bav' CRI response
+    When I submit 'kenneth' details to the CRI stub
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'hmrcKbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeState.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeState.java
@@ -17,6 +17,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 
+import static java.util.Objects.requireNonNullElse;
 import static uk.gov.di.ipv.core.library.domain.JourneyState.JOURNEY_STATE_DELIMITER;
 
 @Data
@@ -64,9 +65,10 @@ public class NestedJourneyInvokeState implements State {
         }
 
         if (result.state() instanceof NestedJourneyInvokeState) {
+            var entryEvent = requireNonNullElse(result.targetEntryEvent(), eventName);
             return result.state()
                     .transition(
-                            eventName,
+                            entryEvent,
                             String.join(JOURNEY_STATE_DELIMITER, stateNameParts),
                             journeyContext);
         }


### PR DESCRIPTION
## Proposed changes

### What changed

We need to resolve `targetEntryEvent` from nested journey exit events.

### Why did it change

We weren't correctly skipping NINO CRI on an M2B + HMRC KBVs journey
