### PR TITLE
BAU: Remove JAVA_TOOL_OPTIONS from local compose file

### DIFF
--- a/local-running/compose.yaml
+++ b/local-running/compose.yaml
@@ -67,7 +67,6 @@ services:
       CI_STORAGE_PUT_LAMBDA_ARN: arn:aws:lambda:eu-west-2:388905755587:function:putContraIndicators-production
       ENVIRONMENT: local
       AWS_XRAY_CONTEXT_MISSING: IGNORE_ERROR
-      JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5002
     ports:
       - "4502:4502"
       - "5002:5002"


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove JAVA_TOOL_OPTIONS from local compose file

### Why did it change

The debugger is being configured by the gradle file now. Having both is causing a clash.

