### PR TITLE
PYIC-7492: add drivingPermit to allowed shared claims

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/domain/SharedClaims.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/domain/SharedClaims.java
@@ -7,6 +7,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import uk.gov.di.ipv.core.library.domain.BaseClaim;
 import uk.gov.di.model.BirthDate;
+import uk.gov.di.model.DrivingPermitDetails;
 import uk.gov.di.model.Name;
 import uk.gov.di.model.PostalAddress;
 import uk.gov.di.model.SocialSecurityRecordDetails;
@@ -25,4 +26,5 @@ public class SharedClaims extends BaseClaim {
     private Set<PostalAddress> address = new HashSet<>();
     private String emailAddress;
     private Set<SocialSecurityRecordDetails> socialSecurityRecord = new HashSet<>();
+    private Set<DrivingPermitDetails> drivingPermit = new HashSet<>();
 }

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
@@ -21,6 +21,7 @@ public class SharedClaimsHelper {
     public static final String SHARED_CLAIM_ATTR_ADDRESS = "address";
     public static final String SHARED_CLAIM_ATTR_EMAIL = "emailAddress";
     public static final String SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD = "socialSecurityRecord";
+    public static final String SHARED_CLAIM_ATTR_DRIVING_PERMIT = "drivingPermit";
 
     private SharedClaimsHelper() {}
 
@@ -44,7 +45,8 @@ public class SharedClaimsHelper {
                         .with("emails", sharedClaims.getEmailAddress() == null ? 0 : 1)
                         .with(
                                 "socialSecurityRecords",
-                                sharedClaims.getSocialSecurityRecord().size()));
+                                sharedClaims.getSocialSecurityRecord().size())
+                        .with("drivingPermits", sharedClaims.getDrivingPermit().size()));
 
         stripDisallowedSharedClaims(sharedClaims, allowedSharedClaims);
 
@@ -73,6 +75,10 @@ public class SharedClaimsHelper {
                     .getSocialSecurityRecord()
                     .addAll(personWithDocuments.getSocialSecurityRecord());
         }
+        if (credentialSubject instanceof PersonWithDocuments personWithDocuments
+                && personWithDocuments.getDrivingPermit() != null) {
+            sharedClaims.getDrivingPermit().addAll(personWithDocuments.getDrivingPermit());
+        }
     }
 
     private static void stripDisallowedSharedClaims(
@@ -91,6 +97,9 @@ public class SharedClaimsHelper {
         }
         if (!allowedSharedAttr.contains(SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD)) {
             credentialsSharedClaims.setSocialSecurityRecord(null);
+        }
+        if (!allowedSharedAttr.contains(SHARED_CLAIM_ATTR_DRIVING_PERMIT)) {
+            credentialsSharedClaims.setDrivingPermit(null);
         }
     }
 }

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -28,6 +28,7 @@ import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
 import uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.model.DrivingPermitDetails;
 import uk.gov.di.model.PostalAddress;
 import uk.gov.di.model.SocialSecurityRecordDetails;
 
@@ -94,7 +95,8 @@ class AuthorizationRequestHelperTest {
                     Set.of(BirthDateGenerator.createBirthDate("2011-01-01")),
                     Set.of(new PostalAddress()),
                     TEST_EMAIL_ADDRESS,
-                    Set.of(new SocialSecurityRecordDetails()));
+                    Set.of(new SocialSecurityRecordDetails()),
+                    Set.of(new DrivingPermitDetails()));
 
     private ECDSASigner signer;
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelperTest.java
@@ -5,6 +5,7 @@ import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.helpers.TestVc;
 import uk.gov.di.model.BirthDate;
+import uk.gov.di.model.DrivingPermitDetails;
 import uk.gov.di.model.Name;
 import uk.gov.di.model.PostalAddress;
 import uk.gov.di.model.SocialSecurityRecordDetails;
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.buildcrioauthrequest.helpers.SharedClaimsHelper.SHARED_CLAIM_ATTR_ADDRESS;
 import static uk.gov.di.ipv.core.buildcrioauthrequest.helpers.SharedClaimsHelper.SHARED_CLAIM_ATTR_BIRTH_DATE;
+import static uk.gov.di.ipv.core.buildcrioauthrequest.helpers.SharedClaimsHelper.SHARED_CLAIM_ATTR_DRIVING_PERMIT;
 import static uk.gov.di.ipv.core.buildcrioauthrequest.helpers.SharedClaimsHelper.SHARED_CLAIM_ATTR_EMAIL;
 import static uk.gov.di.ipv.core.buildcrioauthrequest.helpers.SharedClaimsHelper.SHARED_CLAIM_ATTR_NAME;
 import static uk.gov.di.ipv.core.buildcrioauthrequest.helpers.SharedClaimsHelper.SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD;
@@ -31,6 +33,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.TEST_SUBJECT;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.generateAddressVc;
 import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.generateVerifiableCredential;
 import static uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator.createBirthDate;
+import static uk.gov.di.ipv.core.library.helpers.vocab.DrivingPermitDetailsGenerator.createDrivingPermitDetails;
 import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
 import static uk.gov.di.ipv.core.library.helpers.vocab.SocialSecurityRecordDetailsGenerator.createSocialSecurityRecordDetails;
 
@@ -41,7 +44,8 @@ class SharedClaimsHelperTest {
                     SHARED_CLAIM_ATTR_BIRTH_DATE,
                     SHARED_CLAIM_ATTR_ADDRESS,
                     SHARED_CLAIM_ATTR_EMAIL,
-                    SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD);
+                    SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD,
+                    SHARED_CLAIM_ATTR_DRIVING_PERMIT);
 
     private static final String TEST_EMAIL = "test@example.com";
     private static final Name TEST_NAME = createName("Test", "User");
@@ -49,6 +53,8 @@ class SharedClaimsHelperTest {
     private static final PostalAddress TEST_ADDRESS = ADDRESS_1;
     private static final SocialSecurityRecordDetails TEST_NINO =
             createSocialSecurityRecordDetails("test-nino");
+    private static final DrivingPermitDetails TEST_DRIVING_PERMIT =
+            createDrivingPermitDetails("TESTU710112PBFGA", "2062-02-02", "ISSUER", "2005-02-02");
 
     @Test
     void generatesSharedClaimsForAllSupportedAttributes() {
@@ -67,6 +73,7 @@ class SharedClaimsHelperTest {
                                                                 TEST_NAME.getNameParts())))
                                         .birthDate(List.of(TEST_DOB))
                                         .socialSecurityRecord(List.of(TEST_NINO))
+                                        .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
         var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
@@ -76,6 +83,7 @@ class SharedClaimsHelperTest {
         assertEquals(Set.of(TEST_DOB), sharedClaims.getBirthDate());
         assertEquals(Set.of(TEST_ADDRESS), sharedClaims.getAddress());
         assertEquals(Set.of(TEST_NINO), sharedClaims.getSocialSecurityRecord());
+        assertEquals(Set.of(TEST_DRIVING_PERMIT), sharedClaims.getDrivingPermit());
     }
 
     @Test
@@ -86,6 +94,7 @@ class SharedClaimsHelperTest {
         assertTrue(sharedClaims.getBirthDate().isEmpty());
         assertTrue(sharedClaims.getAddress().isEmpty());
         assertTrue(sharedClaims.getSocialSecurityRecord().isEmpty());
+        assertTrue(sharedClaims.getDrivingPermit().isEmpty());
     }
 
     @Test
@@ -105,6 +114,7 @@ class SharedClaimsHelperTest {
                                                                 TEST_NAME.getNameParts())))
                                         .birthDate(List.of(TEST_DOB))
                                         .socialSecurityRecord(List.of(TEST_NINO))
+                                        .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
         var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, List.of());
@@ -114,6 +124,7 @@ class SharedClaimsHelperTest {
         assertNull(sharedClaims.getBirthDate());
         assertNull(sharedClaims.getAddress());
         assertNull(sharedClaims.getSocialSecurityRecord());
+        assertNull(sharedClaims.getDrivingPermit());
     }
 
     @Test
@@ -149,6 +160,7 @@ class SharedClaimsHelperTest {
                                                         .birthDate(List.of(TEST_DOB))
                                                         .address(List.of(TEST_ADDRESS))
                                                         .socialSecurityRecord(List.of(TEST_NINO))
+                                                        .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                                         .build())
                                         .evidence(DCMAW_FAILED_EVIDENCE)
                                         .build()));
@@ -159,6 +171,7 @@ class SharedClaimsHelperTest {
         assertTrue(sharedClaims.getBirthDate().isEmpty());
         assertTrue(sharedClaims.getAddress().isEmpty());
         assertTrue(sharedClaims.getSocialSecurityRecord().isEmpty());
+        assertTrue(sharedClaims.getDrivingPermit().isEmpty());
     }
 
     @Test
@@ -167,6 +180,8 @@ class SharedClaimsHelperTest {
         var otherDob = createBirthDate("2000-01-01");
         var otherAddress = ADDRESS_2;
         var otherNino = createSocialSecurityRecordDetails("other-nino");
+        var otherDrivingPermit =
+                createDrivingPermitDetails("OTHER123456", "2062-02-02", "ISSUER", "2005-02-02");
 
         var vcs =
                 List.of(
@@ -187,6 +202,7 @@ class SharedClaimsHelperTest {
                                                                 TEST_NAME.getNameParts())))
                                         .birthDate(List.of(TEST_DOB))
                                         .socialSecurityRecord(List.of(TEST_NINO))
+                                        .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()),
                         generateIdentityVc(
                                 TestVc.TestCredentialSubject.builder()
@@ -197,6 +213,7 @@ class SharedClaimsHelperTest {
                                                                 otherName.getNameParts())))
                                         .birthDate(List.of(otherDob))
                                         .socialSecurityRecord(List.of(otherNino))
+                                        .drivingPermit(List.of(otherDrivingPermit))
                                         .build()));
 
         var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
@@ -205,6 +222,8 @@ class SharedClaimsHelperTest {
         assertEquals(Set.of(TEST_DOB, otherDob), sharedClaims.getBirthDate());
         assertEquals(Set.of(TEST_ADDRESS, otherAddress), sharedClaims.getAddress());
         assertEquals(Set.of(TEST_NINO, otherNino), sharedClaims.getSocialSecurityRecord());
+        assertEquals(
+                Set.of(TEST_DRIVING_PERMIT, otherDrivingPermit), sharedClaims.getDrivingPermit());
     }
 
     @Test
@@ -228,6 +247,7 @@ class SharedClaimsHelperTest {
                                                                 TEST_NAME.getNameParts())))
                                         .birthDate(List.of(TEST_DOB))
                                         .socialSecurityRecord(List.of(TEST_NINO))
+                                        .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()),
                         generateIdentityVc(
                                 TestVc.TestCredentialSubject.builder()
@@ -238,6 +258,7 @@ class SharedClaimsHelperTest {
                                                                 TEST_NAME.getNameParts())))
                                         .birthDate(List.of(TEST_DOB))
                                         .socialSecurityRecord(List.of(TEST_NINO))
+                                        .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
         var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
@@ -246,6 +267,7 @@ class SharedClaimsHelperTest {
         assertEquals(Set.of(TEST_DOB), sharedClaims.getBirthDate());
         assertEquals(Set.of(TEST_ADDRESS), sharedClaims.getAddress());
         assertEquals(Set.of(TEST_NINO), sharedClaims.getSocialSecurityRecord());
+        assertEquals(Set.of(TEST_DRIVING_PERMIT), sharedClaims.getDrivingPermit());
     }
 
     private VerifiableCredential generateIdentityVc(TestVc.TestCredentialSubject subject) {

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -367,6 +367,9 @@ core:
     drivingLicenceAuthCheck:
       featureFlags:
         drivingLicenceAuthCheck: true
+      credentialIssuers:
+        drivingLicence:
+          allowedSharedAttributes: "name,birthDate,address,drivingPermit"
     mfaReset:
       featureFlags:
         mfaResetEnabled: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Adds driving permit to allowed shared claims and processes it like the other shared claims.

Associated common-infra changes: https://github.com/govuk-one-login/ipv-core-common-infra/pull/1079

### Why did it change
This will allow us to pass the driving permit from dcmaw to the DL CRI to perform authoritative source check.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7492](https://govukverify.atlassian.net/browse/PYIC-7492)


[PYIC-7492]: https://govukverify.atlassian.net/browse/PYIC-7492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ