### PR TITLE
PYIC-6236: Rename references to f2f stub queue to cri response queue

### DIFF
--- a/api-tests/.env.build
+++ b/api-tests/.env.build
@@ -7,7 +7,7 @@ CORE_BACK_CRI_CLIENT_ID="ipv-core-build"
 ORCHESTRATOR_REDIRECT_URL="https://orch.stubs.account.gov.uk/callback"
 # The below private key is a test key that is already in the public domain. It is not used for anything sensitive.
 JAR_SIGNING_KEY='{"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}' # pragma: allowlist secret
-ASYNC_QUEUE_NAME="stubQueue_F2FQueue_build"
+ASYNC_QUEUE_NAME="stubQueue_criResponseQueue_build"
 ASYNC_QUEUE_DELAY=5
 EVCS_STUB_BASE_URL="https://evcs.stubs.account.gov.uk"
 TICF_STUB_BASE_URL="https://ticf.stubs.account.gov.uk"

--- a/api-tests/README.md
+++ b/api-tests/README.md
@@ -48,7 +48,7 @@ CORE_BACK_EXTERNAL_API_URL="https://api-dev-chrisw.01.dev.identity.account.gov.u
 CORE_BACK_PUBLIC_ENCRYPTION_KEY='{"kty":"RSA","e":"AQAB","kid":"b454ac07-e188-415d-a3c8-f1d0d38aaecd","n":"loHeaSxvMgiHStKmb-ZK5ZPpwRWrhSSQ-nTyuKQj-mYWYFNGgGGNP-37Zvzo453bUGtEeFu1zdlLAoHyT3kgs1XdqXCvPinNccpJ8lWGXcFKGRhj5jxIiIMvEBHfLs\*-cMIWW0166ndTT93ocoXdXaP64mH2iF7WWDyKqOcrVjuaUnbFbS4X2fhJwwRPj_Kin5jpJCx3MJd9eIuYyJB4CltbLTpX25oCwLw9t-p2lzHfazJSITcfTzEbOZV40fPJIR6HlJi7ApXYfAQ-dlbjMsYinFQnY6ILJXkbsjD4JXWUYaB0RbK8WTTKyehFU7P_Q8vFb7qWU4Xj9MTEHc7W3Q"}'
 ORCHESTRATOR_REDIRECT_URL="https://orch-dev-chrisw.01.core.dev.stubs.account.gov.uk/callback"
 JAR_SIGNING_KEY='{"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}' // pragma: allowlist secret
-ASYNC_QUEUE_NAME="stubQueue_F2FQueue_dev-chrisw"
+ASYNC_QUEUE_NAME="stubQueue_criResponseQueue_dev-chrisw"
 ASYNC_QUEUE_DELAY=5
 MANAGEMENT_CIMIT_STUB_API_KEY="example-value" # pragma: allowlist secret
 ```

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -125,7 +125,7 @@ Mappings:
       journeyEngineStepFunctionLogLevel: "ALL"
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
-      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_criResponseQueue_build"
+      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_criResponseQueue"
       asyncCriResponseQueueKmsKeyArn: "arn:aws:kms:eu-west-2:388905755587:key/60feaacf-271c-4cba-81d3-17df3952e605"
       # Should be at most 1/6 of the source queue visibility timeout.
       # See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-queueconfig
@@ -136,7 +136,7 @@ Mappings:
       journeyEngineStepFunctionLogLevel: "ALL"
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
-      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_criResponseQueue_build"
+      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_criResponseQueue"
       asyncCriResponseQueueKmsKeyArn: "arn:aws:kms:eu-west-2:388905755587:key/60feaacf-271c-4cba-81d3-17df3952e605"
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -125,7 +125,7 @@ Mappings:
       journeyEngineStepFunctionLogLevel: "ALL"
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
-      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_F2FQueue"
+      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_criResponseQueue_build"
       asyncCriResponseQueueKmsKeyArn: "arn:aws:kms:eu-west-2:388905755587:key/60feaacf-271c-4cba-81d3-17df3952e605"
       # Should be at most 1/6 of the source queue visibility timeout.
       # See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-queueconfig
@@ -136,7 +136,7 @@ Mappings:
       journeyEngineStepFunctionLogLevel: "ALL"
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
-      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_F2FQueue"
+      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_criResponseQueue_build"
       asyncCriResponseQueueKmsKeyArn: "arn:aws:kms:eu-west-2:388905755587:key/60feaacf-271c-4cba-81d3-17df3952e605"
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -145,7 +145,7 @@ Mappings:
       journeyEngineStepFunctionLogLevel: "ALL"
       pgw500ErrorLimit: 2
       egw500ErrorLimit: 2
-      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_F2FQueue_build"
+      asyncCriResponseQueueArn: "arn:aws:sqs:eu-west-2:388905755587:stubQueue_criResponseQueue_build"
       asyncCriResponseQueueKmsKeyArn: "arn:aws:kms:eu-west-2:388905755587:key/60feaacf-271c-4cba-81d3-17df3952e605"
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables


### PR DESCRIPTION
## Proposed changes

### What changed

- Rename references to f2f stub queue to cri response queue

### Why did it change

- Now needs to be able to take dcmawAsync traffic

### Issue tracking

- [PYIC-6236](https://govukverify.atlassian.net/browse/PYIC-6236)

[PYIC-6236]: https://govukverify.atlassian.net/browse/PYIC-6236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ