### PR TITLE
IPS-1109: Enable metrics for APIGW

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -289,6 +289,11 @@ Resources:
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub IPV Core Private API Gateway ${Environment}
+      MethodSettings:
+        - LoggingLevel: INFO
+          ResourcePath: '/*'
+          HttpMethod: '*'
+          MetricsEnabled: true
       EndpointConfiguration:
         Type: PRIVATE
         VPCEndpointIds:
@@ -353,6 +358,11 @@ Resources:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub IPV Core Private Testing API Gateway ${Environment}
       Description: A parallel to the private internal API but opened up for testing
+      MethodSettings:
+        - LoggingLevel: INFO
+          ResourcePath: '/*'
+          HttpMethod: '*'
+          MetricsEnabled: true
       EndpointConfiguration:
         Type: REGIONAL
       DefinitionBody:
@@ -524,6 +534,11 @@ Resources:
     Properties:
       # checkov:skip=CKV_AWS_120: We are not implementing API Gateway caching at the time.
       Name: !Sub IPV Core External API Gateway ${Environment}
+      MethodSettings:
+        - LoggingLevel: INFO
+          ResourcePath: '/*'
+          HttpMethod: '*'
+          MetricsEnabled: true
       StageName: !Sub ${Environment}
       TracingEnabled: true
       DefinitionBody:


### PR DESCRIPTION
### What changed

- Enable metrics for APIGW

### Why did it change

- To enable specific resource/method 5xx endpoint alarms for canaries
- Other APIs already have this enabled e.g. https://github.com/govuk-one-login/ipv-third-party-stubs/blob/739038dc9a119ecf8b7b10b75318016aa5061a28/infrastructure/bav-template.yaml#L155 and https://github.com/govuk-one-login/ipv-cri-otg-hmrc/blob/2ccf54246663b324510871221ae81d751146c8ac/infrastructure/template.yaml#L394

#### Before
<img width="500" alt="After" src="https://github.com/user-attachments/assets/751dfe0b-63b6-4ff7-b9a1-b37397ccff97">

#### After
<img width="500" alt="After" src="https://github.com/user-attachments/assets/9e5bb0cb-a310-4f48-b32c-9c3edb980d22">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1109](https://govukverify.atlassian.net/browse/IPS-1109)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1109]: https://govukverify.atlassian.net/browse/IPS-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ