### PR TITLE
PYIC-7493: Emit dl-auth-source-check event

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -11,7 +11,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     MFA_RESET("mfaResetEnabled"),
     P1_JOURNEYS_ENABLED("p1JourneysEnabled"),
     SQS_ASYNC("sqsAsync"),
-    KID_JAR_HEADER("kidJarHeaderEnabled");
+    KID_JAR_HEADER("kidJarHeaderEnabled"),
+    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck");
 
     private final String name;
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -941,6 +941,28 @@ public interface VcFixtures {
                             .build(),
                     Instant.ofEpochSecond(1705986521));
 
+    VerifiableCredential DCMAW_PASSPORT_VC =
+            generateVerifiableCredential(
+                    "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
+                    DCMAW,
+                    TestVc.builder()
+                            .evidence(
+                                    List.of(
+                                            TestVc.TestEvidence.builder()
+                                                    .txn("bcd2346")
+                                                    .strengthScore(4)
+                                                    .validityScore(2)
+                                                    .verificationScore(3)
+                                                    .build()))
+                            .credentialSubject(
+                                    TestVc.TestCredentialSubject.builder()
+                                            .name(List.of(MORGAN_SARAH_MEREDYTH_NAME))
+                                            .address(List.of(ADDRESS_4))
+                                            .passport(PASSPORT_DETAILS)
+                                            .build())
+                            .build(),
+                    Instant.ofEpochSecond(1705986521));
+
     static VerifiableCredential vcF2fM1a() {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder()

--- a/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
+++ b/libs/journey-uris/src/main/java/uk/gov/di/ipv/core/library/journeyuris/JourneyUris.java
@@ -9,6 +9,7 @@ public class JourneyUris {
     public static final String JOURNEY_ACCESS_DENIED_PATH = "/journey/access-denied";
     public static final String JOURNEY_COI_CHECK_FAILED_PATH = "/journey/coi-check-failed";
     public static final String JOURNEY_COI_CHECK_PASSED_PATH = "/journey/coi-check-passed";
+    public static final String JOURNEY_DL_AUTH_SOURCE_CHECK_PATH = "/journey/dl-auth-source-check";
     public static final String JOURNEY_ENHANCED_VERIFICATION_F2F_FAIL_PATH =
             "/journey/enhanced-verification-f2f-fail";
     public static final String JOURNEY_ENHANCED_VERIFICATION_PATH =
@@ -19,6 +20,7 @@ public class JourneyUris {
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
     public static final String JOURNEY_IDENTITY_STORED_PATH = "/journey/identity-stored";
     public static final String JOURNEY_IN_MIGRATION_REUSE_PATH = "/journey/in-migration-reuse";
+    public static final String JOURNEY_INVALID_REQUEST_PATH = "/journey/invalid-request";
     public static final String JOURNEY_IPV_GPG45_LOW_PATH = "/journey/ipv-gpg45-low";
     public static final String JOURNEY_IPV_GPG45_MEDIUM_PATH = "/journey/ipv-gpg45-medium";
     public static final String JOURNEY_MET_PATH = "/journey/met";
@@ -38,5 +40,4 @@ public class JourneyUris {
             "/journey/temporarily-unavailable";
     public static final String JOURNEY_UNMET_PATH = "/journey/unmet";
     public static final String JOURNEY_VCS_NOT_CORRELATED = "/journey/vcs-not-correlated";
-    public static final String JOURNEY_INVALID_REQUEST_PATH = "/journey/invalid-request";
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Emit dl-auth-source-check event

### Why did it change

This adds a special case to the process-cri-callback lamdba for when a user is returning from DCMAW with a successful VC, issued against a driving licence, _and_ the user doesn't already have a successful driving licence CRI VC.

In this scenario we emit an event that will be
used to take them to the driving licence CRI so we can do an authoritative source check.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7493](https://govukverify.atlassian.net/browse/PYIC-7493)


[PYIC-7493]: https://govukverify.atlassian.net/browse/PYIC-7493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ