### PR TITLE
BAU: include openAPI schemas in api test image

### DIFF
--- a/api-tests/secure-pipeline/api-tests.Dockerfile
+++ b/api-tests/secure-pipeline/api-tests.Dockerfile
@@ -7,6 +7,7 @@ RUN apt update && \
 
 COPY api-tests /api-tests
 COPY api-tests/secure-pipeline/run-tests.sh /
+COPY openAPI /openAPI
 
 WORKDIR /api-tests
 


### PR DESCRIPTION
## Proposed changes

### What changed

The API tests validate the openAPI schema, so we need to include them in the test image