### PR TITLE
BAU Explicitly set Content-Type for DWP KBV API requests

### DIFF
--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -229,6 +229,11 @@ public class CriApiService {
                 && criOAuthSessionItem.getCriId().equals(DWP_KBV.getId())
                 && configService.getEnvironmentVariable(ENVIRONMENT) != null
                 && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")) {
+            try {
+                httpRequest.setContentType("application/x-www-form-urlencoded");
+            } catch (ParseException ex) {
+                LOGGER.error("Failed to set content type", ex);
+            }
             LOGGER.info(buildRequestDebugLog(httpRequest, "token request"));
         }
 
@@ -270,6 +275,11 @@ public class CriApiService {
         if (cri.equals(DWP_KBV)
                 && configService.getEnvironmentVariable(ENVIRONMENT) != null
                 && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")) {
+            try {
+                credentialRequest.setContentType("text/plain");
+            } catch (ParseException ex) {
+                LOGGER.error("Failed to set content type", ex);
+            }
             LOGGER.info(buildRequestDebugLog(credentialRequest, "credential request"));
         }
         try {


### PR DESCRIPTION
## Proposed changes

### What changed

For the token request, nimbus sets a Content-Type of value `application/x-www-form-urlencoded; charset=UTF-8` which the DWP API gateway doesn't like - instead try explicitly setting it to just `application/x-www-form-urlencoded`

For the credential request, we're passing an empty body so technically don't need a Content-Type but try explicitly setting it to `text/plain` (which is valid for empty body)

### Why did it change

DWP KBV integration debugging

