### PR TITLE
PYIC-7641: journey routing when user indicates DL details are incorrect and drops out of DL CRI during auth source check

### DIFF
--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-family-name-passport-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-family-name-passport-valid/credentialSubject.json
@@ -1,0 +1,28 @@
+{
+  "passport": [
+    {
+      "expiryDate": "2030-01-01",
+      "icaoIssuerCode": "GBR",
+      "documentNumber": "321654987"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "Kenneth"
+        },
+        {
+          "type": "FamilyName",
+          "value": "Smith"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-family-name-passport-valid/evidence.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-family-name-passport-valid/evidence.json
@@ -1,0 +1,15 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "checkMethod": "vri"
+    },
+    {
+      "biometricVerificationProcessLevel": 3,
+      "checkMethod": "bvr"
+    }
+  ],
+  "validityScore": 2,
+  "strengthScore": 4,
+  "type": "IdentityCheck"
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-changed-family-name-and-address-score-2/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-changed-family-name-and-address-score-2/credentialSubject.json
@@ -1,0 +1,34 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "uprn": 100120012047,
+      "buildingName": "",
+      "streetName": "King Road",
+      "postalCode": "BS9 6NR",
+      "buildingNumber": "28",
+      "addressLocality": "BRISTOL",
+      "validFrom": "1000-01-01",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "SMITH"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-changed-family-name-and-address-score-2/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-changed-family-name-and-address-score-2/evidence.json
@@ -1,0 +1,31 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "none",
+      "activityFrom": "1963-01-01",
+      "checkMethod": "data"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "mortality_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "identity_theft_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "synthetic_identity_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "impersonation_risk_check",
+      "txn": "RB000117397035"
+    }
+  ],
+  "ci": [],
+  "txn": "RB000117420948",
+  "identityFraudScore": 2,
+  "type": "IdentityCheck"
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-changed-given-name-and-address-score-2/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-changed-given-name-and-address-score-2/credentialSubject.json
@@ -1,0 +1,34 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "uprn": 100120012047,
+      "buildingName": "",
+      "streetName": "King Road",
+      "postalCode": "BS9 6NR",
+      "buildingNumber": "28",
+      "addressLocality": "BRISTOL",
+      "validFrom": "1000-01-01",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KEN"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-changed-given-name-and-address-score-2/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-changed-given-name-and-address-score-2/evidence.json
@@ -1,0 +1,31 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "none",
+      "activityFrom": "1963-01-01",
+      "checkMethod": "data"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "mortality_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "identity_theft_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "synthetic_identity_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "impersonation_risk_check",
+      "txn": "RB000117397035"
+    }
+  ],
+  "ci": [],
+  "txn": "RB000117420948",
+  "identityFraudScore": 2,
+  "type": "IdentityCheck"
+}

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -41,25 +41,7 @@ Feature: Authoritative source checks with driving licence CRI
       | low-confidence    |
       | medium-confidence |
 
-  Scenario Outline: Journey where user backs out of driving licence CRI leads to other doc type page
-    Given I activate the 'drivingLicenceAuthCheck,p1Journeys' feature sets
-    When I start a new '<journey-type>' journey
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-    Then I get a 'drivingLicence' CRI response
-    When I call the CRI stub with attributes and get an 'access_denied' OAuth error
-      | Attribute | Values          |
-      | context   | "check_details" |
-    Then I get a 'prove-identity-another-type-photo-id' page response with context 'drivingLicence'
-
-    Examples:
-      | journey-type      |
-      | low-confidence    |
-      | medium-confidence |
-
-  Scenario Outline: Separate session enhanced verification mitigation
+  Scenario Outline: Separate session enhanced verification mitigation with DCMAW and driving licence requires auth source check
     Given I activate the 'drivingLicenceAuthCheck' feature set
     And the subject already has the following credentials
       | CRI        | scenario                            |

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -15,7 +15,7 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get a 'page-dcmaw-success' page response
 
     Examples:
-      | journey-type       |
+      | journey-type      |
       | low-confidence    |
       | medium-confidence |
 
@@ -197,19 +197,17 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get a 'page-update-name' page response
     When I submit a 'update-name' event
     Then I get a 'dcmaw' CRI response
-    When I submit '<vc-scenario>' details to the CRI stub
+    When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
     Then I get a 'drivingLicence' CRI response
-    When I submit '<vc-scenario>' details with attributes to the CRI stub
+    When I submit 'kenneth-changed-given-name-driving-permit-valid' details with attributes to the CRI stub
       | Attribute | Values          |
       | context   | "check_details" |
     Then I get a 'page-dcmaw-success' page response with context '<context>'
 
     Examples:
-      | update-type             | vc-scenario                                      | context      |
-      | given-names-only        | kenneth-changed-given-name-driving-permit-valid  | coiNoAddress |
-      | given-names-and-address | kenneth-changed-given-name-driving-permit-valid  | coiAddress   |
-      | family-name-only        | kenneth-changed-family-name-driving-permit-valid | coiNoAddress |
-      | family-name-and-address | kenneth-changed-family-name-driving-permit-valid | coiAddress   |
+      | update-type             | context      |
+      | given-names-only        | coiNoAddress |
+      | given-names-and-address | coiAddress   |
 
   Scenario Outline: Change of details journey that attracts an invalid doc CI from auth source check
     Given I activate the 'drivingLicenceAuthCheck' feature set
@@ -226,7 +224,7 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get a 'page-update-name' page response
     When I submit a 'update-name' event
     Then I get a 'dcmaw' CRI response
-    When I submit '<vc-scenario>' details to the CRI stub
+    When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
     Then I get a 'drivingLicence' CRI response
     When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
       | Attribute | Values          |
@@ -234,8 +232,6 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
 
     Examples:
-      | update-type             | vc-scenario                                      |
-      | given-names-only        | kenneth-changed-given-name-driving-permit-valid  |
-      | given-names-and-address | kenneth-changed-given-name-driving-permit-valid  |
-      | family-name-only        | kenneth-changed-family-name-driving-permit-valid |
-      | family-name-and-address | kenneth-changed-family-name-driving-permit-valid |
+      | update-type             |
+      | given-names-only        |
+      | given-names-and-address |

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -34,7 +34,7 @@ Feature: Authoritative source checks with driving licence CRI
     When I submit an 'end' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity
-    Then I get a 'P0' identity without a 'dcmaw' VC
+    Then I get a 'P0' identity
 
     Examples:
       | journey-type       |

--- a/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
@@ -135,12 +135,12 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       When I submit a 'update-details' event
       Then I get a 'update-details' page response
 
-    Scenario Outline: Change of name only journey - User backs out of DL CRI - Returns to DCMAW to use passport
-      When I submit a '<update-type>' event
+    Scenario: Change of name only journey - User backs out of DL CRI - Returns to DCMAW to use passport
+      When I submit a 'given-names-only' event
       Then I get a 'page-update-name' page response
       When I submit a 'update-name' event
       Then I get a 'dcmaw' CRI response
-      When I submit '<dl-details>' details to the CRI stub
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
       Then I get a 'drivingLicence' CRI response
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error
         | Attribute | Values          |
@@ -148,11 +148,11 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       Then I get a 'uk-driving-licence-details-not-correct' page response
       When I submit a 'next' event
       Then I get a 'dcmaw' CRI response
-      When I submit '<passport-details>' details to the CRI stub
+      When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit '<fraud-details>' details to the CRI stub
+      When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -160,17 +160,12 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       Then I get a 'P2' identity
       And I have a dcmaw VC without 'drivingPermit' details
 
-      Examples:
-        | update-type             | dl-details                                       | passport-details                           | fraud-details                       |
-        | given-names-only        | kenneth-changed-given-name-driving-permit-valid  | kenneth-changed-given-name-passport-valid  | kenneth-changed-given-name-score-2  |
-        | family-name-only        | kenneth-changed-family-name-driving-permit-valid | kenneth-changed-family-name-passport-valid | kenneth-changed-family-name-score-2 |
-
-    Scenario Outline: Change of name and address journey - User backs out of DL CRI - Returns to DCMAW to use passport
-      When I submit a '<update-type>' event
+    Scenario: Change of name and address journey - User backs out of DL CRI - Returns to DCMAW to use passport
+      When I submit a 'family-name-and-address' event
       Then I get a 'page-update-name' page response
       When I submit a 'update-name' event
       Then I get a 'dcmaw' CRI response
-      When I submit '<dl-details>' details to the CRI stub
+      When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
       Then I get a 'drivingLicence' CRI response
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error
         | Attribute | Values          |
@@ -178,31 +173,26 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       Then I get a 'uk-driving-licence-details-not-correct' page response
       When I submit a 'next' event
       Then I get a 'dcmaw' CRI response
-      When I submit '<passport-details>' details to the CRI stub
+      When I submit 'kenneth-changed-family-name-passport-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
       When I submit a 'next' event
       Then I get an 'address' CRI response
       When I submit 'kenneth-changed' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit '<fraud-details>' details to the CRI stub
+      When I submit 'kenneth-changed-family-name-and-address-score-2' details to the CRI stub
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
       And I have a dcmaw VC without 'drivingPermit' details
-
-      Examples:
-        | update-type             | dl-details                                       | passport-details                           | fraud-details                                   |
-        | given-names-and-address | kenneth-changed-given-name-driving-permit-valid  | kenneth-changed-given-name-passport-valid  | kenneth-changed-given-name-and-address-score-2  |
-        | family-name-and-address | kenneth-changed-family-name-driving-permit-valid | kenneth-changed-family-name-passport-valid | kenneth-changed-family-name-and-address-score-2 |
 
     Scenario Outline: Change of details - return to RP with no identity
       When I submit a '<update-type>' event
       Then I get a 'page-update-name' page response
       When I submit a 'update-name' event
       Then I get a 'dcmaw' CRI response
-      When I submit '<dl-details>' details to the CRI stub
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
       Then I get a 'drivingLicence' CRI response
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error
         | Attribute | Values          |
@@ -216,11 +206,9 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       Then I get a 'P0' identity
 
       Examples:
-        | update-type             | dl-details                                       |
-        | given-names-only        | kenneth-changed-given-name-driving-permit-valid  |
-        | given-names-and-address | kenneth-changed-given-name-driving-permit-valid  |
-        | family-name-only        | kenneth-changed-family-name-driving-permit-valid |
-        | family-name-and-address | kenneth-changed-family-name-driving-permit-valid |
+        | update-type             |
+        | given-names-only        |
+        | given-names-and-address |
 
   Rule: Separate session enhanced verification mitigation with DCMAW + DL auth source check
     Background: User returns with an enhanced verification CI and mitigates with DCMAW but user drops out of DL CRI

--- a/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
@@ -53,7 +53,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a '<expected-identity>' identity
-    And I have a dcmaw VC without a 'drivingPermit'
+    And I have a dcmaw VC without 'drivingPermit' details
 
     Examples:
       | journey-type      | expected-identity |
@@ -89,16 +89,16 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     Then I get a 'page-face-to-face-handoff' page response
 
     # Return journey
-    When I start a new 'medium-confidence' journey and return to a 'page-ipv-reuse' page response
+    When I start a new '<journey-type>' journey and return to a 'page-ipv-reuse' page response
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity
-    Then I get a 'P2' identity without a 'dcmaw' VC
+    Then I get a '<expected-identity>' identity without a 'dcmaw' VC
 
     Examples:
-      | journey-type      | context    | evidence-requested-value                    |
-      | low-confidence    | lastChoice | {"scoringPolicy":"gpg45","strengthScore":2} |
-      | medium-confidence | null       | {"scoringPolicy":"gpg45","strengthScore":3} |
+      | journey-type      | context    | evidence-requested-value                    | expected-identity |
+      | low-confidence    | lastChoice | {"scoringPolicy":"gpg45","strengthScore":2} | P1                |
+      | medium-confidence | null       | {"scoringPolicy":"gpg45","strengthScore":3} | P2                |
 
   Scenario Outline: User backs out of DL CRI and selects to return to the RP - should not have a DCMAW VC
     When I start a new '<journey-type>' journey
@@ -158,7 +158,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
-      And I have a dcmaw VC without a 'drivingPermit'
+      And I have a dcmaw VC without 'drivingPermit' details
 
       Examples:
         | update-type             | dl-details                                       | passport-details                           | fraud-details                       |
@@ -190,7 +190,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
-      And I have a dcmaw VC without a 'drivingPermit'
+      And I have a dcmaw VC without 'drivingPermit' details
 
       Examples:
         | update-type             | dl-details                                       | passport-details                           | fraud-details                                   |

--- a/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
@@ -116,7 +116,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     When I submit a 'returnToRp' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity
-    Then I get a 'P0' identity without a 'dcmaw' VC
+    Then I get a 'P0' identity
 
     Examples:
       | journey-type      |
@@ -213,7 +213,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
-      Then I get a 'P0' identity without a 'dcmaw' VC
+      Then I get a 'P0' identity
 
       Examples:
         | update-type             | dl-details                                       |
@@ -257,7 +257,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       When I submit an 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
-      Then I get a 'P0' identity without a 'dcmaw' VC
+      Then I get a 'P0' identity
 
   Rule: Same session enhanced verification mitigation with DCMAW + DL auth source check
     Background: User gets an enhanced verification CI in the same session
@@ -306,4 +306,4 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       When I submit an 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
-      Then I get a 'P0' identity without a 'dcmaw' VC
+      Then I get a 'P0' identity

--- a/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
@@ -1,0 +1,309 @@
+@Build
+Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to incorrect details)
+  Background: Activate the featureSet
+    Given I activate the 'drivingLicenceAuthCheck,p1Journeys' feature sets
+
+  Scenario Outline: User backs out of driving licence CRI is able to return to DCMAW and re-scan their DL
+    When I start a new '<journey-type>' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'uk-driving-licence-details-not-correct' page response
+    When I submit a 'next' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'page-dcmaw-success' page response
+
+    Examples:
+      | journey-type      |
+      | low-confidence    |
+      | medium-confidence |
+
+  Scenario Outline: User backs out of driving licence CRI and returns to DCMAW with a passport - identity has only one DCMAW VC
+    When I start a new '<journey-type>' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'uk-driving-licence-details-not-correct' page response
+    When I submit a 'next' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a '<expected-identity>' identity
+    And I have a dcmaw VC without a 'drivingPermit'
+
+    Examples:
+      | journey-type      | expected-identity |
+      | low-confidence    | P1                |
+      | medium-confidence | P2                |
+
+  Scenario Outline: User backs out of driving licence CRI is able to prove their identity another way - via F2F and has no dcmaw VC
+    When I start a new '<journey-type>' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'uk-driving-licence-details-not-correct' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-another-way' page response
+    When I submit a 'postOffice' event
+    Then I get a 'page-ipv-identity-postoffice-start' page response with context '<context>'
+    When I submit a 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'f2f' CRI response
+    When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
+      | Attribute          | Values                     |
+      | evidence_requested | <evidence-requested-value> |
+    Then I get a 'page-face-to-face-handoff' page response
+
+    # Return journey
+    When I start a new 'medium-confidence' journey and return to a 'page-ipv-reuse' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity without a 'dcmaw' VC
+
+    Examples:
+      | journey-type      | context    | evidence-requested-value                    |
+      | low-confidence    | lastChoice | {"scoringPolicy":"gpg45","strengthScore":2} |
+      | medium-confidence | null       | {"scoringPolicy":"gpg45","strengthScore":3} |
+
+  Scenario Outline: User backs out of DL CRI and selects to return to the RP - should not have a DCMAW VC
+    When I start a new '<journey-type>' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'uk-driving-licence-details-not-correct' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-another-way' page response
+    When I submit a 'returnToRp' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P0' identity without a 'dcmaw' VC
+
+    Examples:
+      | journey-type      |
+      | low-confidence    |
+      | medium-confidence |
+
+  Rule: Change of details journey
+    Background: User has existing credentials and starts an update details journey
+      And the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response
+      When I submit a 'update-details' event
+      Then I get a 'update-details' page response
+
+    Scenario Outline: Change of name only journey - User backs out of DL CRI - Returns to DCMAW to use passport
+      When I submit a '<update-type>' event
+      Then I get a 'page-update-name' page response
+      When I submit a 'update-name' event
+      Then I get a 'dcmaw' CRI response
+      When I submit '<dl-details>' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'uk-driving-licence-details-not-correct' page response
+      When I submit a 'next' event
+      Then I get a 'dcmaw' CRI response
+      When I submit '<passport-details>' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit '<fraud-details>' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+      And I have a dcmaw VC without a 'drivingPermit'
+
+      Examples:
+        | update-type             | dl-details                                       | passport-details                           | fraud-details                       |
+        | given-names-only        | kenneth-changed-given-name-driving-permit-valid  | kenneth-changed-given-name-passport-valid  | kenneth-changed-given-name-score-2  |
+        | family-name-only        | kenneth-changed-family-name-driving-permit-valid | kenneth-changed-family-name-passport-valid | kenneth-changed-family-name-score-2 |
+
+    Scenario Outline: Change of name and address journey - User backs out of DL CRI - Returns to DCMAW to use passport
+      When I submit a '<update-type>' event
+      Then I get a 'page-update-name' page response
+      When I submit a 'update-name' event
+      Then I get a 'dcmaw' CRI response
+      When I submit '<dl-details>' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'uk-driving-licence-details-not-correct' page response
+      When I submit a 'next' event
+      Then I get a 'dcmaw' CRI response
+      When I submit '<passport-details>' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-changed' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit '<fraud-details>' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+      And I have a dcmaw VC without a 'drivingPermit'
+
+      Examples:
+        | update-type             | dl-details                                       | passport-details                           | fraud-details                                   |
+        | given-names-and-address | kenneth-changed-given-name-driving-permit-valid  | kenneth-changed-given-name-passport-valid  | kenneth-changed-given-name-and-address-score-2  |
+        | family-name-and-address | kenneth-changed-family-name-driving-permit-valid | kenneth-changed-family-name-passport-valid | kenneth-changed-family-name-and-address-score-2 |
+
+    Scenario Outline: Change of details - return to RP with no identity
+      When I submit a '<update-type>' event
+      Then I get a 'page-update-name' page response
+      When I submit a 'update-name' event
+      Then I get a 'dcmaw' CRI response
+      When I submit '<dl-details>' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'uk-driving-licence-details-not-correct' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-another-way' page response with context 'noF2f'
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity without a 'dcmaw' VC
+
+      Examples:
+        | update-type             | dl-details                                       |
+        | given-names-only        | kenneth-changed-given-name-driving-permit-valid  |
+        | given-names-and-address | kenneth-changed-given-name-driving-permit-valid  |
+        | family-name-only        | kenneth-changed-family-name-driving-permit-valid |
+        | family-name-and-address | kenneth-changed-family-name-driving-permit-valid |
+
+  Rule: Separate session enhanced verification mitigation with DCMAW + DL auth source check
+    Background: User returns with an enhanced verification CI and mitigates with DCMAW but user drops out of DL CRI
+      And the subject already has the following credentials
+        | CRI        | scenario                            |
+        | ukPassport | kenneth-passport-valid              |
+        | address    | kenneth-current                     |
+        | fraud      | kenneth-score-2                     |
+        | kbv        | kenneth-needs-enhanced-verification |
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'uk-driving-licence-details-not-correct' page response
+
+    Scenario: User is able to return to DCMAW
+      When I submit a 'next' event
+      Then I get a 'dcmaw' CRI response
+
+    Scenario: User is able to mitigate via F2f
+      When I submit an 'end' event
+      Then I get a 'prove-identity-another-way' page response
+      When I submit a 'postOffice' event
+      Then I get a 'pyi-post-office' page response
+
+    Scenario: User returns to RP without identity
+      When I submit an 'end' event
+      Then I get a 'prove-identity-another-way' page response
+      When I submit an 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity without a 'dcmaw' VC
+
+  Rule: Same session enhanced verification mitigation with DCMAW + DL auth source check
+    Background: User gets an enhanced verification CI in the same session
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'kbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'pyi-suggest-other-options' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'uk-driving-licence-details-not-correct' page response
+
+    Scenario: User is able to return to DCMAW
+      When I submit a 'next' event
+      Then I get a 'dcmaw' CRI response
+
+    Scenario: User is able to mitigate via F2f
+      When I submit an 'end' event
+      Then I get a 'prove-identity-another-way' page response
+      When I submit a 'postOffice' event
+      Then I get a 'pyi-post-office' page response
+
+    Scenario: User returns to RP without identity
+      When I submit an 'end' event
+      Then I get a 'prove-identity-another-way' page response
+      When I submit an 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity without a 'dcmaw' VC

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -347,7 +347,7 @@ Then(
 );
 
 Then(
-  /I have a dcmaw VC (with|without) a '(passport|drivingPermit)'/,
+  /I have a dcmaw VC (with|without) '(passport|drivingPermit)' details/,
   async function (
     this: World,
     withOrWithout: "with" | "without",

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -347,6 +347,43 @@ Then(
 );
 
 Then(
+  /I have a dcmaw VC (with|without) a '(passport|drivingPermit)'/,
+  async function (
+    this: World,
+    withOrWithout: "with" | "without",
+    passportOrDrivingPermit: "passport" | "drivingPermit",
+  ): Promise<void> {
+    if (!this.identity) {
+      throw new Error("No identity found.");
+    }
+
+    if (!this.vcs) {
+      throw new Error("No credentials found.");
+    }
+
+    const dcmawVc = this.vcs[buildCredentialIssuerUrl("dcmaw")];
+    if (!dcmawVc) {
+      throw new Error("Identity does not have a dcmaw VC");
+    }
+
+    const credentialSubject = dcmawVc.vc.credentialSubject;
+    if (!credentialSubject) {
+      throw new Error("dcmaw VC does not have a credential subject");
+    }
+
+    const ispassportOrDrivingPermitInVc =
+      passportOrDrivingPermit in credentialSubject;
+
+    assert.ok(
+      withOrWithout === "with"
+        ? ispassportOrDrivingPermitInVc
+        : !ispassportOrDrivingPermitInVc,
+      `dcmaw VC does${withOrWithout === "with" ? " not" : " "}contain ${passportOrDrivingPermit}.`,
+    );
+  },
+);
+
+Then(
   "I get {string} return code(s)",
   function (this: World, expectedReturnCodes: string): void {
     if (!this.identity) {

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
@@ -45,10 +45,10 @@ nestedJourneyStates:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: ALL
+        resetType: ALL # TODO: make this only clear DCMAW VCs
     events:
       next:
-        exitEventToEmit: incomplete-invalid-dl
+        targetState: DL_DETAILS_INCORRECT_PAGE
 
   RESET_SESSION_INVALID_DL:
     response:
@@ -59,3 +59,13 @@ nestedJourneyStates:
     events:
       next:
         exitEventToEmit: alternate-doc-invalid-dl
+
+  DL_DETAILS_INCORRECT_PAGE:
+    response:
+      type: page
+      pageId: uk-driving-licence-details-not-correct
+    events:
+      next:
+        targetState: CRI_DCMAW
+      end:
+        exitEventToEmit: incomplete-invalid-dl

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
@@ -36,11 +36,11 @@ nestedJourneyStates:
       next:
         exitEventToEmit: next
       access-denied:
-        targetState: RESET_SESSION_INCOMPLETE_DL
+        targetState: RESET_DCMAW_INCOMPLETE_DL
       alternate-doc-invalid-dl:
         targetState: RESET_SESSION_INVALID_DL
 
-  RESET_SESSION_INCOMPLETE_DL:
+  RESET_DCMAW_INCOMPLETE_DL:
     response:
       type: process
       lambda: reset-session-identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
@@ -55,7 +55,7 @@ nestedJourneyStates:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: ALL
+        resetType: DCMAW
     events:
       next:
         exitEventToEmit: alternate-doc-invalid-dl

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
@@ -45,7 +45,7 @@ nestedJourneyStates:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: ALL # TODO: make this only clear DCMAW VCs
+        resetType: DCMAW
     events:
       next:
         targetState: DL_DETAILS_INCORRECT_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/app-doc-check.yaml
@@ -36,11 +36,11 @@ nestedJourneyStates:
       next:
         exitEventToEmit: next
       access-denied:
-        targetState: RESET_DCMAW_INCOMPLETE_DL
+        targetState: REMOVE_DCMAW_FROM_SESSION
       alternate-doc-invalid-dl:
         targetState: RESET_SESSION_INVALID_DL
 
-  RESET_DCMAW_INCOMPLETE_DL:
+  REMOVE_DCMAW_FROM_SESSION:
     response:
       type: process
       lambda: reset-session-identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -205,7 +205,10 @@ states:
         targetState: APP_DOC_CHECK
         targetEntryEvent: next
       postOffice:
-        targetState: NINO_START_PAGE
+        targetState: F2F_START_PAGE
+        checkIfDisabled:
+          f2f:
+            targetState: PYI_ESCAPE
       returnToRp:
         targetState: RETURN_TO_RP
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -228,8 +228,7 @@ states:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:
           f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
+            targetState: PYI_ESCAPE
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -191,11 +191,23 @@ states:
       incomplete:
         targetState: MULTIPLE_DOC_CHECK_PAGE
       incomplete-invalid-dl:
-        targetState: WEB_DL_OR_PASSPORT
-        targetEntryEvent: another-way-after-dl
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK
       alternate-doc-invalid-dl:
         targetState: WEB_DL_OR_PASSPORT
         targetEntryEvent: alternate-doc-invalid-dl-another-way
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+      postOffice:
+        targetState: NINO_START_PAGE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -213,7 +225,8 @@ states:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:
           f2f:
-            targetState: PYI_ESCAPE
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -555,14 +568,27 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       incomplete-invalid-dl:
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_MITIGATION_APP_DOC_CHECK
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_MITIGATION_APP_DOC_CHECK:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+    events:
+      anotherTypePhotoId:
+        targetState: MITIGATION_01_APP_DOC_CHECK
+        targetEntryEvent: next
+      postOffice:
         targetState: MITIGATION_01_PYI_POST_OFFICE
         checkIfDisabled:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_01_F2F_START_PAGE:
     response:
@@ -632,14 +658,27 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       incomplete-invalid-dl:
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+      postOffice:
         targetState: PYI_POST_OFFICE
         checkIfDisabled:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_02_OPTIONS_WITH_F2F:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -149,11 +149,27 @@ states:
       incomplete:
         targetState: MULTIPLE_DOC_CHECK_PAGE
       incomplete-invalid-dl:
-        targetState: WEB_DL_OR_PASSPORT
-        targetEntryEvent: another-way-after-dl
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK
       alternate-doc-invalid-dl:
         targetState: WEB_DL_OR_PASSPORT
         targetEntryEvent: alternate-doc-invalid-dl-another-way
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+      postOffice:
+        targetState: F2F_START_PAGE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   STRATEGIC_APP_TRIAGE:
     nestedJourney: STRATEGIC_APP_TRIAGE
@@ -613,14 +629,27 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       incomplete-invalid-dl:
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_MITIGATION_APP_DOC_CHECK
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_MITIGATION_APP_DOC_CHECK:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+    events:
+      anotherTypePhotoId:
+        targetState: MITIGATION_01_APP_DOC_CHECK
+        targetEntryEvent: next
+      postOffice:
         targetState: MITIGATION_01_PYI_POST_OFFICE
         checkIfDisabled:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_01_F2F_START_PAGE:
     response:
@@ -698,6 +727,23 @@ states:
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+      postOffice:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_02_OPTIONS_WITH_F2F:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -719,11 +719,7 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       incomplete-invalid-dl:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -205,11 +205,22 @@ states:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
       incomplete-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_ONLY
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_ONLY:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+      context: noF2f
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK_GIVEN_ONLY
+        targetEntryEvent: next
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   APP_DOC_CHECK_FAMILY_ONLY:
     nestedJourney: APP_DOC_CHECK
@@ -220,11 +231,22 @@ states:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
       incomplete-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_FAMILY_ONLY
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_FAMILY_ONLY:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+      context: noF2f
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK_FAMILY_ONLY
+        targetEntryEvent: next
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   POST_APP_DOC_CHECK_GIVEN_ONLY:
     response:
@@ -367,11 +389,22 @@ states:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
       incomplete-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
+        targetState: PROVE_IDENTITY_ANTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_WITH_ADDRESS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_WITH_ADDRESS:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+      context: noF2f
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK_GIVEN_WITH_ADDRESS
+        targetEntryEvent: next
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   APP_DOC_CHECK_FAMILY_WITH_ADDRESS:
     nestedJourney: APP_DOC_CHECK
@@ -382,11 +415,22 @@ states:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
       incomplete-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_FAMILY_WITH_ADDRESS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_FAMILY_WITH_ADDRESS:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+      context: noF2f
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK_FAMILY_WITH_ADDRESS
+        targetEntryEvent: next
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   POST_APP_DOC_CHECK_GIVEN_WITH_ADDRESS:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -389,7 +389,7 @@ states:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
       incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_WITH_ADDRESS
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_WITH_ADDRESS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.enums;
 
 public enum SessionCredentialsResetType {
     ALL,
+    DCMAW,
     NAME_ONLY_CHANGE,
     ADDRESS_ONLY_CHANGE,
     PENDING_F2F_ALL,

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.SESSION_CREDENTIALS_TTL;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_FRAUD;
 
 public class SessionCredentialsService {
@@ -108,6 +109,9 @@ public class SessionCredentialsService {
                                         item ->
                                                 List.of(ADDRESS.getId(), EXPERIAN_FRAUD.getId())
                                                         .contains(item.getCriId()))
+                                .toList();
+                        case DCMAW -> sessionCredentialItems.stream()
+                                .filter(item -> DCMAW.getId().equals(item.getCriId()))
                                 .toList();
                         case NAME_ONLY_CHANGE -> sessionCredentialItems.stream()
                                 .filter(item -> !item.getCriId().equals(ADDRESS.getId()))

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -326,6 +326,35 @@ class SessionCredentialsServiceTest {
         }
 
         @Test
+        void deleteSessionCredentialsForResetTypeShouldDeleteDcmawVcs() throws Exception {
+            var addressVc = generateVerifiableCredential("userId", ADDRESS, vcClaim(Map.of()));
+            var fraudVc = generateVerifiableCredential("userId", EXPERIAN_FRAUD, vcClaim(Map.of()));
+
+            var dcmawVc = generateVerifiableCredential("userId", DCMAW, vcClaim(Map.of()));
+
+            var hmrcKbvVc = generateVerifiableCredential("userId", HMRC_KBV, vcClaim(Map.of()));
+
+            var sessionFraudCredentialItem = fraudVc.toSessionCredentialItem(SESSION_ID, true);
+            var sessionAddressCredentialItem = addressVc.toSessionCredentialItem(SESSION_ID, true);
+            var sessionDcmawCredentialItem = dcmawVc.toSessionCredentialItem(SESSION_ID, true);
+            var sessionHmrcKbvCredentialItem = hmrcKbvVc.toSessionCredentialItem(SESSION_ID, true);
+
+            when(mockDataStore.getItems(SESSION_ID))
+                    .thenReturn(
+                            List.of(
+                                    sessionFraudCredentialItem,
+                                    sessionAddressCredentialItem,
+                                    sessionDcmawCredentialItem,
+                                    sessionHmrcKbvCredentialItem));
+
+            sessionCredentialService.deleteSessionCredentialsForResetType(
+                    SESSION_ID, SessionCredentialsResetType.DCMAW);
+
+            verify(mockDataStore).getItems(SESSION_ID);
+            verify(mockDataStore).delete(List.of(sessionDcmawCredentialItem));
+        }
+
+        @Test
         void deleteSessionCredentialsForCriShouldThrowIfProblemGetting() {
             when(mockDataStore.getItemsBySortKeyPrefix(SESSION_ID, CREDENTIAL_1.getCri().getId()))
                     .thenThrow(new IllegalStateException());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- routing the user to new screens for DL auth source check
- clearing DCMAW VC after dropping out of DL CRI during DL auth source check
- update unit tests + api tests

### Why did it change
If a user indicates that their DL details are incorrect (e.g. bc of bad scan) then they should be routed to new DL auth source check pages which gives them options to try proving their identity in other ways or return to the RP.
The DCMAW VC gained during their session is also deleted to avoid issues with data integrity further down the journey/

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7641](https://govukverify.atlassian.net/browse/PYIC-7641)


[PYIC-7641]: https://govukverify.atlassian.net/browse/PYIC-7641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ