### PR TITLE
PYIC-7642: Route alt doc CI auth source checks

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -561,11 +561,8 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       alternate-doc-invalid-dl:
-        targetState: MITIGATION_01_PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
+        targetJourney: FAILED
+        targetState: FAILED
 
   MITIGATION_01_F2F_START_PAGE:
     response:
@@ -641,11 +638,8 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       alternate-doc-invalid-dl:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
+        targetJourney: FAILED
+        targetState: FAILED
 
   MITIGATION_02_OPTIONS_WITH_F2F:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -619,11 +619,8 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       alternate-doc-invalid-dl:
-        targetState: MITIGATION_01_PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
+        targetJourney: FAILED
+        targetState: FAILED
 
   MITIGATION_01_F2F_START_PAGE:
     response:
@@ -699,11 +696,8 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       alternate-doc-invalid-dl:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
+        targetJourney: FAILED
+        targetState: FAILED
 
   MITIGATION_02_OPTIONS_WITH_F2F:
     response:


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Route alt doc CI auth source checks

### Why did it change

This updates the routing to ensure we're sending users who receive an alternate doc CI from the driving licence CRI when performing an auth source check to the right place.

Also adds/updates API tests to assert this.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7642](https://govukverify.atlassian.net/browse/PYIC-7642)


[PYIC-7642]: https://govukverify.atlassian.net/browse/PYIC-7642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ