### PR TITLE
PYIC-7476: CRI disabled API tests

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -168,6 +168,7 @@ jobs:
           EVCS_STUB_API_KEY: ${{ secrets.API_KEY_EVCS }}
           CRI_STUB_GEN_CRED_API_KEY: ${{ secrets.CRI_STUB_GEN_CRED_API_KEY }}
           MANAGEMENT_TICF_API_KEY: ${{ secrets.MANAGEMENT_TICF_API_KEY }}
+          CIMIT_INTERNAL_API_KEY: ${{ secrets.API_KEY_CIMIT }}
         run: npm run test:ci
 
       - name: Upload API test report

--- a/api-tests/.env.build
+++ b/api-tests/.env.build
@@ -11,8 +11,7 @@ ASYNC_QUEUE_NAME="stubQueue_F2FQueue_build"
 ASYNC_QUEUE_DELAY=5
 EVCS_STUB_BASE_URL="https://evcs.stubs.account.gov.uk"
 TICF_STUB_BASE_URL="https://ticf.stubs.account.gov.uk"
-
-# These aren't needed for build but are required to have a value for config
+CIMIT_INTERNAL_API_URL="https://cimit-api.stubs.account.gov.uk"
 CIMIT_STUB_BASE_URL="https://cimit.stubs.account.gov.uk"
 
 # Also requires the following to be specified in .env or as an env variable
@@ -21,3 +20,4 @@ CIMIT_STUB_BASE_URL="https://cimit.stubs.account.gov.uk"
 # EVCS_STUB_API_KEY
 # MANAGEMENT_TICF_API_KEY
 # MANAGEMENT_CIMIT_STUB_API_KEY
+# CIMIT_INTERNAL_API_KEY

--- a/api-tests/.env.local
+++ b/api-tests/.env.local
@@ -10,12 +10,14 @@ JAR_SIGNING_KEY='{"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","
 LOCAL_AUDIT_EVENTS=true
 ASYNC_QUEUE_DELAY=2
 CIMIT_STUB_BASE_URL="https://cimit.stubs.account.gov.uk"
+CIMIT_INTERNAL_API_URL="https://cimit-api.stubs.account.gov.uk"
 EVCS_STUB_BASE_URL="https://evcs.stubs.account.gov.uk"
 TICF_STUB_BASE_URL="https://ticf.stubs.account.gov.uk"
 
 # Also requires the following to be specified in .env or as an env variable
 # ASYNC_QUEUE_NAME
 # MANAGEMENT_CIMIT_STUB_API_KEY
+# CIMIT_INTERNAL_API_KEY
 # CRI_STUB_GEN_CRED_API_KEY
 # EVCS_STUB_API_KEY
 # MANAGEMENT_TICF_API_KEY

--- a/api-tests/.env.template
+++ b/api-tests/.env.template
@@ -4,8 +4,11 @@
 # Required for F2F journeys in local, should correspond to the environment
 # ASYNC_QUEUE_NAME="stubQueue_local_dev-<name>"
 
-# Required for CiMit journeys in local, found in API Gateway for Cimit External API
+# Required for CIMIT journeys in local, found in API Gateway for CIMIT external API
 # MANAGEMENT_CIMIT_STUB_API_KEY=
+
+# Required for posting VCs directly into CIMIT, found in API Gateway for CIMIT internal API
+# CIMIT_INTERNAL_API_KEY=
 
 # Required for generating VCs directly with the CRI stubs, found in stubs-common-infra generateCredentialApiKey
 # CRI_STUB_GEN_CRED_API_KEY=

--- a/api-tests/data/cri-stub-requests/kbv/kenneth-needs-enhanced-verification/evidence.json
+++ b/api-tests/data/cri-stub-requests/kbv/kenneth-needs-enhanced-verification/evidence.json
@@ -15,5 +15,6 @@
       "checkMethod": "kbv"
     }
   ],
-  "ci": ["NEEDS-ENHANCED-VERIFICATION"]
+  "ci": ["NEEDS-ENHANCED-VERIFICATION"],
+  "txn": "9Q9RQKCWJA"
 }

--- a/api-tests/data/cri-stub-requests/ukPassport/kenneth-passport-valid/evidence.json
+++ b/api-tests/data/cri-stub-requests/ukPassport/kenneth-passport-valid/evidence.json
@@ -7,5 +7,6 @@
       "checkMethod": "data",
       "dataCheck": "record_check"
     }
-  ]
+  ],
+  "txn": "f401fdbc-c2ca-400c-bd06-40abd43c84ba"
 }

--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -36,7 +36,8 @@ Feature: CIMIT - Alternate doc
       | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
   Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV
-    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Given I activate the 'dwpKbvTest' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -71,7 +72,8 @@ Feature: CIMIT - Alternate doc
       | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
   Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
-    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Given I activate the 'dwpKbvTest' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -106,7 +108,8 @@ Feature: CIMIT - Alternate doc
       | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
   Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV transition page dropout
-    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Given I activate the 'dwpKbvTest' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response

--- a/api-tests/features/cimit/enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/enhanced-verification-mitigation-dcmaw.feature
@@ -61,15 +61,6 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
 
-    Scenario: Same session DCMAW enhanced verification mitigation - DCMAW is unavailable
-      Given I activate the 'dcmawOffTest' feature set
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-technical' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-
   Rule: Separate session journeys
 
     Scenario Outline: Separate session DCMAW enhanced verification mitigation - successful
@@ -102,17 +93,6 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
       Then I get a 'pyi-no-match' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-
-    Scenario: Separate session DCMAW enhanced verification mitigation - DCMAW is unavailable
-      When I start a new 'medium-confidence' journey with feature set 'dcmawOffTest'
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'appTriage' event
-      # This is just ensuring that we handle this journey. It's not really an expected case.
-      Then I get a 'pyi-technical' page response
       When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -101,7 +101,7 @@ Feature: Disabled CRI journeys
       When I submit an 'end' event
       Then I get a 'pyi-escape' page response
 
-    Scenario Outline: Access denied from passport or driving licence CRI returns user to multidoc page
+    Scenario Outline: Choosing another way after access-denied from passport or DL CRIs leads to escape page
       Given I activate the 'f2fDisabled' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
@@ -112,12 +112,14 @@ Feature: Disabled CRI journeys
       When I submit a '<cri>' event
       Then I get a '<cri>' CRI response
       When I submit an 'access-denied' event
-      Then I get a 'page-multiple-doc-check' page response
+      Then I get a 'prove-identity-another-type-photo-id' page response with context '<context>'
+      When I submit an 'f2f' event
+      Then I get a 'pyi-escape' page response
 
       Examples:
-        | cri            |
-        | ukPassport     |
-        | drivingLicence |
+        | cri            | context        |
+        | ukPassport     | passport       |
+        | drivingLicence | drivingLicence |
 
     Scenario: Separate session mitigation with enhanced verification and no photo ID leads to ineligible
       Given the subject already has the following credentials

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -1,0 +1,233 @@
+@Build
+Feature: Disabled CRI journeys
+
+  Rule: DCMAW is disabled
+
+    Scenario: A P1 journey takes the user on a no photo ID journey
+      Given I activate the 'dcmawOffTest,p1Journeys' feature sets
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
+
+    Scenario: A P2 journey takes the user to the document select page
+      Given I activate the 'dcmawOffTest' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'page-multiple-doc-check' page response
+
+    Scenario: Choosing DCMAW after escaping from KBV CRIs leads to technical failure
+      Given I activate the 'dcmawOffTest' feature set
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'kbv' CRI response
+      When I submit 'kenneth-score-0' details to the CRI stub
+      Then I get a 'pyi-cri-escape' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-technical' page response
+
+    Scenario: Separate session enhanced verification mitigation with DCMAW leads to technical failure
+      Given the subject already has the following credentials
+        | CRI        | scenario                            |
+        | ukPassport | kenneth-passport-valid              |
+        | address    | kenneth-current                     |
+        | fraud      | kenneth-score-2                     |
+        | kbv        | kenneth-needs-enhanced-verification |
+      And I activate the 'dcmawOffTest' feature set
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-technical' page response
+
+    Scenario: Same session enhanced verification mitigation with DCMAW leads to technical failure
+      Given I activate the 'dcmawOffTest' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'kbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details to the CRI stub
+      Then I get a 'pyi-suggest-other-options' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-technical' page response
+
+  Rule: F2F is disabled
+
+    Scenario: A P1 journey for a user without a NINO routes to the escape page
+      Given I activate the 'f2fDisabled,p1Journeys' feature sets
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
+      When I submit an 'end' event
+      Then I get a 'pyi-escape' page response
+
+    Scenario: No photo ID leads to ineligible
+      Given I activate the 'f2fDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'pyi-another-way' page response
+
+    Scenario: Choosing not to use passport or driving licence routes to the escape page
+      Given I activate the 'f2fDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit an 'access-denied' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit an 'end' event
+      Then I get a 'pyi-escape' page response
+
+    Scenario Outline: Access denied from passport or driving licence CRI returns user to multidoc page
+      Given I activate the 'f2fDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit an 'access-denied' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit an 'access-denied' event
+      Then I get a 'page-multiple-doc-check' page response
+
+      Examples:
+        | cri            |
+        | ukPassport     |
+        | drivingLicence |
+
+    Scenario: Separate session mitigation with enhanced verification and no photo ID leads to ineligible
+      Given the subject already has the following credentials
+        | CRI        | scenario                            |
+        | ukPassport | kenneth-passport-valid              |
+        | address    | kenneth-current                     |
+        | fraud      | kenneth-score-2                     |
+        | kbv        | kenneth-needs-enhanced-verification |
+      And I activate the 'f2fDisabled' feature set
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'pyi-another-way' page response
+
+    Scenario: Separate session mitigation with enhanced verification and access-denied from DCMAW leads to ineligible
+      Given the subject already has the following credentials
+        | CRI        | scenario                            |
+        | ukPassport | kenneth-passport-valid              |
+        | address    | kenneth-current                     |
+        | fraud      | kenneth-score-2                     |
+        | kbv        | kenneth-needs-enhanced-verification |
+      And I activate the 'f2fDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit an 'access-denied' event
+      Then I get a 'pyi-another-way' page response
+
+  Rule: TICF is disabled
+
+    Scenario: A P2 journey is still successful
+      Given I activate the 'ticfDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity without a TICF VC
+
+  Rule: BAV is disabled
+
+    Scenario: Not having ID suitable for F2F leads to the escape page
+      Given I activate the 'bavDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit an 'end' event
+      Then I get a 'pyi-escape' page response
+
+    Scenario: Choosing to prove your identity another way on web journey leads to the escape page
+      Given I activate the 'bavDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit an 'access-denied' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit an 'end' event
+      Then I get a 'pyi-post-office' page response
+      When I submit an 'end' event
+      Then I get a 'pyi-escape' page response
+
+  Rule: HMRC and DWP KBVs are disabled
+
+    Scenario: Experian KBV is offered first
+      Given I activate the 'hmrcKbvDisabled,dwpKbvDisabled' feature sets
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit an 'access-denied' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'page-pre-experian-kbv-transition' page response
+
+  Rule: HMRC KBV is disabled
+
+    Scenario: Experian KBV is offered if DWP KBV unsuitable
+      Given I activate the 'dwpKbvTest' feature sets
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit an 'access-denied' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'personal-independence-payment' page response
+      When I submit an 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -256,7 +256,7 @@ Feature: Disabled CRI journeys
   Rule: HMRC KBV is disabled
 
     Scenario: Experian KBV is offered if DWP KBV unsuitable
-      Given I activate the 'dwpKbvTest' feature sets
+      Given I activate the 'dwpKbvTest' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -211,6 +211,48 @@ Feature: Disabled CRI journeys
       When I submit 'kenneth-score-2' details to the CRI stub
       Then I get a 'page-pre-experian-kbv-transition' page response
 
+  Rule: DWP KBV is disabled and HMRC KBV is enabled
+
+    Scenario: NINO then HMRC KBV is offered if user doesn't have an existing NINO
+      Given I activate the 'dwpKbvDisabled,hmrcKbvBeta' feature sets
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit an 'access-denied' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'nino' CRI response
+      When I submit a 'next' event
+      Then I get an 'hmrcKbv' CRI response
+
+    Scenario: HMRC KBV is offered if user already has a NINO
+      Given I activate the 'dwpKbvDisabled,m2bBetaHmrcKbv' feature sets
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response
+      When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit a 'next' event
+      Then I get a 'bav' CRI response
+      When I submit a 'next' event
+      Then I get a 'nino' CRI response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit a 'next' event
+      Then I get a 'hmrcKbv' CRI response
+
   Rule: HMRC KBV is disabled
 
     Scenario: Experian KBV is offered if DWP KBV unsuitable

--- a/api-tests/features/p1-journeys.feature
+++ b/api-tests/features/p1-journeys.feature
@@ -2,7 +2,8 @@
 Feature: P1 journey
 
   Scenario: P1 App Journey
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -21,7 +22,8 @@ Feature: P1 journey
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 Passport after DCMAW dropout
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -46,7 +48,8 @@ Feature: P1 journey
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 Driving Licence after DCMAW dropout
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -71,7 +74,8 @@ Feature: P1 journey
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 Face to Face after DCMAW dropout
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -91,7 +95,8 @@ Feature: P1 journey
     Then I get a 'page-face-to-face-handoff' page response
 
   Scenario: P1 Passport after multiple dropouts
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -124,7 +129,8 @@ Feature: P1 journey
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 DCMAW after KBV dropout Journey
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
@@ -157,7 +163,8 @@ Feature: P1 journey
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 F2F Journey
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -2,7 +2,8 @@
 Feature: P1 No Photo Id Journey
 
   Scenario: P1 No Photo Id Journey
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
@@ -33,7 +34,8 @@ Feature: P1 No Photo Id Journey
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 No Photo Id after DCMAW dropout Journey
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -68,7 +70,8 @@ Feature: P1 No Photo Id Journey
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 No Photo Id Journey - NINO dropout
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
+    Given I activate the 'p1Journeys,dwpKbvTest' feature sets
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
@@ -84,7 +87,8 @@ Feature: P1 No Photo Id Journey
     Then I get a 'no-photo-id-abandon-find-another-way' page response
 
   Scenario: P1 No Photo Id Journey - DWP KBV
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
+    Given I activate the 'p1Journeys,dwpKbvTest' feature sets
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
@@ -116,7 +120,8 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id Journey - DWP KBV PIP page dropout
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
+    Given I activate the 'p1Journeys,dwpKbvTest' feature sets
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
@@ -148,7 +153,8 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id Journey - DWP KBV transition page dropout
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys,dwpKbvTest'
+    Given I activate the 'p1Journeys,dwpKbvTest' feature sets
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
@@ -180,7 +186,8 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No suitable ID
-    Given I start a new 'low-confidence' journey with feature set 'p1Journeys'
+    Given I activate the 'p1Journeys' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'

--- a/api-tests/features/p2-coi-delete-identity.feature
+++ b/api-tests/features/p2-coi-delete-identity.feature
@@ -7,7 +7,8 @@ Feature: Delete identity
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
-    When I start a new 'medium-confidence' journey with feature set 'updateDetailsAccountDeletion'
+    And I activate the 'updateDetailsAccountDeletion' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'update-details' event
     Then I get a 'update-details' page response

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -25,7 +25,8 @@ Feature: P2 F2F journey
 
     Scenario: Pending F2F request delete identity
       # Initial journey
-      Given I start a new 'medium-confidence' journey with feature set 'pendingF2FResetEnabled'
+      Given I activate the 'pendingF2FResetEnabled' feature set
+      When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
       When I submit a 'next' event
       Then I get a 'pyi-f2f-delete-details' page response
@@ -37,7 +38,8 @@ Feature: P2 F2F journey
 
     Scenario: Pending F2F request continue without delete identity
       # Initial journey
-      Given I start a new 'medium-confidence' journey with feature set 'pendingF2FResetEnabled'
+      Given I activate the 'pendingF2FResetEnabled' feature set
+      When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
       When I submit a 'next' event
       Then I get a 'pyi-f2f-delete-details' page response

--- a/api-tests/features/p2-m2b.feature
+++ b/api-tests/features/p2-m2b.feature
@@ -2,7 +2,8 @@
 Feature: M2B No Photo Id Journey
 
   Scenario: M2B Journey
-    Given I start a new 'medium-confidence' journey with feature set 'm2bBetaExperianKbv'
+    Given I activate the 'm2bBetaExperianKbv' feature set
+    Given I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response
@@ -34,7 +35,8 @@ Feature: M2B No Photo Id Journey
     Then I get a 'P2' identity
 
   Scenario: M2B Journey with HMRC KBV
-    Given I start a new 'medium-confidence' journey with feature set 'm2bBetaHmrcKbv'
+    Given I activate the 'm2bBetaHmrcKbv' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -2,7 +2,8 @@
 Feature: M2B Strategic App Journeys
 
   Scenario: MAM journey iphone
-    Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -12,7 +13,8 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
 
   Scenario: MAM journey android
-    Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -22,7 +24,8 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'android'
 
   Scenario: MAM journey no compatible smartphone
-    Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -32,7 +35,8 @@ Feature: M2B Strategic App Journeys
     Then I get a 'page-multiple-doc-check' page response
 
   Scenario: DAD journey iphone
-    Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -42,7 +46,8 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone'
 
   Scenario: DAD journey android
-    Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -52,7 +57,8 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-desktop-download-app' page response with context 'android'
 
   Scenario: DAD journey no compatible smartphone
-    Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -62,7 +68,8 @@ Feature: M2B Strategic App Journeys
     Then I get a 'page-multiple-doc-check' page response
 
   Scenario: Strategic app no photo ID goes to F2F
-    Given I start a new 'medium-confidence' journey with feature set 'strategicApp'
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -33,7 +33,8 @@ Feature: P2 Web document journey
       | ukPassport     | kenneth-passport-valid       |
 
   Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV
-    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Given I activate the 'dwpKbvTest' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -64,7 +65,8 @@ Feature: P2 Web document journey
       | ukPassport     | kenneth-passport-valid       |
 
   Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV PIP page dropout
-    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Given I activate the 'dwpKbvTest' feature sets
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -95,7 +97,8 @@ Feature: P2 Web document journey
       | ukPassport     | kenneth-passport-valid       |
 
   Scenario Outline: Successful P2 identity via Web using - DWP KBV transition page dropout
-    Given I start a new 'medium-confidence' journey with feature set 'dwpKbvTest'
+    Given I activate the 'dwpKbvTest' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -81,7 +81,8 @@ Feature: TICF failed/error journeys
 
   Rule: Via no-photo-id
     Scenario: TICF failed M2B journey - PYI_ESCAPE_M2B
-      When I start a new 'medium-confidence' journey with feature set 'm2bBetaExperianKbv'
+      Given I activate the 'm2bBetaExperianKbv' feature set
+      When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response

--- a/api-tests/features/ticf/ticf-successful-responses.feature
+++ b/api-tests/features/ticf/ticf-successful-responses.feature
@@ -69,7 +69,8 @@ Feature: TICF successful responses
     Scenario: Via app - TICF request has a response delay less than 5s
       Given TICF CRI will respond with default parameters
         | responseDelay | 4         |
-      When I start a new 'medium-confidence' journey with feature set 'ticfCriBeta'
+      And I activate the 'ticfCriBeta' feature set
+      When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
@@ -94,7 +95,8 @@ Feature: TICF successful responses
       # To prime TICF to time out, we set txn to be undefined
       Given TICF CRI will respond with default parameters
         | txn   |                             |
-      When I start a new 'medium-confidence' journey with feature set 'ticfCriBeta'
+      And I activate the 'ticfCriBeta' feature set
+      When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response

--- a/api-tests/secure-pipeline/run-tests.sh
+++ b/api-tests/secure-pipeline/run-tests.sh
@@ -22,6 +22,9 @@ export MANAGEMENT_TICF_API_KEY
 MANAGEMENT_CIMIT_STUB_API_KEY=$(aws ssm get-parameter --name /tests/core-back-build/cimit_api_key | jq -r .Parameter.Value)
 export MANAGEMENT_CIMIT_STUB_API_KEY
 
+CIMIT_INTERNAL_API_KEY=$(aws secretsmanager get-secret-value --secret-id /build/core/cimitApi/apiKey | jq -r .SecretString)
+export CIMIT_INTERNAL_API_KEY
+
 cd /api-tests
 
 npm run test:build -- --profile codepipeline

--- a/api-tests/src/clients/cimit-stub-client.ts
+++ b/api-tests/src/clients/cimit-stub-client.ts
@@ -1,0 +1,45 @@
+import config from "../config/config.js";
+import {
+  CimitStubDetectRequest,
+  CimitStubMitigateRequest,
+} from "../types/cimit-stub.js";
+
+export const postDetectCi = async (
+  body: CimitStubDetectRequest,
+): Promise<void> => {
+  const response = await fetch(
+    `${config.cimit.internalApiUrl}/contra-indicators/detect`,
+    {
+      headers: {
+        "x-api-key": config.cimit.internalApiKey,
+        "content-type": "application/json",
+      },
+      method: "POST",
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`postDetectCI request failed: ${response.statusText}`);
+  }
+};
+
+export const postMitigateCi = async (
+  body: CimitStubMitigateRequest,
+): Promise<void> => {
+  const response = await fetch(
+    `${config.cimit.internalApiUrl}/contra-indicators/mitigate`,
+    {
+      headers: {
+        "x-api-key": config.cimit.internalApiKey,
+        "content-type": "application/json",
+      },
+      method: "POST",
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`postMitigateCI request failed: ${response.statusText}`);
+  }
+};

--- a/api-tests/src/clients/cimit-stub-client.ts
+++ b/api-tests/src/clients/cimit-stub-client.ts
@@ -1,8 +1,5 @@
 import config from "../config/config.js";
-import {
-  CimitStubDetectRequest,
-  CimitStubMitigateRequest,
-} from "../types/cimit-stub.js";
+import { CimitStubDetectRequest } from "../types/cimit-stub.js";
 
 export const postDetectCi = async (
   body: CimitStubDetectRequest,
@@ -21,25 +18,5 @@ export const postDetectCi = async (
 
   if (!response.ok) {
     throw new Error(`postDetectCI request failed: ${response.statusText}`);
-  }
-};
-
-export const postMitigateCi = async (
-  body: CimitStubMitigateRequest,
-): Promise<void> => {
-  const response = await fetch(
-    `${config.cimit.internalApiUrl}/contra-indicators/mitigate`,
-    {
-      headers: {
-        "x-api-key": config.cimit.internalApiKey,
-        "content-type": "application/json",
-      },
-      method: "POST",
-      body: JSON.stringify(body),
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(`postMitigateCI request failed: ${response.statusText}`);
   }
 };

--- a/api-tests/src/config/config.ts
+++ b/api-tests/src/config/config.ts
@@ -42,6 +42,8 @@ const config = {
   cimit: {
     managementCimitUrl: getMandatoryConfig("CIMIT_STUB_BASE_URL"),
     managementCimitApiKey: getMandatoryConfig("MANAGEMENT_CIMIT_STUB_API_KEY"),
+    internalApiUrl: getMandatoryConfig("CIMIT_INTERNAL_API_URL"),
+    internalApiKey: getMandatoryConfig("CIMIT_INTERNAL_API_KEY"),
   },
   credentialIssuers: {
     generateCredentialApiKey: getMandatoryConfig("CRI_STUB_GEN_CRED_API_KEY"),

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -338,6 +338,5 @@ When(
     for (const credential of credentials) {
       await cimitStubClient.postDetectCi({ signed_jwt: credential });
     }
-    await cimitStubClient.postMitigateCi({ signed_jwts: credentials });
   },
 );

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -3,6 +3,7 @@ import { World } from "../types/world.js";
 import * as internalClient from "../clients/core-back-internal-client.js";
 import * as criStubClient from "../clients/cri-stub-client.js";
 import * as evcsStubClient from "../clients/evcs-stub-client.js";
+import * as cimitStubClient from "../clients/cimit-stub-client.js";
 import {
   generateCriStubBody,
   generateCriStubOAuthErrorBody,
@@ -334,5 +335,9 @@ When(
       this.userId,
       generatePostVcsBody(credentials),
     );
+    for (const credential of credentials) {
+      await cimitStubClient.postDetectCi({ signed_jwt: credential });
+    }
+    await cimitStubClient.postMitigateCi({ signed_jwts: credentials });
   },
 );

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -89,7 +89,7 @@ const startNewJourney = async (
 ): Promise<void> => {
   world.userId = world.userId ?? getRandomString(16);
   world.journeyId = getRandomString(16);
-  world.featureSet = featureSet;
+  world.featureSet = featureSet || world.featureSet;
   world.ipvSessionId = await internalClient.initialiseIpvSession(
     await generateInitialiseIpvSessionBody({
       subject: world.userId,

--- a/api-tests/src/types/cimit-stub.ts
+++ b/api-tests/src/types/cimit-stub.ts
@@ -1,0 +1,7 @@
+export interface CimitStubDetectRequest {
+  signed_jwt: string;
+}
+
+export interface CimitStubMitigateRequest {
+  signed_jwts: string[];
+}

--- a/api-tests/src/types/cimit-stub.ts
+++ b/api-tests/src/types/cimit-stub.ts
@@ -1,7 +1,3 @@
 export interface CimitStubDetectRequest {
   signed_jwt: string;
 }
-
-export interface CimitStubMitigateRequest {
-  signed_jwts: string[];
-}

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializer.java
@@ -112,7 +112,7 @@ public class StateMachineInitializer {
                     if (event instanceof ExitNestedJourneyEvent exitNestedJourneyEvent) {
                         exitNestedJourneyEvent.setNestedJourneyExitEvents(nestedJourneyExitEvents);
                     } else {
-                        event.initialize(eventName, eventStatesSource);
+                        event.initialize(eventName, eventStatesSource, nestedJourneyExitEvents);
                     }
                 });
     }
@@ -124,12 +124,11 @@ public class StateMachineInitializer {
             Map<String, Event> nestedJourneyExitEvents) {
         state.setName(stateName);
         state.setJourneyType(journeyType);
-        NestedJourneyDefinition nestedJourneyDefinition =
-                nestedJourneyDefinitions.get(state.getNestedJourney());
-        NestedJourneyDefinition nestedJourneyDefinitionCopy =
-                deepCopyNestedJourneyDefinition(nestedJourneyDefinition);
         state.setNestedJourneyDefinition(
-                initializeNestedJourneyDefinition(state, nestedJourneyDefinitionCopy));
+                initializeNestedJourneyDefinition(
+                        state,
+                        deepCopyNestedJourneyDefinition(
+                                nestedJourneyDefinitions.get(state.getNestedJourney()))));
         initializeExitStateEvents(state, journeyStates, nestedJourneyExitEvents);
     }
 

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEvent.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEvent.java
@@ -80,7 +80,8 @@ public class BasicEvent implements Event {
     }
 
     @Override
-    public void initialize(String name, Map<String, State> states) {
+    public void initialize(
+            String name, Map<String, State> states, Map<String, Event> nestedJourneyExitEvents) {
         this.name = name;
         if (targetJourney != null) {
             this.targetStateObj =
@@ -89,13 +90,31 @@ public class BasicEvent implements Event {
             this.targetStateObj = states.get(targetState);
         }
         if (checkIfDisabled != null) {
-            checkIfDisabled.forEach((eventName, event) -> event.initialize(eventName, states));
+            checkIfDisabled.forEach(
+                    (eventName, event) ->
+                            initialiseEvent(event, eventName, states, nestedJourneyExitEvents));
         }
         if (checkFeatureFlag != null) {
-            checkFeatureFlag.forEach((eventName, event) -> event.initialize(eventName, states));
+            checkFeatureFlag.forEach(
+                    (eventName, event) ->
+                            initialiseEvent(event, eventName, states, nestedJourneyExitEvents));
         }
         if (checkJourneyContext != null) {
-            checkJourneyContext.forEach((eventName, event) -> event.initialize(eventName, states));
+            checkJourneyContext.forEach(
+                    (eventName, event) ->
+                            initialiseEvent(event, eventName, states, nestedJourneyExitEvents));
+        }
+    }
+
+    private void initialiseEvent(
+            Event event,
+            String eventName,
+            Map<String, State> states,
+            Map<String, Event> nestedJourneyExitEvents) {
+        if (event instanceof ExitNestedJourneyEvent exitNestedJourneyEvent) {
+            exitNestedJourneyEvent.setNestedJourneyExitEvents(nestedJourneyExitEvents);
+        } else {
+            event.initialize(eventName, states, nestedJourneyExitEvents);
         }
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/Event.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/Event.java
@@ -9,6 +9,7 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.Journey
 
 import java.util.Map;
 
+@SuppressWarnings({"javaarchitecture:S7027"}) // Circular dependency with implementations
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = BasicEvent.class),

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/Event.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/Event.java
@@ -17,5 +17,6 @@ import java.util.Map;
 public interface Event {
     TransitionResult resolve(JourneyContext journeyContext) throws UnknownEventException;
 
-    void initialize(String name, Map<String, State> states);
+    void initialize(
+            String name, Map<String, State> states, Map<String, Event> nestedJourneyExitEvents);
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEvent.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEvent.java
@@ -24,7 +24,8 @@ public class ExitNestedJourneyEvent implements Event {
     }
 
     @Override
-    public void initialize(String name, Map<String, State> states) {
+    public void initialize(
+            String name, Map<String, State> states, Map<String, Event> nestedJourneyExitEvents) {
         throw new UnsupportedOperationException(
                 "Initialize of ExitNestedJourneyEvent not supported");
     }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -21,9 +21,6 @@ nestedJourneyStates:
         targetState: ADDRESS_AND_FRAUD_AFTER_PASSPORT
       access-denied:
         targetState: PROVE_ANOTHER_WAY_AFTER_PASSPORT
-        checkIfDisabled:
-          f2f:
-            exitEventToEmit: access-denied-passport-or-dl
       alternate-doc-invalid-passport:
         targetState: MITIGATION_PP_NO_MATCH_ANOTHER_WAY
         auditEvents:
@@ -59,9 +56,6 @@ nestedJourneyStates:
         targetState: ADDRESS_AND_FRAUD_AFTER_DL
       access-denied:
         targetState: PROVE_ANOTHER_WAY_AFTER_DL
-        checkIfDisabled:
-          f2f:
-            exitEventToEmit: access-denied-passport-or-dl
       alternate-doc-invalid-dl:
         targetState: MITIGATION_DL_NO_MATCH_ANOTHER_WAY
         auditEvents:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -23,7 +23,7 @@ nestedJourneyStates:
         targetState: PROVE_ANOTHER_WAY_AFTER_PASSPORT
         checkIfDisabled:
           f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
+            exitEventToEmit: access-denied-passport-or-dl
       alternate-doc-invalid-passport:
         targetState: MITIGATION_PP_NO_MATCH_ANOTHER_WAY
         auditEvents:
@@ -61,7 +61,7 @@ nestedJourneyStates:
         targetState: PROVE_ANOTHER_WAY_AFTER_DL
         checkIfDisabled:
           f2f:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
+            exitEventToEmit: access-denied-passport-or-dl
       alternate-doc-invalid-dl:
         targetState: MITIGATION_DL_NO_MATCH_ANOTHER_WAY
         auditEvents:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -229,6 +229,8 @@ states:
         targetState: MITIGATION_KBVS
       alternate-doc-next-passport:
         targetState: MITIGATION_KBVS
+      access-denied-passport-or-dl:
+        targetState: MULTIPLE_DOC_CHECK_PAGE
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -229,8 +229,6 @@ states:
         targetState: MITIGATION_KBVS
       alternate-doc-next-passport:
         targetState: MITIGATION_KBVS
-      access-denied-passport-or-dl:
-        targetState: MULTIPLE_DOC_CHECK_PAGE
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -230,6 +230,8 @@ states:
         targetState: MITIGATION_CHECK_FRAUD_AFTER_DL
       alternate-doc-next-passport:
         targetState: MITIGATION_KBVS
+      access-denied-passport-or-dl:
+        targetState: MULTIPLE_DOC_CHECK_PAGE
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -230,8 +230,6 @@ states:
         targetState: MITIGATION_CHECK_FRAUD_AFTER_DL
       alternate-doc-next-passport:
         targetState: MITIGATION_KBVS
-      access-denied-passport-or-dl:
-        targetState: MULTIPLE_DOC_CHECK_PAGE
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/JourneyMapTest.java
@@ -288,6 +288,45 @@ class JourneyMapTest {
                     if (event instanceof ExitNestedJourneyEvent exitNestedJourneyEvent) {
                         actualExitEvents.add(exitNestedJourneyEvent.getExitEventToEmit());
                     }
+                    if (event instanceof BasicEvent basicEvent) {
+                        if (basicEvent.getCheckIfDisabled() != null) {
+                            basicEvent.getCheckIfDisabled().values().stream()
+                                    .filter(
+                                            disableEvent ->
+                                                    disableEvent instanceof ExitNestedJourneyEvent)
+                                    .forEach(
+                                            disabledEvent ->
+                                                    actualExitEvents.add(
+                                                            ((ExitNestedJourneyEvent) disabledEvent)
+                                                                    .getExitEventToEmit()));
+                        }
+                        if (basicEvent.getCheckFeatureFlag() != null) {
+                            basicEvent.getCheckFeatureFlag().values().stream()
+                                    .filter(
+                                            checkFlagEvent ->
+                                                    checkFlagEvent
+                                                            instanceof ExitNestedJourneyEvent)
+                                    .forEach(
+                                            checkFlagEvent ->
+                                                    actualExitEvents.add(
+                                                            ((ExitNestedJourneyEvent)
+                                                                            checkFlagEvent)
+                                                                    .getExitEventToEmit()));
+                        }
+                        if (basicEvent.getCheckJourneyContext() != null) {
+                            basicEvent.getCheckJourneyContext().values().stream()
+                                    .filter(
+                                            checkContextEvent ->
+                                                    checkContextEvent
+                                                            instanceof ExitNestedJourneyEvent)
+                                    .forEach(
+                                            checkContextEvent ->
+                                                    actualExitEvents.add(
+                                                            ((ExitNestedJourneyEvent)
+                                                                            checkContextEvent)
+                                                                    .getExitEventToEmit()));
+                        }
+                    }
                 }
             }
             if (nestedState instanceof NestedJourneyInvokeState nestedNestedState) {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEventTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/BasicEventTest.java
@@ -108,26 +108,60 @@ class BasicEventTest {
 
     @Test
     void initializeShouldSetAttributes() {
-        BasicEvent basicEvent = new BasicEvent();
-        BasicState targetStateObj = new BasicState();
+        var basicEvent = new BasicEvent();
+        var targetStateObj = new BasicState();
         basicEvent.setTargetState("TARGET_STATE");
 
-        BasicEvent checkIfDisabledEvent = new BasicEvent();
-        checkIfDisabledEvent.setTargetState("CHECK_STATE");
-        BasicState checkStateObj = new BasicState();
+        var checkIfDisabledEvent = new BasicEvent();
+        checkIfDisabledEvent.setTargetState("CHECK_IF_DISABLED_STATE");
+        var checkIfDisabledStateObj = new BasicState();
 
-        basicEvent.setCheckIfDisabled(new LinkedHashMap<>(Map.of("aCriId", checkIfDisabledEvent)));
+        var exitNestedJourneyEvent = new ExitNestedJourneyEvent();
+        exitNestedJourneyEvent.setExitEventToEmit("getMetOut");
+        var nestedJourneyExitEvent = new BasicEvent();
+
+        var checkFeatureFlagEvent = new BasicEvent();
+        checkFeatureFlagEvent.setTargetState("CHECK_FLAG_STATE");
+        var checkFeatureFlagStateObj = new BasicState();
+
+        var checkJourneyContextEvent = new BasicEvent();
+        checkJourneyContextEvent.setTargetState("CHECK_CONTEXT_STATE");
+        var checkJourneyContextStateObj = new BasicState();
+
+        basicEvent.setCheckIfDisabled(
+                new LinkedHashMap<>(
+                        Map.of(
+                                "aCriId",
+                                checkIfDisabledEvent,
+                                "exitEvent",
+                                exitNestedJourneyEvent)));
+        basicEvent.setCheckFeatureFlag(new LinkedHashMap<>(Map.of("aFlag", checkFeatureFlagEvent)));
+        basicEvent.setCheckJourneyContext(
+                new LinkedHashMap<>(Map.of("aContext", checkJourneyContextEvent)));
 
         basicEvent.initialize(
                 "eventName",
                 Map.of(
                         "TARGET_STATE", targetStateObj,
-                        "CHECK_STATE", checkStateObj));
+                        "CHECK_IF_DISABLED_STATE", checkIfDisabledStateObj,
+                        "CHECK_FLAG_STATE", checkFeatureFlagStateObj,
+                        "CHECK_CONTEXT_STATE", checkJourneyContextStateObj),
+                Map.of("getMeOut", nestedJourneyExitEvent));
 
         assertEquals("eventName", basicEvent.getName());
         assertEquals(targetStateObj, basicEvent.getTargetStateObj());
         assertEquals(
-                checkStateObj,
+                checkIfDisabledStateObj,
                 ((BasicEvent) basicEvent.getCheckIfDisabled().get("aCriId")).getTargetStateObj());
+        assertEquals(
+                checkFeatureFlagStateObj,
+                ((BasicEvent) basicEvent.getCheckFeatureFlag().get("aFlag")).getTargetStateObj());
+        assertEquals(
+                checkJourneyContextStateObj,
+                ((BasicEvent) basicEvent.getCheckJourneyContext().get("aContext"))
+                        .getTargetStateObj());
+        assertEquals(
+                nestedJourneyExitEvent,
+                exitNestedJourneyEvent.getNestedJourneyExitEvents().get("getMeOut"));
     }
 }

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEventTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEventTest.java
@@ -5,7 +5,6 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
-import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
 
 import java.util.Map;
@@ -47,9 +46,8 @@ class ExitNestedJourneyEventTest {
     @Test
     void initializeShouldThrowAnUnsupportedOperationException() {
         ExitNestedJourneyEvent exitNestedJourneyEvent = new ExitNestedJourneyEvent();
-        Map<String, State> emptyMap = Map.of();
         assertThrows(
                 UnsupportedOperationException.class,
-                () -> exitNestedJourneyEvent.initialize("name", emptyMap));
+                () -> exitNestedJourneyEvent.initialize("name", Map.of(), Map.of()));
     }
 }

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEventTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/ExitNestedJourneyEventTest.java
@@ -5,6 +5,7 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.JourneyContext;
 
 import java.util.Map;
@@ -46,8 +47,11 @@ class ExitNestedJourneyEventTest {
     @Test
     void initializeShouldThrowAnUnsupportedOperationException() {
         ExitNestedJourneyEvent exitNestedJourneyEvent = new ExitNestedJourneyEvent();
+        Map<String, State> emptyStateMap = Map.of();
+        Map<String, Event> emptyEventMap = Map.of();
+
         assertThrows(
                 UnsupportedOperationException.class,
-                () -> exitNestedJourneyEvent.initialize("name", Map.of(), Map.of()));
+                () -> exitNestedJourneyEvent.initialize("name", emptyStateMap, emptyEventMap));
     }
 }

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -386,47 +386,15 @@ core:
     updateDetailsAccountDeletion:
       featureFlags:
         updateDetailsAccountDeletion: true
-    hmrcKbvBeta:
-      credentialIssuers:
-        hmrcKbv:
-          enabled: true
-    drivingLicenseTest:
-      credentialIssuers:
-        drivingLicence:
-          enabled: false
-    dcmawOffTest:
-      credentialIssuers:
-        dcmaw:
-          enabled: false
-    hmrcKbvAndCimitSepSession:
-      credentialIssuers:
-        hmrcKbv:
-          enabled: true
     clearUsersIdentity:
       featureFlags:
         resetIdentity: true
-    m2bBetaHmrcKbv:
-      credentialIssuers:
-        bav:
-          enabled: true
-        hmrcKbv:
-          enabled: true
-    m2bBetaExperianKbv:
-      credentialIssuers:
-        bav:
-          enabled: true
-        hmrcKbv:
-          enabled: false
     deleteDetailsTestJourney:
       featureFlags:
         deleteDetailsEnabled: true
     pendingF2FResetEnabled:
       featureFlags:
         pendingF2FResetEnabled: true
-    ticfCriBeta:
-      credentialIssuers:
-        ticf:
-          enabled: true
     strategicApp:
       featureFlags:
         strategicAppEnabled: true
@@ -439,6 +407,61 @@ core:
     p1Journeys:
       featureFlags:
         p1JourneysEnabled: true
+    # Disabling CRIs
+    f2fDisabled:
+      credentialIssuers:
+        f2f:
+          enabled: false
+    ticfDisabled:
+      credentialIssuers:
+        ticf:
+          enabled: false
+    bavDisabled:
+      credentialIssuers:
+        bav:
+          enabled: false
+    hmrcKbvDisabled:
+      credentialIssuers:
+        hmrcKbv:
+          enabled: false
+    dwpKbvDisabled:
+      credentialIssuers:
+        dwpKbv:
+          enabled: false
+    drivingLicenseTest:
+      credentialIssuers:
+        drivingLicence:
+          enabled: false
+    dcmawOffTest:
+      credentialIssuers:
+        dcmaw:
+          enabled: false
+    # Enabling CRIs
+    hmrcKbvBeta:
+      credentialIssuers:
+        hmrcKbv:
+          enabled: true
+    hmrcKbvAndCimitSepSession:
+      credentialIssuers:
+        hmrcKbv:
+          enabled: true
+    ticfCriBeta:
+      credentialIssuers:
+        ticf:
+          enabled: true
+    # CRI enablement combinations
+    m2bBetaHmrcKbv:
+      credentialIssuers:
+        bav:
+          enabled: true
+        hmrcKbv:
+          enabled: true
+    m2bBetaExperianKbv:
+      credentialIssuers:
+        bav:
+          enabled: true
+        hmrcKbv:
+          enabled: false
     dwpKbvTest:
       credentialIssuers:
         dwpKbv:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

[PYIC-7476: Allow nested journey exit events behind conditionals](https://github.com/govuk-one-login/ipv-core-back/commit/ba8e1abe885e68dd52bcc6f5589aa96933b77be6)

The state manchine initializer wasn't correctly initializing exit nested
journey events that were defined behind journey map conditionals
(checkIfDisabled etc). This change makes sure that they are.

It also fixes a couple of places in the journey map where we were trying
to exit to states defined outside of the nested journey definition. It
now uses an exit event to route to the expected state.


[PYIC-7476: Add cimit-stub client](https://github.com/govuk-one-login/ipv-core-back/commit/87095fa06900ec4bf9b99fe7b360a3f539b7757d) 

We have the ability to send VCs directly to the EVCS stub to allow quick
creation of existing identities. This however skips sending the VCs to
CIMIT.

This adds a new client for doing that. It doesn't use the management API
of CIMIT and instead posts directly into the internal API.

This allows for quick creation of separate session mitigation journeys.

[PYIC-7476: Add disabled CRI API tests](https://github.com/govuk-one-login/ipv-core-back/commit/75ee60f138aef98c9c4ecebdca631300ef3bb608)

This adds a suite of API tests for journeys when we've disabled a CRI.

The tests for currently disabled by default CRIs (BAV, HMRC and DWP
KBVs) are slightly future proofing - when those CRIs are enabled these
tests should still be valid and pass.

This commit adds a couple of `txn` properties to some of the evidence
JSON blobs. Without these our CIMIT stub gets very upset - and evidence
blocks should have them anyway.

Also adds some logic to prevent exiting feature sets from being wiped
out if they exist.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7476](https://govukverify.atlassian.net/browse/PYIC-7476)


[PYIC-7476]: https://govukverify.atlassian.net/browse/PYIC-7476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ