### PR TITLE
PYIC-7486: DWP thin file buffer page routing

### DIFF
--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -102,6 +102,8 @@ Feature: CIMIT - Alternate doc
     When I call the CRI stub with attributes and get an 'invalid_request' OAuth error
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+    Then I get a 'page-different-security-questions' page response
+    When I submit a 'next' event
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -43,7 +43,7 @@ nestedJourneyStates:
       enhanced-verification:
         exitEventToEmit: enhanced-verification
       invalid-request:
-        targetState: PRE_EXPERIAN_PAGE
+        targetState: DWP_THIN_FILE_PAGE
       access-denied:
         targetState: PRE_EXPERIAN_PAGE
   CRI_HMRC_KBV:
@@ -100,3 +100,10 @@ nestedJourneyStates:
         targetState: CRI_DWP_KBV
       end:
         exitEventToEmit: end
+  DWP_THIN_FILE_PAGE:
+    response:
+      type: page
+      pageId: page-different-security-questions
+    events:
+      next:
+        targetState: PRE_EXPERIAN_PAGE


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

If a DWP KBV user has a thin file (insufficient questions) DWP return us an invalid_request OAuth error via the callback. At the moment in this case we route directly to Experian KBVs (via the start page) as the fallback. Instead we should first route to a new buffer page

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7486](https://govukverify.atlassian.net/browse/PYIC-7486)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7486]: https://govukverify.atlassian.net/browse/PYIC-7486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ