### PR TITLE
PYIC-7507: Journey routing for DL auth source checks

### DIFF
--- a/api-tests/data/cri-stub-requests/drivingLicence/kenneth-changed-family-name-driving-permit-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/drivingLicence/kenneth-changed-family-name-driving-permit-valid/credentialSubject.json
@@ -1,0 +1,36 @@
+{
+  "address": [
+    {
+      "postalCode": "BA2 5AA"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "SMITH"
+        }
+      ]
+    }
+  ],
+  "drivingPermit": [
+    {
+      "expiryDate": "2033-01-18",
+      "issueNumber": "5",
+      "issuedBy": "DVLA",
+      "fullAddress": "8 HADLEY ROAD BATH BA2 5AA",
+      "personalNumber": "DECER607085K9123",
+      "issueDate": "2023-01-18"
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/drivingLicence/kenneth-changed-family-name-driving-permit-valid/evidence.json
+++ b/api-tests/data/cri-stub-requests/drivingLicence/kenneth-changed-family-name-driving-permit-valid/evidence.json
@@ -1,0 +1,13 @@
+{
+  "type": "IdentityCheck",
+  "validityScore": 2,
+  "strengthScore": 3,
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "published",
+      "activityFrom": "1982-05-23",
+      "checkMethod": "data"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/drivingLicence/kenneth-changed-given-name-driving-permit-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/drivingLicence/kenneth-changed-given-name-driving-permit-valid/credentialSubject.json
@@ -1,0 +1,36 @@
+{
+  "address": [
+    {
+      "postalCode": "BA2 5AA"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KEN"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "drivingPermit": [
+    {
+      "expiryDate": "2033-01-18",
+      "issueNumber": "5",
+      "issuedBy": "DVLA",
+      "fullAddress": "8 HADLEY ROAD BATH BA2 5AA",
+      "personalNumber": "DECER607085K9123",
+      "issueDate": "2023-01-18"
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/drivingLicence/kenneth-changed-given-name-driving-permit-valid/evidence.json
+++ b/api-tests/data/cri-stub-requests/drivingLicence/kenneth-changed-given-name-driving-permit-valid/evidence.json
@@ -1,0 +1,13 @@
+{
+  "type": "IdentityCheck",
+  "validityScore": 2,
+  "strengthScore": 3,
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "published",
+      "activityFrom": "1982-05-23",
+      "checkMethod": "data"
+    }
+  ]
+}

--- a/api-tests/features/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks.feature
@@ -1,0 +1,183 @@
+@Build
+Feature: Authoritative source checks with driving licence CRI
+
+  Scenario Outline: Journey through DCMAW with driving licence requires authoritative source check
+    Given I activate the 'drivingLicenceAuthCheck,p1Journeys' feature sets
+    When I start a new '<journey-type>' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'page-dcmaw-success' page response
+
+    Examples:
+      | journey-type       |
+      | low-confidence    |
+      | medium-confidence |
+
+  Scenario Outline: Journey with auth source check that attracts a CI leads to a mitigation journey
+    Given I activate the 'drivingLicenceAuthCheck,p1Journeys' feature sets
+    When I start a new '<journey-type>' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'pyi-driving-licence-no-match-another-way' page response
+
+    Examples:
+      | journey-type       |
+      | low-confidence    |
+      | medium-confidence |
+
+  Scenario Outline: Journey where user backs out of driving licence CRI leads to other doc type page
+    Given I activate the 'drivingLicenceAuthCheck,p1Journeys' feature sets
+    When I start a new '<journey-type>' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'prove-identity-another-type-photo-id' page response with context 'drivingLicence'
+
+    Examples:
+      | journey-type      |
+      | low-confidence    |
+      | medium-confidence |
+
+  Scenario: Separate session enhanced verification mitigation with DCMAW and driving licence requires auth source check
+    Given I activate the 'drivingLicenceAuthCheck' feature set
+    And the subject already has the following credentials
+      | CRI        | scenario                            |
+      | ukPassport | kenneth-passport-valid              |
+      | address    | kenneth-current                     |
+      | fraud      | kenneth-score-2                     |
+      | kbv        | kenneth-needs-enhanced-verification |
+
+    # Return journey
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'page-dcmaw-success' page response
+
+  Scenario: Same session enhanced verification mitigation with DCMAW and driving licence requires auth source check
+    Given I activate the 'drivingLicenceAuthCheck' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit a 'ukPassport' event
+    Then I get a 'ukPassport' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+    Then I get a 'pyi-suggest-other-options' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'page-ipv-success' page response
+
+  Scenario: Auth source check is not required if user already has a good driving licence VC
+    Given I activate the 'drivingLicenceAuthCheck' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'page-multiple-doc-check' page response
+    When I submit a 'drivingLicence' event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+    Then I get a 'pyi-suggest-other-options' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+    Then I get a 'page-ipv-success' page response
+
+  Scenario: Reverification journeys with a driving licence require an auth source check
+    Give I activate the 'drivingLicenceAuthCheck' feature set
+    And the subject already has the following credentials
+      | CRI     | scenario                     |
+      | dcmaw   | kenneth-driving-permit-valid |
+      | address | kenneth-current              |
+      | fraud   | kenneth-score-2              |
+    When I start a new 'reverification' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    Given I activate the 'drivingLicenceAuthCheck' feature set
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'page-dcmaw-success' page response
+
+  Scenario Outline: Change of details journey through DCMAW with driving licence requires auth source check
+    Given I activate the 'drivingLicenceAuthCheck' feature set
+    And the subject already has the following credentials
+      | CRI     | scenario                     |
+      | dcmaw   | kenneth-driving-permit-valid |
+      | address | kenneth-current              |
+      | fraud   | kenneth-score-2              |
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-reuse' page response
+    When I submit a 'update-details' event
+    Then I get a 'update-details' page response
+    When I submit a '<update-type>' event
+    Then I get a 'page-update-name' page response
+    When I submit a 'update-name' event
+    Then I get a 'dcmaw' CRI response
+    When I submit '<vc-scenario>' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I submit '<vc-scenario>' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'page-dcmaw-success' page response with context '<context>'
+
+    Examples:
+      | update-type             | vc-scenario                                      | context      |
+      | given-names-only        | kenneth-changed-given-name-driving-permit-valid  | coiNoAddress |
+      | given-names-and-address | kenneth-changed-given-name-driving-permit-valid  | coiAddress   |
+      | family-name-only        | kenneth-changed-family-name-driving-permit-valid | coiNoAddress |
+      | family-name-and-address | kenneth-changed-family-name-driving-permit-valid | coiAddress   |

--- a/api-tests/features/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks.feature
@@ -31,6 +31,10 @@ Feature: Authoritative source checks with driving licence CRI
       | Attribute | Values          |
       | context   | "check_details" |
     Then I get a 'pyi-driving-licence-no-match-another-way' page response
+    When I submit an 'end' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P0' identity without a 'dcmaw' VC
 
     Examples:
       | journey-type       |

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -320,11 +320,12 @@ When(
 );
 
 Then(
-  /^I get a '([<>\w-]+)' identity( without a TICF VC)?$/,
+  /^I get a '([<>\w-]+)' identity(?: (with|without) a (.+) VC)?$/,
   function (
     this: World,
     vot: string,
-    checkForTicfAbsence: " without a TICF VC" | undefined,
+    withOrWithout: string | undefined,
+    criToCheckNoVc: string | undefined,
   ): void {
     if (!this.identity) {
       throw new Error("No identity found.");
@@ -335,7 +336,13 @@ Then(
     }
 
     assert.equal(this.identity.vot, vot);
-    assertIdentityContainsVc("ticf", !!checkForTicfAbsence, this.vcs);
+    if (criToCheckNoVc) {
+      assertIdentityContainsVc(
+        criToCheckNoVc,
+        withOrWithout === "without",
+        this.vcs,
+      );
+    }
   },
 );
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -46,8 +46,8 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       dl-auth-source-check:
-        targetJourney: FAILED
-        targetState: FAILED
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   CRI_TICF_STATE:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -45,6 +45,9 @@ states:
       alternate-doc-invalid-passport:
         targetJourney: FAILED
         targetState: FAILED
+      dl-auth-source-check:
+        targetJourney: FAILED
+        targetState: FAILED
 
   CRI_TICF_STATE:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -8,8 +8,12 @@ entryEvents:
     targetState: CRI_DRIVING_LICENCE
   alternate-doc-invalid-dl:
     targetState: MITIGATION_DL_NO_MATCH
+  alternate-doc-invalid-dl-another-way:
+    targetState: MITIGATION_DL_NO_MATCH_ANOTHER_WAY
   alternate-doc-invalid-passport:
     targetState: MITIGATION_PP_NO_MATCH
+  another-way-after-dl:
+    targetState: PROVE_ANOTHER_WAY_AFTER_DL
 nestedJourneyStates:
   CRI_UK_PASSPORT:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -79,6 +79,9 @@ states:
       alternate-doc-invalid-passport:
         targetJourney: FAILED
         targetState: FAILED
+      dl-auth-source-check:
+        targetJourney: FAILED
+        targetState: FAILED
 
   CRI_TICF_STATE:
     events:
@@ -189,6 +192,8 @@ states:
     events:
       next:
         targetState: POST_DCMAW_SUCCESS_PAGE
+      dl-auth-source-check:
+        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK
       not-found:
         targetState: MULTIPLE_DOC_CHECK_PAGE
       access-denied:
@@ -197,6 +202,41 @@ states:
         targetState: MULTIPLE_DOC_CHECK_PAGE
       fail-with-no-ci:
         targetState: MULTIPLE_DOC_CHECK_PAGE
+
+  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      access-denied:
+        targetState: RESET_SESSION_BEFORE_PROVE_ANOTHER_WAY_AFTER_DL
+      alternate-doc-invalid-dl:
+        targetState: RESET_SESSION_BEFORE_DL_ALT_DOC_MITIGATION
+
+  RESET_SESSION_BEFORE_PROVE_ANOTHER_WAY_AFTER_DL:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        targetState: WEB_DL_OR_PASSPORT
+        targetEntryEvent: another-way-after-dl
+
+  RESET_SESSION_BEFORE_DL_ALT_DOC_MITIGATION:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        targetState: WEB_DL_OR_PASSPORT
+        targetEntryEvent: alternate-doc-invalid-dl-another-way
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -207,6 +207,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -80,8 +80,8 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       dl-auth-source-check:
-        targetJourney: FAILED
-        targetState: FAILED
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   CRI_TICF_STATE:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -212,6 +212,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:
@@ -681,6 +682,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:
@@ -806,6 +808,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -689,8 +689,6 @@ states:
         targetState: POST_DCMAW_SUCCESS_PAGE
       access-denied:
         targetState: MITIGATION_01_RESET_SESSION_BEFORE_PYI_POST_OFFICE
-      temporarily-unavailable:
-        targetState: MITIGATION_01_RESET_SESSION_BEFORE_PYI_POST_OFFICE
 
   MITIGATION_01_RESET_SESSION_BEFORE_PYI_POST_OFFICE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -80,8 +80,8 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       dl-auth-source-check:
-        targetJourney: FAILED
-        targetState: FAILED
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   CRI_TICF_STATE:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -79,6 +79,9 @@ states:
       alternate-doc-invalid-passport:
         targetJourney: FAILED
         targetState: FAILED
+      dl-auth-source-check:
+        targetJourney: FAILED
+        targetState: FAILED
 
   CRI_TICF_STATE:
     events:
@@ -194,6 +197,8 @@ states:
     events:
       next:
         targetState: POST_DCMAW_SUCCESS_PAGE
+      dl-auth-source-check:
+        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK
       not-found:
         targetState: MULTIPLE_DOC_CHECK_PAGE
       access-denied:
@@ -202,6 +207,41 @@ states:
         targetState: MULTIPLE_DOC_CHECK_PAGE
       fail-with-no-ci:
         targetState: MULTIPLE_DOC_CHECK_PAGE
+
+  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      access-denied:
+        targetState: RESET_SESSION_BEFORE_PROVE_ANOTHER_WAY_AFTER_DL
+      alternate-doc-invalid-dl:
+        targetState: RESET_SESSION_BEFORE_DL_ALT_DOC_MITIGATION
+
+  RESET_SESSION_BEFORE_PROVE_ANOTHER_WAY_AFTER_DL:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        targetState: WEB_DL_OR_PASSPORT
+        targetEntryEvent: another-way-after-dl
+
+  RESET_SESSION_BEFORE_DL_ALT_DOC_MITIGATION:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        targetState: WEB_DL_OR_PASSPORT
+        targetEntryEvent: alternate-doc-invalid-dl-another-way
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -607,6 +647,8 @@ states:
     events:
       next:
         targetState: POST_DCMAW_SUCCESS_PAGE
+      dl-auth-source-check:
+        targetState: MITIGATION_01_CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK
       not-found:
         targetJourney: FAILED
         targetState: FAILED
@@ -629,6 +671,33 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       enhanced-verification:
+        targetState: MITIGATION_01_PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+
+  MITIGATION_01_CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
+      access-denied:
+        targetState: MITIGATION_01_RESET_SESSION_BEFORE_PYI_POST_OFFICE
+      temporarily-unavailable:
+        targetState: MITIGATION_01_RESET_SESSION_BEFORE_PYI_POST_OFFICE
+
+  MITIGATION_01_RESET_SESSION_BEFORE_PYI_POST_OFFICE:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
         targetState: MITIGATION_01_PYI_POST_OFFICE
         checkIfDisabled:
           f2f:
@@ -700,6 +769,8 @@ states:
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
+      dl-auth-source-check:
+        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_AFTER_PYI_ESCAPE
       not-found:
         targetState: PYI_POST_OFFICE
         checkIfDisabled:
@@ -730,6 +801,16 @@ states:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
+
+  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_AFTER_PYI_ESCAPE:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetJourney: EVALUATE_SCORES
+        targetState: START
 
   MITIGATION_02_OPTIONS_WITH_F2F:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -48,6 +48,9 @@ states:
       alternate-doc-invalid-passport:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      dl-auth-source-check:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -49,8 +49,8 @@ states:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
       dl-auth-source-check:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -55,6 +55,9 @@ states:
       alternate-doc-invalid-passport:
         targetJourney: FAILED
         targetState: FAILED
+      dl-auth-source-check:
+        targetJourney: FAILED
+        targetState: FAILED
 
   CRI_TICF_STATE:
     events:
@@ -123,6 +126,17 @@ states:
       temporarily-unavailable:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      dl-auth-source-check:
+        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK
+
+  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE
 
   POST_DCMAW_SUCCESS_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -133,6 +133,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -56,8 +56,8 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       dl-auth-source-check:
-        targetJourney: FAILED
-        targetState: FAILED
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   CRI_TICF_STATE:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -65,8 +65,8 @@ states:
             targetJourney: FAILED
             targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
       dl-auth-source-check:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -64,6 +64,9 @@ states:
           updateDetailsAccountDeletion:
             targetJourney: FAILED
             targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+      dl-auth-source-check:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -100,7 +100,9 @@ states:
           updateDetailsAccountDeletion:
             targetJourney: FAILED
             targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
-
+      dl-auth-source-check:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
 
   # Journey States
 
@@ -202,6 +204,8 @@ states:
     events:
       next:
         targetState: POST_DCMAW_SUCCESS_PAGE_GIVEN_ONLY
+      dl-auth-source-check:
+        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_GIVEN_ONLY
       not-found:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
@@ -215,6 +219,15 @@ states:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
 
+  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_GIVEN_ONLY:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE_GIVEN_ONLY
+
   DCMAW_FAMILY_ONLY:
     response:
       type: cri
@@ -223,6 +236,8 @@ states:
     events:
       next:
         targetState: POST_DCMAW_SUCCESS_PAGE_FAMILY_ONLY
+      dl-auth-source-check:
+        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_FAMILY_ONLY
       not-found:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
@@ -235,6 +250,15 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
+
+  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_FAMILY_ONLY:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE_FAMILY_ONLY
 
   POST_DCMAW_SUCCESS_PAGE_GIVEN_ONLY:
     response:
@@ -376,6 +400,8 @@ states:
     events:
       next:
         targetState: POST_DCMAW_SUCCESS_PAGE_GIVEN_WITH_ADDRESS
+      dl-auth-source-check:
+        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_GIVEN_WITH_ADDRESS
       not-found:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
@@ -389,6 +415,15 @@ states:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
 
+  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_GIVEN_WITH_ADDRESS:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE_GIVEN_WITH_ADDRESS
+
   DCMAW_FAMILY_WITH_ADDRESS:
     response:
       type: cri
@@ -397,6 +432,8 @@ states:
     events:
       next:
         targetState: POST_DCMAW_SUCCESS_PAGE_FAMILY_WITH_ADDRESS
+      dl-auth-source-check:
+        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_FAMILY_WITH_ADDRESS
       not-found:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
@@ -409,6 +446,15 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
+
+  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK_FAMILY_WITH_ADDRESS:
+    response:
+      type: cri
+      criId: drivingLicence
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: POST_DCMAW_SUCCESS_PAGE_FAMILY_WITH_ADDRESS
 
   POST_DCMAW_SUCCESS_PAGE_GIVEN_WITH_ADDRESS:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -101,8 +101,8 @@ states:
             targetJourney: FAILED
             targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
       dl-auth-source-check:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   # Journey States
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -223,6 +223,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:
@@ -255,6 +256,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:
@@ -419,6 +421,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:
@@ -451,6 +454,7 @@ states:
     response:
       type: cri
       criId: drivingLicence
+      context: check_details
     parent: CRI_STATE
     events:
       next:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Journey routing for DL auth source checks

### Why did it change

This adds journey routing to all the instances of a DCMAW state we have, and handles their unique subtleties... sort of.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7507](https://govukverify.atlassian.net/browse/PYIC-7507)


[PYIC-7507]: https://govukverify.atlassian.net/browse/PYIC-7507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ