### PR TITLE
PYIC-6242: Include state in clientCallbackUrl

### DIFF
--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
@@ -106,7 +106,8 @@ public class DcmawAsyncCriService {
             case DAD:
                 break;
             case MAM:
-                clientCallbackUrl = criConfig.getClientCallbackUrl().toString();
+                clientCallbackUrl =
+                        criConfig.getClientCallbackUrl().toString() + "?state=" + oauthState;
                 break;
             default:
                 throw new HttpResponseExceptionWithErrorBody(

--- a/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java
+++ b/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java
@@ -138,7 +138,7 @@ class DcmawAsyncCriServiceTest {
 
     private static Stream<Arguments> mobileAppJourneyTypesAndClientCallbackUrls() {
         return Stream.of(
-                Arguments.of(MobileAppJourneyType.MAM, REDIRECT_URL),
+                Arguments.of(MobileAppJourneyType.MAM, REDIRECT_URL + "?state=" + CRI_OAUTH_STATE),
                 Arguments.of(MobileAppJourneyType.DAD, null));
     }
 }

--- a/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
+++ b/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
@@ -76,13 +76,11 @@ public class ProcessMobileAppCallbackHandler
             validateCallback(callbackRequest);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_OK, JOURNEY_NEXT);
-        } catch (InvalidMobileAppCallbackRequestException e) {
+        } catch (InvalidMobileAppCallbackRequestException | ClientOauthSessionNotFoundException e) {
             return buildErrorResponse(e, HttpStatus.SC_BAD_REQUEST, e.getErrorResponse());
         } catch (IpvSessionNotFoundException e) {
             return buildErrorResponse(
                     e, HttpStatus.SC_BAD_REQUEST, ErrorResponse.IPV_SESSION_NOT_FOUND);
-        } catch (ClientOauthSessionNotFoundException e) {
-            return buildErrorResponse(e, HttpStatus.SC_BAD_REQUEST, e.getErrorResponse());
         } catch (InvalidCriResponseException e) {
             return buildErrorResponse(e, HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getErrorResponse());
         }

--- a/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/exception/InvalidMobileAppCallbackRequestException.java
+++ b/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/exception/InvalidMobileAppCallbackRequestException.java
@@ -1,14 +1,13 @@
 package uk.gov.di.ipv.core.processmobileappcallback.exception;
 
 import lombok.Getter;
+import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 @Getter
-public class InvalidMobileAppCallbackRequestException extends Exception {
-    private final ErrorResponse errorResponse;
-
+public class InvalidMobileAppCallbackRequestException extends HttpResponseExceptionWithErrorBody {
     public InvalidMobileAppCallbackRequestException(ErrorResponse errorResponse) {
-        super(errorResponse.getMessage());
-        this.errorResponse = errorResponse;
+        super(HttpStatusCode.INTERNAL_SERVER_ERROR, errorResponse);
     }
 }

--- a/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
+++ b/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
@@ -24,7 +25,6 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.processmobileappcallback.dto.MobileAppCallbackRequest;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -53,7 +53,7 @@ class ProcessMobileAppCallbackHandlerTest {
                 .thenReturn(buildValidIpvSessionItem());
         when(clientOAuthSessionDetailsService.getClientOAuthSession(TEST_CLIENT_OAUTH_SESSION_ID))
                 .thenReturn(buildValidClientOAuthSessionItem());
-        when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE))
+        when(criResponseService.getCriResponseItem(TEST_USER_ID, Cri.DCMAW_ASYNC))
                 .thenReturn(buildValidCriResponseItem());
 
         // Act
@@ -141,8 +141,7 @@ class ProcessMobileAppCallbackHandlerTest {
                 .thenReturn(buildValidIpvSessionItem());
         when(clientOAuthSessionDetailsService.getClientOAuthSession(TEST_CLIENT_OAUTH_SESSION_ID))
                 .thenReturn(buildValidClientOAuthSessionItem());
-        when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE))
-                .thenReturn(Optional.empty());
+        when(criResponseService.getCriResponseItem(TEST_USER_ID, Cri.DCMAW_ASYNC)).thenReturn(null);
 
         // Act
         var lambdaResponse =
@@ -168,7 +167,7 @@ class ProcessMobileAppCallbackHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(TEST_CLIENT_OAUTH_SESSION_ID))
                 .thenReturn(buildValidClientOAuthSessionItem());
         var criResponseItem = buildValidCriResponseItem(CriResponseService.STATUS_ERROR);
-        when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE))
+        when(criResponseService.getCriResponseItem(TEST_USER_ID, Cri.DCMAW_ASYNC))
                 .thenReturn(criResponseItem);
 
         // Act
@@ -207,16 +206,15 @@ class ProcessMobileAppCallbackHandlerTest {
         return ClientOAuthSessionItem.builder().userId(TEST_USER_ID).build();
     }
 
-    private Optional<CriResponseItem> buildValidCriResponseItem() {
+    private CriResponseItem buildValidCriResponseItem() {
         return buildValidCriResponseItem(null);
     }
 
-    private Optional<CriResponseItem> buildValidCriResponseItem(String status) {
-        return Optional.of(
-                CriResponseItem.builder()
-                        .userId(TEST_USER_ID)
-                        .oauthState(TEST_OAUTH_STATE)
-                        .status(status)
-                        .build());
+    private CriResponseItem buildValidCriResponseItem(String status) {
+        return CriResponseItem.builder()
+                .userId(TEST_USER_ID)
+                .oauthState(TEST_OAUTH_STATE)
+                .status(status)
+                .build();
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Include state in the clientCallbackUrl
- Make the fetching of CriResponseItem more robust to state collision

### Why did it change

- clientCallbackUrl needs to be dynamic with the state as the query

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6242](https://govukverify.atlassian.net/browse/PYIC-6242)

[PYIC-6242]: https://govukverify.atlassian.net/browse/PYIC-6242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ