### PR TITLE
PYIC-7580: Handle access-denied for f2f in CheckExisitingIndentityHandler

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -598,6 +598,10 @@ public class CheckExistingIdentityHandler
                 LOGGER.info(LogHelper.buildLogMessage("F2F cri pending verification."));
                 return JOURNEY_PENDING;
             }
+            case CriResponseService.STATUS_ABANDON -> {
+                LOGGER.info(LogHelper.buildLogMessage("F2F cri abandon."));
+                return JOURNEY_F2F_FAIL;
+            }
             case CriResponseService.STATUS_ERROR -> {
                 LOGGER.warn(LogHelper.buildLogMessage("F2F cri error."));
                 return JOURNEY_F2F_FAIL;

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -735,7 +735,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
-        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_PENDING);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(false);
 
@@ -885,7 +886,8 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnPendingResponseIfFaceToFaceVerificationIsPending() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_PENDING);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -906,7 +908,8 @@ class CheckExistingIdentityHandlerTest {
     void shouldReturnPendingResponseIfFaceToFaceVerificationIsPendingAndBreachingCi()
             throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_PENDING);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -946,10 +949,32 @@ class CheckExistingIdentityHandlerTest {
     }
 
     @Test
+    void shouldReturnFailResponseIfFaceToFaceVerificationIsAbandon() throws Exception {
+        when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_ABANDON);
+        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+
+        JourneyResponse journeyResponse =
+                toResponseClass(
+                        checkExistingIdentityHandler.handleRequest(event, context),
+                        JourneyResponse.class);
+
+        assertEquals(JOURNEY_F2F_FAIL, journeyResponse);
+
+        verify(ipvSessionItem, never()).setVot(any());
+        assertNull(ipvSessionItem.getVot());
+        assertEquals(P2, ipvSessionItem.getTargetVot());
+    }
+
+    @Test
     void shouldReturnFailResponseForFaceToFaceVerificationIfNoMatchedProfile() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
-        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_PENDING);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -976,7 +1001,8 @@ class CheckExistingIdentityHandlerTest {
     void shouldReturnFailResponseForFaceToFaceIfVCsDoNotCorrelate() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
-        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_PENDING);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -1284,7 +1310,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
-        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_PENDING);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(cimitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(testContraIndicators);
@@ -1317,7 +1344,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
-        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_PENDING);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(cimitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(testContraIndicators);
@@ -1353,7 +1381,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(mockVerifiableCredentialService.getVcs(TEST_USER_ID)).thenReturn(List.of(vcF2fM1a()));
-        CriResponseItem criResponseItem = createCriResponseStoreItem();
+        CriResponseItem criResponseItem =
+                createCriResponseStoreItem(CriResponseService.STATUS_PENDING);
         when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(cimitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
                 .thenReturn(testContraIndicators);
@@ -1666,13 +1695,13 @@ class CheckExistingIdentityHandlerTest {
         return OBJECT_MAPPER.convertValue(handlerOutput, responseClass);
     }
 
-    private CriResponseItem createCriResponseStoreItem() {
+    private CriResponseItem createCriResponseStoreItem(String criResponseStatus) {
         CriResponseItem criResponseItem = new CriResponseItem();
         criResponseItem.setUserId(TEST_USER_ID);
         criResponseItem.setCredentialIssuer(F2F.getId());
         criResponseItem.setIssuerResponse(PASSPORT_NON_DCMAW_SUCCESSFUL_VC.getVcString());
         criResponseItem.setDateCreated(Instant.now());
-        criResponseItem.setStatus(CriResponseService.STATUS_PENDING);
+        criResponseItem.setStatus(criResponseStatus);
         return criResponseItem;
     }
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Rather than a VC we may receive an asynchronous error response off the queue. In the case of a user abandon/abort (where the user has opted to abandon the app) the error response will contain an access-denied error code

F2F use access-denied but it seems they do. The behaviour will be the same (route to JOURNEY_F2F_FAIL) but we don’t want to warn log it as an unexpected status.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7580](https://govukverify.atlassian.net/browse/PYIC-7580)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


[PYIC-7580]: https://govukverify.atlassian.net/browse/PYIC-7580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ