### PR TITLE
BAU Test credential request in staging without explicitly setting Content-Type

### DIFF
--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -50,6 +50,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.Objects;
 
+import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ENVIRONMENT;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
@@ -314,9 +315,16 @@ public class CriApiService {
             request.setBody(bodyString);
             request.setHeader(HEADER_CONTENT_TYPE, "application/json");
         } else {
-            request.setHeader(
-                    HEADER_CONTENT_TYPE,
-                    ""); // remove the default, no request body so we don't need a content type
+            if (configService.getEnvironmentVariable(ENVIRONMENT) != null
+                    && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")) {
+                LOGGER.info(
+                        "Credential request default content-type: "
+                                + request.getEntityContentType());
+            } else {
+                request.setHeader(
+                        HEADER_CONTENT_TYPE,
+                        ""); // remove the default, no request body so we don't need a content type
+            }
         }
 
         if (apiKey != null) {


### PR DESCRIPTION
## Proposed changes

### What changed

In staging only, just log the default content type for the credential request and don't set it to empty string

### Why did it change

DWP KBV's credential server is rejecting our request with a 403 and it may be because we're setting Content-Type as empty string

