### PR TITLE
PYIC-6736: Delete mobileApp event from journey map now that core-fron…

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -476,16 +476,6 @@ states:
       type: page
       pageId: no-photo-id-abandon-find-another-way
     events:
-#      PYIC-6736 Delete once core front is updated to use appTriage
-      mobileApp:
-        targetState: CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
       appTriage:
         targetState: CRI_DCMAW
         checkFeatureFlag:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -519,16 +519,6 @@ states:
       type: page
       pageId: no-photo-id-abandon-find-another-way
     events:
-#      PYIC-6736 Delete once core front is updated to use appTriage
-      mobileApp:
-        targetState: CRI_DCMAW
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
       appTriage:
         targetState: CRI_DCMAW
         checkFeatureFlag:


### PR DESCRIPTION
This PR is against the PYIC-6736 branch to show just the differences there. It will eventually be merged to main.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove obsolete event from journey map

### Why did it change

Core front has been updated to use appTriage in https://github.com/govuk-one-login/ipv-core-front/pull/1585. Do not merge this PR before that one.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6736](https://govukverify.atlassian.net/browse/PYIC-6736)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[PYIC-6736]: https://govukverify.atlassian.net/browse/PYIC-6736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ