### PR TITLE
PYIC-7470: Reduce GOAWAY limit

### DIFF
--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
@@ -69,7 +69,7 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
     private static final int ONE_MINUTE_IN_MS = 60_000;
     private static final String PAGE_ITEM_COUNT = "pageItemCount";
     private static final String PAGE_EXCLUSIVE_START_KEY = "pageExclusiveStartKey";
-    private static final int EVCS_CLIENT_GOAWAY_LIMIT = 10_000;
+    private static final int EVCS_CLIENT_GOAWAY_LIMIT = 9_000;
     private static final String REPORT = "report";
     private final ScanDynamoDataStore<ReportUserIdentityItem> reportUserIdentityScanDynamoDataStore;
     private final VerifiableCredentialService verifiableCredentialService;
@@ -168,7 +168,8 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
                 LOGGER.info(
                         LogHelper.buildLogMessage("Processing page")
                                 .with(PAGE_EXCLUSIVE_START_KEY, pageSummary.getExclusiveStartKey())
-                                .with(PAGE_ITEM_COUNT, pageSummary.getCount()));
+                                .with(PAGE_ITEM_COUNT, pageSummary.getCount())
+                                .with("pageCount", report.getPageSummaries().size() + 1));
 
                 // Updating for next loop while we still have access to the page
                 previousPageLastEvaluatedHashUserId = getPageLastEvaluatedHashUserId(page);

--- a/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
+++ b/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
@@ -374,7 +374,12 @@ class BulkMigrateVcsHandlerTest {
 
         var mockPage = (Page<ReportUserIdentityItem>) mock(Page.class);
         when(mockPage.items()).thenReturn(List.of());
-        when(mockPage.count()).thenReturn(10_001).thenReturn(10_010).thenReturn(20_001);
+        when(mockPage.count())
+                .thenReturn(9_000)
+                .thenReturn(9_000)
+                .thenReturn(9_010)
+                .thenReturn(9_010)
+                .thenReturn(18_001);
         when(mockPage.lastEvaluatedKey()).thenReturn(null);
         when(mockPageIterable.iterator())
                 .thenReturn(List.of(mockPage, mockPage, mockPage).iterator());


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Reduce GOAWAY limit

### Why did it change

Testing in build showed we were still getting some GOAWAY responses from API gateway. They were happening while processing the page before refreshing the EVCS client. This drops the limit by 1000 to help us avoid these.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ