### PR TITLE
BAU: Fix doc type detection

### DIFF
--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -77,7 +77,9 @@ export const processCriCallback = async (
   });
 
   if (!response.ok) {
-    throw new Error(`sendJourneyEvent request failed: ${response.statusText}`);
+    throw new Error(
+      `processCriCallback request failed: ${response.statusText}`,
+    );
   }
 
   return await response.json();


### PR DESCRIPTION
## Proposed changes

### What changed

Only try to deduplicate evidence VCs (i.e. those with a strength + validity)

### Why did it change

Other VCs do not correspond properly to documents - e.g. the HMRC KBV VC contains a NINO in the subject, but should not be treated as NINO evidence.
