### PR TITLE
PYIC-7345: Add reprove F2F test

### DIFF
--- a/api-tests/features/p2-reprove-identity.feature
+++ b/api-tests/features/p2-reprove-identity.feature
@@ -11,3 +11,23 @@ Feature: Reprove Identity Journey
         Then I get a 'reprove-identity-start' page response
         When I submit a 'next' event
         Then I get a 'page-ipv-identity-document-start' page response
+
+    Scenario: User needs to reprove their identity with F2F pending
+        Given I start a new 'medium-confidence' journey
+        Then I get a 'page-ipv-identity-document-start' page response
+        When I submit an 'end' event
+        Then I get a 'page-ipv-identity-postoffice-start' page response
+        When I submit a 'next' event
+        Then I get a 'claimedIdentity' CRI response
+        When I submit 'kenneth-current' details to the CRI stub
+        Then I get an 'address' CRI response
+        When I submit 'kenneth-current' details to the CRI stub
+        Then I get a 'fraud' CRI response
+        When I submit 'kenneth-score-2' details to the CRI stub
+        Then I get a 'f2f' CRI response
+        When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+        Then I get a 'page-face-to-face-handoff' page response
+        When I start a new 'medium-confidence' journey with reprove identity
+        Then I get a 'reprove-identity-start' page response
+        When I submit a 'next' event
+        Then I get a 'page-ipv-identity-document-start' page response


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add API test for reprove identity during face to face

### Why did it change

Moving re-prove identity tests from end-to-end to API tests.

Note that there was already a test for normal re-prove identity, and for identity re-use so we only need to move one test over.
All non-reprove identity tests set the reprove claim to false so we don't need to test that explicitly here. Orchestration always sends a claim value now so we don't need the test for claim not being set.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7345](https://govukverify.atlassian.net/browse/PYIC-7345)


[PYIC-7345]: https://govukverify.atlassian.net/browse/PYIC-7345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ