### PR TITLE
PYIC-7498: Add HMRC KBVs journeys API tests

### DIFF
--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -138,6 +138,39 @@ Feature: CIMIT - Alternate doc
       | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
       | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
+  Scenario Outline: Alternate doc mitigation via passport or DL - HMRC KBV
+    Given I start a new 'medium-confidence' journey with feature set 'm2bBetaHmrcKbv'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit an <initialCri> event
+    Then I get a <initialCri> CRI response
+    When I submit <initialInvalidDoc> details to the CRI stub
+    Then I get a <noMatchPage> page response
+    When I submit a 'next' event
+    Then I get a <mitigatingCri> CRI response
+    When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details to the CRI stub
+    Then I get a 'hmrcKbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
+      | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
+      | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+
   Scenario Outline: Mitigation of alternate-doc CI via <mitigating-cri> when user initially drops out of <mitigating-cri>
     When I submit a '<initial-cri>' event
     Then I get a '<initial-cri>' CRI response

--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -171,6 +171,43 @@ Feature: CIMIT - Alternate doc
       | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
       | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
+  Scenario Outline: Alternate doc mitigation user drops out of HMRC KBV CRI via thin file or failed checks - HMRC KBV
+    Given I start a new 'medium-confidence' journey with feature set 'm2bBetaHmrcKbv'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit an <initialCri> event
+    Then I get a <initialCri> CRI response
+    When I submit <initialInvalidDoc> details to the CRI stub
+    Then I get a <noMatchPage> page response
+    When I submit a 'next' event
+    Then I get a <mitigatingCri> CRI response
+    When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details to the CRI stub
+    Then I get a 'hmrcKbv' CRI response
+    When I get an 'invalid_request' OAuth error from the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
+      | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
+      | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+
   Scenario Outline: Mitigation of alternate-doc CI via <mitigating-cri> when user initially drops out of <mitigating-cri>
     When I submit a '<initial-cri>' event
     Then I get a '<initial-cri>' CRI response

--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -70,6 +70,45 @@ Feature: CIMIT - Alternate doc
       | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
       | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
+  Scenario Outline: Alternate doc mitigation user drops out of DWP KBV CRI via thin file or failed checks - DWP KBV
+    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit an <initialCri> event
+    Then I get a <initialCri> CRI response
+    When I submit <initialInvalidDoc> details to the CRI stub
+    Then I get a <noMatchPage> page response
+    When I submit a 'next' event
+    Then I get a <mitigatingCri> CRI response
+    When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'dwpKbv' CRI response
+    When I get an 'invalid_request' OAuth error from the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
+      | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
+      | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+
   Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
     Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -179,6 +179,32 @@ Feature: P1 No Photo Id Journey
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
 
+  Scenario: P1 No Photo Id Journey - HMRC KBV
+    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,m2bBetaHmrcKbv'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
+    When I submit an 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "hmrc_check"   |
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'hmrcKbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P1' identity
+
   Scenario: P1 No suitable ID
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -115,6 +115,40 @@ Feature: P1 No Photo Id Journey
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
 
+  Scenario: P1 No Photo Id Journey user drops out of DWP KBV CRI via thin file or failed checks - DWP KBV
+    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
+    When I submit an 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "hmrc_check"   |
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'dwpKbv' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P1' identity
+
   Scenario: P1 No Photo Id Journey - DWP KBV PIP page dropout
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -205,6 +205,36 @@ Feature: P1 No Photo Id Journey
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
 
+  Scenario: P1 No Photo Id Journey user drops out of HMRC KBV CRI via thin file or failed checks - HMRC KBV
+    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,m2bBetaHmrcKbv'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
+    When I submit an 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "hmrc_check"   |
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'hmrcKbv' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P1' identity
+
   Scenario: P1 No suitable ID
     Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -127,6 +127,41 @@ Feature: P2 Web document journey
       | drivingLicence | kenneth-driving-permit-valid |
       | ukPassport     | kenneth-passport-valid       |
 
+  Scenario Outline: User drops out of DWP KBV CRI via thin file or failed checks using <cri> - DWP KBV
+    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit a '<cri>' event
+    Then I get a '<cri>' CRI response
+    When I submit '<details>' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'next' event
+    Then I get a 'page-pre-dwp-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'dwpKbv' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | cri            | details                      |
+      | drivingLicence | kenneth-driving-permit-valid |
+      | ukPassport     | kenneth-passport-valid       |
+
   Scenario Outline: Successful P2 identity via Web using <cri> - HMRC KBV
     Given I start a new 'medium-confidence' journey with feature set 'm2bBetaHmrcKbv'
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -156,6 +156,39 @@ Feature: P2 Web document journey
       | drivingLicence | kenneth-driving-permit-valid |
       | ukPassport     | kenneth-passport-valid       |
 
+  Scenario Outline: User drops out of HMRC KBV CRI via thin file or failed checks using <cri> - HMRC KBV
+    Given I start a new 'medium-confidence' journey with feature set 'm2bBetaHmrcKbv'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit a '<cri>' event
+    Then I get a '<cri>' CRI response
+    When I submit '<details>' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details to the CRI stub
+    Then I get a 'hmrcKbv' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | cri            | details                      |
+      | drivingLicence | kenneth-driving-permit-valid |
+      | ukPassport     | kenneth-passport-valid       |
+
   Scenario Outline: Allows use of <alternative-doc-cri> when user drops out of <initial-cri> CRI
     When I submit a '<initial-cri>' event
     Then I get a '<initial-cri>' CRI response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -127,6 +127,35 @@ Feature: P2 Web document journey
       | drivingLicence | kenneth-driving-permit-valid |
       | ukPassport     | kenneth-passport-valid       |
 
+  Scenario Outline: Successful P2 identity via Web using <cri> - HMRC KBV
+    Given I start a new 'medium-confidence' journey with feature set 'm2bBetaHmrcKbv'
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I get an 'access_denied' OAuth error from the CRI stub
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit a '<cri>' event
+    Then I get a '<cri>' CRI response
+    When I submit '<details>' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth' details to the CRI stub
+    Then I get a 'hmrcKbv' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    Examples:
+      | cri            | details                      |
+      | drivingLicence | kenneth-driving-permit-valid |
+      | ukPassport     | kenneth-passport-valid       |
+
   Scenario Outline: Allows use of <alternative-doc-cri> when user drops out of <initial-cri> CRI
     When I submit a '<initial-cri>' event
     Then I get a '<initial-cri>' CRI response


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

HMRC KBVs scenarios (HMRC KBV enabled, DWP KBD disabled):
- P2 photo id web journey
- P2 no-photo-id (M2B) journey (already done)
- P1 no-photo-id journey
- D02 mitigation journey

Including at least one set of unhappy path CI fail and dropout/thin file scenarios 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7498](https://govukverify.atlassian.net/browse/PYIC-7498)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7498]: https://govukverify.atlassian.net/browse/PYIC-7498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ