### PR TITLE
PYIC-7489 openapi types

### DIFF
--- a/api-tests/package-lock.json
+++ b/api-tests/package-lock.json
@@ -15,20 +15,23 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "jose": "^5.9.2",
+        "jsonschema": "^1.4.1",
         "prettier": "3.3.2",
         "start-server-and-test": "^2.0.4",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.2",
-        "typescript-eslint": "^8.8.0"
+        "typescript-eslint": "^8.8.0",
+        "yaml": "^2.5.1"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.25.7",
+        "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -36,21 +39,23 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -64,6 +69,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -76,6 +82,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -90,6 +97,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -98,13 +106,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -114,6 +124,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -2249,7 +2260,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -2287,6 +2299,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -3906,9 +3927,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
-      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
       "dev": true,
       "bin": {
         "yaml": "bin.mjs"

--- a/api-tests/package.json
+++ b/api-tests/package.json
@@ -21,10 +21,12 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "jose": "^5.9.2",
+    "jsonschema": "^1.4.1",
     "prettier": "3.3.2",
     "start-server-and-test": "^2.0.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
-    "typescript-eslint": "^8.8.0"
+    "typescript-eslint": "^8.8.0",
+    "yaml": "^2.5.1"
   }
 }

--- a/api-tests/src/types/world.ts
+++ b/api-tests/src/types/world.ts
@@ -26,7 +26,7 @@ export interface World extends CucumberWorld {
   mfaResetResult?: MfaResetResult;
 
   // Healthcheck results
-  healthCheckResult?: boolean;
+  healthCheckResult?: string;
 
   // JWKS result
   jwksResult?: JSONWebKeySet;

--- a/api-tests/src/utils/schema-validator.ts
+++ b/api-tests/src/utils/schema-validator.ts
@@ -1,0 +1,55 @@
+import { readFile } from "fs/promises";
+import { Schema, Validator } from "jsonschema";
+import YAML from "yaml";
+
+interface OpenApiSchema {
+  components: {
+    schemas: Record<string, Schema>;
+  };
+}
+
+interface VocabSchema extends Schema {
+  $defs: Record<string, Schema>;
+}
+
+// Fetch an external schema from https://vocab.account.gov.uk
+const fetchVocabSchema = async (ref: string): Promise<VocabSchema> => {
+  const refUri = new URL(ref);
+  if (refUri.origin !== "https://vocab.account.gov.uk") {
+    throw new Error(`Refusing to import schema from ${ref}`);
+  }
+  const res = await fetch(refUri);
+  if (!res.ok) {
+    throw new Error(`Could not import schema ${ref}, status ${res.status}`);
+  }
+  const vocabSchema = (await res.json()) as VocabSchema;
+  // The schema IDs in the vocab schema are non-unique and don't match their URLs
+  // so we override them here instead
+  vocabSchema.$id = ref;
+  return vocabSchema;
+};
+
+export const createValidator = async (
+  openApiPath: string,
+): Promise<Validator> => {
+  const validator = new Validator();
+  const openApiSchema = YAML.parse(
+    await readFile(openApiPath, "utf-8"),
+  ) as OpenApiSchema;
+
+  Object.entries(openApiSchema.components.schemas).forEach(([key, schema]) =>
+    validator.addSchema(schema, `/${key}`),
+  );
+
+  for (const ref of validator.unresolvedRefs) {
+    const schema = await fetchVocabSchema(ref);
+    validator.addSchema(schema);
+
+    // The vocab schemas contain nested definitions, which need to be added as well
+    for (const [nestedName, nestedSchema] of Object.entries(schema.$defs)) {
+      validator.addSchema(nestedSchema, `${ref}#/$defs/${nestedName}`);
+    }
+  }
+
+  return validator;
+};

--- a/api-tests/src/utils/schema-validator.ts
+++ b/api-tests/src/utils/schema-validator.ts
@@ -41,7 +41,8 @@ export const createValidator = async (
     validator.addSchema(schema, `/${key}`),
   );
 
-  for (const ref of validator.unresolvedRefs) {
+  while (validator.unresolvedRefs.length) {
+    const ref = validator.unresolvedRefs[0];
     const schema = await fetchVocabSchema(ref);
     validator.addSchema(schema);
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +29,7 @@ import static uk.gov.di.ipv.core.library.domain.VocabConstants.VOT_CLAIM_NAME;
 @Setter
 @ExcludeFromGeneratedCoverageReport
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserIdentity {
 
     @JsonProperty(VCS_CLAIM_NAME)

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -258,9 +258,7 @@ components:
             birthDate:
               type: array
               items:
-                # TODO: we should export the BirthDate schema as well!
-                # $ref: https://vocab.account.gov.uk/v1/json-schemas/BirthDate.json
-                type: object
+                $ref: https://vocab.account.gov.uk/v1/json-schemas/BirthDate.json
           required:
             - name
             - birthDate

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -14,6 +14,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/tokenResponse"
+        400:
+          description: "Bad request - e.g. an malformed request"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
+        401:
+          description: "Unauthorized - e.g. bad client authentication"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
+        500:
+          description: "Internal server error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
@@ -23,7 +41,7 @@ paths:
 
   /user-identity:
     get:
-      description: "Returns a list of Verifiable Credentials representig the users identity"
+      description: "List of Verifiable Credentials and claims representing the user's identity"
       responses:
         200:
           description: "The list of Verifiable Credentials"
@@ -31,9 +49,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/userIdentityResponse"
+        401:
+          description: "Unauthorized - e.g. missing access token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
         403:
-          description: "403 Response"
-          content: {}
+          description: "Forbidden - e.g. expired access token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
+        500:
+          description: "Internal server error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
@@ -43,7 +76,7 @@ paths:
 
   /reverification:
     get:
-      description: "Returns a success or failure response based on the results of the reverification journey"
+      description: "Result of a reverification journey"
       responses:
         200:
           description: "Reverification success or failure response"
@@ -51,9 +84,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/reverificationResponse"
+        401:
+          description: "Unauthorized - e.g. missing access token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
         403:
-          description: "403 Response"
-          content: {}
+          description: "Forbidden - e.g. expired access token"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
+        500:
+          description: "Internal server error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/oauthError"
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
@@ -63,7 +111,7 @@ paths:
 
   /.well-known/jwks.json:
     get:
-      description: "returns JWKS Json"
+      description: "JSON Web Key Set (JWKS) for IPV Core public keys"
       responses:
         200:
           description: "The list of public keys"
@@ -72,7 +120,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/jwksResponse"
         500:
-          description: 500 response
+          description: "Error fetching public keys"
           content: {}
       x-amazon-apigateway-integration:
         type: aws
@@ -98,7 +146,7 @@ paths:
 
   /healthcheck:
     get:
-      description: "returns a 200 for Route53 health checks to use"
+      description: "Stub endpoint for service health checks to use"
       responses:
         200:
           description: "A healthcheck response"
@@ -134,6 +182,17 @@ components:
         - scope
         - token_type
         - expires_in
+      additionalProperties: false
+
+    oauthError:
+      type: object
+      properties:
+        error:
+          type: string
+        error_description:
+          type: string
+      required:
+        - error
       additionalProperties: false
 
     userIdentityResponse:

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -49,7 +49,7 @@ paths:
     get:
       description: "List of Verifiable Credentials and claims representing the user's identity"
       security:
-        - bearerAuth: ["user-identity"]
+        - bearerAuth: []
       responses:
         200:
           description: "The list of Verifiable Credentials"
@@ -86,7 +86,7 @@ paths:
     get:
       description: "Result of a reverification journey"
       security:
-        - bearerAuth: ["reverification"]
+        - bearerAuth: []
       responses:
         200:
           description: "Reverification success or failure response"

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -13,7 +13,7 @@ paths:
           content:
             application/json:
               schema:
-                type: "object"
+                $ref: "#/components/schemas/tokenResponse"
       x-amazon-apigateway-integration:
         type: "aws_proxy"
         httpMethod: "POST"
@@ -30,9 +30,7 @@ paths:
           content:
             application/json:
               schema:
-                type: "array"
-                items:
-                  type: "object"
+                $ref: "#/components/schemas/userIdentityResponse"
         403:
           description: "403 Response"
           content: {}
@@ -52,7 +50,7 @@ paths:
           content:
             application/json:
               schema:
-                type: "object"
+                $ref: "#/components/schemas/reverificationResponse"
         403:
           description: "403 Response"
           content: {}
@@ -72,7 +70,7 @@ paths:
           content:
             application/json:
               schema:
-                type: "object"
+                $ref: "#/components/schemas/jwksResponse"
         500:
           description: 500 response
           content: {}
@@ -107,7 +105,7 @@ paths:
           content:
             application/json:
               schema:
-                type: "object"
+                $ref: "#/components/schemas/healthcheckResponse"
       x-amazon-apigateway-integration:
         type: "MOCK"
         requestTemplates:
@@ -117,3 +115,123 @@ paths:
             statusCode: 200
             responseTemplates:
               application/json: "{\"healthcheck\": \"ok\"}"
+
+components:
+  schemas:
+    tokenResponse:
+      type: object
+      properties:
+        access_token:
+          type: string
+        scope:
+          type: string
+        token_type:
+          type: string
+        expires_in:
+          type: number
+      required:
+        - access_token
+        - scope
+        - token_type
+        - expires_in
+      additionalProperties: false
+
+    userIdentityResponse:
+      type: object
+      properties:
+        sub:
+          type: string
+        vot:
+          type: string
+        vtm:
+          type: string
+        "https://vocab.account.gov.uk/v1/credentialJWT":
+          type: array
+          items:
+            type: string
+        "https://vocab.account.gov.uk/v1/coreIdentity":
+          type: "object"
+          properties:
+            name:
+              type: array
+              items:
+                $ref: https://vocab.account.gov.uk/v1/json-schemas/Name.json
+            birthDate:
+              type: array
+              items:
+                # TODO: we should export the BirthDate schema as well!
+                # $ref: https://vocab.account.gov.uk/v1/json-schemas/BirthDate.json
+                type: object
+          required:
+            - name
+            - birthDate
+          additionalProperties: false
+        "https://vocab.account.gov.uk/v1/address":
+          type: "array"
+          items:
+            $ref: https://vocab.account.gov.uk/v1/json-schemas/PostalAddress.json
+        "https://vocab.account.gov.uk/v1/passport":
+          type: "array"
+          items:
+            $ref: https://vocab.account.gov.uk/v1/json-schemas/PassportDetails.json
+        "https://vocab.account.gov.uk/v1/drivingPermit":
+          type: "array"
+          items:
+            $ref: https://vocab.account.gov.uk/v1/json-schemas/DrivingPermit.json
+        "https://vocab.account.gov.uk/v1/socialSecurityRecord":
+          type: "array"
+          items:
+            $ref: https://vocab.account.gov.uk/v1/json-schemas/SocialSecurityRecord.json
+        "https://vocab.account.gov.uk/v1/returnCode":
+          type: array
+          items:
+            type: object
+            properties:
+              code:
+                type: string
+            required:
+              - code
+            additionalProperties: false
+      required:
+        - sub
+        - vot
+        - vtm
+        - "https://vocab.account.gov.uk/v1/credentialJWT"
+        - "https://vocab.account.gov.uk/v1/returnCode"
+      additionalProperties: false
+
+    reverificationResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        sub:
+          type: string
+        error_code:
+          type: string
+        error_description:
+          type: string
+      required:
+        - success
+        - sub
+      additionalProperties: false
+
+    jwksResponse:
+      type: object
+      properties:
+        keys:
+          type: array
+          items:
+            type: object
+      required:
+        - keys
+      additionalProperties: false
+
+    healthcheckResponse:
+      type: object
+      properties:
+        healthcheck:
+          type: string
+      required:
+        - healthcheck
+      additionalProperties: false

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -7,6 +7,12 @@ paths:
   /token:
     post:
       description: "Exchange an authorization code for an access token"
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/tokenRequest"
       responses:
         200:
           description: "The access token"
@@ -42,6 +48,8 @@ paths:
   /user-identity:
     get:
       description: "List of Verifiable Credentials and claims representing the user's identity"
+      security:
+        - bearerAuth: ["user-identity"]
       responses:
         200:
           description: "The list of Verifiable Credentials"
@@ -77,6 +85,8 @@ paths:
   /reverification:
     get:
       description: "Result of a reverification journey"
+      security:
+        - bearerAuth: ["reverification"]
       responses:
         200:
           description: "Reverification success or failure response"
@@ -165,7 +175,37 @@ paths:
               application/json: "{\"healthcheck\": \"ok\"}"
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+
   schemas:
+    tokenRequest:
+      type: object
+      properties:
+        grant_type:
+          type: string
+          enum: ["authorization_code"]
+        code:
+          type: string
+        redirect_uri:
+          type: string
+        client_id:
+          type: string
+        client_assertion_type:
+          type: string
+          enum: ["urn:ietf:params:oauth:client-assertion-type:jwt-bearer"]
+        client_assertion:
+          type: string
+      required:
+        - grant_type
+        - code
+        - redirect_uri
+        - client_id
+        - client_assertion_type
+        - client_assertion
+
     tokenResponse:
       type: object
       properties:


### PR DESCRIPTION
## Proposed changes

### What changed

- Added response schemas to the external OpenAPI schema
- Load and validate those schemas against responses received in the API tests

### Why did it change

- Our external API needs to be accurately documented, and other teams may rely on this
- Validating in the API tests helps ensure these definitions do not get out of date

### Issue tracking

- [PYIC-7489](https://govukverify.atlassian.net/browse/PYIC-7489)


[PYIC-7489]: https://govukverify.atlassian.net/browse/PYIC-7489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Screenshots

Endpoint configuration after pasting into swagger editor:

![image](https://github.com/user-attachments/assets/e9b24ab4-5a9d-4a1a-b291-6f6947c6d450)

Token exchange request

![image](https://github.com/user-attachments/assets/91a963cc-2446-40d4-b6b8-ab91930aaee2)

User identity response (with Vocab schema types)

![image](https://github.com/user-attachments/assets/5765ec93-7116-4974-9eec-2c0c1dd49eea)
