### PR TITLE
PYIC-7470: Recreate EvcsClient in bulk migration

### DIFF
--- a/lambdas/bulk-migrate-vcs/build.gradle
+++ b/lambdas/bulk-migrate-vcs/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	annotationProcessor libs.lombok
 
 	aspect libs.powertoolsLogging,
+			libs.powertoolsTracing,
 			libs.aspectj
 
 	testImplementation libs.junitJupiter,

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/factories/EvcsClientFactory.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/factories/EvcsClientFactory.java
@@ -1,0 +1,20 @@
+package uk.gov.di.ipv.core.bulkmigratevcs.factories;
+
+import software.amazon.lambda.powertools.tracing.Tracing;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.client.EvcsClient;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+
+@ExcludeFromGeneratedCoverageReport
+public class EvcsClientFactory {
+    private final ConfigService configService;
+
+    public EvcsClientFactory(ConfigService configService) {
+        this.configService = configService;
+    }
+
+    @Tracing
+    public EvcsClient getClient() {
+        return new EvcsClient(configService);
+    }
+}

--- a/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
+++ b/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import uk.gov.di.ipv.core.bulkmigratevcs.domain.EvcsMetadata;
 import uk.gov.di.ipv.core.bulkmigratevcs.domain.Request;
 import uk.gov.di.ipv.core.bulkmigratevcs.domain.RequestBatchDetails;
+import uk.gov.di.ipv.core.bulkmigratevcs.factories.EvcsClientFactory;
 import uk.gov.di.ipv.core.bulkmigratevcs.factories.ForkJoinPoolFactory;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
@@ -51,7 +52,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.quality.Strictness.LENIENT;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BULK_MIGRATION_ROLLBACK_BATCHES;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
@@ -72,6 +78,7 @@ class BulkMigrateVcsHandlerTest {
     @Captor private ArgumentCaptor<List<VerifiableCredential>> vcListCaptor;
     @Mock private ScanDynamoDataStore<ReportUserIdentityItem> mockScanDataStore;
     @Mock private VerifiableCredentialService mockVerifiableCredentialService;
+    @Mock private EvcsClientFactory mockEvcsClientFactory;
     @Mock private EvcsClient mockEvcsClient;
     @Mock private ForkJoinPoolFactory mockForkJoinPoolFactory;
     @Mock private ConfigService mockConfigService;
@@ -88,6 +95,7 @@ class BulkMigrateVcsHandlerTest {
     @BeforeEach
     public void setup() {
         when(mockForkJoinPoolFactory.getForkJoinPool(anyInt())).thenCallRealMethod();
+        when(mockEvcsClientFactory.getClient()).thenReturn(mockEvcsClient);
     }
 
     @AfterEach


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Recreate EvcsClient in bulk migration

### Why did it change

Testing of the bulk migration script has shown that we're getting predicatable GOAWAY responses from the API gateway in front of the EVCS stub.

These are happening in clusters at a cadence of every 11500 - 11750 identities migrated. I can't find anything in AWS docs to directly suggest the reason, however I did note that an ALB will do this if it receives over 10'000 requests from any given connection. So I suspect there is a similar mechanism happening here.

To resolve this, we can generate a new EVCS client for each page of results we're processing. This should keep us well under the figure noted above. There doesn't seem to be any way to force the client to drop any open connections easily, so recreating might be the easiest.

I did consider adding a GOAWAY response as a valid reason for a retry, in the retry logic in in the client, but didn't want to impact the core system code.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ