### PR TITLE
PYIC-7580: Handle access-denied error response

### DIFF
--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -157,7 +157,11 @@ public class ProcessAsyncCriCredentialHandler
 
         criResponseItem.ifPresent(
                 responseItem -> {
-                    responseItem.setStatus(CriResponseService.STATUS_ERROR);
+                    if ("access_denied".equals(errorAsyncCriResponse.getError())) {
+                        responseItem.setStatus(CriResponseService.STATUS_ABANDON);
+                    } else {
+                        responseItem.setStatus(CriResponseService.STATUS_ERROR);
+                    }
                     criResponseService.updateCriResponseItem(responseItem);
                 });
 

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -157,7 +157,8 @@ public class ProcessAsyncCriCredentialHandler
 
         criResponseItem.ifPresent(
                 responseItem -> {
-                    if ("access_denied".equals(errorAsyncCriResponse.getError())) {
+                    if (CriResponseService.ERROR_ACCESS_DENIED.equals(
+                            errorAsyncCriResponse.getError())) {
                         responseItem.setStatus(CriResponseService.STATUS_ABANDON);
                     } else {
                         responseItem.setStatus(CriResponseService.STATUS_ERROR);

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -179,6 +179,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         List<AuditEvent> auditEvents = auditEventCaptor.getAllValues();
         assertEquals(1, auditEvents.size());
         assertEquals(AuditEventTypes.IPV_F2F_CRI_VC_ERROR, auditEvents.get(0).getEventName());
+        assertEquals(CriResponseService.STATUS_ERROR, TEST_CRI_RESPONSE_ITEM.getStatus());
     }
 
     @Test

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -78,7 +78,9 @@ class ProcessAsyncCriCredentialHandlerTest {
                     0,
                     List.of(EVCS_ASYNC_WRITE_ENABLED.getName()));
 
-    private static final String TEST_ASYNC_ERROR = "access_denied";
+    private static final String TEST_ASYNC_ACCESS_DENIED_ERROR = "access_denied";
+    private static final String TEST_ASYNC_ERROR = "invalid";
+
     private static final String TEST_ASYNC_ERROR_DESCRIPTION =
             "Additional information on the error";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -162,7 +164,7 @@ class ProcessAsyncCriCredentialHandlerTest {
 
     @Test
     void shouldProcessErrorAsyncVerifiableCredentialSuccessfully() throws JsonProcessingException {
-        final SQSEvent testEvent = createErrorTestEvent();
+        final SQSEvent testEvent = createErrorTestEvent(TEST_ASYNC_ERROR);
         when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE))
                 .thenReturn(Optional.of(TEST_CRI_RESPONSE_ITEM));
 
@@ -177,6 +179,27 @@ class ProcessAsyncCriCredentialHandlerTest {
         List<AuditEvent> auditEvents = auditEventCaptor.getAllValues();
         assertEquals(1, auditEvents.size());
         assertEquals(AuditEventTypes.IPV_F2F_CRI_VC_ERROR, auditEvents.get(0).getEventName());
+    }
+
+    @Test
+    void shouldProcessAccessDeniedErrorAsyncVerifiableCredentialSuccessfully()
+            throws JsonProcessingException {
+        final SQSEvent testEvent = createErrorTestEvent(TEST_ASYNC_ACCESS_DENIED_ERROR);
+        when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE))
+                .thenReturn(Optional.of(TEST_CRI_RESPONSE_ITEM));
+
+        final SQSBatchResponse batchResponse = handler.handleRequest(testEvent, null);
+
+        verify(criResponseService, times(1)).updateCriResponseItem(TEST_CRI_RESPONSE_ITEM);
+
+        assertEquals(0, batchResponse.getBatchItemFailures().size());
+
+        ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
+        verify(auditService, times(1)).sendAuditEvent(auditEventCaptor.capture());
+        List<AuditEvent> auditEvents = auditEventCaptor.getAllValues();
+        assertEquals(1, auditEvents.size());
+        assertEquals(AuditEventTypes.IPV_F2F_CRI_VC_ERROR, auditEvents.get(0).getEventName());
+        assertEquals(CriResponseService.STATUS_ABANDON, TEST_CRI_RESPONSE_ITEM.getStatus());
     }
 
     @Test
@@ -283,14 +306,14 @@ class ProcessAsyncCriCredentialHandlerTest {
         verifyBatchResponseFailures(testEvent, batchResponse);
     }
 
-    private SQSEvent createErrorTestEvent() throws JsonProcessingException {
+    private SQSEvent createErrorTestEvent(String errorType) throws JsonProcessingException {
         final SQSEvent sqsEvent = new SQSEvent();
         final CriResponseMessageDto criResponseMessageDto =
                 new CriResponseMessageDto(
                         TEST_USER_ID,
                         TEST_OAUTH_STATE,
                         null,
-                        TEST_ASYNC_ERROR,
+                        errorType,
                         TEST_ASYNC_ERROR_DESCRIPTION);
         final SQSEvent.SQSMessage message = new SQSEvent.SQSMessage();
         message.setMessageId(TEST_MESSAGE_ID);

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -18,6 +18,7 @@ public class CriResponseService {
     public static final String STATUS_PENDING = "pending";
     public static final String STATUS_ERROR = "error";
     public static final String STATUS_ABANDON = "abandon";
+    public static final String ERROR_ACCESS_DENIED = "access_denied";
     private final DataStore<CriResponseItem> dataStore;
 
     @ExcludeFromGeneratedCoverageReport

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -17,6 +17,7 @@ public class CriResponseService {
 
     public static final String STATUS_PENDING = "pending";
     public static final String STATUS_ERROR = "error";
+    public static final String STATUS_ABANDON = "abandon";
     private final DataStore<CriResponseItem> dataStore;
 
     @ExcludeFromGeneratedCoverageReport


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Rather than a VC we may receive an asynchronous error response off the queue. 
In the case of a user abandon/abort (where the user has opted to abandon the app) the error response will contain an access-denied 
At present when we process an asychronous response error, we simply update the CRI response item ('pending record') with status error regardless of the specific error code. 
We should use a new status type abandon for this scenario and update the CRI response accordingly (with error used for all other error codes).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7580](https://govukverify.atlassian.net/browse/PYIC-7580)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7580]: https://govukverify.atlassian.net/browse/PYIC-7580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ