### PR TITLE
PYIC-7530: Add routing for the new live-in-uk page

### DIFF
--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -34,6 +34,20 @@ Feature: P2 Web document journey
       | drivingLicence | kenneth-driving-permit-valid |
       | ukPassport     | kenneth-passport-valid       |
 
+  Scenario Outline: Visit UK landing page - yes
+    Given I activate the 'internationalAddress' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'next' event
+    Then I get a 'page-ipv-identity-document-start' page response
+
+  Scenario Outline: Visit UK landing page - no
+    Given I activate the 'internationalAddress' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'end' event
+    Then I get a 'identify-device' page response
+
   Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV
     Given I activate the 'dwpKbvTest' feature set
     When I start a new 'medium-confidence' journey

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -10,6 +10,9 @@ states:
     events:
       next:
         targetState: IDENTITY_START_PAGE
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: LIVE_IN_UK_PAGE
 
   ENHANCED_VERIFICATION:
     events:
@@ -766,3 +769,15 @@ states:
           mitigationType: enhanced-verification
       end:
         targetState: RETURN_TO_RP
+
+  # Live in uk journey
+  LIVE_IN_UK_PAGE:
+    response:
+      type: page
+      pageId: live-in-uk
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+      end:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -351,6 +351,7 @@ core:
     deleteDetailsEnabled: false
     pendingF2FResetEnabled: false
     strategicAppEnabled: false
+    internationalAddressEnabled: false
     inheritedIdentity: true
     repeatFraudCheckEnabled: true
     evcsWriteEnabled: true
@@ -364,6 +365,9 @@ core:
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: false
   features:
+    internationalAddress:
+      featureFlags:
+        internationalAddressEnabled: true
     drivingLicenceAuthCheck:
       featureFlags:
         drivingLicenceAuthCheck: true


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We want to enable users who do not currently live in the UK to prove their identity without having to falsely declare a UK address and without getting stuck in the process 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7530](https://govukverify.atlassian.net/browse/PYIC-7530)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7530]: https://govukverify.atlassian.net/browse/PYIC-7530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ