### PR TITLE
BAU: Avoid logging subject identifier in validation failure

### DIFF
--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidator.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidator.java
@@ -199,8 +199,14 @@ public class VerifiableCredentialValidator {
         try {
             verifier.verify(verifiableCredential.getJWTClaimsSet(), null);
         } catch (BadJWTException | ParseException e) {
-            LOGGER.error(
-                    LogHelper.buildErrorMessage("Verifiable credential claims set not valid", e));
+            if (e instanceof BadJWTException badJWTException
+                    && badJWTException.getMessage().contains("JWT sub claim has value")) {
+                LOGGER.error(LogHelper.buildLogMessage("JWT sub claim does not match expected"));
+            } else {
+                LOGGER.error(
+                        LogHelper.buildErrorMessage(
+                                "Verifiable credential claims set not valid", e));
+            }
             throw new VerifiableCredentialException(
                     HTTPResponse.SC_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL);


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Avoid logging subject identifier in validation failure

### Why did it change

When we receive a VC we check that the subject in it exactly matches the subject we received from orchestrator. If they don't match we throw an error. The nimbus lib will log the difference between any claims that we've configured to be exact matches.

We because aware of this after a CRI team asked us to investigate a failure in staging. The failure was due to mismatching subjects and it triggered the identifiers to be logged.

I've searched in Splunk for if this has ever occured in prod - and it hasn't. This change should prevent us from logging any PII should we ever receive an unexpected subject.
