### PR TITLE
BAU: Remove JAVA_TOOLS_OPTIONS from Dockerfile as they are now specified in Gradle

### DIFF
--- a/local-running/Dockerfile
+++ b/local-running/Dockerfile
@@ -24,7 +24,6 @@ WORKDIR /core-back
 COPY --from=build /core-back/untarred/local-running .
 COPY --from=build /core-back/local-running/*.yaml .
 
-ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5002
 ENV PORT 4502
 EXPOSE $PORT
 EXPOSE 5002


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove JAVA_TOOLS_OPTIONS from Dockerfile

### Why did it change

It was breaking local running:
<img width="843" alt="image" src="https://github.com/user-attachments/assets/ef7cceb7-4d53-40b9-bd25-bd29660b7279">
