### PR TITLE
PYIC-6996: Condition exclusion of BAV VCs for dob correlation

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -12,7 +12,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     P1_JOURNEYS_ENABLED("p1JourneysEnabled"),
     SQS_ASYNC("sqsAsync"),
     KID_JAR_HEADER("kidJarHeaderEnabled"),
-    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck");
+    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
+    DOB_EXPERIAN_CHECK_ENABLED("dobExperianCheckEnabled");
 
     private final String name;
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Condition exclusion of BAV VCs for dob correlation
  - Add DOB_EXPERIAN_CHECK_ENABLED feature flag
  - Optionally omit BAV from exclusion list

### Why did it change

- Will want to do DOB validation testing for BAV

### Issue tracking

- [PYIC-6996](https://govukverify.atlassian.net/browse/PYIC-6996)

[PYIC-6996]: https://govukverify.atlassian.net/browse/PYIC-6996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ