### PR TITLE
PYIC-7571: Fetch all CRI by issuer once

### DIFF
--- a/lambdas/reconcile-migrated-vcs/src/test/java/uk/gov/di/ipv/core/reconcilemigratedvcs/ReconcileMigratedVcsHandlerTest.java
+++ b/lambdas/reconcile-migrated-vcs/src/test/java/uk/gov/di/ipv/core/reconcilemigratedvcs/ReconcileMigratedVcsHandlerTest.java
@@ -158,10 +158,11 @@ class ReconcileMigratedVcsHandlerTest {
         var ecVc = vcExperianFraudMissingName();
         var rsaVc = PASSPORT_NON_DCMAW_SUCCESSFUL_RSA_SIGNED_VC;
 
-        when(mockConfigService.getCriByIssuer(ecVc.getClaimsSet().getIssuer()))
-                .thenReturn(EXPERIAN_FRAUD);
-        when(mockConfigService.getCriByIssuer(rsaVc.getClaimsSet().getIssuer()))
-                .thenReturn(PASSPORT);
+        when(mockConfigService.getAllCrisByIssuer())
+                .thenReturn(
+                        Map.of(
+                                ecVc.getClaimsSet().getIssuer(), EXPERIAN_FRAUD,
+                                rsaVc.getClaimsSet().getIssuer(), PASSPORT));
         when(mockConfigService.getHistoricSigningKeys("fraud"))
                 .thenReturn(List.of(TEST_EC_PUBLIC_JWK));
         when(mockConfigService.getHistoricSigningKeys("ukPassport"))
@@ -199,8 +200,8 @@ class ReconcileMigratedVcsHandlerTest {
     @Test
     void handlerShouldHandleInvalidSignatures() throws Exception {
         var vc = vcDrivingPermit();
-        when(mockConfigService.getCriByIssuer(vc.getClaimsSet().getIssuer()))
-                .thenReturn(DRIVING_LICENCE);
+        when(mockConfigService.getAllCrisByIssuer())
+                .thenReturn(Map.of(vc.getClaimsSet().getIssuer(), DRIVING_LICENCE));
         when(mockConfigService.getHistoricSigningKeys("drivingLicence"))
                 .thenReturn(List.of(EC_PUBLIC_JWK_2));
         when(mockForkJoinPoolFactory.getForkJoinPool(anyInt())).thenCallRealMethod();
@@ -228,8 +229,8 @@ class ReconcileMigratedVcsHandlerTest {
     @Test
     void handlerShouldCheckSignaturesWithAllKeys() throws Exception {
         var vc = vcDrivingPermit();
-        when(mockConfigService.getCriByIssuer(vc.getClaimsSet().getIssuer()))
-                .thenReturn(DRIVING_LICENCE);
+        when(mockConfigService.getAllCrisByIssuer())
+                .thenReturn(Map.of(vc.getClaimsSet().getIssuer(), DRIVING_LICENCE));
         when(mockConfigService.getHistoricSigningKeys("drivingLicence"))
                 .thenReturn(List.of(EC_PUBLIC_JWK_2, TEST_EC_PUBLIC_JWK));
         when(mockForkJoinPoolFactory.getForkJoinPool(anyInt())).thenCallRealMethod();
@@ -257,8 +258,8 @@ class ReconcileMigratedVcsHandlerTest {
     @Test
     void handlerShouldHandleIdentityWithP2() throws Exception {
         var vc = vcDrivingPermit();
-        when(mockConfigService.getCriByIssuer(vc.getClaimsSet().getIssuer()))
-                .thenReturn(DRIVING_LICENCE);
+        when(mockConfigService.getAllCrisByIssuer())
+                .thenReturn(Map.of(vc.getClaimsSet().getIssuer(), DRIVING_LICENCE));
         when(mockConfigService.getHistoricSigningKeys("drivingLicence"))
                 .thenReturn(List.of(EC_PUBLIC_JWK_2, TEST_EC_PUBLIC_JWK));
         when(mockForkJoinPoolFactory.getForkJoinPool(anyInt())).thenCallRealMethod();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -179,6 +179,16 @@ public abstract class ConfigService {
         }
     }
 
+    public Map<String, Cri> getAllCrisByIssuer() {
+        Map<String, Cri> issuerMap = new HashMap<>();
+        for (var cri : Cri.values()) {
+            for (var componentId : getCriComponentIds(cri)) {
+                issuerMap.put(componentId, cri);
+            }
+        }
+        return issuerMap;
+    }
+
     public Cri getCriByIssuer(String issuer) throws NoCriForIssuerException {
         for (var cri : Cri.values()) {
             for (var componentId : getCriComponentIds(cri)) {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
@@ -44,6 +44,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -700,6 +701,17 @@ class SsmConfigServiceTest {
             assertThrows(
                     NoCriForIssuerException.class,
                     () -> configService.getCriByIssuer("https://non-existant-component-id"));
+        }
+
+        @Test
+        void getAllCrisByIssuerShouldReturnMapOfAllIssuersAndCri() {
+            Map<String, Cri> expectedMap = new HashMap<>();
+            for (var cri : Cri.values()) {
+                expectedMap.put(String.format("https://main-%s-component-id", cri.getId()), cri);
+                expectedMap.put(String.format("https://stub-%s-component-id", cri.getId()), cri);
+            }
+            var actual = configService.getAllCrisByIssuer();
+            assertEquals(expectedMap, actual);
         }
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fetch all CRI by issuer once

### Why did it change

When running the reconciliation lambda in parallel (more than one lambda execution at once), we were seeing SSM rate limiting errors from powertools. This is weird because it would appear that it's not always respecting the cache.

To avoid this issue this create a new method on the config service which will create a map of all configured issuers for the env to allow a lookup of the associated CRI. We then use this to populate a map for the script which it can refer to throughout the duration of its running.

I've run four parallel exections of this script with this change and experienced no issues. This allowed the checking of the signatures for 100000 identities in less than two minutes.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7571](https://govukverify.atlassian.net/browse/PYIC-7571)


[PYIC-7571]: https://govukverify.atlassian.net/browse/PYIC-7571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ