### PR TITLE
PYIC-7470: Handle edge case for rollback batch IDs

### DIFF
--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
@@ -351,24 +351,25 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
             String batchId,
             PageSummary pageSummary)
             throws TooManyBatchIdsException {
-        var vcBatchIds = vcs.stream().map(VerifiableCredential::getBatchId).distinct().toList();
-        if (vcBatchIds.isEmpty()) {
+        var batchIds = vcs.stream().map(VerifiableCredential::getBatchId).distinct().toList();
+        if (batchIds.isEmpty()) {
             return false;
         }
-        if (vcBatchIds.size() > 1) {
+        if (batchIds.size() > 1) {
             // This is an unexpected case
             LOGGER.error(
                     annotateLog(
-                                    "Too many batch IDs found in identity VCs",
+                                    "Inconsistent batch IDs in identity VCs",
                                     reportItem,
                                     batchId,
                                     pageSummary)
-                            .with("batchIds", vcBatchIds));
-            throw new TooManyBatchIdsException("Too many batch IDs found in identity VCs");
+                            .with("vcBatchIds", batchIds)
+                            .with("vcCount", vcs.size()));
+            throw new TooManyBatchIdsException("Inconsistent batch IDs in identity VCs");
         }
         if (!configService
                 .getStringListParameter(BULK_MIGRATION_ROLLBACK_BATCHES)
-                .contains(vcBatchIds.get(0))) {
+                .contains(batchIds.get(0))) {
             return false;
         }
         LOGGER.info(
@@ -377,7 +378,7 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
                                 reportItem,
                                 batchId,
                                 pageSummary)
-                        .with("batchId", vcBatchIds.get(0)));
+                        .with("rollbackBatchId", batchIds.get(0)));
         return true;
     }
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Handle edge case for rollback batch IDs

### Why did it change
Handles the unexpected case where a migrated identity has a bulk batch ID for some VCs, and no batch ID at all for others.

Also fixes some logging to avoid overwriting the batch ID.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ