### PR TITLE
BAU: Always compare page contexts in API tests

### DIFF
--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -146,7 +146,7 @@ Feature: CIMIT - Alternate doc
     When I submit a 'next' event
     Then I get a '<mitigating-cri>' CRI response
     When I get an 'access_denied' OAuth error from the CRI stub
-    Then I get a 'prove-identity-no-other-photo-id' page response
+    Then I get a 'prove-identity-no-other-photo-id' page response with context '<prove-identity-no-other-photo-id-context>'
     When I submit a 'back' event
     Then I get a '<mitigating-cri>' CRI response
     When I submit '<mitigating-doc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
@@ -165,9 +165,9 @@ Feature: CIMIT - Alternate doc
     Then I get a 'P2' identity
 
     Examples:
-      | initial-cri    | initial-invalid-doc                        | no-match-page                            | mitigating-cri | mitigating-doc               |
-      | ukPassport     | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
-      | drivingLicence | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+      | initial-cri    | initial-invalid-doc                        | no-match-page                            | mitigating-cri | mitigating-doc               | prove-identity-no-other-photo-id-context |
+      | ukPassport     | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid | drivingLicence                           |
+      | drivingLicence | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       | passport                                 |
 
   Scenario: Returns P0 when user continues to service from prove-identity-no-other-photo-id page during CI mitigation
     When I submit a 'ukPassport' event
@@ -177,7 +177,7 @@ Feature: CIMIT - Alternate doc
     When I submit a 'next' event
     Then I get a 'drivingLicence' CRI response
     When I get an 'access_denied' OAuth error from the CRI stub
-    Then I get a 'prove-identity-no-other-photo-id' page response
+    Then I get a 'prove-identity-no-other-photo-id' page response with context 'drivingLicence'
     When I submit a 'returnToRp' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity

--- a/api-tests/features/inherited-identity/extended-scenarios.feature
+++ b/api-tests/features/inherited-identity/extended-scenarios.feature
@@ -166,7 +166,7 @@ Feature: Inherited identity extended scenarios
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
     When I submit 'kenneth-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
+    Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity

--- a/api-tests/features/p1-journeys.feature
+++ b/api-tests/features/p1-journeys.feature
@@ -127,7 +127,7 @@ Feature: P1 journey
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit a 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details with attributes to the CRI stub
@@ -160,7 +160,7 @@ Feature: P1 journey
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response with context 'lastChoice'
     When I submit a 'next' event

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -5,7 +5,7 @@ Feature: P1 No Photo Id Journey
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details with attributes to the CRI stub
@@ -71,7 +71,7 @@ Feature: P1 No Photo Id Journey
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details with attributes to the CRI stub
@@ -87,7 +87,7 @@ Feature: P1 No Photo Id Journey
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details with attributes to the CRI stub
@@ -119,7 +119,7 @@ Feature: P1 No Photo Id Journey
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details with attributes to the CRI stub
@@ -151,7 +151,7 @@ Feature: P1 No Photo Id Journey
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details with attributes to the CRI stub
@@ -169,7 +169,7 @@ Feature: P1 No Photo Id Journey
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
     When I submit a 'end' event
-    Then I get a 'no-photo-id-security-questions-find-another-way' page response
+    Then I get a 'no-photo-id-security-questions-find-another-way' page response with context 'dropout'
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -183,7 +183,7 @@ Feature: P1 No Photo Id Journey
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response with context 'lastChoice'
     When I submit a 'end' event

--- a/api-tests/features/p2-coi-delete-identity.feature
+++ b/api-tests/features/p2-coi-delete-identity.feature
@@ -14,61 +14,61 @@ Feature: Delete identity
 
   Scenario: Account deletion update dob
     When I submit a 'dob' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'end' event
     Then I get a 'delete-handover' page response
     When I submit a 'back' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'back' event
     Then I get a 'update-details' page response
     When I submit a 'dob-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'end' event
     Then I get a 'delete-handover' page response
     When I submit a 'back' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'back' event
     Then I get a 'update-details' page response
     When I submit a 'dob-family' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'end' event
     Then I get a 'delete-handover' page response
     When I submit a 'back' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'back' event
     Then I get a 'update-details' page response
     When I submit a 'dob-family-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'end' event
     Then I get a 'delete-handover' page response
     When I submit a 'back' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'back' event
     Then I get a 'update-details' page response
     When I submit a 'address-dob' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'end' event
     Then I get a 'delete-handover' page response
     When I submit a 'back' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'back' event
     Then I get a 'update-details' page response
     When I submit a 'address-dob-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'end' event
     Then I get a 'delete-handover' page response
     When I submit a 'back' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'back' event
     Then I get a 'update-details' page response
     When I submit a 'address-dob-family' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'end' event
     Then I get a 'delete-handover' page response
 
   Scenario: Account deletion update aborted
     When I submit a 'dob' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'reuse'
     When I submit a 'continue' event
     Then I get an OAuth response
     And an 'IPV_USER_DETAILS_UPDATE_ABORTED' audit event was recorded [local only]

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -26,29 +26,29 @@ Feature: P2 F2F journey
     Scenario: Pending F2F request delete identity
       # Initial journey
       Given I start a new 'medium-confidence' journey with feature set 'pendingF2FResetEnabled'
-      Then I get a 'page-ipv-pending' page response
+      Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
       When I submit a 'next' event
       Then I get a 'pyi-f2f-delete-details' page response
       When I submit a 'next' event
-      Then I get a 'pyi-confirm-delete-details' page response
+      Then I get a 'pyi-confirm-delete-details' page response with context 'f2f'
       When I submit a 'next' event
-      Then I get a 'pyi-details-deleted' page response
+      Then I get a 'pyi-details-deleted' page response with context 'f2f'
       And an 'IPV_F2F_USER_CANCEL_START' audit event was recorded [local only]
 
     Scenario: Pending F2F request continue without delete identity
       # Initial journey
       Given I start a new 'medium-confidence' journey with feature set 'pendingF2FResetEnabled'
-      Then I get a 'page-ipv-pending' page response
+      Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
       When I submit a 'next' event
       Then I get a 'pyi-f2f-delete-details' page response
       When I submit a 'end' event
-      Then I get a 'page-ipv-pending' page response
+      Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
       When I submit a 'next' event
       Then I get a 'pyi-f2f-delete-details' page response
       When I submit a 'next' event
-      Then I get a 'pyi-confirm-delete-details' page response
+      Then I get a 'pyi-confirm-delete-details' page response with context 'f2f'
       When I submit a 'end' event
-      Then I get a 'page-ipv-pending' page response
+      Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
 
   Rule: Successful F2F journeys
     Scenario Outline: Successful P2 identity via F2F using <doc>

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -9,7 +9,7 @@ Feature: M2B Strategic App Journeys
     When I submit a 'smartphone' event
     Then I get a 'pyi-triage-select-smartphone' page response
     When I submit an 'iphone' event
-    Then I get a 'pyi-triage-mobile-download-app' page response
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
 
   Scenario: MAM journey android
     Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
@@ -19,7 +19,7 @@ Feature: M2B Strategic App Journeys
     When I submit a 'smartphone' event
     Then I get a 'pyi-triage-select-smartphone' page response
     When I submit an 'android' event
-    Then I get a 'pyi-triage-mobile-download-app' page response
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'android'
 
   Scenario: MAM journey no compatible smartphone
     Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
@@ -39,7 +39,7 @@ Feature: M2B Strategic App Journeys
     When I submit a 'computer-or-tablet' event
     Then I get a 'pyi-triage-select-smartphone' page response
     When I submit an 'iphone' event
-    Then I get a 'pyi-triage-desktop-download-app' page response
+    Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone'
 
   Scenario: DAD journey android
     Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
@@ -49,7 +49,7 @@ Feature: M2B Strategic App Journeys
     When I submit a 'computer-or-tablet' event
     Then I get a 'pyi-triage-select-smartphone' page response
     When I submit an 'android' event
-    Then I get a 'pyi-triage-desktop-download-app' page response
+    Then I get a 'pyi-triage-desktop-download-app' page response with context 'android'
 
   Scenario: DAD journey no compatible smartphone
     Given I start a new 'medium-confidence' journey with feature set 'strategicApp'

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -131,7 +131,7 @@ Feature: P2 Web document journey
     When I submit a '<initial-cri>' event
     Then I get a '<initial-cri>' CRI response
     When I get an 'access_denied' OAuth error from the CRI stub
-    Then I get a 'prove-identity-another-type-photo-id' page response
+    Then I get a 'prove-identity-another-type-photo-id' page response with context '<prove-identity-another-type-photo-id-context>'
     When I submit a 'otherPhotoId' event
     Then I get a '<alternative-doc-cri>' CRI response
     When I submit '<alternative-doc>' details to the CRI stub
@@ -150,15 +150,15 @@ Feature: P2 Web document journey
     Then I get a 'P2' identity
 
     Examples:
-      | initial-cri    | alternative-doc-cri | alternative-doc              |
-      | ukPassport     | drivingLicence      | kenneth-driving-permit-valid |
-      | drivingLicence | ukPassport          | kenneth-passport-valid       |
+      | initial-cri    | alternative-doc-cri | alternative-doc              | prove-identity-another-type-photo-id-context |
+      | ukPassport     | drivingLicence      | kenneth-driving-permit-valid | passport                                     |
+      | drivingLicence | ukPassport          | kenneth-passport-valid       | drivingLicence                               |
 
   Scenario: User is able to continue to service from the prove-identity-another-type-photo-id page without an identity
     When I submit a 'ukPassport' event
     Then I get a 'ukPassport' CRI response
     When I get an 'access_denied' OAuth error from the CRI stub
-    Then I get a 'prove-identity-another-type-photo-id' page response
+    Then I get a 'prove-identity-another-type-photo-id' page response with context 'passport'
     When I submit a 'returnToRp' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity
@@ -168,7 +168,7 @@ Feature: P2 Web document journey
     When I submit a 'ukPassport' event
     Then I get a 'ukPassport' CRI response
     When I get an 'access_denied' OAuth error from the CRI stub
-    Then I get a 'prove-identity-another-type-photo-id' page response
+    Then I get a 'prove-identity-another-type-photo-id' page response with context 'passport'
     When I submit an 'f2f' event
     Then I get a 'pyi-post-office' page response
     When I submit a 'next' event

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -14,7 +14,7 @@ Feature: Repeat fraud check failures
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
       When I submit a 'given-names-only' event
-      Then I get a 'page-update-name' page response
+      Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
       When I submit an 'update-name' event
       Then I get a 'dcmaw' CRI response
 
@@ -22,7 +22,7 @@ Feature: Repeat fraud check failures
     Scenario: DCMAW access denied OAuth error
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I get an 'access_denied' OAuth error from the CRI stub
-      Then I get an 'update-details-failed' page response
+      Then I get an 'update-details-failed' page response with context 'existingIdentityInvalid'
       When I submit a 'return-to-service' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -34,7 +34,7 @@ Feature: Repeat fraud check failures
     Scenario: User is able to delete account from update-details-failed screen
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I get an 'access_denied' OAuth error from the CRI stub
-      Then I get an 'update-details-failed' page response
+      Then I get an 'update-details-failed' page response with context 'existingIdentityInvalid'
       When I submit a 'delete' event
       Then I get a 'delete-handover' page response
 
@@ -52,7 +52,7 @@ Feature: Repeat fraud check failures
     Scenario: Breaching CI received from DCMAW
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -64,13 +64,13 @@ Feature: Repeat fraud check failures
     Scenario: User is able to delete account from sorry-could-not-confirm-details screen
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'delete' event
       Then I get a 'delete-handover' page response
 
     Scenario: Zero score in fraud CRI
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
@@ -86,11 +86,11 @@ Feature: Repeat fraud check failures
     Scenario: Zero score in fraud CRI
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -100,7 +100,7 @@ Feature: Repeat fraud check failures
 
     Scenario: Breaching CI received from fraud CRI
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-breaching-ci' details to the CRI stub
@@ -116,11 +116,11 @@ Feature: Repeat fraud check failures
     Scenario: Breaching CI received from fraud CRI
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-breaching-ci' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -130,7 +130,7 @@ Feature: Repeat fraud check failures
 
     Scenario: Failed COI check
       When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
@@ -140,11 +140,11 @@ Feature: Repeat fraud check failures
     Scenario: Failed COI check
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -156,7 +156,7 @@ Feature: Repeat fraud check failures
       Given TICF CRI will respond with default parameters and
         | cis | BREACHING |
       When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
@@ -171,7 +171,7 @@ Feature: Repeat fraud check failures
 
     Scenario: Fraud access denied OAuth error
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I get an 'access_denied' OAuth error from the CRI stub
@@ -187,11 +187,11 @@ Feature: Repeat fraud check failures
     Scenario: Fraud access denied OAuth error
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
       When I get an 'access_denied' OAuth error from the CRI stub
-      Then I get an 'sorry-could-not-confirm-details' page response
+      Then I get an 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -227,7 +227,7 @@ Feature: Repeat fraud check failures
     Scenario: Address access denied OAuth error
       Given I activate the 'updateDetailsAccountDeletion' feature set
       When I get an 'access_denied' OAuth error from the CRI stub
-      Then I get an 'sorry-could-not-confirm-details' page response
+      Then I get an 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -17,7 +17,7 @@ Feature: Repeat fraud check journeys
     When I submit a 'next' event
     Then I get a 'fraud' CRI response
     When I submit expired 'kenneth-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
+    Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity
@@ -26,11 +26,11 @@ Feature: Repeat fraud check journeys
   Scenario: Fraud 6 Months Expiry + Given Name Update
     # Repeat fraud check with update name
     When I submit a 'given-names-only' event
-    Then I get a 'page-update-name' page response
+    Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
     When I submit a 'update-name' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
+    Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
     When I submit a 'next' event
     Then I get a 'fraud' CRI response
     When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
@@ -45,11 +45,11 @@ Feature: Repeat fraud check journeys
   Scenario: Fraud 6 Months Expiry + Family Name Update
     # Repeat fraud check with update family name
     When I submit a 'family-name-only' event
-    Then I get a 'page-update-name' page response
+    Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
     When I submit a 'update-name' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
+    Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
     When I submit a 'next' event
     Then I get a 'fraud' CRI response
     When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
@@ -68,7 +68,7 @@ Feature: Repeat fraud check journeys
     When I submit 'kenneth-changed' details to the CRI stub
     Then I get a 'fraud' CRI response
     When I submit 'kenneth-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
+    Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity
@@ -79,11 +79,11 @@ Feature: Repeat fraud check journeys
   Scenario: Fraud 6 Months Expiry + Address and Family Name Update
     # Repeat fraud check with update address and family name
     When I submit a 'family-name-and-address' event
-    Then I get a 'page-update-name' page response
+    Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
     When I submit a 'update-name' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
+    Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
     When I submit a 'next' event
     Then I get a 'address' CRI response
     When I submit 'kenneth-changed' details to the CRI stub
@@ -100,11 +100,11 @@ Feature: Repeat fraud check journeys
   Scenario: Fraud 6 Months Expiry + Address and Given Name Update
     # Repeat fraud check with update address and given name
     When I submit a 'given-names-and-address' event
-    Then I get a 'page-update-name' page response
+    Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
     When I submit a 'update-name' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
+    Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
     When I submit a 'next' event
     Then I get a 'address' CRI response
     When I submit 'kenneth-changed' details to the CRI stub
@@ -121,40 +121,40 @@ Feature: Repeat fraud check journeys
   Scenario: Unsupported Changes
     # Repeat fraud check with various unsupported events and back navigation
     When I submit a 'dob' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'address-dob' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'dob-family' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'dob-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'family-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'address-family-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'address-dob-family-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'address-dob-family' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'address-dob-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'
     When I submit a 'back' event
     Then I get a 'confirm-your-details' page response
     When I submit a 'address-family-given' event
-    Then I get a 'update-name-date-birth' page response
+    Then I get a 'update-name-date-birth' page response with context 'repeatFraudCheck'

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -50,7 +50,7 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
 
-        Scenario: Breaching CI received from DCMAW
+        Scenario: Breaching CI received from DCMAW - receives P0
             When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
             Then I get a 'sorry-could-not-confirm-details' page response
             When I submit a 'end' event
@@ -61,10 +61,10 @@ Feature: Identity reuse update details failures
             Then I get a 'pyi-no-match' page response
 
         @FastFollow
-        Scenario: Breaching CI received from DCMAW
+        Scenario: Breaching CI received from DCMAW - doesn't receive old identity
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-            Then I get a 'sorry-could-not-confirm-details' page response
+            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
             When I submit a 'returnToRp' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
@@ -76,13 +76,13 @@ Feature: Identity reuse update details failures
         Scenario: User is able to delete account from sorry-could-not-confirm-details page
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-            Then I get a 'sorry-could-not-confirm-details' page response
+            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
             When I submit a 'delete' event
             Then I get a 'delete-handover' page response
 
-        Scenario: Zero score in fraud CRI
+        Scenario: Zero score in fraud CRI - receives P0
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
@@ -95,14 +95,14 @@ Feature: Identity reuse update details failures
             Then I get a 'page-ipv-reuse' page response
 
         @FastFollow
-        Scenario: Zero score in fraud CRI
+        Scenario: Zero score in fraud CRI - receives old identity (P2)
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
-            Then I get a 'sorry-could-not-confirm-details' page response
+            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
             When I submit a 'returnToRp' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
@@ -110,9 +110,9 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
 
-        Scenario: Breaching CI received from fraud CRI
+        Scenario: Breaching CI received from fraud CRI - receives P0
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I submit 'kenneth-breaching-ci' details to the CRI stub
@@ -125,14 +125,14 @@ Feature: Identity reuse update details failures
             Then I get a 'pyi-no-match' page response
 
         @FastFollow
-        Scenario: Breaching CI received from fraud CRI
+        Scenario: Breaching CI received from fraud CRI - doesn't receive old identity
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I submit 'kenneth-breaching-ci' details to the CRI stub
-            Then I get a 'sorry-could-not-confirm-details' page response
+            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
             When I submit a 'returnToRp' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
@@ -144,7 +144,7 @@ Feature: Identity reuse update details failures
             Given TICF CRI will respond with default parameters and
                 | cis | BREACHING |
             When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
@@ -158,9 +158,9 @@ Feature: Identity reuse update details failures
                 | type | RiskAssessment |
 
 
-        Scenario: Failed COI check
+        Scenario: Failed COI check - receives P0
             When I submit 'alice-passport-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I submit 'alice-score-2' details to the CRI stub
@@ -171,14 +171,14 @@ Feature: Identity reuse update details failures
             Then I get a 'P0' identity
 
         @FastFollow
-        Scenario: Failed COI check
+        Scenario: Failed COI check - receives old identity (P2)
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I submit 'alice-passport-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I submit 'alice-score-2' details to the CRI stub
-            Then I get a 'sorry-could-not-confirm-details' page response
+            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
             When I submit an 'returnToRp' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
@@ -186,9 +186,9 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
 
-        Scenario: Fraud access denied OAuth error
+        Scenario: Fraud access denied OAuth error - receives P0
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I get an 'access_denied' OAuth error from the CRI stub
@@ -201,14 +201,14 @@ Feature: Identity reuse update details failures
             Then I get a 'page-ipv-reuse' page response
 
         @FastFollow
-        Scenario: Fraud access denied OAuth error
+        Scenario: Fraud access denied OAuth error - receives old identity (P2)
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
+            Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
             When I get an 'access_denied' OAuth error from the CRI stub
-            Then I get an 'sorry-could-not-confirm-details' page response
+            Then I get an 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
             When I submit a 'returnToRp' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
@@ -245,7 +245,7 @@ Feature: Identity reuse update details failures
         Scenario: Address access denied OAuth error - receives old identity (P2) when continuing to service
             Given I activate the 'updateDetailsAccountDeletion' feature set
             When I get an 'access_denied' OAuth error from the CRI stub
-            Then I get an 'sorry-could-not-confirm-details' page response
+            Then I get an 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
             When I submit a 'returnToRp' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
@@ -18,7 +18,7 @@ Feature: Identity reuse update details
         When I submit a 'update-name' event
         Then I get a 'dcmaw' CRI response
         When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
+        Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
         When I submit a 'next' event
         Then I get a 'fraud' CRI response
         When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
@@ -31,7 +31,7 @@ Feature: Identity reuse update details
         When I submit a 'update-name' event
         Then I get a 'dcmaw' CRI response
         When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
+        Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
         When I submit a 'next' event
         Then I get a 'fraud' CRI response
         When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
@@ -48,7 +48,7 @@ Feature: Identity reuse update details
         When I submit a 'update-name' event
         Then I get a 'dcmaw' CRI response
         When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
+        Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
         When I submit a 'next' event
         Then I get a 'fraud' CRI response
         When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
@@ -65,7 +65,7 @@ Feature: Identity reuse update details
         When I submit 'kenneth-changed' details to the CRI stub
         Then I get a 'fraud' CRI response
         When I submit 'kenneth-score-2' details to the CRI stub
-        Then I get a 'page-ipv-success' page response
+        Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
         When I submit a 'next' event
         Then I get an OAuth response
         When I use the OAuth response to get my identity
@@ -78,7 +78,7 @@ Feature: Identity reuse update details
         When I submit a 'update-name' event
         Then I get a 'dcmaw' CRI response
         When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
+        Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
         When I submit a 'next' event
         Then I get a 'address' CRI response
         When I submit 'kenneth-changed' details to the CRI stub
@@ -98,7 +98,7 @@ Feature: Identity reuse update details
         When I submit a 'update-name' event
         Then I get a 'dcmaw' CRI response
         When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response
+        Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
         When I submit a 'next' event
         Then I get a 'address' CRI response
         When I submit 'kenneth-changed' details to the CRI stub

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -234,12 +234,10 @@ Then(
       `got a ${describeResponse(this.lastJourneyEngineResponse)}`,
     );
     assert.equal(this.lastJourneyEngineResponse.page, expectedPage);
-    if (expectedContext) {
-      assert.equal(
-        this.lastJourneyEngineResponse.context,
-        expectedContext === "null" ? null : expectedContext,
-      );
-    }
+    assert.equal(
+      this.lastJourneyEngineResponse.context,
+      expectedContext === "null" ? null : expectedContext,
+    );
   },
 );
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Always compare the page context with the specified context even when the test doesn't specify a context

### Why did it change

We should always specify a context to ensure that the page is displayed as expected.
