### PR TITLE
PYIC-7647: Add international address question to COI and RFC journeys

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
@@ -6,11 +6,24 @@ entryEvents:
     targetState: CRI_ADDRESS
   enhanced-verification:
     targetState: CRI_ADDRESS
+  askInternationalAddress:
+    targetState: CRI_ADDRESS_ASK_INTERNATIONAL
 nestedJourneyStates:
   CRI_ADDRESS:
     response:
       type: cri
       criId: address
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CRI_FRAUD
+      enhanced-verification:
+        targetState: CRI_FRAUD
+  CRI_ADDRESS_ASK_INTERNATIONAL:
+    response:
+      type: cri
+      criId: address
+      context: international_user
     parent: CRI_STATE
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -79,6 +79,10 @@ states:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
+            targetEntryEvent: askInternationalAddress
 
   ADDRESS_AND_FRAUD_UPDATE_ADDRESS:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -440,6 +440,10 @@ states:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_GIVEN
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: ADDRESS_AND_FRAUD_GIVEN
+            targetEntryEvent: askInternationalAddress
 
   POST_APP_DOC_CHECK_FAMILY_WITH_ADDRESS:
     response:
@@ -449,6 +453,10 @@ states:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_FAMILY
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: ADDRESS_AND_FRAUD_FAMILY
+            targetEntryEvent: askInternationalAddress
 
   ADDRESS_AND_FRAUD_GIVEN:
     nestedJourney: ADDRESS_AND_FRAUD


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added context for address CRI when in a COI or RFC journey

### Why did it change

As part of the international address changes

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7647](https://govukverify.atlassian.net/browse/PYIC-7647)


[PYIC-7647]: https://govukverify.atlassian.net/browse/PYIC-7647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ