### PR TITLE
BAU: TS agnostic local-running configuration

### DIFF
--- a/local-running/compose.yaml
+++ b/local-running/compose.yaml
@@ -47,13 +47,10 @@ services:
       PORT: 4501
       CDN_DOMAIN:
       ENABLE_PREVIEW: "development"
+      NPM_CONFIG_NODE_OPTIONS: "--inspect=0.0.0.0"
     ports:
       - "4501:4501"
       - "5001:9229"
-    command:
-      - node
-      - "--inspect=0.0.0.0"
-      - "src/app.js"
 
   core-back:
     image: core-back:latest


### PR DESCRIPTION
## Proposed changes

### What changed

Rather than overriding the launch command, we can set an environment variable which tells NPM to enable debugging for us

### Why did it change

The location of `app.js` changed with the introduction of TS, but core-back shouldn't need to know about this anyway
