### PR TITLE
BAU DWP KBV clean up debug logging and explicitly set headers

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -60,10 +60,7 @@ import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
 
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ENVIRONMENT;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
-import static uk.gov.di.ipv.core.library.domain.Cri.DWP_KBV;
-import static uk.gov.di.ipv.core.library.domain.Cri.NINO;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeyuris.JourneyUris.JOURNEY_NOT_FOUND_PATH;
 
@@ -285,13 +282,6 @@ public class ProcessCriCallbackHandler
 
         // Retrieve, store and check cri credentials
         var accessToken = criApiService.fetchAccessToken(callbackRequest, criOAuthSessionItem);
-        // Temporarily logging staging token for debugging purposes
-        if ((callbackRequest.getCredentialIssuer().equals(DWP_KBV)
-                        || callbackRequest.getCredentialIssuer().equals(NINO))
-                && configService.getEnvironmentVariable(ENVIRONMENT) != null
-                && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")) {
-            LOGGER.info("test bearer token: " + accessToken.getValue());
-        }
         var vcResponse =
                 criApiService.fetchVerifiableCredential(
                         accessToken, callbackRequest.getCredentialIssuer(), criOAuthSessionItem);

--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -233,7 +233,7 @@ public class CriApiService {
                 && configService.getEnvironmentVariable(ENVIRONMENT) != null
                 && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")) {
             httpRequest.setHeader("Content-Type", "application/x-www-form-urlencoded");
-            httpRequest.setAccept("application/json");
+            httpRequest.setHeader("Accept", "application/json");
             LOGGER.info(buildRequestDebugLog(httpRequest, "token request"));
             // Try making barebones http request
             var client = HttpClient.newHttpClient();
@@ -302,11 +302,8 @@ public class CriApiService {
         if (cri.equals(DWP_KBV)
                 && configService.getEnvironmentVariable(ENVIRONMENT) != null
                 && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")) {
-            try {
-                credentialRequest.setContentType("text/plain");
-            } catch (ParseException ex) {
-                LOGGER.error("Failed to set content type", ex);
-            }
+            credentialRequest.setHeader("Content-Type", "text/plain");
+            credentialRequest.setHeader("Accept", "application/json");
             LOGGER.info(buildRequestDebugLog(credentialRequest, "credential request"));
         }
         try {


### PR DESCRIPTION
## Proposed changes

### What changed

Clean up DWP KBV debugging logging to date
Explicitly set Accept and Content-Type headers for DWP KBV API requests, for now

### Why did it change

DWP KBV API's gateway is rejecting our requests because nimbus sets header values in the underlying http requests that include `charset` parameters eg. `Accept: application/json; charset=UTF-8`. While these are valid header values, DWP doesn't like them so while discussions are ongoing we'll explicitly set the headers without the charset for now.
