### PR TITLE
IPS-1185: Update state machine deployment strategy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1510,7 +1510,7 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionDeploymentPreference
-        Interval: 10
+        Interval: 1
         Percentage: 10
         Alarms: !If
           - UseCanaryDeploymentAlarms


### PR DESCRIPTION
### What changed

- Update state machine deployment strategy
- Now LINEAR in build, previously CANARY
- i.e. 10% every 1 minute: https://github.com/govuk-one-login/identity-common-infra/pull/530

### Why did it change

- Send an increased proportion of traffic to new version to catch errors, if any

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1185](https://govukverify.atlassian.net/browse/IPS-1185)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1185]: https://govukverify.atlassian.net/browse/IPS-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ