### PR TITLE
BAU: Reduce response delay timeout to 1s for API test TICF response delay less than 5s

### DIFF
--- a/api-tests/features/ticf/ticf-successful-responses.feature
+++ b/api-tests/features/ticf/ticf-successful-responses.feature
@@ -65,10 +65,10 @@ Feature: TICF successful responses
         | cis  | BREACHING                    |
         | type | RiskAssessment               |
 
-  Rule: TICF response delay less than 5s
+  Rule: TICF response delay less than 2s
     Scenario: Via app - TICF request has a response delay less than 5s
       Given TICF CRI will respond with default parameters
-        | responseDelay | 4         |
+        | responseDelay | 1         |
       And I activate the 'ticfCriBeta' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response


### PR DESCRIPTION
## Proposed changes

### What changed

- Reduce response delay timeout to 1s for API test TICF response delay less than 5s

### Why did it change

- Fix pipeline for change brought in with [this ticket](https://govukverify.atlassian.net/browse/PYIC-7658)