### PR TITLE
PYIC-7578: Retry on `SnapStartNotReadyException`

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -11,7 +11,14 @@
         "featureSet.$": "$$.Execution.Input.featureSet",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
-      "Next": "ProcessJourneyStepResult"
+      "Next": "ProcessJourneyStepResult",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "ProcessJourneyStepResult": {
       "Type": "Choice",
@@ -85,7 +92,14 @@
         "featureSet.$": "$$.Execution.Input.featureSet",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "ResetSessionIdentityLambda": {
       "Type": "Task",
@@ -99,7 +113,14 @@
         "deviceInformation.$": "$$.Execution.Input.deviceInformation",
         "lambdaInput.$": "$.lambdaInput"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "BuildCriOauthRequestLambda": {
       "Type": "Task",
@@ -113,7 +134,14 @@
         "deviceInformation.$": "$$.Execution.Input.deviceInformation",
         "language.$": "$$.Execution.Input.language"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "BuildClientOauthResponseLambda": {
       "Type": "Task",
@@ -126,7 +154,14 @@
         "featureSet.$": "$$.Execution.Input.featureSet",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "EvaluateGpg45Scores": {
       "Type": "Task",
@@ -139,7 +174,14 @@
         "featureSet.$": "$$.Execution.Input.featureSet",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "CheckGpg45ScoreLambda": {
       "Type": "Task",
@@ -152,7 +194,14 @@
         "lambdaInput.$": "$.lambdaInput",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "CallTicfCriLambda": {
       "Type": "Task",
@@ -164,7 +213,14 @@
         "featureSet.$": "$$.Execution.Input.featureSet",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "CallDcmawAsyncCriLambda": {
       "Type": "Task",
@@ -176,7 +232,14 @@
         "featureSet.$": "$$.Execution.Input.featureSet",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "StoreIdentityLambda": {
       "Type": "Task",
@@ -188,7 +251,14 @@
         "lambdaInput.$": "$.lambdaInput",
         "deviceInformation.$": "$$.Execution.Input.deviceInformation"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "CheckCoiLambda": {
       "Type": "Task",
@@ -198,7 +268,14 @@
         "featureSet.$": "$$.Execution.Input.featureSet",
         "lambdaInput.$": "$.lambdaInput"
       },
-      "Next": "ProcessNextJourney"
+      "Next": "ProcessNextJourney",
+      "Retry": [{
+        "ErrorEquals": ["Lambda.SnapStartNotReadyException"],
+        "IntervalSeconds": 1,
+        "BackoffRate": 2,
+        "MaxAttempts": 5,
+        "MaxDelaySeconds": 4
+      }]
     },
     "ProcessNextJourney": {
       "Type": "Choice",


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Retry on `SnapStartNotReadyException`

### Why did it change

We've seen some errors in perf tests where SnapStart not being ready has caused the lambda invocation to fail. This happens when a function hasn't been used for more than 14 days and the snapstart snapshot has been binned by AWS. We can catch that error and retry to try to prevent failures.

This doesn't go as far as retrying for other error types. Mostly because we're not sure how idempotent our lambdas are, and we haven't seen a problem so far so no need to fix it.

It was suggested we could try to retry the issues with are seeing when a lambda segfaults. Unfortunatley the error returned to the step function (`Runtime.ExitError`) isn't specific enought to reliably only retry that error.

This also only fixes this issue for lambdas orchstrated by a stepfunction. Those that are invoked directly by the API gateway will suffer from this issue. APIGateway doesn't appear to offer anything, so we'd need to handle and retry on the client side (core-front) if wanted to try and fix them.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7578](https://govukverify.atlassian.net/browse/PYIC-7578)


[PYIC-7578]: https://govukverify.atlassian.net/browse/PYIC-7578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ