### PR TITLE
BAU Temporarily log DWP KBV VC token for integration debugging

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -60,7 +60,9 @@ import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
 
+import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ENVIRONMENT;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
+import static uk.gov.di.ipv.core.library.domain.Cri.DWP_KBV;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NOT_FOUND_PATH;
 
@@ -282,6 +284,12 @@ public class ProcessCriCallbackHandler
 
         // Retrieve, store and check cri credentials
         var accessToken = criApiService.fetchAccessToken(callbackRequest, criOAuthSessionItem);
+        // Temporarily logging DWP KBV token for integration debugging
+        if (callbackRequest.getCredentialIssuer().equals(DWP_KBV)
+                && configService.getEnvironmentVariable(ENVIRONMENT) != null
+                && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")) {
+            LOGGER.info("test bearer token: " + accessToken.getValue());
+        }
         var vcResponse =
                 criApiService.fetchVerifiableCredential(
                         accessToken, callbackRequest.getCredentialIssuer(), criOAuthSessionItem);


### PR DESCRIPTION
Temporarily log DWP KBV VC token for integration debugging, so we can recreate the credential request locally - this is purely a test token used against their test environment in staging