### PR TITLE
PYIC-5095: Add PIP & transition page for dwpKbv 

### DIFF
--- a/api-tests/data/cri-stub-requests/dwpKbv/kenneth-score-1/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dwpKbv/kenneth-score-1/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/dwpKbv/kenneth-score-1/evidence.json
+++ b/api-tests/data/cri-stub-requests/dwpKbv/kenneth-score-1/evidence.json
@@ -1,0 +1,21 @@
+{
+  "type": "IdentityCheck",
+  "verificationScore": 1,
+  "checkDetails": [
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 3,
+      "checkMethod": "kbv"
+    },
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 3,
+      "checkMethod": "kbv"
+    },
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 2,
+      "checkMethod": "kbv"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/dwpKbv/kenneth-score-2/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dwpKbv/kenneth-score-2/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/dwpKbv/kenneth-score-2/evidence.json
+++ b/api-tests/data/cri-stub-requests/dwpKbv/kenneth-score-2/evidence.json
@@ -1,0 +1,21 @@
+{
+  "type": "IdentityCheck",
+  "verificationScore": 2,
+  "checkDetails": [
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 3,
+      "checkMethod": "kbv"
+    },
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 3,
+      "checkMethod": "kbv"
+    },
+    {
+      "kbvResponseMode": "multiple_choice",
+      "kbvQuality": 2,
+      "checkMethod": "kbv"
+    }
+  ]
+}

--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -35,6 +35,41 @@ Feature: CIMIT - Alternate doc
       | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
       | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
+  Scenario Outline: Alternate doc mitigation via passport or DL using DWP KBV
+    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit an <initialCri> event
+    Then I get a <initialCri> CRI response
+    When I submit <initialInvalidDoc> details to the CRI stub
+    Then I get a <noMatchPage> page response
+    When I submit a 'next' event
+    Then I get a <mitigatingCri> CRI response
+    When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'dwpKbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
+      | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
+      | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+
   Scenario Outline: Mitigation of alternate-doc CI via <mitigating-cri> when user initially drops out of <mitigating-cri>
     When I submit a '<initial-cri>' event
     Then I get a '<initial-cri>' CRI response

--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -35,7 +35,7 @@ Feature: CIMIT - Alternate doc
       | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
       | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
-  Scenario Outline: Alternate doc mitigation via passport or DL using DWP KBV
+  Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV
     Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -64,6 +64,74 @@ Feature: CIMIT - Alternate doc
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
+
+    Examples:
+      | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
+      | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
+      | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+
+  Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
+    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit an <initialCri> event
+    Then I get a <initialCri> CRI response
+    When I submit <initialInvalidDoc> details to the CRI stub
+    Then I get a <noMatchPage> page response
+    When I submit a 'next' event
+    Then I get a <mitigatingCri> CRI response
+    When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
+      | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
+      | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+
+  Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV transition page dropout
+    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit an <initialCri> event
+    Then I get a <initialCri> CRI response
+    When I submit <initialInvalidDoc> details to the CRI stub
+    Then I get a <noMatchPage> page response
+    When I submit a 'next' event
+    Then I get a <mitigatingCri> CRI response
+    When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'end' event
+    Then I get a 'pyi-another-way' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P0' identity
 
     Examples:
       | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -62,3 +62,67 @@ Feature: P1 No Photo Id Journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
+
+  Scenario: P1 No Photo Id Journey - DWP KBV PIP page dropout
+    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response
+    When I submit an 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "hmrc_check"   |
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P1' identity
+
+  Scenario: P1 No Photo Id Journey - DWP KBV transition page dropout
+    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response
+    When I submit an 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "hmrc_check"   |
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'end' event
+    Then I get a 'no-photo-id-security-questions-find-another-way' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P1' identity

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -30,3 +30,35 @@ Feature: P1 No Photo Id Journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
+
+  Scenario: P1 No Photo Id Journey - DWP KBV
+    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response
+    When I submit an 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "hmrc_check"   |
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'dwpKbv' CRI response
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P1' identity

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -32,6 +32,38 @@ Feature: P2 Web document journey
       | drivingLicence | kenneth-driving-permit-valid |
       | ukPassport     | kenneth-passport-valid       |
 
+  Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV
+    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit a '<cri>' event
+    Then I get a '<cri>' CRI response
+    When I submit '<details>' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'dwpKbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
+
+    Examples:
+      | cri            | details                      |
+      | drivingLicence | kenneth-driving-permit-valid |
+      | ukPassport     | kenneth-passport-valid       |
+
   Scenario Outline: Allows use of <alternative-doc-cri> when user drops out of <initial-cri> CRI
     When I submit a '<initial-cri>' event
     Then I get a '<initial-cri>' CRI response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -57,7 +57,70 @@ Feature: P2 Web document journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
+
+    Examples:
+      | cri            | details                      |
+      | drivingLicence | kenneth-driving-permit-valid |
+      | ukPassport     | kenneth-passport-valid       |
+
+  Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV PIP page dropout
+    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit a '<cri>' event
+    Then I get a '<cri>' CRI response
+    When I submit '<details>' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | cri            | details                      |
+      | drivingLicence | kenneth-driving-permit-valid |
+      | ukPassport     | kenneth-passport-valid       |
+
+  Scenario Outline: Successful P2 identity via Web using - DWP KBV transition page dropout
+    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit a '<cri>' event
+    Then I get a '<cri>' CRI response
+    When I submit '<details>' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'end' event
+    Then I get a 'pyi-cri-escape' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
 
     Examples:
       | cri            | details                      |

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journey-definitions.yaml
@@ -385,7 +385,7 @@ KBVS:
     corresponding to the target Vector of Trust (P1 or P2).
   entryEvents:
     next:
-      targetState: CRI_DWP_KBV
+      targetState: PRE_DWP_KBV_PIP_PAGE
       checkIfDisabled:
         dwpKbv:
           targetState: CRI_NINO
@@ -393,7 +393,7 @@ KBVS:
             hmrcKbv:
               targetState: PRE_EXPERIAN_PAGE
     next-with-nino:
-      targetState: CRI_DWP_KBV
+      targetState: PRE_DWP_KBV_PIP_PAGE
       checkIfDisabled:
         dwpKbv:
           targetState: CRI_HMRC_KBV
@@ -439,13 +439,6 @@ KBVS:
           targetState: PRE_EXPERIAN_PAGE
         access-denied:
           targetState: PRE_EXPERIAN_PAGE
-    PRE_EXPERIAN_PAGE:
-      response:
-        type: page
-        pageId: page-pre-experian-kbv-transition
-      events:
-        next:
-          targetState: CRI_EXPERIAN_KBV
     CRI_EXPERIAN_KBV:
       response:
         type: cri
@@ -458,3 +451,31 @@ KBVS:
           exitEventToEmit: next
         enhanced-verification:
           exitEventToEmit: enhanced-verification
+    PRE_EXPERIAN_PAGE:
+      response:
+        type: page
+        pageId: page-pre-experian-kbv-transition
+      events:
+        next:
+          targetState: CRI_EXPERIAN_KBV
+    PRE_DWP_KBV_PIP_PAGE:
+      response:
+        type: page
+        pageId: personal-independence-payment
+      events:
+        next:
+          targetState: PRE_DWP_KBV_TRANSITION_PAGE
+        end:
+          targetState: CRI_NINO
+          checkIfDisabled:
+            hmrcKbv:
+              targetState: PRE_EXPERIAN_PAGE
+    PRE_DWP_KBV_TRANSITION_PAGE:
+      response:
+        type: page
+        pageId: page-pre-dwp-kbv-transition
+      events:
+        next:
+          targetState: CRI_DWP_KBV
+        end:
+          exitEventToEmit: end

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -317,6 +317,11 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_CRI_ESCAPE_NO_F2F
+      end:
+        targetState: PYI_CRI_ESCAPE
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
@@ -419,6 +424,11 @@ states:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      end:
         targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
@@ -712,6 +722,9 @@ states:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+      end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -332,6 +332,11 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_CRI_ESCAPE_NO_F2F
+      end:
+        targetState: PYI_CRI_ESCAPE
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
@@ -448,6 +453,11 @@ states:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
+        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_CRI_ESCAPE_NO_F2F
+      end:
         targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
         checkIfDisabled:
           f2f:
@@ -754,6 +764,9 @@ states:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+      end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
       next:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The first page that a user will land on when they begin the DWP KBV journey will consist of a 2 pages. This will qualify the user being routed down the DWP KBV journey or other KBV journeys respective of their answers.

If DWP KBV enabled, route to this ‘eligibility’ page. ‘Yes’ continues to DWP KBV CRI (via the start page). ‘No’/'prefer not to say' continues to HMRC KBV if enabled, otherwise Experian KBV (via the start page).

If the user clicks ‘I need to prove my identity another way’ should go to pyi-cri-escape (photo id) or no-photo-id-security-questions-find-another-way/en?context=dropout (no photo id)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5095](https://govukverify.atlassian.net/browse/PYIC-5095)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-5095]: https://govukverify.atlassian.net/browse/PYIC-5095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ