### PR TITLE
PYIC-7470: Only recreate EVCS client when needed

### DIFF
--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
@@ -29,6 +29,7 @@ import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.EvcsCreateUserVCsDto;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.exception.AuditException;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -61,16 +62,18 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
     private static final String HASH_USER_ID = "hashUserId";
     private static final String USER_ID = "userId";
     private static final String IDENTITY = "identity";
-    public static final int DEFAULT_PARALLELISM = 4;
-    public static final int ONE_MINUTE_IN_MS = 60_000;
-    public static final String PAGE_ITEM_COUNT = "pageItemCount";
-    public static final String PAGE_EXCLUSIVE_START_KEY = "pageExclusiveStartKey";
+    private static final int DEFAULT_PARALLELISM = 4;
+    private static final int ONE_MINUTE_IN_MS = 60_000;
+    private static final String PAGE_ITEM_COUNT = "pageItemCount";
+    private static final String PAGE_EXCLUSIVE_START_KEY = "pageExclusiveStartKey";
+    private static final int EVCS_CLIENT_GOAWAY_LIMIT = 10_000;
     private final ScanDynamoDataStore<ReportUserIdentityItem> reportUserIdentityScanDynamoDataStore;
     private final VerifiableCredentialService verifiableCredentialService;
     private final ForkJoinPoolFactory forkJoinPoolFactory;
     private final EvcsClientFactory evcsClientFactory;
     private final ConfigService configService;
     private final AuditService auditService;
+    private EvcsClient evcsClient;
 
     public BulkMigrateVcsHandler(
             ScanDynamoDataStore<ReportUserIdentityItem> reportUserIdentityScanDynamoDataStore,
@@ -130,6 +133,8 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
                         .with("parallelism", forkJoinPool.getParallelism())
                         .with("exclusiveStartKey", exclusiveStartKey));
 
+        evcsClient = evcsClientFactory.getClient();
+
         try {
             for (var page :
                     reportUserIdentityScanDynamoDataStore.scan(
@@ -138,6 +143,15 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
                             HASH_USER_ID,
                             USER_ID,
                             IDENTITY)) {
+
+                if ((report.getTotalMigrated() + page.count()) > EVCS_CLIENT_GOAWAY_LIMIT) {
+                    // API gateway seems to have a limit on the number of requests from one
+                    // connection
+                    LOGGER.info(
+                            LogHelper.buildLogMessage(
+                                    "Approaching EVCS client GOAWAY limit, refreshing client"));
+                    evcsClient = evcsClientFactory.getClient();
+                }
 
                 var pageSummary =
                         new PageSummary(previousPageLastEvaluatedHashUserId, page.count());
@@ -191,7 +205,13 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
                 }
             }
         } finally {
-            auditService.awaitAuditEvents();
+            try {
+                auditService.awaitAuditEvents();
+            } catch (AuditException e) {
+                LOGGER.error(
+                        LogHelper.buildLogMessage(
+                                "Error awaiting audit events - returning report"));
+            }
             forkJoinPool.shutdown();
         }
 
@@ -203,7 +223,6 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
             Page<ReportUserIdentityItem> page,
             PageSummary pageSummary,
             String batchId) {
-        var evcsClient = evcsClientFactory.getClient();
         try {
             forkJoinPool
                     .submit(
@@ -214,8 +233,7 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
                                                             migrateIdentity(
                                                                     reportItem,
                                                                     pageSummary,
-                                                                    batchId,
-                                                                    evcsClient)))
+                                                                    batchId)))
                     .get();
         } catch (InterruptedException | ExecutionException e) {
             if (e instanceof InterruptedException) {
@@ -230,10 +248,7 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
     }
 
     private void migrateIdentity(
-            ReportUserIdentityItem reportItem,
-            PageSummary pageSummary,
-            String batchId,
-            EvcsClient evcsClient) {
+            ReportUserIdentityItem reportItem, PageSummary pageSummary, String batchId) {
         var userId = reportItem.getUserId();
         // Skip any non P2 identities
         if (!Vot.P2.name().equals(reportItem.getIdentity())) {
@@ -322,7 +337,7 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
         // Migrate identity
         var timestamp = Instant.now();
         try {
-            storeVcsInEvcs(reportItem.getUserId(), vcs, batchId, timestamp, evcsClient);
+            storeVcsInEvcs(reportItem.getUserId(), vcs, batchId, timestamp);
         } catch (Exception e) {
             logError(
                     "Migration failed - error writing to EVCS",
@@ -390,11 +405,7 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
     }
 
     private void storeVcsInEvcs(
-            String userId,
-            List<VerifiableCredential> vcs,
-            String batchId,
-            Instant timestamp,
-            EvcsClient evcsClient)
+            String userId, List<VerifiableCredential> vcs, String batchId, Instant timestamp)
             throws EvcsServiceException {
         evcsClient.storeUserVCs(
                 userId,

--- a/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
+++ b/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
@@ -370,17 +370,19 @@ class BulkMigrateVcsHandlerTest {
     void handlerShouldRefreshEvcsClientWhenApproachingLimit() {
         when(mockScanDataStore.scan(null, 100, HASH_USER_ID, USER_ID, IDENTITY))
                 .thenReturn(mockPageIterable);
+        when(mockContext.getRemainingTimeInMillis()).thenReturn(100_000);
 
         var mockPage = (Page<ReportUserIdentityItem>) mock(Page.class);
         when(mockPage.items()).thenReturn(List.of());
-        when(mockPage.count()).thenReturn(10_0001);
+        when(mockPage.count()).thenReturn(10_001).thenReturn(10_010).thenReturn(20_001);
         when(mockPage.lastEvaluatedKey()).thenReturn(null);
-        when(mockPageIterable.iterator()).thenReturn(List.of(mockPage).iterator());
+        when(mockPageIterable.iterator())
+                .thenReturn(List.of(mockPage, mockPage, mockPage).iterator());
 
         bulkMigrateVcsHandler.handleRequest(
                 new Request(new RequestBatchDetails("batchId", null, 2000), 100, 1), mockContext);
 
-        verify(mockEvcsClientFactory, times(2)).getClient();
+        verify(mockEvcsClientFactory, times(3)).getClient();
     }
 
     @Nested

--- a/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
+++ b/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
@@ -366,6 +366,23 @@ class BulkMigrateVcsHandlerTest {
         assertEquals(2, report.getPageSummaries().size());
     }
 
+    @Test
+    void handlerShouldRefreshEvcsClientWhenApproachingLimit() {
+        when(mockScanDataStore.scan(null, 100, HASH_USER_ID, USER_ID, IDENTITY))
+                .thenReturn(mockPageIterable);
+
+        var mockPage = (Page<ReportUserIdentityItem>) mock(Page.class);
+        when(mockPage.items()).thenReturn(List.of());
+        when(mockPage.count()).thenReturn(10_0001);
+        when(mockPage.lastEvaluatedKey()).thenReturn(null);
+        when(mockPageIterable.iterator()).thenReturn(List.of(mockPage).iterator());
+
+        bulkMigrateVcsHandler.handleRequest(
+                new Request(new RequestBatchDetails("batchId", null, 2000), 100, 1), mockContext);
+
+        verify(mockEvcsClientFactory, times(2)).getClient();
+    }
+
     @Nested
     class Rollbacks {
         @Test


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Only recreate EVCS client when needed

### Why did it change

Recreating the EVCS client solved the GOAWAY issue, but it introduced a new one. The audit service was unable to open a socket due to too many files being open.

This updates the logic to only recreate the client when the number of migrated identities is approaching 10_000. This should dramatically reduce the number of client created.

There doesn't seem to be an easy way to close an HttpClient in Java 17 (in 21 it's been made AutoCloseable), which would have been nicer.

This also handles errors thrown by the AuditService to ensure that we get the report back from the lambda. The errors will be logged in the application logs.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ