### PR TITLE
PYIC-6236: Make ProcessAsyncCriCredentialHandler inclusive for DCMAW

### DIFF
--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/BaseAsyncCriResponse.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/BaseAsyncCriResponse.java
@@ -4,13 +4,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.Cri;
 
 @ExcludeFromGeneratedCoverageReport
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class BaseAsyncCriResponse {
-    private final Cri credentialIssuer;
     private final String userId;
     private final String oauthState;
 }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/ErrorAsyncCriResponse.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/ErrorAsyncCriResponse.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.processasynccricredential.domain;
 import lombok.Builder;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.Cri;
 
 @ExcludeFromGeneratedCoverageReport
 @Getter
@@ -13,12 +12,8 @@ public class ErrorAsyncCriResponse extends BaseAsyncCriResponse {
 
     @Builder
     private ErrorAsyncCriResponse(
-            Cri credentialIssuer,
-            String userId,
-            String oauthState,
-            String error,
-            String errorDescription) {
-        super(credentialIssuer, userId, oauthState);
+            String userId, String oauthState, String error, String errorDescription) {
+        super(userId, oauthState);
         this.error = error;
         this.errorDescription = errorDescription;
     }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/SuccessAsyncCriResponse.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/SuccessAsyncCriResponse.java
@@ -3,7 +3,6 @@ package uk.gov.di.ipv.core.processasynccricredential.domain;
 import lombok.Builder;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.Cri;
 
 import java.util.List;
 
@@ -14,11 +13,8 @@ public class SuccessAsyncCriResponse extends BaseAsyncCriResponse {
 
     @Builder
     private SuccessAsyncCriResponse(
-            Cri credentialIssuer,
-            String userId,
-            String oauthState,
-            List<String> verifiableCredentialJWTs) {
-        super(credentialIssuer, userId, oauthState);
+            String userId, String oauthState, List<String> verifiableCredentialJWTs) {
+        super(userId, oauthState);
         this.verifiableCredentialJWTs = verifiableCredentialJWTs;
     }
 }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/helpers/AsyncCriResponseHelper.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/helpers/AsyncCriResponseHelper.java
@@ -7,8 +7,6 @@ import uk.gov.di.ipv.core.processasynccricredential.domain.ErrorAsyncCriResponse
 import uk.gov.di.ipv.core.processasynccricredential.domain.SuccessAsyncCriResponse;
 import uk.gov.di.ipv.core.processasynccricredential.dto.CriResponseMessageDto;
 
-import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
-
 public class AsyncCriResponseHelper {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -21,14 +19,12 @@ public class AsyncCriResponseHelper {
 
         if (criResponseMessageDto.getError() == null) {
             return SuccessAsyncCriResponse.builder()
-                    .credentialIssuer(F2F)
                     .userId(criResponseMessageDto.getUserId())
                     .oauthState(criResponseMessageDto.getOauthState())
                     .verifiableCredentialJWTs(criResponseMessageDto.getVerifiableCredentialJWTs())
                     .build();
         } else {
             return ErrorAsyncCriResponse.builder()
-                    .credentialIssuer(F2F)
                     .userId(criResponseMessageDto.getUserId())
                     .oauthState(criResponseMessageDto.getOauthState())
                     .error(criResponseMessageDto.getError())

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/helpers/AsyncCriResponseHelperTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/helpers/AsyncCriResponseHelperTest.java
@@ -10,7 +10,6 @@ import uk.gov.di.ipv.core.processasynccricredential.domain.SuccessAsyncCriRespon
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.processasynccricredential.helpers.AsyncCriResponseHelper.getAsyncResponseMessage;
 import static uk.gov.di.ipv.core.processasynccricredential.helpers.AsyncCriResponseHelper.isSuccessAsyncCriResponse;
 
@@ -40,7 +39,6 @@ class AsyncCriResponseHelperTest {
         assertTrue(isSuccessAsyncCriResponse(response));
         var successAsyncCriResponse = (SuccessAsyncCriResponse) response;
         assertEquals(TEST_USER, successAsyncCriResponse.getUserId());
-        assertEquals(F2F, successAsyncCriResponse.getCredentialIssuer());
         assertEquals(1, successAsyncCriResponse.getVerifiableCredentialJWTs().size());
         assertEquals(TEST_JWT, successAsyncCriResponse.getVerifiableCredentialJWTs().get(0));
     }
@@ -51,7 +49,6 @@ class AsyncCriResponseHelperTest {
         assertFalse(isSuccessAsyncCriResponse(response));
         var errorAsyncCriResponse = (ErrorAsyncCriResponse) response;
         assertEquals(TEST_USER, errorAsyncCriResponse.getUserId());
-        assertEquals(F2F, errorAsyncCriResponse.getCredentialIssuer());
         assertEquals(TEST_ERROR, errorAsyncCriResponse.getError());
         assertEquals(TEST_ERROR_DESCRIPTION, errorAsyncCriResponse.getErrorDescription());
     }

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -27,6 +27,10 @@ public class CriResponseService {
         this.dataStore = dataStore;
     }
 
+    public List<CriResponseItem> getCriResponseItemsByUserId(String userId) {
+        return dataStore.getItems(userId);
+    }
+
     public CriResponseItem getCriResponseItem(String userId, Cri cri) {
         return dataStore.getItem(userId, cri.getId());
     }


### PR DESCRIPTION
## Proposed changes

### What changed

- Use state to index userId's cri response instead of criId.
- Make sending audit events conditional only for F2F cri.
- Remove criId from expected queue response dto.

### Why did it change

- We need to find out the criId instead of hardcoding F2F, as we are trying to be inclusive to DCMAW async VCs.
- Cri Id isn't sent via queue message, but state is.
- Audit events are only expected for F2F at the moment.

### Issue tracking

- [PYIC-5039](https://govukverify.atlassian.net/browse/PYIC-5039)

### Notes

- Tested it and it works: DCMAW async VC gets stored & no audit events
- Still want to check assumptions (see comments)
- CRI oauth configs to have signing key

[PYIC-5039]: https://govukverify.atlassian.net/browse/PYIC-5039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ