### PR TITLE
BAU: Update pipeline dashboard to show commit-msg

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -16,7 +16,6 @@ anything bad™️ happens in Dynatrace. If you update a dashboard you should pr
 * Receive file
 
 ## How to upload a dashboard in Dynatrace
-
 * Open Dynatrace
 * Navigate to the "Dashboards" app
 * Click the "Upload" button

--- a/dashboards/pipeline-overview-dashboard.json
+++ b/dashboards/pipeline-overview-dashboard.json
@@ -1,1 +1,3864 @@
-{"version":15,"variables":[],"tiles":{"0":{"type":"markdown","title":"","content":"## core-back"},"1":{"type":"markdown","title":"","content":"---\n## core-front"},"2":{"type":"markdown","title":"","content":"## Build"},"3":{"type":"markdown","title":"","content":"## Staging"},"4":{"type":"markdown","title":"","content":"## Integration"},"5":{"type":"markdown","title":"","content":"## Production"},"6":{"type":"markdown","title":"","content":"## Build"},"7":{"type":"markdown","title":"","content":"## Staging"},"8":{"type":"markdown","title":"","content":"## Integration"},"9":{"type":"markdown","title":"","content":"## Production"},"10":{"type":"data","title":"deploy","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-back-build\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["interval"],"valueAxisLabel":"interval","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"value":1,"comparator":"≥","color":"#7DC540"},{"id":238674,"value":0,"comparator":"≥","color":"#DC172A"}],"colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"11":{"type":"data","title":"selenium tests","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-build\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["interval"],"valueAxisLabel":"interval","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#DC172A","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"12":{"type":"data","title":"api tests","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (stage == \"parallel-test\") AND (`sam-stack-name` == \"core-back-build\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"13":{"type":"data","title":"deploy","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-staging\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["interval"],"valueAxisLabel":"interval","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"14":{"type":"data","title":"selenium tests","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-staging\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["interval"],"valueAxisLabel":"interval","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"15":{"type":"data","title":"deploy","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-integration\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"16":{"type":"data","title":"selenium tests","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-integration\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"17":{"type":"data","title":"deploy","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-production\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"18":{"type":"data","title":"deploy","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-front-build\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"19":{"type":"data","title":"selenium tests","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-front-build\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"20":{"type":"data","title":"deploy","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-front-staging\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"21":{"type":"data","title":"selenium tests","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-front-staging\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"22":{"type":"data","title":"deploy","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (stage == \"deploy\") AND (`sam-stack-name` == \"core-front-integration\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"23":{"type":"data","title":"selenium tests","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (stage == \"test\") AND (`sam-stack-name` == \"core-front-integration\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"24":{"type":"data","title":"deploy","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-front-production\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"honeycomb","visualizationSettings":{"thresholds":[],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"stage","categoryAxisLabel":"stage","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["stage"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"stage","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"rowDensity":"condensed","enableSparklines":false,"hiddenColumns":[],"linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnWidths":{},"columnTypeOverrides":[]},"honeycomb":{"shape":"hexagon","legend":{"0":"h","1":"i","2":"d","3":"d","4":"e","5":"n","hidden":true},"colorMode":"custom-colors","customColors":[{"id":0,"color":"#7dc540","comparator":"≥","value":1},{"id":2,"color":"#dc172a","comparator":"≥","value":0}],"colorPalette":"purple-yellow","dataMappings":{"value":"interval"},"displayedFields":["stage","end-time-utc","commit-sha"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"unspecified","displayUnit":"","decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"25":{"type":"data","title":"Build history - core-back","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-back-build\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"table","visualizationSettings":{"thresholds":[{"id":"0","title":"","field":"deployment","rules":[{"id":"0","label":"","comparator":"=","color":"#7dc540","value":1},{"id":"2","label":"","comparator":"=","color":"#dc172a","value":0}],"isEnabled":true}],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"end-time-utc","categoryAxisLabel":"end-time-utc","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["end-time-utc"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"end-time-utc","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"hiddenColumns":[["timeframe"],["interval"]],"colorThresholdTarget":"background","linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnTypeOverrides":[{"id":858351,"fields":[],"value":"number"},{"id":951044,"fields":["end-time-utc"],"value":"date"}],"rowDensity":"condensed","enableThresholdInRow":false,"selectedColumnForRowThreshold":"deployment","columnWidths":{"[\"commit-sha\"]":134.95001220703125,"[\"duration\"]":143.10000610351562}},"honeycomb":{"shape":"hexagon","legend":{"hidden":false,"position":"auto"},"colorMode":"color-palette","colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["end-time-utc","stage","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"none","displayUnit":null,"decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"33":{"type":"data","title":"Staging history - core-back","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-back-staging\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"table","visualizationSettings":{"thresholds":[{"id":"0","title":"","field":"deployment","rules":[{"id":"0","label":"","comparator":"=","color":"#7dc540","value":1},{"id":"2","label":"","comparator":"=","color":"#dc172a","value":0}],"isEnabled":true}],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"end-time-utc","categoryAxisLabel":"end-time-utc","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["end-time-utc"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"end-time-utc","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"hiddenColumns":[["timeframe"],["interval"]],"colorThresholdTarget":"background","linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnTypeOverrides":[{"id":858351,"fields":[],"value":"number"},{"id":951044,"fields":["end-time-utc"],"value":"date"}],"rowDensity":"condensed","enableThresholdInRow":false,"selectedColumnForRowThreshold":"deployment","columnWidths":{"[\"commit-sha\"]":134.95001220703125,"[\"duration\"]":143.10000610351562}},"honeycomb":{"shape":"hexagon","legend":{"hidden":false,"position":"auto"},"colorMode":"color-palette","colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["end-time-utc","stage","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"none","displayUnit":null,"decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"34":{"type":"data","title":"Integration history - core-back","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-back-integration\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"table","visualizationSettings":{"thresholds":[{"id":"0","title":"","field":"deployment","rules":[{"id":"0","label":"","comparator":"=","color":"#7dc540","value":1},{"id":"2","label":"","comparator":"=","color":"#dc172a","value":0}],"isEnabled":true}],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"end-time-utc","categoryAxisLabel":"end-time-utc","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["end-time-utc"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"end-time-utc","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"hiddenColumns":[["timeframe"],["interval"]],"colorThresholdTarget":"background","linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnTypeOverrides":[{"id":858351,"fields":[],"value":"number"},{"id":951044,"fields":["end-time-utc"],"value":"date"}],"rowDensity":"condensed","enableThresholdInRow":false,"selectedColumnForRowThreshold":"deployment","columnWidths":{"[\"commit-sha\"]":134.95001220703125,"[\"duration\"]":143.10000610351562}},"honeycomb":{"shape":"hexagon","legend":{"hidden":false,"position":"auto"},"colorMode":"color-palette","colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["end-time-utc","stage","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"none","displayUnit":null,"decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"35":{"type":"data","title":"Production history - core-back","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-back-production\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"table","visualizationSettings":{"thresholds":[{"id":"0","title":"","field":"deployment","rules":[{"id":"0","label":"","comparator":"=","color":"#7dc540","value":1},{"id":"2","label":"","comparator":"=","color":"#dc172a","value":0}],"isEnabled":true}],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"end-time-utc","categoryAxisLabel":"end-time-utc","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["end-time-utc"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"end-time-utc","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"hiddenColumns":[["timeframe"],["interval"]],"colorThresholdTarget":"background","linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnTypeOverrides":[{"id":858351,"fields":[],"value":"number"},{"id":951044,"fields":["end-time-utc"],"value":"date"}],"rowDensity":"condensed","enableThresholdInRow":false,"selectedColumnForRowThreshold":"deployment","columnWidths":{"[\"commit-sha\"]":134.95001220703125,"[\"duration\"]":143.10000610351562}},"honeycomb":{"shape":"hexagon","legend":{"hidden":false,"position":"auto"},"colorMode":"color-palette","colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["end-time-utc","stage","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"none","displayUnit":null,"decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"36":{"type":"data","title":"Build history - core-front","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-front-build\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"table","visualizationSettings":{"thresholds":[{"id":"0","title":"","field":"deployment","rules":[{"id":"0","label":"","comparator":"=","color":"#7dc540","value":1},{"id":"2","label":"","comparator":"=","color":"#dc172a","value":0}],"isEnabled":true}],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"end-time-utc","categoryAxisLabel":"end-time-utc","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["end-time-utc"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"end-time-utc","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"hiddenColumns":[["timeframe"],["interval"]],"colorThresholdTarget":"background","linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnTypeOverrides":[{"id":858351,"fields":[],"value":"number"},{"id":951044,"fields":["end-time-utc"],"value":"date"}],"rowDensity":"condensed","enableThresholdInRow":false,"selectedColumnForRowThreshold":"deployment","columnWidths":{"[\"commit-sha\"]":134.95001220703125,"[\"duration\"]":143.10000610351562}},"honeycomb":{"shape":"hexagon","legend":{"hidden":false,"position":"auto"},"colorMode":"color-palette","colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["end-time-utc","stage","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"none","displayUnit":null,"decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"37":{"type":"data","title":"Staging history - core-front","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-front-staging\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"table","visualizationSettings":{"thresholds":[{"id":"0","title":"","field":"deployment","rules":[{"id":"0","label":"","comparator":"=","color":"#7dc540","value":1},{"id":"2","label":"","comparator":"=","color":"#dc172a","value":0}],"isEnabled":true}],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"end-time-utc","categoryAxisLabel":"end-time-utc","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["end-time-utc"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"end-time-utc","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"hiddenColumns":[["timeframe"],["interval"]],"colorThresholdTarget":"background","linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnTypeOverrides":[{"id":858351,"fields":[],"value":"number"},{"id":951044,"fields":["end-time-utc"],"value":"date"}],"rowDensity":"condensed","enableThresholdInRow":false,"selectedColumnForRowThreshold":"deployment","columnWidths":{"[\"commit-sha\"]":134.95001220703125,"[\"duration\"]":143.10000610351562}},"honeycomb":{"shape":"hexagon","legend":{"hidden":false,"position":"auto"},"colorMode":"color-palette","colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["end-time-utc","stage","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"none","displayUnit":null,"decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"38":{"type":"data","title":"Integration history - core-front","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-front-integration\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"table","visualizationSettings":{"thresholds":[{"id":"0","title":"","field":"deployment","rules":[{"id":"0","label":"","comparator":"=","color":"#7dc540","value":1},{"id":"2","label":"","comparator":"=","color":"#dc172a","value":0}],"isEnabled":true}],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"end-time-utc","categoryAxisLabel":"end-time-utc","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["end-time-utc"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"end-time-utc","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"hiddenColumns":[["timeframe"],["interval"]],"colorThresholdTarget":"background","linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnTypeOverrides":[{"id":858351,"fields":[],"value":"number"},{"id":951044,"fields":["end-time-utc"],"value":"date"}],"rowDensity":"condensed","enableThresholdInRow":false,"selectedColumnForRowThreshold":"deployment","columnWidths":{"[\"commit-sha\"]":134.95001220703125,"[\"duration\"]":143.10000610351562}},"honeycomb":{"shape":"hexagon","legend":{"hidden":false,"position":"auto"},"colorMode":"color-palette","colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["end-time-utc","stage","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"none","displayUnit":null,"decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}},"39":{"type":"data","title":"Production history - core-front","query":"timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-front-production\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10","davis":{"enabled":false,"davisVisualization":{"isAvailable":true}},"visualization":"table","visualizationSettings":{"thresholds":[{"id":"0","title":"","field":"deployment","rules":[{"id":"0","label":"","comparator":"=","color":"#7dc540","value":1},{"id":"2","label":"","comparator":"=","color":"#dc172a","value":0}],"isEnabled":true}],"chartSettings":{"xAxisScaling":"analyzedTimeframe","gapPolicy":"gap","circleChartSettings":{"groupingThresholdType":"relative","groupingThresholdValue":0,"valueType":"relative"},"categoryOverrides":{},"curve":"linear","pointsDisplay":"auto","categoricalBarChartSettings":{"layout":"vertical","categoryAxisTickLayout":"horizontal","scale":"absolute","groupMode":"stacked","colorPaletteMode":"multi-color","categoryAxis":"end-time-utc","categoryAxisLabel":"end-time-utc","valueAxis":["deployment"],"valueAxisLabel":"deployment","tooltipVariant":"single"},"colorPalette":"categorical","truncationMode":"middle","hiddenLegendFields":[],"fieldMapping":{"timestamp":"timeframe","leftAxisValues":["interval"],"leftAxisDimensions":["end-time-utc"]}},"singleValue":{"showLabel":true,"label":"","prefixIcon":"","recordField":"end-time-utc","autoscale":true,"alignment":"center","colorThresholdTarget":"value"},"table":{"hiddenColumns":[["timeframe"],["interval"]],"colorThresholdTarget":"background","linewrapEnabled":false,"lineWrapIds":[],"monospacedFontEnabled":false,"monospacedFontColumns":[],"columnTypeOverrides":[{"id":858351,"fields":[],"value":"number"},{"id":951044,"fields":["end-time-utc"],"value":"date"}],"rowDensity":"condensed","enableThresholdInRow":false,"selectedColumnForRowThreshold":"deployment","columnWidths":{"[\"commit-sha\"]":134.95001220703125,"[\"duration\"]":143.10000610351562}},"honeycomb":{"shape":"hexagon","legend":{"hidden":false,"position":"auto"},"colorMode":"color-palette","colorPalette":"blue","dataMappings":{"value":"interval"},"displayedFields":["end-time-utc","stage","commit-sha","duration"]},"histogram":{"legend":"auto","yAxis":{"label":"Frequency","scale":"linear"},"colorPalette":"categorical","dataMappings":[{"valueAxis":"interval","rangeAxis":""},{"valueAxis":"deployment","rangeAxis":""}]},"unitsOverrides":[{"identifier":"deployment","unitCategory":"unspecified","baseUnit":"none","displayUnit":null,"decimals":0,"suffix":"","delimiter":false,"added":0,"id":"deployment"}]},"querySettings":{"maxResultRecords":1000,"defaultScanLimitGbytes":500,"maxResultMegaBytes":1,"defaultSamplingRatio":10,"enableSampling":false}}},"layouts":{"0":{"x":0,"y":0,"w":87,"h":1},"1":{"x":0,"y":17,"w":87,"h":2},"2":{"x":0,"y":1,"w":24,"h":1},"3":{"x":26,"y":1,"w":16,"h":1},"4":{"x":43,"y":1,"w":17,"h":1},"5":{"x":62,"y":1,"w":13,"h":1},"6":{"x":0,"y":19,"w":16,"h":1},"7":{"x":17,"y":19,"w":18,"h":1},"8":{"x":37,"y":19,"w":16,"h":1},"9":{"x":54,"y":19,"w":13,"h":1},"10":{"x":0,"y":2,"w":8,"h":3},"11":{"x":8,"y":2,"w":8,"h":3},"12":{"x":16,"y":2,"w":8,"h":3},"13":{"x":26,"y":2,"w":8,"h":3},"14":{"x":34,"y":2,"w":8,"h":3},"15":{"x":44,"y":2,"w":8,"h":3},"16":{"x":52,"y":2,"w":8,"h":3},"17":{"x":62,"y":2,"w":8,"h":3},"18":{"x":0,"y":20,"w":8,"h":3},"19":{"x":8,"y":20,"w":8,"h":3},"20":{"x":18,"y":20,"w":8,"h":3},"21":{"x":26,"y":20,"w":9,"h":3},"22":{"x":37,"y":20,"w":8,"h":3},"23":{"x":45,"y":20,"w":8,"h":3},"24":{"x":55,"y":20,"w":9,"h":3},"25":{"x":0,"y":5,"w":42,"h":6},"33":{"x":44,"y":5,"w":40,"h":6},"34":{"x":0,"y":11,"w":42,"h":6},"35":{"x":44,"y":11,"w":40,"h":6},"36":{"x":0,"y":23,"w":41,"h":6},"37":{"x":44,"y":23,"w":39,"h":6},"38":{"x":0,"y":29,"w":41,"h":6},"39":{"x":44,"y":29,"w":39,"h":6}},"importedWithCode":false,"settings":{"defaultTimeframe":{"value":{"from":"now()-7d","to":"now()"},"enabled":true}},"gridColumnsCount":88}
+{
+  "version": 15,
+  "variables": [],
+  "tiles": {
+    "0": {
+      "type": "markdown",
+      "title": "",
+      "content": "## core-back"
+    },
+    "1": {
+      "type": "markdown",
+      "title": "",
+      "content": "---\n## core-front"
+    },
+    "2": {
+      "type": "markdown",
+      "title": "",
+      "content": "## Build"
+    },
+    "3": {
+      "type": "markdown",
+      "title": "",
+      "content": "## Staging"
+    },
+    "4": {
+      "type": "markdown",
+      "title": "",
+      "content": "## Integration"
+    },
+    "5": {
+      "type": "markdown",
+      "title": "",
+      "content": "## Production"
+    },
+    "6": {
+      "type": "markdown",
+      "title": "",
+      "content": "## Build"
+    },
+    "7": {
+      "type": "markdown",
+      "title": "",
+      "content": "## Staging"
+    },
+    "8": {
+      "type": "markdown",
+      "title": "",
+      "content": "## Integration"
+    },
+    "9": {
+      "type": "markdown",
+      "title": "",
+      "content": "## Production"
+    },
+    "10": {
+      "type": "data",
+      "title": "deploy",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-back-build\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "interval"
+            ],
+            "valueAxisLabel": "interval",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "value": 1,
+              "comparator": "≥",
+              "color": "#7DC540"
+            },
+            {
+              "id": 238674,
+              "value": 0,
+              "comparator": "≥",
+              "color": "#DC172A"
+            }
+          ],
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "11": {
+      "type": "data",
+      "title": "selenium tests",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-build\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "interval"
+            ],
+            "valueAxisLabel": "interval",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#DC172A",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "12": {
+      "type": "data",
+      "title": "api tests",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (stage == \"parallel-test\") AND (`sam-stack-name` == \"core-back-build\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "13": {
+      "type": "data",
+      "title": "deploy",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-staging\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "interval"
+            ],
+            "valueAxisLabel": "interval",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "14": {
+      "type": "data",
+      "title": "selenium tests",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-staging\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "interval"
+            ],
+            "valueAxisLabel": "interval",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "15": {
+      "type": "data",
+      "title": "deploy",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-integration\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "16": {
+      "type": "data",
+      "title": "selenium tests",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-integration\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "17": {
+      "type": "data",
+      "title": "deploy",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-back-production\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "18": {
+      "type": "data",
+      "title": "deploy",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha`, duration }, filter: { (`sam-stack-name` == \"core-front-build\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "19": {
+      "type": "data",
+      "title": "selenium tests",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-front-build\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "20": {
+      "type": "data",
+      "title": "deploy",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-front-staging\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "21": {
+      "type": "data",
+      "title": "selenium tests",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-front-staging\") AND (stage == \"test\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "22": {
+      "type": "data",
+      "title": "deploy",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (stage == \"deploy\") AND (`sam-stack-name` == \"core-front-integration\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "23": {
+      "type": "data",
+      "title": "selenium tests",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (stage == \"test\") AND (`sam-stack-name` == \"core-front-integration\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "24": {
+      "type": "data",
+      "title": "deploy",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { stage, `end-time-utc`, `commit-sha` }, filter: { (`sam-stack-name` == \"core-front-production\") AND (stage == \"deploy\") }\n| fieldsAdd deployment = arrayLast(deployment)\n| limit 1",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "honeycomb",
+      "visualizationSettings": {
+        "thresholds": [],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "stage",
+            "categoryAxisLabel": "stage",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "stage"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "stage",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "rowDensity": "condensed",
+          "enableSparklines": false,
+          "hiddenColumns": [],
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnWidths": {},
+          "columnTypeOverrides": []
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "0": "h",
+            "1": "i",
+            "2": "d",
+            "3": "d",
+            "4": "e",
+            "5": "n",
+            "hidden": true
+          },
+          "colorMode": "custom-colors",
+          "customColors": [
+            {
+              "id": 0,
+              "color": "#7dc540",
+              "comparator": "≥",
+              "value": 1
+            },
+            {
+              "id": 2,
+              "color": "#dc172a",
+              "comparator": "≥",
+              "value": 0
+            }
+          ],
+          "colorPalette": "purple-yellow",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "stage",
+            "end-time-utc",
+            "commit-sha"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "unspecified",
+            "displayUnit": "",
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "25": {
+      "type": "data",
+      "title": "Build history - core-back",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-msg`, duration }, filter: { (`sam-stack-name` == \"core-back-build\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "table",
+      "visualizationSettings": {
+        "thresholds": [
+          {
+            "id": "0",
+            "title": "",
+            "field": "deployment",
+            "rules": [
+              {
+                "id": "0",
+                "label": "",
+                "comparator": "=",
+                "color": "#7dc540",
+                "value": 1
+              },
+              {
+                "id": "2",
+                "label": "",
+                "comparator": "=",
+                "color": "#dc172a",
+                "value": 0
+              }
+            ],
+            "isEnabled": true
+          }
+        ],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "end-time-utc",
+            "categoryAxisLabel": "end-time-utc",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "end-time-utc"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "end-time-utc",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "hiddenColumns": [
+            [
+              "timeframe"
+            ],
+            [
+              "interval"
+            ]
+          ],
+          "colorThresholdTarget": "background",
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnTypeOverrides": [
+            {
+              "id": 858351,
+              "fields": [],
+              "value": "number"
+            },
+            {
+              "id": 951044,
+              "fields": [
+                "end-time-utc"
+              ],
+              "value": "date"
+            }
+          ],
+          "rowDensity": "condensed",
+          "enableThresholdInRow": false,
+          "selectedColumnForRowThreshold": "deployment",
+          "columnWidths": {
+            "[\"commit-sha\"]": 134.95001220703125,
+            "[\"duration\"]": 107.10000610351562,
+            "[\"commit-msg\"]": 306.3500061035156
+          }
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "hidden": false,
+            "position": "auto"
+          },
+          "colorMode": "color-palette",
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "end-time-utc",
+            "stage",
+            "commit-msg",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "none",
+            "displayUnit": null,
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "33": {
+      "type": "data",
+      "title": "Staging history - core-back",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-msg`, duration }, filter: { (`sam-stack-name` == \"core-back-staging\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "table",
+      "visualizationSettings": {
+        "thresholds": [
+          {
+            "id": "0",
+            "title": "",
+            "field": "deployment",
+            "rules": [
+              {
+                "id": "0",
+                "label": "",
+                "comparator": "=",
+                "color": "#7dc540",
+                "value": 1
+              },
+              {
+                "id": "2",
+                "label": "",
+                "comparator": "=",
+                "color": "#dc172a",
+                "value": 0
+              }
+            ],
+            "isEnabled": true
+          }
+        ],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "end-time-utc",
+            "categoryAxisLabel": "end-time-utc",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "end-time-utc"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "end-time-utc",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "hiddenColumns": [
+            [
+              "timeframe"
+            ],
+            [
+              "interval"
+            ]
+          ],
+          "colorThresholdTarget": "background",
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnTypeOverrides": [
+            {
+              "id": 858351,
+              "fields": [],
+              "value": "number"
+            },
+            {
+              "id": 951044,
+              "fields": [
+                "end-time-utc"
+              ],
+              "value": "date"
+            }
+          ],
+          "rowDensity": "condensed",
+          "enableThresholdInRow": false,
+          "selectedColumnForRowThreshold": "deployment",
+          "columnWidths": {
+            "[\"commit-sha\"]": 134.95001220703125,
+            "[\"duration\"]": 102.10000610351562,
+            "[\"commit-msg\"]": 284.1499938964844,
+            "[\"stage\"]": 83.39999389648438
+          }
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "hidden": false,
+            "position": "auto"
+          },
+          "colorMode": "color-palette",
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "end-time-utc",
+            "stage",
+            "commit-msg",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "none",
+            "displayUnit": null,
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "34": {
+      "type": "data",
+      "title": "Integration history - core-back",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-msg`, duration }, filter: { (`sam-stack-name` == \"core-back-integration\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "table",
+      "visualizationSettings": {
+        "thresholds": [
+          {
+            "id": "0",
+            "title": "",
+            "field": "deployment",
+            "rules": [
+              {
+                "id": "0",
+                "label": "",
+                "comparator": "=",
+                "color": "#7dc540",
+                "value": 1
+              },
+              {
+                "id": "2",
+                "label": "",
+                "comparator": "=",
+                "color": "#dc172a",
+                "value": 0
+              }
+            ],
+            "isEnabled": true
+          }
+        ],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "end-time-utc",
+            "categoryAxisLabel": "end-time-utc",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "end-time-utc"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "end-time-utc",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "hiddenColumns": [
+            [
+              "timeframe"
+            ],
+            [
+              "interval"
+            ]
+          ],
+          "colorThresholdTarget": "background",
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnTypeOverrides": [
+            {
+              "id": 858351,
+              "fields": [],
+              "value": "number"
+            },
+            {
+              "id": 951044,
+              "fields": [
+                "end-time-utc"
+              ],
+              "value": "date"
+            }
+          ],
+          "rowDensity": "condensed",
+          "enableThresholdInRow": false,
+          "selectedColumnForRowThreshold": "deployment",
+          "columnWidths": {
+            "[\"commit-sha\"]": 134.95001220703125,
+            "[\"duration\"]": 103.10000610351562,
+            "[\"commit-msg\"]": 318.1499938964844
+          }
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "hidden": false,
+            "position": "auto"
+          },
+          "colorMode": "color-palette",
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "end-time-utc",
+            "stage",
+            "commit-msg",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "none",
+            "displayUnit": null,
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "35": {
+      "type": "data",
+      "title": "Production history - core-back",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-msg`, duration }, filter: { (`sam-stack-name` == \"core-back-production\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "table",
+      "visualizationSettings": {
+        "thresholds": [
+          {
+            "id": "0",
+            "title": "",
+            "field": "deployment",
+            "rules": [
+              {
+                "id": "0",
+                "label": "",
+                "comparator": "=",
+                "color": "#7dc540",
+                "value": 1
+              },
+              {
+                "id": "2",
+                "label": "",
+                "comparator": "=",
+                "color": "#dc172a",
+                "value": 0
+              }
+            ],
+            "isEnabled": true
+          }
+        ],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "end-time-utc",
+            "categoryAxisLabel": "end-time-utc",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "end-time-utc"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "end-time-utc",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "hiddenColumns": [
+            [
+              "timeframe"
+            ],
+            [
+              "interval"
+            ]
+          ],
+          "colorThresholdTarget": "background",
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnTypeOverrides": [
+            {
+              "id": 858351,
+              "fields": [],
+              "value": "number"
+            },
+            {
+              "id": 951044,
+              "fields": [
+                "end-time-utc"
+              ],
+              "value": "date"
+            }
+          ],
+          "rowDensity": "condensed",
+          "enableThresholdInRow": false,
+          "selectedColumnForRowThreshold": "deployment",
+          "columnWidths": {
+            "[\"commit-sha\"]": 134.95001220703125,
+            "[\"duration\"]": 103.10000610351562,
+            "[\"commit-msg\"]": 284.3500061035156
+          }
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "hidden": false,
+            "position": "auto"
+          },
+          "colorMode": "color-palette",
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "end-time-utc",
+            "stage",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "none",
+            "displayUnit": null,
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "36": {
+      "type": "data",
+      "title": "Build history - core-front",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-msg`, duration }, filter: { (`sam-stack-name` == \"core-front-build\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "table",
+      "visualizationSettings": {
+        "thresholds": [
+          {
+            "id": "0",
+            "title": "",
+            "field": "deployment",
+            "rules": [
+              {
+                "id": "0",
+                "label": "",
+                "comparator": "=",
+                "color": "#7dc540",
+                "value": 1
+              },
+              {
+                "id": "2",
+                "label": "",
+                "comparator": "=",
+                "color": "#dc172a",
+                "value": 0
+              }
+            ],
+            "isEnabled": true
+          }
+        ],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "end-time-utc",
+            "categoryAxisLabel": "end-time-utc",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "end-time-utc"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "end-time-utc",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "hiddenColumns": [
+            [
+              "timeframe"
+            ],
+            [
+              "interval"
+            ]
+          ],
+          "colorThresholdTarget": "background",
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnTypeOverrides": [
+            {
+              "id": 858351,
+              "fields": [],
+              "value": "number"
+            },
+            {
+              "id": 951044,
+              "fields": [
+                "end-time-utc"
+              ],
+              "value": "date"
+            }
+          ],
+          "rowDensity": "condensed",
+          "enableThresholdInRow": false,
+          "selectedColumnForRowThreshold": "deployment",
+          "columnWidths": {
+            "[\"commit-sha\"]": 134.95001220703125,
+            "[\"duration\"]": 119.10000610351562,
+            "[\"commit-msg\"]": 300.95001220703125
+          }
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "hidden": false,
+            "position": "auto"
+          },
+          "colorMode": "color-palette",
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "end-time-utc",
+            "stage",
+            "commit-msg",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "none",
+            "displayUnit": null,
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "37": {
+      "type": "data",
+      "title": "Staging history - core-front",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-msg`, duration }, filter: { (`sam-stack-name` == \"core-front-staging\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "table",
+      "visualizationSettings": {
+        "thresholds": [
+          {
+            "id": "0",
+            "title": "",
+            "field": "deployment",
+            "rules": [
+              {
+                "id": "0",
+                "label": "",
+                "comparator": "=",
+                "color": "#7dc540",
+                "value": 1
+              },
+              {
+                "id": "2",
+                "label": "",
+                "comparator": "=",
+                "color": "#dc172a",
+                "value": 0
+              }
+            ],
+            "isEnabled": true
+          }
+        ],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "end-time-utc",
+            "categoryAxisLabel": "end-time-utc",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "end-time-utc"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "end-time-utc",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "hiddenColumns": [
+            [
+              "timeframe"
+            ],
+            [
+              "interval"
+            ]
+          ],
+          "colorThresholdTarget": "background",
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnTypeOverrides": [
+            {
+              "id": 858351,
+              "fields": [],
+              "value": "number"
+            },
+            {
+              "id": 951044,
+              "fields": [
+                "end-time-utc"
+              ],
+              "value": "date"
+            }
+          ],
+          "rowDensity": "condensed",
+          "enableThresholdInRow": false,
+          "selectedColumnForRowThreshold": "deployment",
+          "columnWidths": {
+            "[\"commit-sha\"]": 134.95001220703125,
+            "[\"duration\"]": 102.10000610351562,
+            "[\"commit-msg\"]": 267.95001220703125
+          }
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "hidden": false,
+            "position": "auto"
+          },
+          "colorMode": "color-palette",
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "end-time-utc",
+            "stage",
+            "commit-msg",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "none",
+            "displayUnit": null,
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "38": {
+      "type": "data",
+      "title": "Integration history - core-front",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-msg`, duration }, filter: { (`sam-stack-name` == \"core-front-integration\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "table",
+      "visualizationSettings": {
+        "thresholds": [
+          {
+            "id": "0",
+            "title": "",
+            "field": "deployment",
+            "rules": [
+              {
+                "id": "0",
+                "label": "",
+                "comparator": "=",
+                "color": "#7dc540",
+                "value": 1
+              },
+              {
+                "id": "2",
+                "label": "",
+                "comparator": "=",
+                "color": "#dc172a",
+                "value": 0
+              }
+            ],
+            "isEnabled": true
+          }
+        ],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "end-time-utc",
+            "categoryAxisLabel": "end-time-utc",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "end-time-utc"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "end-time-utc",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "hiddenColumns": [
+            [
+              "timeframe"
+            ],
+            [
+              "interval"
+            ]
+          ],
+          "colorThresholdTarget": "background",
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnTypeOverrides": [
+            {
+              "id": 858351,
+              "fields": [],
+              "value": "number"
+            },
+            {
+              "id": 951044,
+              "fields": [
+                "end-time-utc"
+              ],
+              "value": "date"
+            }
+          ],
+          "rowDensity": "condensed",
+          "enableThresholdInRow": false,
+          "selectedColumnForRowThreshold": "deployment",
+          "columnWidths": {
+            "[\"commit-sha\"]": 134.95001220703125,
+            "[\"duration\"]": 103.10000610351562,
+            "[\"commit-msg\"]": 301.3500061035156
+          }
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "hidden": false,
+            "position": "auto"
+          },
+          "colorMode": "color-palette",
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "end-time-utc",
+            "stage",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "none",
+            "displayUnit": null,
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    },
+    "39": {
+      "type": "data",
+      "title": "Production history - core-front",
+      "query": "timeseries deployment = max(`devplatform.sam-pipelines.deployment`), by: { `end-time-utc`, stage, `commit-msg`, duration }, filter: { (`sam-stack-name` == \"core-front-production\") AND ((stage == \"test\") OR (stage == \"deploy\") OR (stage == \"parallel-test\")) }\n| fieldsAdd deployment = arrayLast(deployment)\n| sort `end-time-utc` desc\n| limit 10",
+      "davis": {
+        "enabled": false,
+        "davisVisualization": {
+          "isAvailable": true
+        }
+      },
+      "visualization": "table",
+      "visualizationSettings": {
+        "thresholds": [
+          {
+            "id": "0",
+            "title": "",
+            "field": "deployment",
+            "rules": [
+              {
+                "id": "0",
+                "label": "",
+                "comparator": "=",
+                "color": "#7dc540",
+                "value": 1
+              },
+              {
+                "id": "2",
+                "label": "",
+                "comparator": "=",
+                "color": "#dc172a",
+                "value": 0
+              }
+            ],
+            "isEnabled": true
+          }
+        ],
+        "chartSettings": {
+          "xAxisScaling": "analyzedTimeframe",
+          "gapPolicy": "gap",
+          "circleChartSettings": {
+            "groupingThresholdType": "relative",
+            "groupingThresholdValue": 0,
+            "valueType": "relative"
+          },
+          "categoryOverrides": {},
+          "curve": "linear",
+          "pointsDisplay": "auto",
+          "categoricalBarChartSettings": {
+            "layout": "vertical",
+            "categoryAxisTickLayout": "horizontal",
+            "scale": "absolute",
+            "groupMode": "stacked",
+            "colorPaletteMode": "multi-color",
+            "categoryAxis": "end-time-utc",
+            "categoryAxisLabel": "end-time-utc",
+            "valueAxis": [
+              "deployment"
+            ],
+            "valueAxisLabel": "deployment",
+            "tooltipVariant": "single"
+          },
+          "colorPalette": "categorical",
+          "truncationMode": "middle",
+          "hiddenLegendFields": [],
+          "fieldMapping": {
+            "timestamp": "timeframe",
+            "leftAxisValues": [
+              "interval"
+            ],
+            "leftAxisDimensions": [
+              "end-time-utc"
+            ]
+          }
+        },
+        "singleValue": {
+          "showLabel": true,
+          "label": "",
+          "prefixIcon": "",
+          "recordField": "end-time-utc",
+          "autoscale": true,
+          "alignment": "center",
+          "colorThresholdTarget": "value"
+        },
+        "table": {
+          "hiddenColumns": [
+            [
+              "timeframe"
+            ],
+            [
+              "interval"
+            ]
+          ],
+          "colorThresholdTarget": "background",
+          "linewrapEnabled": false,
+          "lineWrapIds": [],
+          "monospacedFontEnabled": false,
+          "monospacedFontColumns": [],
+          "columnTypeOverrides": [
+            {
+              "id": 858351,
+              "fields": [],
+              "value": "number"
+            },
+            {
+              "id": 951044,
+              "fields": [
+                "end-time-utc"
+              ],
+              "value": "date"
+            }
+          ],
+          "rowDensity": "condensed",
+          "enableThresholdInRow": false,
+          "selectedColumnForRowThreshold": "deployment",
+          "columnWidths": {
+            "[\"commit-sha\"]": 134.95001220703125,
+            "[\"duration\"]": 102.10000610351562,
+            "[\"commit-msg\"]": 268.3500061035156
+          }
+        },
+        "honeycomb": {
+          "shape": "hexagon",
+          "legend": {
+            "hidden": false,
+            "position": "auto"
+          },
+          "colorMode": "color-palette",
+          "colorPalette": "blue",
+          "dataMappings": {
+            "value": "interval"
+          },
+          "displayedFields": [
+            "end-time-utc",
+            "stage",
+            "duration"
+          ]
+        },
+        "histogram": {
+          "legend": "auto",
+          "yAxis": {
+            "label": "Frequency",
+            "scale": "linear"
+          },
+          "colorPalette": "categorical",
+          "dataMappings": [
+            {
+              "valueAxis": "interval",
+              "rangeAxis": ""
+            },
+            {
+              "valueAxis": "deployment",
+              "rangeAxis": ""
+            }
+          ]
+        },
+        "unitsOverrides": [
+          {
+            "identifier": "deployment",
+            "unitCategory": "unspecified",
+            "baseUnit": "none",
+            "displayUnit": null,
+            "decimals": 0,
+            "suffix": "",
+            "delimiter": false,
+            "added": 0,
+            "id": "deployment"
+          }
+        ]
+      },
+      "querySettings": {
+        "maxResultRecords": 1000,
+        "defaultScanLimitGbytes": 500,
+        "maxResultMegaBytes": 1,
+        "defaultSamplingRatio": 10,
+        "enableSampling": false
+      }
+    }
+  },
+  "layouts": {
+    "0": {
+      "x": 0,
+      "y": 0,
+      "w": 87,
+      "h": 1
+    },
+    "1": {
+      "x": 0,
+      "y": 17,
+      "w": 87,
+      "h": 2
+    },
+    "2": {
+      "x": 0,
+      "y": 1,
+      "w": 24,
+      "h": 1
+    },
+    "3": {
+      "x": 26,
+      "y": 1,
+      "w": 16,
+      "h": 1
+    },
+    "4": {
+      "x": 43,
+      "y": 1,
+      "w": 17,
+      "h": 1
+    },
+    "5": {
+      "x": 62,
+      "y": 1,
+      "w": 13,
+      "h": 1
+    },
+    "6": {
+      "x": 0,
+      "y": 19,
+      "w": 16,
+      "h": 1
+    },
+    "7": {
+      "x": 17,
+      "y": 19,
+      "w": 18,
+      "h": 1
+    },
+    "8": {
+      "x": 37,
+      "y": 19,
+      "w": 16,
+      "h": 1
+    },
+    "9": {
+      "x": 54,
+      "y": 19,
+      "w": 13,
+      "h": 1
+    },
+    "10": {
+      "x": 0,
+      "y": 2,
+      "w": 8,
+      "h": 3
+    },
+    "11": {
+      "x": 8,
+      "y": 2,
+      "w": 8,
+      "h": 3
+    },
+    "12": {
+      "x": 16,
+      "y": 2,
+      "w": 8,
+      "h": 3
+    },
+    "13": {
+      "x": 26,
+      "y": 2,
+      "w": 8,
+      "h": 3
+    },
+    "14": {
+      "x": 34,
+      "y": 2,
+      "w": 8,
+      "h": 3
+    },
+    "15": {
+      "x": 44,
+      "y": 2,
+      "w": 8,
+      "h": 3
+    },
+    "16": {
+      "x": 52,
+      "y": 2,
+      "w": 8,
+      "h": 3
+    },
+    "17": {
+      "x": 62,
+      "y": 2,
+      "w": 8,
+      "h": 3
+    },
+    "18": {
+      "x": 0,
+      "y": 20,
+      "w": 8,
+      "h": 3
+    },
+    "19": {
+      "x": 8,
+      "y": 20,
+      "w": 8,
+      "h": 3
+    },
+    "20": {
+      "x": 18,
+      "y": 20,
+      "w": 8,
+      "h": 3
+    },
+    "21": {
+      "x": 26,
+      "y": 20,
+      "w": 9,
+      "h": 3
+    },
+    "22": {
+      "x": 37,
+      "y": 20,
+      "w": 8,
+      "h": 3
+    },
+    "23": {
+      "x": 45,
+      "y": 20,
+      "w": 8,
+      "h": 3
+    },
+    "24": {
+      "x": 55,
+      "y": 20,
+      "w": 9,
+      "h": 3
+    },
+    "25": {
+      "x": 0,
+      "y": 5,
+      "w": 42,
+      "h": 6
+    },
+    "33": {
+      "x": 44,
+      "y": 5,
+      "w": 40,
+      "h": 6
+    },
+    "34": {
+      "x": 0,
+      "y": 11,
+      "w": 42,
+      "h": 6
+    },
+    "35": {
+      "x": 44,
+      "y": 11,
+      "w": 40,
+      "h": 6
+    },
+    "36": {
+      "x": 0,
+      "y": 23,
+      "w": 42,
+      "h": 6
+    },
+    "37": {
+      "x": 44,
+      "y": 23,
+      "w": 39,
+      "h": 6
+    },
+    "38": {
+      "x": 0,
+      "y": 29,
+      "w": 41,
+      "h": 6
+    },
+    "39": {
+      "x": 44,
+      "y": 29,
+      "w": 39,
+      "h": 6
+    }
+  },
+  "importedWithCode": false,
+  "settings": {
+    "defaultTimeframe": {
+      "value": {
+        "from": "now()-7d",
+        "to": "now()"
+      },
+      "enabled": true
+    }
+  },
+  "gridColumnsCount": 88
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update pipeline dashboard to show commit-msg

### Why did it change

The dynatrace metric was recently updated to include the commit-msg as a dimension. The dashboard has been chaged to use it, and this is the JSON export of it. With formatting.

### Screenshot

<img width="1470" alt="Screenshot 2024-10-10 at 16 02 33" src="https://github.com/user-attachments/assets/9adf5d36-794b-4636-8a0c-cee7626f950f">

