### PR TITLE
PYIC-7533: Expire pending F2F record on failure

### DIFF
--- a/api-tests/data/cri-stub-requests/f2f/kenneth-passport-verification-1/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/f2f/kenneth-passport-verification-1/credentialSubject.json
@@ -1,0 +1,28 @@
+{
+  "passport": [
+    {
+      "expiryDate": "2030-01-01",
+      "icaoIssuerCode": "GBR",
+      "documentNumber": "321654987"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "Kenneth"
+        },
+        {
+          "type": "FamilyName",
+          "value": "Decerqueira"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/f2f/kenneth-passport-verification-1/evidence.json
+++ b/api-tests/data/cri-stub-requests/f2f/kenneth-passport-verification-1/evidence.json
@@ -1,0 +1,6 @@
+{
+  "validityScore": 2,
+  "strengthScore": 4,
+  "verificationScore": 1,
+  "type": "IdentityCheck"
+}

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -215,3 +215,44 @@ Feature: P2 F2F journey
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":4} |
       Then I get a 'page-face-to-face-handoff' page response
+
+  Rule: Failed F2F journeys are only shown the fail page once
+    Background:
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-passport-verification-1' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+    Scenario: User chooses to prove their identity again
+      # Return journey
+      When I start a new 'medium-confidence' journey and return to a 'pyi-f2f-technical' page response
+      And I submit a 'next' event
+      Then I get a 'page-ipv-identity-document-start' page response
+
+      # Start another return journey
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+
+    Scenario: User chooses to return to the service
+      # Return journey
+      When I start a new 'medium-confidence' journey and return to a 'pyi-f2f-technical' page response
+      And I submit an 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity without a TICF VC
+
+      # Start another return journey
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-failed.yaml
@@ -21,9 +21,29 @@ states:
       pageId: pyi-f2f-technical
     events:
       next:
+        targetState: RESET_SESSION_BEFORE_NEW_P2_IDENTITY
+      end:
+        targetState: RESET_SESSION_BEFORE_RETURN_TO_RP
+
+  RESET_SESSION_BEFORE_NEW_P2_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: PENDING_F2F_ALL
+    events:
+      next:
         targetJourney: NEW_P2_IDENTITY
         targetState: START
-      end:
+
+  RESET_SESSION_BEFORE_RETURN_TO_RP:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: PENDING_F2F_ALL
+    events:
+      next:
         targetState: RETURN_TO_RP
 
   RETURN_TO_RP:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Expire pending F2F record on failure

### Why did it change

When a user fails to prove their identity using F2F for non-CI related reasons, such as a low score, we show them a error page on their return journey. This page offers them to try again, or to go back to the service.

Once they've seen this, we shouldn't need to show it to them again. This change removes their pending F2F record, so they're not flagged as a failed F2F jourey on return.

This also solves a bug with an error being thrown if a user has a mitigated alterate doc CI, and a failed F2F journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7533](https://govukverify.atlassian.net/browse/PYIC-7533)


[PYIC-7533]: https://govukverify.atlassian.net/browse/PYIC-7533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ