### PR TITLE
BAU: Retry on Connection reset errors

### DIFF
--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/TracingHttpClientTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/TracingHttpClientTest.java
@@ -1,0 +1,51 @@
+package uk.gov.di.ipv.core.library;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TracingHttpClientTest {
+    @Mock private HttpClient mockHttpClient;
+    @InjectMocks private TracingHttpClient tracingHttpClient;
+
+    @Test
+    void sendShouldRetryGoawayResponse() throws Exception {
+        when(mockHttpClient.send(any(), any()))
+                .thenThrow(new IOException("GOAWAY received"))
+                .thenReturn(null);
+
+        tracingHttpClient.send(
+                HttpRequest.newBuilder().uri(URI.create("https://example.com")).build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        verify(mockHttpClient, times(2)).send(any(), any());
+    }
+
+    @Test
+    void sendShouldRetryConnectionReset() throws Exception {
+        when(mockHttpClient.send(any(), any()))
+                .thenThrow(new IOException("Connection reset"))
+                .thenReturn(null);
+
+        tracingHttpClient.send(
+                HttpRequest.newBuilder().uri(URI.create("https://example.com")).build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        verify(mockHttpClient, times(2)).send(any(), any());
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Retry on Connection reset errors

### Why did it change

We're seeing exceptions due to connections being reset when attempting to fetch an access token from the CRI stubs in the build env.

This seems to be happening due to idle connections being picked up from the connection pool of the http client. It seems the connection is being reset by something upstream. I've seen it happen when a connection is over 8 minutes old, but it could be happening earlier.

Setting the keepalive timeout system property to a low value should resolve this, but it doesn't. I've tried it at 30 seconds and we're still getting the issue.

Retrying seems to be the simplest option, although it comes with a risk that the retry will occur with a connection in the pool which is has also been reset.

The inherently spikey nature of traffic in the build env - nothing, then a bunch of parallel tests hitting it at once - might explain why we see this. We create a bunch of connections to satisfy all the requests, and then they become stale.

There is some chat online about it being a NAT gateway sending a RST response, rather than FIN that is causing the issue. We seem to have the same issue as described there, including using keepalive timeout not working: https://stackoverflow.com/questions/63605720/intermittent-java-io-ioexception-connection-reset-not-connection-reset-by-peer
