### PR TITLE
PYIC-7491: add drivingLicenceAuthCheck to local-running

### DIFF
--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -362,7 +362,11 @@ core:
     sqsAsync: true
     updateDetailsAccountDeletion: false
     kidJarHeaderEnabled: true
+    drivingLicenceAuthCheck: false
   features:
+    drivingLicenceAuthCheck:
+      featureFlags:
+        drivingLicenceAuthCheck: true
     mfaReset:
       featureFlags:
         mfaResetEnabled: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Adds `drivingLicenceAuthCheck` feature flag to local-running

### Why did it change
Keeping local-running config up-to-date with configs in common-infra

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7491](https://govukverify.atlassian.net/browse/PYIC-7491)


[PYIC-7491]: https://govukverify.atlassian.net/browse/PYIC-7491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ