### PR TITLE
BAU: Max out bulk migration memory

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2747,6 +2747,7 @@ Resources:
       # checkov:skip=CKV_AWS_116: Lambdas invoked via API Gateway do not support Dead Letter Queues.
       # checkov:skip=CKV_AWS_117: Lambdas will migrate to our own VPC in future work.
       FunctionName: !Sub "bulk-migrate-vcs-${Environment}"
+      MemorySize: 10240
       Handler: uk.gov.di.ipv.core.bulkmigratevcs.BulkMigrateVcsHandler::handleRequest
       PackageType: Zip
       CodeUri: ../lambdas/bulk-migrate-vcs


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Max out bulk migration memory

### Why did it change

The extra cost per run is neglible and it might speed thing up a bit.
