### PR TITLE
PYIC-7470: Increase bulk migration lambda timeout to 900

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2481,7 +2481,7 @@ Resources:
       Handler: uk.gov.di.ipv.core.bulkmigratevcs.BulkMigrateVcsHandler::handleRequest
       PackageType: Zip
       CodeUri: ../lambdas/bulk-migrate-vcs
-      Timeout: 600
+      Timeout: 900
       Tracing: Active
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Increase bulk migration lambda timeout to 900

### Why did it change

This sets the timeout to 15 minutes, the max allowable.

This will give us a little more headroom to process larger batches if we want to.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ