### PR TITLE
PYIC-7470: Wrap EVCS metadata

### DIFF
--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
@@ -11,9 +11,10 @@ import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.lambda.powertools.logging.Logging;
 import uk.gov.di.ipv.core.bulkmigratevcs.domain.BatchReport;
-import uk.gov.di.ipv.core.bulkmigratevcs.domain.EvcsMetadata;
 import uk.gov.di.ipv.core.bulkmigratevcs.domain.PageSummary;
 import uk.gov.di.ipv.core.bulkmigratevcs.domain.Request;
+import uk.gov.di.ipv.core.bulkmigratevcs.domain.metadata.MigrationMetadata;
+import uk.gov.di.ipv.core.bulkmigratevcs.domain.metadata.MigrationMetadataBatchDetails;
 import uk.gov.di.ipv.core.bulkmigratevcs.exceptions.TooManyBatchIdsException;
 import uk.gov.di.ipv.core.bulkmigratevcs.factories.EvcsClientFactory;
 import uk.gov.di.ipv.core.bulkmigratevcs.factories.ForkJoinPoolFactory;
@@ -430,7 +431,9 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
                                         new EvcsCreateUserVCsDto(
                                                 vc.getVcString(),
                                                 CURRENT,
-                                                new EvcsMetadata(batchId, timestamp.toString()),
+                                                new MigrationMetadata(
+                                                        new MigrationMetadataBatchDetails(
+                                                                batchId, timestamp.toString())),
                                                 MIGRATED))
                         .toList());
     }

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/EvcsMetadata.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/EvcsMetadata.java
@@ -1,3 +1,0 @@
-package uk.gov.di.ipv.core.bulkmigratevcs.domain;
-
-public record EvcsMetadata(String batchId, String timestamp) {}

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/metadata/MigrationMetadata.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/metadata/MigrationMetadata.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.core.bulkmigratevcs.domain.metadata;
+
+public record MigrationMetadata(MigrationMetadataBatchDetails migrationV001) {}

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/metadata/MigrationMetadataBatchDetails.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/metadata/MigrationMetadataBatchDetails.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.core.bulkmigratevcs.domain.metadata;
+
+public record MigrationMetadataBatchDetails(String batchId, String timestamp) {}

--- a/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
+++ b/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
@@ -16,9 +16,9 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import uk.gov.di.ipv.core.bulkmigratevcs.domain.EvcsMetadata;
 import uk.gov.di.ipv.core.bulkmigratevcs.domain.Request;
 import uk.gov.di.ipv.core.bulkmigratevcs.domain.RequestBatchDetails;
+import uk.gov.di.ipv.core.bulkmigratevcs.domain.metadata.MigrationMetadata;
 import uk.gov.di.ipv.core.bulkmigratevcs.factories.EvcsClientFactory;
 import uk.gov.di.ipv.core.bulkmigratevcs.factories.ForkJoinPoolFactory;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -167,10 +167,14 @@ class BulkMigrateVcsHandlerTest {
         assertEquals(CURRENT, evcsCreateUserVCsDtoList.get(0).state());
         assertEquals(MIGRATED, evcsCreateUserVCsDtoList.get(0).provenance());
         assertEquals(
-                "batchId", ((EvcsMetadata) evcsCreateUserVCsDtoList.get(0).metadata()).batchId());
+                "batchId",
+                ((MigrationMetadata) evcsCreateUserVCsDtoList.get(0).metadata())
+                        .migrationV001()
+                        .batchId());
         assertTrue(
                 Instant.parse(
-                                ((EvcsMetadata) evcsCreateUserVCsDtoList.get(0).metadata())
+                                ((MigrationMetadata) evcsCreateUserVCsDtoList.get(0).metadata())
+                                        .migrationV001()
                                         .timestamp())
                         .isAfter(Instant.now().minusSeconds(1)));
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Wrap EVCS metadata

### Why did it change

The Bravo team have asked that we wrap the existing metadata on the migrated VCs in an outer object, to give the timestamp context that it's for a migration. The name for the outer property is as requested by them, to allow future iterations that won't cause data loss.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ