### PR TITLE
BAU: fix broken p2 target state for kbv nested journey

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -225,6 +225,7 @@ states:
         targetState: CHECK_FRAUD_AFTER_DL
       next-passport:
         targetState: KBV_PHOTO_ID
+        targetEntryEvent: next
       alternate-doc-next-dl:
         targetState: MITIGATION_CHECK_FRAUD_AFTER_DL
       alternate-doc-next-passport:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
event did not match any of the entry events for the kbv nested journey so required `targetEntryEvent`

