### PR TITLE
PYIC-7501: Switch lambdas to arm64

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -8,6 +8,8 @@ Globals:
     Timeout: 40
     SnapStart:
       ApplyOn: PublishedVersions
+    Architectures:
+      - arm64
     MemorySize: !If [IsDevelopment, 1024, 3072]
     Runtime: java17
     Environment:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
 Switch lambdas to arm64

### Why did it change

We used to use arm64, but switched to x86 at it was the only arch supported by snapstart.

Snapstart is now compatible with arm64 meaning we can switch back. Arm64 is cheaper.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7501](https://govukverify.atlassian.net/browse/PYIC-7501)


[PYIC-7501]: https://govukverify.atlassian.net/browse/PYIC-7501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ