### PR TITLE
PYIC-6243: Fix Cri.DCMAW_ASYNC reference in CheckMobileAppVcReceiptHandler

### DIFF
--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -72,14 +72,12 @@ public class CheckMobileAppVcReceiptHandler
             var status = getStatus(request);
 
             return ApiGatewayResponseGenerator.proxyResponse(status);
-        } catch (InvalidCheckMobileAppVcReceiptRequestException e) {
+        } catch (InvalidCheckMobileAppVcReceiptRequestException
+                | ClientOauthSessionNotFoundException e) {
             LOGGER.info(buildErrorMessage(e.getErrorResponse()));
             return ApiGatewayResponseGenerator.proxyResponse(HttpStatus.SC_BAD_REQUEST);
         } catch (IpvSessionNotFoundException e) {
             LOGGER.info(buildErrorMessage(ErrorResponse.IPV_SESSION_NOT_FOUND));
-            return ApiGatewayResponseGenerator.proxyResponse(HttpStatus.SC_BAD_REQUEST);
-        } catch (ClientOauthSessionNotFoundException e) {
-            LOGGER.info(buildErrorMessage(e.getErrorResponse()));
             return ApiGatewayResponseGenerator.proxyResponse(HttpStatus.SC_BAD_REQUEST);
         } catch (InvalidCriResponseException e) {
             LOGGER.info(buildErrorMessage(e.getErrorResponse()));

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -128,7 +128,7 @@ public class CheckMobileAppVcReceiptHandler
         }
 
         if (!CriResponseService.STATUS_PENDING.equals(criResponse.getStatus())
-                || verifiableCredentialService.getVc(userId, Cri.DCMAW_ASYNC.toString()) != null) {
+                || verifiableCredentialService.getVc(userId, Cri.DCMAW_ASYNC.getId()) != null) {
             return HttpStatus.SC_OK;
         }
 

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/exception/InvalidCheckMobileAppVcReceiptRequestException.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/exception/InvalidCheckMobileAppVcReceiptRequestException.java
@@ -1,14 +1,14 @@
 package uk.gov.di.ipv.core.checkmobileappvcreceipt.exception;
 
 import lombok.Getter;
+import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 
 @Getter
-public class InvalidCheckMobileAppVcReceiptRequestException extends Exception {
-    private final ErrorResponse errorResponse;
-
+public class InvalidCheckMobileAppVcReceiptRequestException
+        extends HttpResponseExceptionWithErrorBody {
     public InvalidCheckMobileAppVcReceiptRequestException(ErrorResponse errorResponse) {
-        super(errorResponse.getMessage());
-        this.errorResponse = errorResponse;
+        super(HttpStatusCode.BAD_REQUEST, errorResponse);
     }
 }

--- a/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
@@ -122,8 +122,7 @@ class CheckMobileAppVcReceiptHandlerTest {
                                         "vc",
                                         Map.of("type", List.of("IdentityAssertionCredential")))));
         var vc = VerifiableCredential.fromValidJwt(TEST_USER_ID, Cri.DCMAW_ASYNC, mockSignedJwt);
-        when(verifiableCredentialService.getVc(TEST_USER_ID, Cri.DCMAW_ASYNC.toString()))
-                .thenReturn(vc);
+        when(verifiableCredentialService.getVc(TEST_USER_ID, "dcmawAsync")).thenReturn(vc);
 
         // Act
         var response = checkMobileAppVcReceiptHandler.handleRequest(requestEvent, mockContext);
@@ -171,7 +170,7 @@ class CheckMobileAppVcReceiptHandlerTest {
     private CriResponseItem buildValidCriResponseItem(String status) {
         return CriResponseItem.builder()
                 .userId(TEST_USER_ID)
-                .credentialIssuer(Cri.DCMAW_ASYNC.toString())
+                .credentialIssuer(Cri.DCMAW_ASYNC.getId())
                 .status(status)
                 .build();
     }

--- a/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/exception/InvalidMobileAppCallbackRequestException.java
+++ b/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/exception/InvalidMobileAppCallbackRequestException.java
@@ -8,6 +8,6 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 @Getter
 public class InvalidMobileAppCallbackRequestException extends HttpResponseExceptionWithErrorBody {
     public InvalidMobileAppCallbackRequestException(ErrorResponse errorResponse) {
-        super(HttpStatusCode.INTERNAL_SERVER_ERROR, errorResponse);
+        super(HttpStatusCode.BAD_REQUEST, errorResponse);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Fix Cri.DCMAW_ASYNC reference in CheckMobileAppVcReceiptHandler
- Fixed test to ensure that this issue is prevented in future

### Why did it change

- QA discovered checking/ fetching the VC didn't work

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6243](https://govukverify.atlassian.net/browse/PYIC-6243)

[PYIC-6243]: https://govukverify.atlassian.net/browse/PYIC-6243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ