### PR TITLE
PYIC-7571: Track verifier use

### DIFF
--- a/lambdas/reconcile-migrated-vcs/src/main/java/uk/gov/di/ipv/core/reconcilemigratedvcs/ReconcileMigratedVcsHandler.java
+++ b/lambdas/reconcile-migrated-vcs/src/main/java/uk/gov/di/ipv/core/reconcilemigratedvcs/ReconcileMigratedVcsHandler.java
@@ -222,12 +222,12 @@ public class ReconcileMigratedVcsHandler implements RequestHandler<Request, Reco
         // Compare VCs
         if (!evcsVcsStrings.equals(tacticalVcsStrings)) {
             logVcDifferences(evcsVcsStrings, tacticalVcsStrings, hashedUserId);
-            reconciliationReport.incrementDifferenceInVcs(hashedUserId);
+            reconciliationReport.incrementIdentitiesWithDifferentVcs(hashedUserId);
             reconciliationReport.incrementIdentitiesFullyProcessed();
             processedIdentities.add(userId);
             return;
         } else {
-            reconciliationReport.incrementVcsMatch();
+            reconciliationReport.incrementIdentitiesWithMatchingVcs(evcsVcsStrings.size());
         }
 
         if (reconciliationReport.isCheckSignatures() || reconciliationReport.isCheckP2()) {

--- a/lambdas/reconcile-migrated-vcs/src/main/java/uk/gov/di/ipv/core/reconcilemigratedvcs/domain/ReconciliationReport.java
+++ b/lambdas/reconcile-migrated-vcs/src/main/java/uk/gov/di/ipv/core/reconcilemigratedvcs/domain/ReconciliationReport.java
@@ -3,10 +3,12 @@ package uk.gov.di.ipv.core.reconcilemigratedvcs.domain;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @ExcludeFromGeneratedCoverageReport
@@ -37,6 +39,7 @@ public class ReconciliationReport {
     private final List<String> failedToAttainP2HashedUserIds = new ArrayList<>();
     private final List<String> differenceInVcsHashedUserIds = new ArrayList<>();
     @Setter private List<String> unprocessedHashedUserIds = new ArrayList<>();
+    @Setter private Map<Cri, List<VerifierAndUseCount>> verifierUse;
 
     public ReconciliationReport(Request request) {
         batchId = request.batchId();

--- a/lambdas/reconcile-migrated-vcs/src/main/java/uk/gov/di/ipv/core/reconcilemigratedvcs/domain/ReconciliationReport.java
+++ b/lambdas/reconcile-migrated-vcs/src/main/java/uk/gov/di/ipv/core/reconcilemigratedvcs/domain/ReconciliationReport.java
@@ -18,8 +18,9 @@ public class ReconciliationReport {
     private final boolean checkP2;
     private final int batchSize;
     private int identitiesFullyProcessed;
+    private int identitiesWithMatchingVcs;
     private int vcsMatchedCount;
-    private int vcsDifferentCount;
+    private int identitiesWithDifferentVcsCount;
     private int identityWithValidSignaturesCount;
     private int identityWithInvalidSignaturesCount;
     private int invalidVcSignatureCount;
@@ -37,7 +38,7 @@ public class ReconciliationReport {
     private final List<String> identityWithAnyInvalidSignaturesHashedUserIds = new ArrayList<>();
     private final List<String> invalidVcSignatureHashedUserIdAndCri = new ArrayList<>();
     private final List<String> failedToAttainP2HashedUserIds = new ArrayList<>();
-    private final List<String> differenceInVcsHashedUserIds = new ArrayList<>();
+    private final List<String> identitiesWithDifferentVcsHashedUserIds = new ArrayList<>();
     @Setter private List<String> unprocessedHashedUserIds = new ArrayList<>();
     @Setter private Map<Cri, List<VerifierAndUseCount>> verifierUse;
 
@@ -52,8 +53,14 @@ public class ReconciliationReport {
         identitiesFullyProcessed++;
     }
 
-    public synchronized void incrementVcsMatch() {
-        vcsMatchedCount++;
+    public synchronized void incrementIdentitiesWithMatchingVcs(int vcCount) {
+        identitiesWithMatchingVcs++;
+        vcsMatchedCount += vcCount;
+    }
+
+    public synchronized void incrementIdentitiesWithDifferentVcs(String hashedUserId) {
+        identitiesWithDifferentVcsCount++;
+        identitiesWithDifferentVcsHashedUserIds.add(hashedUserId);
     }
 
     public synchronized void incrementFailedEvcsRead(String hashedUserId) {
@@ -101,10 +108,5 @@ public class ReconciliationReport {
 
     public synchronized void incrementSuccessfullyMatchedP2Count() {
         successfullyAttainedP2Count++;
-    }
-
-    public synchronized void incrementDifferenceInVcs(String hashedUserId) {
-        vcsDifferentCount++;
-        differenceInVcsHashedUserIds.add(hashedUserId);
     }
 }

--- a/lambdas/reconcile-migrated-vcs/src/main/java/uk/gov/di/ipv/core/reconcilemigratedvcs/domain/VerifierAndUseCount.java
+++ b/lambdas/reconcile-migrated-vcs/src/main/java/uk/gov/di/ipv/core/reconcilemigratedvcs/domain/VerifierAndUseCount.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.core.reconcilemigratedvcs.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.nimbusds.jose.JWSVerifier;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Getter
+@AllArgsConstructor
+public class VerifierAndUseCount {
+    @JsonIgnore private final JWSVerifier verifier;
+    private final String publicKey;
+    private final AtomicInteger useCount;
+}

--- a/lambdas/reconcile-migrated-vcs/src/test/java/uk/gov/di/ipv/core/reconcilemigratedvcs/ReconcileMigratedVcsHandlerTest.java
+++ b/lambdas/reconcile-migrated-vcs/src/test/java/uk/gov/di/ipv/core/reconcilemigratedvcs/ReconcileMigratedVcsHandlerTest.java
@@ -91,8 +91,9 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals("vcs-match-batch-id", reconciliationReport.getBatchId());
         assertEquals(1, reconciliationReport.getBatchSize());
         assertEquals(1, reconciliationReport.getIdentitiesFullyProcessed());
-        assertEquals(1, reconciliationReport.getVcsMatchedCount());
-        assertEquals(0, reconciliationReport.getVcsDifferentCount());
+        assertEquals(1, reconciliationReport.getIdentitiesWithMatchingVcs());
+        assertEquals(3, reconciliationReport.getVcsMatchedCount());
+        assertEquals(0, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertFalse(reconciliationReport.isCheckSignatures());
         assertFalse(reconciliationReport.isCheckP2());
     }
@@ -122,7 +123,7 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals(1, reconciliationReport.getBatchSize());
         assertEquals(1, reconciliationReport.getIdentitiesFullyProcessed());
         assertEquals(0, reconciliationReport.getVcsMatchedCount());
-        assertEquals(1, reconciliationReport.getVcsDifferentCount());
+        assertEquals(1, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertFalse(reconciliationReport.isCheckSignatures());
         assertFalse(reconciliationReport.isCheckP2());
     }
@@ -151,7 +152,7 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals(1, reconciliationReport.getBatchSize());
         assertEquals(1, reconciliationReport.getIdentitiesFullyProcessed());
         assertEquals(0, reconciliationReport.getVcsMatchedCount());
-        assertEquals(1, reconciliationReport.getVcsDifferentCount());
+        assertEquals(1, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertFalse(reconciliationReport.isCheckSignatures());
         assertFalse(reconciliationReport.isCheckP2());
     }
@@ -193,8 +194,9 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals("vcs-valid-sig-batch-id", reconciliationReport.getBatchId());
         assertEquals(1, reconciliationReport.getBatchSize());
         assertEquals(1, reconciliationReport.getIdentitiesFullyProcessed());
-        assertEquals(1, reconciliationReport.getVcsMatchedCount());
-        assertEquals(0, reconciliationReport.getVcsDifferentCount());
+        assertEquals(1, reconciliationReport.getIdentitiesWithMatchingVcs());
+        assertEquals(2, reconciliationReport.getVcsMatchedCount());
+        assertEquals(0, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertEquals(1, reconciliationReport.getIdentityWithValidSignaturesCount());
         assertEquals(0, reconciliationReport.getIdentityWithInvalidSignaturesCount());
         assertEquals(0, reconciliationReport.getInvalidVcSignatureCount());
@@ -224,7 +226,7 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals(1, reconciliationReport.getBatchSize());
         assertEquals(1, reconciliationReport.getIdentitiesFullyProcessed());
         assertEquals(1, reconciliationReport.getVcsMatchedCount());
-        assertEquals(0, reconciliationReport.getVcsDifferentCount());
+        assertEquals(0, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertEquals(0, reconciliationReport.getIdentityWithValidSignaturesCount());
         assertEquals(1, reconciliationReport.getIdentityWithInvalidSignaturesCount());
         assertEquals(1, reconciliationReport.getInvalidVcSignatureCount());
@@ -254,7 +256,7 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals(1, reconciliationReport.getBatchSize());
         assertEquals(1, reconciliationReport.getIdentitiesFullyProcessed());
         assertEquals(1, reconciliationReport.getVcsMatchedCount());
-        assertEquals(0, reconciliationReport.getVcsDifferentCount());
+        assertEquals(0, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertEquals(1, reconciliationReport.getIdentityWithValidSignaturesCount());
         assertEquals(0, reconciliationReport.getIdentityWithInvalidSignaturesCount());
         assertEquals(0, reconciliationReport.getInvalidVcSignatureCount());
@@ -287,7 +289,7 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals(1, reconciliationReport.getBatchSize());
         assertEquals(1, reconciliationReport.getIdentitiesFullyProcessed());
         assertEquals(1, reconciliationReport.getVcsMatchedCount());
-        assertEquals(0, reconciliationReport.getVcsDifferentCount());
+        assertEquals(0, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertEquals(1, reconciliationReport.getIdentityWithValidSignaturesCount());
         assertEquals(0, reconciliationReport.getIdentityWithInvalidSignaturesCount());
         assertEquals(0, reconciliationReport.getInvalidVcSignatureCount());
@@ -317,7 +319,7 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals(1, reconciliationReport.getBatchSize());
         assertEquals(1, reconciliationReport.getIdentitiesFullyProcessed());
         assertEquals(1, reconciliationReport.getVcsMatchedCount());
-        assertEquals(0, reconciliationReport.getVcsDifferentCount());
+        assertEquals(0, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertEquals(0, reconciliationReport.getIdentityWithValidSignaturesCount());
         assertEquals(0, reconciliationReport.getIdentityWithInvalidSignaturesCount());
         assertEquals(0, reconciliationReport.getInvalidVcSignatureCount());
@@ -344,8 +346,8 @@ class ReconcileMigratedVcsHandlerTest {
         assertEquals("timeout-batch-id", reconciliationReport.getBatchId());
         assertEquals(2, reconciliationReport.getBatchSize());
         assertEquals(2, reconciliationReport.getIdentitiesFullyProcessed());
-        assertEquals(2, reconciliationReport.getVcsMatchedCount());
-        assertEquals(0, reconciliationReport.getVcsDifferentCount());
+        assertEquals(2, reconciliationReport.getIdentitiesWithMatchingVcs());
+        assertEquals(0, reconciliationReport.getIdentitiesWithDifferentVcsCount());
         assertEquals("Lambda close to timeout", reconciliationReport.getExitReason());
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Track verifier use and number of VCs matched

### Why did it change

Lots of VCs were failing signature verification in staging. Turns out they were signed with an unexpected key. It would be useful to understand how many VCs are signed with this key (which has been added to config).
This would also potentially be interesting when we recondile in production to understand the proportion of passport VCs signed with the old and new keys.

Also, It would be good to be able to easily say that we've matched the same
number of VCs as expected, rather than just the number of identities.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7571](https://govukverify.atlassian.net/browse/PYIC-7571)


[PYIC-7571]: https://govukverify.atlassian.net/browse/PYIC-7571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ