### PR TITLE
BAU: Allow debugging of core-back in local running

### DIFF
--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -54,6 +54,9 @@ java {
 
 application {
 	mainClass = 'uk.gov.di.ipv.coreback.App'
+	applicationDefaultJvmArgs = [
+		"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5002"
+	]
 }
 
 sonar {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow debugging of core-back in local running

### Why did it change

When running core-back on its own with the gradle task we don't expose the debugging port. This adds args to the application that will allow us to connect on the same port as when using the compose file.
