### PR TITLE
PYIC-7470: Track migrated VCs count in bulk migration

### DIFF
--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
@@ -354,6 +354,7 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
         var timestamp = Instant.now();
         try {
             storeVcsInEvcs(reportItem.getUserId(), vcs, batchId, timestamp);
+            pageSummary.incrementMigratedVcs(vcs.size());
         } catch (Exception e) {
             logError(
                     "Migration failed - error writing to EVCS",

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/BatchReport.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/BatchReport.java
@@ -12,6 +12,7 @@ public class BatchReport {
     private final List<PageSummary> pageSummaries;
     private int totalEvaluated;
     private int totalMigrated;
+    private int totalMigratedVcs;
     private int totalSkippedNonP2;
     private int totalSkippedAlreadyMigrated;
     private int totalSkippedPartiallyMigrated;
@@ -38,6 +39,7 @@ public class BatchReport {
 
     public void addPageSummary(PageSummary summary) {
         totalMigrated += summary.getMigrated();
+        totalMigratedVcs += summary.getMigratedVcs();
         totalSkippedNonP2 += summary.getSkippedNonP2();
         totalSkippedAlreadyMigrated += summary.getSkippedAlreadyMigrated();
         totalSkippedPartiallyMigrated += summary.getSkippedPartiallyMigrated();

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/PageSummary.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/domain/PageSummary.java
@@ -10,6 +10,7 @@ public class PageSummary {
     private final String exclusiveStartKey;
     private final int count;
     private int migrated;
+    private int migratedVcs;
     private int skippedNonP2;
     private int skippedAlreadyMigrated;
     private int skippedPartiallyMigrated;
@@ -40,6 +41,10 @@ public class PageSummary {
     public synchronized void incrementMigrated() {
         migrated++;
         total++;
+    }
+
+    public synchronized void incrementMigratedVcs(int migratedVcsCount) {
+        migratedVcs += migratedVcsCount;
     }
 
     public synchronized void incrementSkippedNonP2() {

--- a/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
+++ b/lambdas/bulk-migrate-vcs/src/test/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandlerTest.java
@@ -105,6 +105,7 @@ class BulkMigrateVcsHandlerTest {
         auditInOrder.verifyNoMoreInteractions();
     }
 
+    @SuppressWarnings("java:S5961") // Too many assertions
     @Test
     void handlerShouldCorrectlyHandleMigrateAndSkip() throws Exception {
         var reportUserIdentityItems =
@@ -142,6 +143,7 @@ class BulkMigrateVcsHandlerTest {
                         mockContext);
 
         assertEquals(1, report.getTotalMigrated());
+        assertEquals(3, report.getTotalMigratedVcs());
         assertEquals(1, report.getTotalSkippedNoVcs());
         assertEquals(1, report.getTotalSkippedAlreadyMigrated());
         assertEquals(1, report.getTotalSkippedPartiallyMigrated());
@@ -421,6 +423,7 @@ class BulkMigrateVcsHandlerTest {
 
             assertEquals(1, report.getTotalEvaluated());
             assertEquals(1, report.getTotalMigrated());
+            assertEquals(3, report.getTotalMigratedVcs());
 
             verify(mockAuditService).sendAuditEvent(auditEventArgumentCaptor.capture());
             assertEquals(1, auditEventArgumentCaptor.getAllValues().size());
@@ -464,6 +467,7 @@ class BulkMigrateVcsHandlerTest {
 
             assertEquals(1, report.getTotalEvaluated());
             assertEquals(0, report.getTotalMigrated());
+            assertEquals(0, report.getTotalMigratedVcs());
 
             verify(mockAuditService).sendAuditEvent(auditEventArgumentCaptor.capture());
             assertEquals(1, auditEventArgumentCaptor.getAllValues().size());
@@ -508,6 +512,7 @@ class BulkMigrateVcsHandlerTest {
             assertEquals(3, report.getTotalEvaluated());
             assertEquals(2, report.getTotalFailedTooManyBatchIds());
             assertEquals(1, report.getTotalMigrated());
+            assertEquals(1, report.getTotalMigratedVcs());
             assertEquals(2, report.getAllFailedTooManyBatchIdsHashUserIds().size());
             assertTrue(report.getAllFailedTooManyBatchIdsHashUserIds().get(0).startsWith("f34"));
             assertTrue(report.getAllFailedTooManyBatchIdsHashUserIds().get(1).startsWith("b45"));


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Track migrated VCs count in bulk migration

### Why did it change

It's easier for EVCS to see how many VCs have been migrated, rather than how many identities. Having this figure to hand will be useful.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ