### PR TITLE
BAU: Traced CRI HTTP requests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,6 @@ powertoolsLogging = { module = "software.amazon.lambda:powertools-logging", vers
 powertoolsParameters = { module = "software.amazon.lambda:powertools-parameters", version.ref = "powertools" }
 powertoolsTracing = { module = "software.amazon.lambda:powertools-tracing", version.ref = "powertools" }
 systemStubs = "uk.org.webcompere:system-stubs-jupiter:2.1.3"
-wiremock = "com.github.tomakehurst:wiremock-jre8:3.0.1"
 
 [bundles]
 log4j = ["log4jApi", "log4jCore"]

--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
@@ -13,16 +13,12 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.enums.MobileAppJourneyType;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
-import uk.gov.di.ipv.core.library.kmses256signer.SignerFactory;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.CriOAuthSessionService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialResponse;
-
-import java.time.Clock;
 
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CONNECTION;
@@ -39,12 +35,7 @@ public class DcmawAsyncCriService {
     @ExcludeFromGeneratedCoverageReport
     public DcmawAsyncCriService(ConfigService configService) {
         this.configService = configService;
-        this.criApiService =
-                new CriApiService(
-                        configService,
-                        new SignerFactory(configService),
-                        SecureTokenHelper.getInstance(),
-                        Clock.systemDefaultZone());
+        this.criApiService = new CriApiService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);
     }

--- a/lambdas/check-mobile-app-vc-receipt/build.gradle
+++ b/lambdas/check-mobile-app-vc-receipt/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
-			libs.wiremock,
 			project(path: ':libs:common-services', configuration: 'tests')
 
 	testRuntimeOnly libs.junitPlatform

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -21,8 +21,7 @@ dependencies {
 			libs.powertoolsTracing,
 			libs.aspectj
 
-	testImplementation libs.wiremock,
-			libs.junitJupiter,
+	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
 			libs.pactConsumerJunit,
 			project(path: ':libs:common-services', configuration: 'tests'),

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -30,7 +30,6 @@ dependencies {
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
 			libs.pactConsumerJunit,
-			libs.wiremock,
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(":libs:pact-test-helpers")
 

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -32,9 +32,7 @@ import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
-import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.helpers.StepFunctionHelpers;
-import uk.gov.di.ipv.core.library.kmses256signer.SignerFactory;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -56,7 +54,6 @@ import uk.gov.di.ipv.core.processcricallback.exception.InvalidCriCallbackRequest
 import uk.gov.di.ipv.core.processcricallback.exception.ParseCriCallbackRequestException;
 import uk.gov.di.ipv.core.processcricallback.service.CriCheckingService;
 
-import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
 
@@ -117,12 +114,7 @@ public class ProcessCriCallbackHandler
         var sessionCredentialsService = new SessionCredentialsService(configService);
         var cimitService = new CimitService(configService);
 
-        criApiService =
-                new CriApiService(
-                        configService,
-                        new SignerFactory(configService),
-                        SecureTokenHelper.getInstance(),
-                        Clock.systemDefaultZone());
+        criApiService = new CriApiService(configService);
         criCheckingService =
                 new CriCheckingService(
                         configService,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.processcricallback.service;
 
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -223,7 +222,7 @@ class CriCheckingServiceTest {
     void validateSessionIdsShouldThrowExceptionWhenIpvSessionIdIsBlank() {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
-        callbackRequest.setIpvSessionId(StringUtils.EMPTY);
+        callbackRequest.setIpvSessionId("");
 
         // Act & Assert
         assertThrows(
@@ -236,8 +235,8 @@ class CriCheckingServiceTest {
     void validateSessionIdsShouldThrowExceptionWhenBothSessionIdsAreBlank() {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
-        callbackRequest.setIpvSessionId(StringUtils.EMPTY);
-        callbackRequest.setState(StringUtils.EMPTY);
+        callbackRequest.setIpvSessionId("");
+        callbackRequest.setState("");
 
         // Act & Assert
         assertThrows(
@@ -250,7 +249,7 @@ class CriCheckingServiceTest {
     void validateSessionIdsShouldThrowExceptionWithNoIpvForCriOauthSessionError() {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
-        callbackRequest.setIpvSessionId(StringUtils.EMPTY);
+        callbackRequest.setIpvSessionId("");
 
         // Act & Assert
         var exception =
@@ -264,7 +263,7 @@ class CriCheckingServiceTest {
     void validateSessionIdsShouldNotThrowExceptionWithMissingOauthStateErrorWhenOnlyStateIsBlank() {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
-        callbackRequest.setState(StringUtils.EMPTY);
+        callbackRequest.setState("");
 
         // Act & Assert
         assertDoesNotThrow(() -> criCheckingService.validateSessionIds(callbackRequest));
@@ -287,7 +286,7 @@ class CriCheckingServiceTest {
     void validateCallbackRequestShouldThrowExceptionWhenAuthorizationCodeIsBlank() {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
-        callbackRequest.setAuthorizationCode(StringUtils.EMPTY);
+        callbackRequest.setAuthorizationCode("");
 
         // Act & Assert
         assertThrows(
@@ -319,7 +318,7 @@ class CriCheckingServiceTest {
     void validateCallbackRequestShouldThrowExceptionWhenIpvSessionIdIsBlank() {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
-        callbackRequest.setIpvSessionId(StringUtils.EMPTY);
+        callbackRequest.setIpvSessionId("");
 
         // Act & Assert
         assertThrows(
@@ -335,7 +334,7 @@ class CriCheckingServiceTest {
     void validateCallbackRequestShouldThrowExceptionWhenStateIsBlank() {
         // Arrange
         var callbackRequest = buildValidCallbackRequest();
-        callbackRequest.setState(StringUtils.EMPTY);
+        callbackRequest.setState("");
 
         // Act & Assert
         assertThrows(

--- a/lambdas/process-mobile-app-callback/build.gradle
+++ b/lambdas/process-mobile-app-callback/build.gradle
@@ -21,7 +21,6 @@ dependencies {
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
-			libs.wiremock,
 			project(path: ':libs:common-services', configuration: 'tests')
 
 	testRuntimeOnly libs.junitPlatform

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/HttpRequestHelper.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/HttpRequestHelper.java
@@ -1,0 +1,56 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.Flow;
+
+public class HttpRequestHelper {
+    private HttpRequestHelper() {}
+
+    public static String extractBody(HttpRequest httpRequest) {
+        return httpRequest
+                .bodyPublisher()
+                .map(
+                        p -> {
+                            var subscriber = new StringSubscriber();
+                            p.subscribe(subscriber);
+                            return subscriber.getResult();
+                        })
+                .orElse(null);
+    }
+
+    static final class StringSubscriber implements Flow.Subscriber<ByteBuffer> {
+        final HttpResponse.BodySubscriber<String> bodySubscriber;
+
+        StringSubscriber() {
+            this.bodySubscriber = HttpResponse.BodySubscribers.ofString(StandardCharsets.UTF_8);
+        }
+
+        public String getResult() {
+            return bodySubscriber.getBody().toCompletableFuture().join();
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            bodySubscriber.onSubscribe(subscription);
+        }
+
+        @Override
+        public void onNext(ByteBuffer item) {
+            bodySubscriber.onNext(List.of(item));
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            bodySubscriber.onError(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            bodySubscriber.onComplete();
+        }
+    }
+}

--- a/libs/cri-api-service/build.gradle
+++ b/libs/cri-api-service/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
-			libs.wiremock,
 			project(path: ':libs:common-services', configuration: 'tests')
 
 	testRuntimeOnly libs.junitPlatform

--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -18,6 +18,7 @@ import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPRequestSender;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -40,6 +41,7 @@ import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.kmses256signer.SignerFactory;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
 import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialResponse;
 import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialStatus;
 import uk.gov.di.ipv.core.library.verifiablecredential.dto.VerifiableCredentialResponseDto;
@@ -68,17 +70,44 @@ public class CriApiService {
     private final SignerFactory signerFactory;
     private final SecureTokenHelper secureTokenHelper;
     private final Clock clock;
+    private final HTTPRequestSender httpRequestSender;
 
     @ExcludeFromGeneratedCoverageReport
+    public CriApiService(ConfigService configService) {
+        this(
+                configService,
+                new SignerFactory(configService),
+                SecureTokenHelper.getInstance(),
+                Clock.systemDefaultZone(),
+                new JavaHttpRequestSender(TracingHttpClient.newHttpClient()));
+    }
+
+    // Used for contract tests
     public CriApiService(
             ConfigService configService,
             SignerFactory signerFactory,
             SecureTokenHelper secureTokenHelper,
             Clock clock) {
+        this(
+                configService,
+                signerFactory,
+                secureTokenHelper,
+                clock,
+                new JavaHttpRequestSender(TracingHttpClient.newHttpClient()));
+    }
+
+    // Used for unit tests
+    public CriApiService(
+            ConfigService configService,
+            SignerFactory signerFactory,
+            SecureTokenHelper secureTokenHelper,
+            Clock clock,
+            HTTPRequestSender httpRequestSender) {
         this.configService = configService;
         this.signerFactory = signerFactory;
         this.secureTokenHelper = secureTokenHelper;
         this.clock = clock;
+        this.httpRequestSender = httpRequestSender;
     }
 
     private String getApiKey(OauthCriConfig criConfig, CriOAuthSessionItem criOAuthSessionItem) {
@@ -117,7 +146,7 @@ public class CriApiService {
     private BearerAccessToken fetchAccessToken(HTTPRequest accessTokenRequest)
             throws CriApiException {
         try {
-            var httpResponse = accessTokenRequest.send();
+            var httpResponse = accessTokenRequest.send(httpRequestSender);
             var tokenResponse = TokenResponse.parse(httpResponse);
 
             if (tokenResponse instanceof TokenErrorResponse) {
@@ -242,7 +271,7 @@ public class CriApiService {
     private VerifiableCredentialResponse fetchVerifiableCredential(
             Cri cri, HTTPRequest credentialRequest) throws CriApiException {
         try {
-            var response = credentialRequest.send();
+            var response = credentialRequest.send(httpRequestSender);
             if (!response.indicatesSuccess()) {
                 LOGGER.error(
                         LogHelper.buildErrorMessage(

--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -173,7 +173,7 @@ public class CriApiService {
         }
     }
 
-    public HTTPRequest buildAccessTokenRequestWithJwtAuthenticationAndAuthorizationCode(
+    private HTTPRequest buildAccessTokenRequestWithJwtAuthenticationAndAuthorizationCode(
             String authorisationCode, CriOAuthSessionItem criOAuthSessionItem)
             throws CriApiException {
         var criConfig = configService.getOauthCriConfig(criOAuthSessionItem);
@@ -209,7 +209,7 @@ public class CriApiService {
         }
     }
 
-    public HTTPRequest buildAccessTokenRequestWithBasicAuthenticationAndClientCredentials(
+    private HTTPRequest buildAccessTokenRequestWithBasicAuthenticationAndClientCredentials(
             String basicAuthClientId,
             String basicAuthClientSecret,
             CriOAuthSessionItem criOAuthSessionItem) {
@@ -330,7 +330,7 @@ public class CriApiService {
         }
     }
 
-    public HTTPRequest buildFetchVerifiableCredentialRequest(
+    private HTTPRequest buildFetchVerifiableCredentialRequest(
             BearerAccessToken accessToken,
             Cri cri,
             CriOAuthSessionItem criOAuthSessionItem,

--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/JavaHttpRequestSender.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/JavaHttpRequestSender.java
@@ -1,0 +1,72 @@
+package uk.gov.di.ipv.core.library.criapiservice;
+
+import com.nimbusds.oauth2.sdk.http.HTTPRequestSender;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.http.ReadOnlyHTTPRequest;
+import com.nimbusds.oauth2.sdk.http.ReadOnlyHTTPResponse;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class JavaHttpRequestSender implements HTTPRequestSender {
+    private final HttpClient httpClient;
+
+    public JavaHttpRequestSender(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public ReadOnlyHTTPResponse send(ReadOnlyHTTPRequest joseHttpRequest) throws IOException {
+        try {
+            var javaRequest = joseRequestToJavaRequest(joseHttpRequest);
+            var javaResponse = httpClient.send(javaRequest, HttpResponse.BodyHandlers.ofString());
+            return javaResponseToJoseResponse(javaResponse);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        }
+    }
+
+    private HttpRequest joseRequestToJavaRequest(ReadOnlyHTTPRequest joseHttpRequest) {
+        var requestBuilder = HttpRequest.newBuilder().uri(joseHttpRequest.getURI());
+
+        if (joseHttpRequest.getBody() != null) {
+            requestBuilder.method(
+                    joseHttpRequest.getMethod().name(),
+                    HttpRequest.BodyPublishers.ofString(joseHttpRequest.getBody()));
+        } else {
+            requestBuilder.method(
+                    joseHttpRequest.getMethod().name(), HttpRequest.BodyPublishers.noBody());
+        }
+
+        for (var header : joseHttpRequest.getHeaderMap().entrySet()) {
+            var key = header.getKey();
+            var values = header.getValue();
+            if (values != null && !values.isEmpty()) {
+                for (var value : values) {
+                    requestBuilder.header(key, value);
+                }
+            }
+        }
+
+        return requestBuilder.build();
+    }
+
+    private ReadOnlyHTTPResponse javaResponseToJoseResponse(HttpResponse<String> javaResponse) {
+        var joseResponse = new HTTPResponse(javaResponse.statusCode());
+
+        for (var header : javaResponse.headers().map().entrySet()) {
+            var key = header.getKey();
+            var value = header.getValue();
+            if (value != null && !value.isEmpty()) {
+                joseResponse.setHeader(key, value.toArray(new String[0]));
+            }
+        }
+
+        joseResponse.setBody(javaResponse.body());
+
+        return joseResponse;
+    }
+}

--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/JavaHttpRequestSender.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/JavaHttpRequestSender.java
@@ -44,9 +44,11 @@ public class JavaHttpRequestSender implements HTTPRequestSender {
         for (var header : joseHttpRequest.getHeaderMap().entrySet()) {
             var key = header.getKey();
             var values = header.getValue();
-            if (values != null && !values.isEmpty()) {
+            if (values != null) {
                 for (var value : values) {
-                    requestBuilder.header(key, value);
+                    if (value != null) {
+                        requestBuilder.header(key, value);
+                    }
                 }
             }
         }

--- a/libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java
+++ b/libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java
@@ -83,6 +83,8 @@ class CriApiServiceTest {
 
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
+    // TODO: replace wiremock with this standard mock!
+    // @Mock private HttpClient mockHttpClient;
     private CriApiService criApiService;
 
     @BeforeEach
@@ -93,6 +95,7 @@ class CriApiServiceTest {
                         mockSignerFactory,
                         SecureTokenHelper.getInstance(),
                         Clock.systemDefaultZone());
+        //                        new JavaHttpRequestSender(mockHttpClient));
 
         var criConfig = getOauthCriConfig(wmRuntimeInfo);
         when(mockConfigService.getOauthCriConfig(any())).thenReturn(criConfig);

--- a/libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java
+++ b/libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java
@@ -139,7 +139,7 @@ class CriApiServiceTest {
         when(mockResponse.body())
                 .thenReturn(
                         String.format(
-                                "{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":3600}%n",
+                                "{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":3600}",
                                 TEST_ACCESS_TOKEN));
 
         // Act
@@ -183,7 +183,7 @@ class CriApiServiceTest {
         when(mockResponse.body())
                 .thenReturn(
                         String.format(
-                                "{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":3600}%n",
+                                "{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":3600}",
                                 TEST_ACCESS_TOKEN));
 
         // Act
@@ -223,7 +223,7 @@ class CriApiServiceTest {
         when(mockResponse.body())
                 .thenReturn(
                         String.format(
-                                "{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":3600}%n",
+                                "{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":3600}",
                                 TEST_ACCESS_TOKEN));
 
         // Act

--- a/libs/kms-es256-signer/build.gradle
+++ b/libs/kms-es256-signer/build.gradle
@@ -19,8 +19,7 @@ dependencies {
 	compileOnly libs.lombok
 	annotationProcessor libs.lombok
 
-	testImplementation libs.wiremock,
-			libs.junitJupiter,
+	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
 			libs.systemStubs,
 			project(":libs:common-services").sourceSets.test.output


### PR DESCRIPTION
## Proposed changes

### What changed

Use a custom `HTTPRequestSender` for CRI requests, which can use our existing `TracingHttpClient` based on `java.net.HttpClient`.
- Token exchange endpoint
- Credential endpoint

Also updated the tests and removed wiremock as a dependency.

### Why did it change

The existing implementation uses an internal Nimbus implementation, based on `java.net.HttpURLConnection`.

This makes it difficult to instrument for X-Ray tracing, and means we don't get other benefits from using a proper HTTP client, such as connection reuse.

The additional instrumentation means we can monitor response times per CRI and endpoint, if we wish.
