### PR TITLE
IPS-1185: Refine canary alarms

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3201,14 +3201,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: "Error returned from the IssueClientAccessTokenFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-IssueClientAccessTokenFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-IssueClientAccessTokenFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-IssueClientAccessTokenFunction:live"
+          Value: !Sub "issue-client-access-token-${Environment}:live"
         - Name: FunctionName
           Value: !Ref IssueClientAccessTokenFunction
         - Name: ExecutedVersion
@@ -3229,10 +3227,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "IssueClientAccessTokenFunction returning 5xx response."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-IssueClientAccessTokenFunction-5xxErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-IssueClientAccessTokenFunction-5xxErrorCanary
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -3259,14 +3255,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the InitialiseIpvSessionFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-InitialiseIpvSessionFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-InitialiseIpvSessionFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-InitialiseIpvSessionFunction:live"
+          Value: !Sub "initialise-ipv-session-${Environment}:live"
         - Name: FunctionName
           Value: !Ref InitialiseIpvSessionFunction
         - Name: ExecutedVersion
@@ -3287,10 +3281,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "InitialiseIpvSessionFunction returning 5xx response."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-InitialiseIpvSessionFunction-5xxErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-InitialiseIpvSessionFunction-5xxErrorCanary
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -3317,14 +3309,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the ProcessCriCallbackFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-ProcessCriCallbackFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-ProcessCriCallbackFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-ProcessCriCallbackFunction:live"
+          Value: !Sub "process-cri-callback-${Environment}:live"
         - Name: FunctionName
           Value: !Ref ProcessCriCallbackFunction
         - Name: ExecutedVersion
@@ -3345,10 +3335,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "ProcessCriCallbackFunction returning 5xx response."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-ProcessCriCallbackFunction-5xxErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-ProcessCriCallbackFunction-5xxErrorCanary
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -3375,14 +3363,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the BuildUserIdentityFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-BuildUserIdentityFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-BuildUserIdentityFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-BuildUserIdentityFunction:live"
+          Value: !Sub "build-user-identity-${Environment}:live"
         - Name: FunctionName
           Value: !Ref BuildUserIdentityFunction
         - Name: ExecutedVersion
@@ -3403,10 +3389,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "BuildUserIdentityFunction returning 5xx response."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-BuildUserIdentityFunction-5xxErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-BuildUserIdentityFunction-5xxErrorCanary
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -3433,14 +3417,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the ProcessAsyncCriCredentialFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-ProcessAsyncCriCredentialFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-ProcessAsyncCriCredentialFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-ProcessAsyncCriCredentialFunction:live"
+          Value: !Sub "process-async-cri-credential-${Environment}:live"
         - Name: FunctionName
           Value: !Ref ProcessAsyncCriCredentialFunction
         - Name: ExecutedVersion
@@ -3461,14 +3443,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the BuildProvenUserIdentityDetailsFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-BuildProvenUserIdentityDetailsFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-BuildProvenUserIdentityDetailsFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-BuildProvenUserIdentityDetailsFunction:live"
+          Value: !Sub "build-proven-user-identity-details-${Environment}:live"
         - Name: FunctionName
           Value: !Ref BuildProvenUserIdentityDetailsFunction
         - Name: ExecutedVersion
@@ -3489,10 +3469,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "BuildProvenUserIdentityDetailsFunction returning 5xx response."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-BuildProvenUserIdentityDetailsFunction-5xxErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-BuildProvenUserIdentityDetailsFunction-5xxErrorCanary
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -3525,9 +3503,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-JourneyEngineStepFunction-ExecutionFailedCanary
+      AlarmName: !Sub ${AWS::StackName}-JourneyEngineStepFunction-ExecutionFailedCanary
       AlarmDescription: !Sub "Error returned from the JourneyEngineStepFunction ${JourneyEngineStepFunction.StateMachineRevisionId}"
       MetricName: ExecutionsFailed
       Dimensions:
@@ -3558,9 +3534,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-JourneyEngineStepFunction-TaskFailedCanary
+      AlarmName: !Sub ${AWS::StackName}-JourneyEngineStepFunction-TaskFailedCanary
       AlarmDescription: !Sub "TaskFailed error returned from the JourneyEngineStepFunction"
       MetricName: "JourneyEngineStepFunctionTaskFailed"
       Namespace: !Sub ${AWS::StackName}/LogMessages
@@ -3578,9 +3552,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-JourneyEngineStepFunction-5xxErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-JourneyEngineStepFunction-5xxErrorCanary
       AlarmDescription: "JourneyEngineStepFunction returning 5xx response."
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
@@ -3608,14 +3580,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the IPVProcessJourneyEventFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-IPVProcessJourneyEventFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-IPVProcessJourneyEventFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-IPVProcessJourneyEventFunction:live"
+          Value: !Sub "process-journey-event-${Environment}:live"
         - Name: FunctionName
           Value: !Ref IPVProcessJourneyEventFunction
         - Name: ExecutedVersion
@@ -3636,14 +3606,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the CheckExistingIdentityFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-CheckExistingIdentityFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-CheckExistingIdentityFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-CheckExistingIdentityFunction:live"
+          Value: !Sub "check-existing-identity-${Environment}:live"
         - Name: FunctionName
           Value: !Ref CheckExistingIdentityFunction
         - Name: ExecutedVersion
@@ -3664,14 +3632,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the BuildCriOauthRequestFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-BuildCriOauthRequestFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-BuildCriOauthRequestFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-BuildCriOauthRequestFunction:live"
+          Value: !Sub "build-cri-oauth-request-${Environment}:live"
         - Name: FunctionName
           Value: !Ref BuildCriOauthRequestFunction
         - Name: ExecutedVersion
@@ -3692,14 +3658,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the BuildClientOauthResponseFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-BuildClientOauthResponseFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-BuildClientOauthResponseFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-BuildClientOauthResponseFunction:live"
+          Value: !Sub "build-client-oauth-response-${Environment}:live"
         - Name: FunctionName
           Value: !Ref BuildClientOauthResponseFunction
         - Name: ExecutedVersion
@@ -3720,14 +3684,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the CheckGpg45ScoreFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-CheckGpg45ScoreFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-CheckGpg45ScoreFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-CheckGpg45ScoreFunction:live"
+          Value: !Sub "check-gpg45-score-${Environment}:live"
         - Name: FunctionName
           Value: !Ref CheckGpg45ScoreFunction
         - Name: ExecutedVersion
@@ -3748,14 +3710,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the EvaluateGpg45ScoresFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-EvaluateGpg45ScoresFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-EvaluateGpg45ScoresFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-EvaluateGpg45ScoresFunction:live"
+          Value: !Sub "evaluate-gpg45-scores-${Environment}:live"
         - Name: FunctionName
           Value: !Ref EvaluateGpg45ScoresFunction
         - Name: ExecutedVersion
@@ -3776,14 +3736,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the CallTicfCriFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-CallTicfCriFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-CallTicfCriFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-CallTicfCriFunction:live"
+          Value: !Sub "call-ticf-cri-${Environment}:live"
         - Name: FunctionName
           Value: !Ref CallTicfCriFunction
         - Name: ExecutedVersion
@@ -3804,14 +3762,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the CallDcmawAsyncCriFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-CallDcmawAsyncCriFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-CallDcmawAsyncCriFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-CallDcmawAsyncCriFunction:live"
+          Value: !Sub "call-dcmaw-async-cri-${Environment}:live"
         - Name: FunctionName
           Value: !Ref CallDcmawAsyncCriFunction
         - Name: ExecutedVersion
@@ -3832,14 +3788,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the StoreIdentityFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-StoreIdentityFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-StoreIdentityFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-StoreIdentityFunction:live"
+          Value: !Sub "store-identity-${Environment}:live"
         - Name: FunctionName
           Value: !Ref StoreIdentityFunction
         - Name: ExecutedVersion
@@ -3860,14 +3814,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the ResetSessionIdentityFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-ResetSessionIdentityFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-ResetSessionIdentityFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-ResetSessionIdentityFunction:live"
+          Value: !Sub "reset-session-identity-${Environment}:live"
         - Name: FunctionName
           Value: !Ref ResetSessionIdentityFunction
         - Name: ExecutedVersion
@@ -3888,14 +3840,12 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      OKActions:
-        - !ImportValue alarm-alerts-topic
       AlarmDescription: !Sub "Error returned from the CheckCoiFunction."
-      AlarmName: !Sub ${AWS::StackName}-${Environment}-CheckCoiFunction-ErrorCanary
+      AlarmName: !Sub ${AWS::StackName}-CheckCoiFunction-ErrorCanary
       MetricName: Errors
       Dimensions:
         - Name: Resource
-          Value: !Sub "${AWS::StackName}-CheckCoiFunction:live"
+          Value: !Sub "check-coi-${Environment}:live"
         - Name: FunctionName
           Value: !Ref CheckCoiFunction
         - Name: ExecutedVersion


### PR DESCRIPTION
### What changed

Refine alarms:
- Remove env from name as this is already included in the stack name
- Remove OKActions from canary alarms so notifications are only sent on failure (as is the case for pipelines in #[#di-ipv-core-notifications](https://gds.slack.com/archives/C035N5QJ90T)
- Rename alarm resource

### Why did it change

- Alarm improvements

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1185](https://govukverify.atlassian.net/browse/IPS-1185)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1185]: https://govukverify.atlassian.net/browse/IPS-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ