### PR TITLE
PYIC-7470: Extend cache duraation for bulk migration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2507,6 +2507,7 @@ Resources:
           USER_ISSUED_CREDENTIALS_TABLE_NAME: !Ref UserIssuedCredentialsV2Table
           REPORT_USER_IDENTITY_TABLE_NAME: !Ref ReportUserIdentityTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          CONFIG_SERVICE_CACHE_DURATION_MINUTES: 16
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA

--- a/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
+++ b/lambdas/bulk-migrate-vcs/src/main/java/uk/gov/di/ipv/core/bulkmigratevcs/BulkMigrateVcsHandler.java
@@ -257,6 +257,7 @@ public class BulkMigrateVcsHandler implements RequestHandler<Request, BatchRepor
             }
             LOGGER.error(
                     LogHelper.buildErrorMessage("Parallel execution failed", e)
+                            .with(LOG_ERROR_STACK.getFieldName(), e.getStackTrace())
                             .with(LOG_BATCH_ID.getFieldName(), batchId)
                             .with(PAGE_EXCLUSIVE_START_KEY, pageSummary.getExclusiveStartKey())
                             .with(PAGE_ITEM_COUNT, pageSummary.getCount()));


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Extend cache duraation for bulk migration

### Why did it change

We've seen some weird NPEs when running the bulk migration script. They are getting thrown by powertools when the parameter cached gets refreshed after 3 minutes. I suspect some sort of bug when it refreshes config whilst getting hammered with requests.

The config used by the bulk migration script shouldn't change while we're running it, so lets just extend it to longer than timeout of the lambda to avoid this issue.

Also log stack traces.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7470](https://govukverify.atlassian.net/browse/PYIC-7470)


[PYIC-7470]: https://govukverify.atlassian.net/browse/PYIC-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ