### PR TITLE
PYIC-7500: throw error when client auth jwt id has already been used

### DIFF
--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidator.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidator.java
@@ -72,7 +72,7 @@ public class TokenRequestValidator {
         }
     }
 
-    private void validateJwtId(JWTAuthenticationClaimsSet claimsSet) {
+    private void validateJwtId(JWTAuthenticationClaimsSet claimsSet) throws InvalidClientException {
         JWTID jwtId = claimsSet.getJWTID();
         if (jwtId == null || StringUtils.isBlank(jwtId.getValue())) {
             LOGGER.warn(LogHelper.buildLogMessage("The client auth JWT id (jti) is missing"));
@@ -81,7 +81,8 @@ public class TokenRequestValidator {
         ClientAuthJwtIdItem clientAuthJwtIdItem =
                 clientAuthJwtIdService.getClientAuthJwtIdItem(jwtId.getValue());
         if (clientAuthJwtIdItem != null) {
-            logWarningJtiHasAlreadyBeenUsed(clientAuthJwtIdItem);
+            logErrorJtiHasAlreadyBeenUsed(clientAuthJwtIdItem);
+            throw new InvalidClientException("The client auth JWT id (jti) has already been used.");
         }
         clientAuthJwtIdService.persistClientAuthJwtId(jwtId.getValue());
     }
@@ -94,13 +95,13 @@ public class TokenRequestValidator {
                 Set.of(new Audience(configService.getParameter(COMPONENT_ID))));
     }
 
-    private void logWarningJtiHasAlreadyBeenUsed(ClientAuthJwtIdItem clientAuthJwtIdItem) {
+    private void logErrorJtiHasAlreadyBeenUsed(ClientAuthJwtIdItem clientAuthJwtIdItem) {
         LoggingUtils.appendKey(
                 LogHelper.LogField.LOG_JTI.getFieldName(), clientAuthJwtIdItem.getJwtId());
         LoggingUtils.appendKey(
                 LogHelper.LogField.LOG_JTI_USED_AT.getFieldName(),
                 clientAuthJwtIdItem.getUsedAtDateTime());
-        LOGGER.warn(
+        LOGGER.error(
                 LogHelper.buildLogMessage("The client auth JWT id (jti) has already been used"));
         LoggingUtils.removeKeys(
                 LogHelper.LogField.LOG_JTI.getFieldName(),

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidator.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidator.java
@@ -75,8 +75,8 @@ public class TokenRequestValidator {
     private void validateJwtId(JWTAuthenticationClaimsSet claimsSet) throws InvalidClientException {
         JWTID jwtId = claimsSet.getJWTID();
         if (jwtId == null || StringUtils.isBlank(jwtId.getValue())) {
-            LOGGER.warn(LogHelper.buildLogMessage("The client auth JWT id (jti) is missing"));
-            return;
+            LOGGER.error(LogHelper.buildLogMessage("The client auth JWT id (jti) is missing."));
+            throw new InvalidClientException("The client auth JWT id (jti) is missing.");
         }
         ClientAuthJwtIdItem clientAuthJwtIdItem =
                 clientAuthJwtIdService.getClientAuthJwtIdItem(jwtId.getValue());

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidatorTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidatorTest.java
@@ -235,7 +235,7 @@ class TokenRequestValidatorTest {
     }
 
     @Test
-    void shouldCheckIfJwtIdIsMissingOrEmpty() throws Exception {
+    void shouldThrowIfJwtIdIsMissingOrEmpty() throws Exception {
         when(mockConfigService.getParameter(
                         eq(PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY), anyString()))
                 .thenReturn(TestFixtures.RSA_PUBLIC_CERT);
@@ -243,9 +243,21 @@ class TokenRequestValidatorTest {
         Map<String, Object> claimsSetValues = getClaimsSetValuesMissingJwtId();
         String clientAssertion = generateClientAssertionWithRS256(claimsSetValues);
 
-        validator.authenticateClient(queryMapToString(getValidQueryParams(clientAssertion)));
+        ClientAuthenticationException exception =
+                assertThrows(
+                        ClientAuthenticationException.class,
+                        () ->
+                                validator.authenticateClient(
+                                        queryMapToString(getValidQueryParams(clientAssertion))));
+
+        assertTrue(
+                exception
+                        .getMessage()
+                        .contains(
+                                "InvalidClientException: The client auth JWT id (jti) is missing."));
 
         verify(mockClientAuthJwtIdService, Mockito.times(0)).getClientAuthJwtIdItem(anyString());
+        verify(mockClientAuthJwtIdService, Mockito.times(0)).persistClientAuthJwtId(anyString());
     }
 
     @Test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
When we detect a replay of client auth JWTs or if the id is missing or empty, we now fail the request by throwing an error and no longer storing the ID instead of just logging a warning message.

### Why did it change
The request should fail anyway as the auth code has already been consumed so we should be throwing an error instead of just logging a warning.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7500](https://govukverify.atlassian.net/browse/PYIC-7500)

[PYIC-7500]: https://govukverify.atlassian.net/browse/PYIC-7500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ