### PR TITLE
BAU DWP KBV try API calls without header workaround

### DIFF
--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -206,15 +206,6 @@ public class CriApiService {
 
         var httpRequest = tokenRequest.toHTTPRequest();
 
-        // Temporary for DWP integration testing
-        if (criOAuthSessionItem.getCriId() != null
-                && criOAuthSessionItem.getCriId().equals(DWP_KBV.getId())
-                && configService.getEnvironmentVariable(ENVIRONMENT) != null
-                && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")) {
-            httpRequest.setHeader(HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
-            httpRequest.setHeader(HEADER_ACCEPT, MIME_TYPE_APPLICATION_JSON);
-        }
-
         if (apiKey != null) {
             LOGGER.info(
                     LogHelper.buildLogMessage(
@@ -330,7 +321,6 @@ public class CriApiService {
             if (configService.getEnvironmentVariable(ENVIRONMENT) != null
                     && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")
                     && cri.equals(DWP_KBV)) {
-                request.setHeader(HEADER_CONTENT_TYPE, MIME_TYPE_APPLICATION_JSON);
                 request.setHeader(HEADER_ACCEPT, "application/jwt");
             } else {
                 request.setHeader(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

DWP KBV try API calls without header workaround

### Why did it change

DWP have relaxed their gateway rules which were rejecting `charset=UTF-8` parameters present in our request header values which nimbus sends in the token and credential requests

