### PR TITLE
BAU: Avoid calling TICF twice and simplify

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/evaluate-scores.yaml
@@ -9,11 +9,6 @@ states:
       next:
         targetState: EVALUATE_GPG45_SCORES
 
-  START_NO_STORE:
-    events:
-      next:
-        targetState: EVALUATE_GPG45_SCORES_NO_STORE
-
   # Parent states
   CRI_TICF_STATE:
     events:
@@ -48,20 +43,6 @@ states:
         targetJourney: FAILED
         targetState: FAILED
 
-  EVALUATE_GPG45_SCORES_NO_STORE:
-    response:
-      type: process
-      lambda: evaluate-gpg45-scores
-    events:
-      met:
-        targetState: CRI_TICF_BEFORE_RP_RETURN_NO_STORE
-      unmet:
-        targetJourney: FAILED
-        targetState: FAILED
-      vcs-not-correlated:
-        targetJourney: FAILED
-        targetState: FAILED
-
   CRI_TICF_BEFORE_SUCCESS:
     response:
       type: process
@@ -70,15 +51,6 @@ states:
     events:
       next:
         targetState: STORE_IDENTITY_BEFORE_SUCCESS
-
-  CRI_TICF_BEFORE_RP_RETURN_NO_STORE:
-    response:
-      type: process
-      lambda: call-ticf-cri
-    parent: CRI_TICF_STATE
-    events:
-      next:
-        targetState: RETURN_TO_RP
 
   STORE_IDENTITY_BEFORE_SUCCESS:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -322,8 +322,23 @@ states:
         resetType: REINSTATE
     events:
       next:
-        targetJourney: EVALUATE_SCORES
-        targetState: START_NO_STORE
+        targetState: EVALUATE_GPG45_SCORES
+
+  EVALUATE_GPG45_SCORES:
+    response:
+      type: process
+      lambda: evaluate-gpg45-scores
+    events:
+      met:
+        targetState: RETURN_TO_RP
+      # The user should always have a valid profile to reach this point,
+      # if they don't then it's an error.
+      unmet:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      vcs-not-correlated:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
   DELETE_HANDOVER_PAGE:
     response:


### PR DESCRIPTION
## Proposed changes

### What changed

We don't need to resubmit to the TICF CRI after the failure screen, and once that's down to a single state it makes sense to keep in the failed journey for context.

Also updated the failure cases to a technical error, as this should not be possible (and we shouldn't just display another failure screen).