### PR TITLE
PYIC-7660: Update local stub client ids and jwksUrl

### DIFF
--- a/api-tests/data/jar-requests/low-confidence.json
+++ b/api-tests/data/jar-requests/low-confidence.json
@@ -1,8 +1,8 @@
 {
   "sub": "",
-  "iss": "orchestrator",
+  "iss": "orchStub",
   "response_type": "code",
-  "client_id": "orchestrator",
+  "client_id": "orchStub",
   "govuk_signin_journey_id": "",
   "aud": "",
   "nbf": 1,

--- a/api-tests/data/jar-requests/medium-confidence-invalid-redirect-uri.json
+++ b/api-tests/data/jar-requests/medium-confidence-invalid-redirect-uri.json
@@ -1,8 +1,8 @@
 {
   "sub": "",
-  "iss": "orchestrator",
+  "iss": "orchStub",
   "response_type": "code",
-  "client_id": "orchestrator",
+  "client_id": "orchStub",
   "govuk_signin_journey_id": "",
   "aud": "",
   "nbf": 1,

--- a/api-tests/data/jar-requests/medium-confidence-pcl200-pcl250.json
+++ b/api-tests/data/jar-requests/medium-confidence-pcl200-pcl250.json
@@ -1,8 +1,8 @@
 {
   "sub": "",
-  "iss": "orchestrator",
+  "iss": "orchStub",
   "response_type": "code",
-  "client_id": "orchestrator",
+  "client_id": "orchStub",
   "govuk_signin_journey_id": "",
   "aud": "",
   "nbf": 1,

--- a/api-tests/data/jar-requests/medium-confidence-pcl250.json
+++ b/api-tests/data/jar-requests/medium-confidence-pcl250.json
@@ -1,8 +1,8 @@
 {
   "sub": "",
-  "iss": "orchestrator",
+  "iss": "orchStub",
   "response_type": "code",
-  "client_id": "orchestrator",
+  "client_id": "orchStub",
   "govuk_signin_journey_id": "",
   "aud": "",
   "nbf": 1,

--- a/api-tests/data/jar-requests/medium-confidence-with-invalid-audience.json
+++ b/api-tests/data/jar-requests/medium-confidence-with-invalid-audience.json
@@ -1,8 +1,8 @@
 {
   "sub": "",
-  "iss": "orchestrator",
+  "iss": "orchStub",
   "response_type": "code",
-  "client_id": "orchestrator",
+  "client_id": "orchStub",
   "govuk_signin_journey_id": "",
   "aud": "invalid-audience",
   "nbf": 1,

--- a/api-tests/data/jar-requests/medium-confidence.json
+++ b/api-tests/data/jar-requests/medium-confidence.json
@@ -1,8 +1,8 @@
 {
   "sub": "",
-  "iss": "orchestrator",
+  "iss": "orchStub",
   "response_type": "code",
-  "client_id": "orchestrator",
+  "client_id": "orchStub",
   "govuk_signin_journey_id": "",
   "aud": "",
   "nbf": 1,

--- a/api-tests/data/jar-requests/reverification.json
+++ b/api-tests/data/jar-requests/reverification.json
@@ -1,8 +1,8 @@
 {
   "sub": "",
-  "iss": "stubAuth",
+  "iss": "authStub",
   "response_type": "code",
-  "client_id": "stubAuth",
+  "client_id": "authStub",
   "govuk_signin_journey_id": "",
   "aud": "",
   "nbf": 1,

--- a/api-tests/src/utils/request-body-generators.ts
+++ b/api-tests/src/utils/request-body-generators.ts
@@ -16,7 +16,7 @@ import {
 } from "../types/internal-api.js";
 import { EvcsStubPostVcsRequest } from "../types/evcs-stub.js";
 
-const ORCHESTRATOR_CLIENT_ID = "orchestrator";
+const ORCHESTRATOR_CLIENT_ID = "orchStub";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 type JsonType = "credentialSubject" | "evidence";
 

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -42,12 +42,14 @@ core:
       publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "openid"
+      jwksUrl: "http://localhost:4500/.well-known/jwks.json"
     authStub:
       id: authStub
       issuer: authStub
       publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "reverification"
+      jwksUrl: "http://localhost:4500/.well-known/jwks.json"
   cimit:
     componentId: "https://cimit.stubs.account.gov.uk"
     signingKey: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -36,15 +36,15 @@ core:
   bulkMigration:
     rolledBackBatchIds: "noneConfigured"
   clients:
-    orchestrator:
-      id: orchestrator
-      issuer: orchestrator
+    orchStub:
+      id: orchStub
+      issuer: orchStub
       publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "openid"
-    stubAuth:
-      id: stubAuth
-      issuer: stubAuth
+    authStub:
+      id: authStub
+      issuer: authStub
       publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "reverification"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update local stub client ids and jwksUrl

### Why did it change

[PYIC-7660: Update client IDs](https://github.com/govuk-one-login/ipv-core-back/commit/d214ba96bb34affef102eaa54e03a964c7957e8f)

Updates the client IDs used for orch and auth stub in the API tests as
well as local running

[BAU: Configure local running clients jwksUrl](https://github.com/govuk-one-login/ipv-core-back/commit/95d46a348bf7104f482fc172f27b3c8e90853999)

The orch stub has a jwks endpoint, and we should add it to the clients
configuration.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7660](https://govukverify.atlassian.net/browse/PYIC-7660)


[PYIC-7660]: https://govukverify.atlassian.net/browse/PYIC-7660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ