### PR TITLE
PYIC-7508: Check doc ID in auth source check

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -36,8 +36,7 @@ import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredenti
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.ipv.core.processcricallback.exception.InvalidCriCallbackRequestException;
-import uk.gov.di.model.DrivingPermitDetails;
-import uk.gov.di.model.PersonWithDocuments;
+import uk.gov.di.model.IdentityCheckSubject;
 
 import java.util.Arrays;
 import java.util.List;
@@ -45,7 +44,10 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.DL_AUTH_SOURCE_CHECK;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
+import static uk.gov.di.ipv.core.library.domain.Cri.DRIVING_LICENCE;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_VALIDATE_VERIFIABLE_CREDENTIAL_RESPONSE;
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ACCESS_DENIED_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DL_AUTH_SOURCE_CHECK_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
@@ -269,31 +271,44 @@ public class CriCheckingService {
 
     private boolean requiresAuthoritativeSourceCheck(
             List<VerifiableCredential> newVcs, List<VerifiableCredential> sessionVcs) {
-        return extractDrivingPermitIdentifier(newVcs, Cri.DCMAW, false)
+        return findSuccessfulVcFromCri(DCMAW, newVcs)
+                .map(this::getDrivingPermitIdentifier)
                 .map(
-                        identifier ->
-                                !identifier.equals(
-                                        extractDrivingPermitIdentifier(
-                                                        sessionVcs, Cri.DRIVING_LICENCE, true)
-                                                .orElse(null)))
+                        dcmawDpId ->
+                                findSuccessfulVcFromCri(DRIVING_LICENCE, sessionVcs)
+                                        .map(
+                                                dlVc ->
+                                                        !Objects.equals(
+                                                                dcmawDpId,
+                                                                getDrivingPermitIdentifier(dlVc)))
+                                        .orElse(true))
                 .orElse(false);
     }
 
-    private Optional<String> extractDrivingPermitIdentifier(
-            List<VerifiableCredential> vcs, Cri cri, boolean successfulCheck) {
+    private Optional<VerifiableCredential> findSuccessfulVcFromCri(
+            Cri cri, List<VerifiableCredential> vcs) {
         return vcs.stream()
                 .filter(vc -> cri.equals(vc.getCri()))
-                .filter(successfulCheck ? VcHelper::isSuccessfulVc : x -> true)
-                .map(
-                        vc ->
-                                vc.getCredential().getCredentialSubject()
-                                                instanceof PersonWithDocuments personWithDocuments
-                                        ? personWithDocuments.getDrivingPermit()
-                                        : null)
-                .filter(Objects::nonNull)
-                .filter(drivingPermitDetailsList -> !drivingPermitDetailsList.isEmpty())
-                .map(drivingPermitDetailsList -> drivingPermitDetailsList.get(0))
-                .map(DrivingPermitDetails::getPersonalNumber)
+                .filter(VcHelper::isSuccessfulVc)
                 .findFirst();
+    }
+
+    private String getDrivingPermitIdentifier(VerifiableCredential vc) {
+        if (vc.getCredential().getCredentialSubject()
+                        instanceof IdentityCheckSubject identityCheckSubject
+                && identityCheckSubject.getDrivingPermit() != null
+                && !identityCheckSubject.getDrivingPermit().isEmpty()) {
+            var permit = identityCheckSubject.getDrivingPermit().get(0);
+            return String.format(
+                    "drivingPermit/%s/%s/%s/%s",
+                    permit.getIssuingCountry(),
+                    permit.getIssuedBy(),
+                    permit.getPersonalNumber(),
+                    permit.getIssueDate());
+        }
+        LOGGER.warn(
+                LogHelper.buildLogMessage("Unable to get driving permit identifier from VC")
+                        .with(LOG_CRI_ID.getFieldName(), vc.getCri()));
+        return null;
     }
 }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -52,6 +52,8 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.DCMAW_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1B_DCMAW_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitEmptyDrivingPermit;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitMissingDrivingPermit;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitNonDcmaw;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ACCESS_DENIED_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DL_AUTH_SOURCE_CHECK_PATH;
@@ -666,20 +668,61 @@ class CriCheckingServiceTest {
         }
 
         @Test
-        void
-                checkVcResponseShouldReturnDlAuthSourceCheckForDlDcmawVcAndUnsuccessfulDrivingLicenceVc()
-                        throws Exception {
+        void checkVcResponseShouldReturnDlAuthSourceCheckForDlDcmawVcAndFailedDrivingLicenceVc()
+                throws Exception {
             var callbackRequest = buildValidCallbackRequest();
             var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
             var ipvSessionItem = buildValidIpvSessionItem();
 
-            mockedVcHelper
-                    .when(() -> VcHelper.isSuccessfulVc(any()))
-                    .thenReturn(true)
-                    .thenReturn(false);
+            var drivingPermitVc = vcDrivingPermit();
             when(mockSessionCredentialsService.getCredentials(
                             ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId()))
-                    .thenReturn(List.of(vcDrivingPermit()));
+                    .thenReturn(List.of(drivingPermitVc));
+
+            mockedVcHelper.when(() -> VcHelper.isSuccessfulVc(M1B_DCMAW_VC)).thenCallRealMethod();
+            mockedVcHelper.when(() -> VcHelper.isSuccessfulVc(drivingPermitVc)).thenReturn(false);
+
+            JourneyResponse result =
+                    criCheckingService.checkVcResponse(
+                            List.of(M1B_DCMAW_VC),
+                            callbackRequest.getIpAddress(),
+                            clientOAuthSessionItem,
+                            ipvSessionItem);
+
+            assertEquals(new JourneyResponse(JOURNEY_DL_AUTH_SOURCE_CHECK_PATH), result);
+        }
+
+        @Test
+        void checkVcResponseShouldReturnDlAuthSourceCheckForDlDcmawVcAndDlVcWithMissingPermit()
+                throws Exception {
+            var callbackRequest = buildValidCallbackRequest();
+            var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
+            var ipvSessionItem = buildValidIpvSessionItem();
+
+            when(mockSessionCredentialsService.getCredentials(
+                            ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId()))
+                    .thenReturn(List.of(vcDrivingPermitMissingDrivingPermit()));
+
+            JourneyResponse result =
+                    criCheckingService.checkVcResponse(
+                            List.of(M1B_DCMAW_VC),
+                            callbackRequest.getIpAddress(),
+                            clientOAuthSessionItem,
+                            ipvSessionItem);
+
+            assertEquals(new JourneyResponse(JOURNEY_DL_AUTH_SOURCE_CHECK_PATH), result);
+        }
+
+        @Test
+        void checkVcResponseShouldReturnDlAuthSourceCheckForDlDcmawVcAndDlVcEmptyDrivingPermit()
+                throws Exception {
+            var callbackRequest = buildValidCallbackRequest();
+            var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
+            var ipvSessionItem = buildValidIpvSessionItem();
+
+            when(mockSessionCredentialsService.getCredentials(
+                            ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId()))
+                    .thenReturn(List.of(vcDrivingPermitEmptyDrivingPermit()));
 
             JourneyResponse result =
                     criCheckingService.checkVcResponse(
@@ -705,7 +748,7 @@ class CriCheckingServiceTest {
             JourneyResponse result =
                     criCheckingService.checkVcResponse(
                             List.of(M1B_DCMAW_VC),
-                            callbackRequest,
+                            callbackRequest.getIpAddress(),
                             clientOAuthSessionItem,
                             ipvSessionItem);
 
@@ -714,7 +757,7 @@ class CriCheckingServiceTest {
 
         @Test
         void
-                checkVcResponseShouldNotReturnDlAuthSourceCheckForDlDcmawVcAndSuccessfulDrivingLicenceVc()
+                checkVcResponseShouldNotReturnDlAuthSourceCheckForDlDcmawVcAndDrivingLicenceVcIfIdentifiersMatch()
                         throws Exception {
             var callbackRequest = buildValidCallbackRequest();
             var clientOAuthSessionItem = buildValidClientOAuthSessionItem();

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -52,6 +52,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.DCMAW_PASSPORT_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1B_DCMAW_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitNonDcmaw;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ACCESS_DENIED_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DL_AUTH_SOURCE_CHECK_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
@@ -684,6 +685,27 @@ class CriCheckingServiceTest {
                     criCheckingService.checkVcResponse(
                             List.of(M1B_DCMAW_VC),
                             callbackRequest.getIpAddress(),
+                            clientOAuthSessionItem,
+                            ipvSessionItem);
+
+            assertEquals(new JourneyResponse(JOURNEY_DL_AUTH_SOURCE_CHECK_PATH), result);
+        }
+
+        @Test
+        void checkVcResponseShouldReturnDlAuthSourceIfDrivingPermitIdentifiersDiffer()
+                throws Exception {
+            var callbackRequest = buildValidCallbackRequest();
+            var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
+            var ipvSessionItem = buildValidIpvSessionItem();
+
+            when(mockSessionCredentialsService.getCredentials(
+                            ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId()))
+                    .thenReturn(List.of(vcDrivingPermitNonDcmaw()));
+
+            JourneyResponse result =
+                    criCheckingService.checkVcResponse(
+                            List.of(M1B_DCMAW_VC),
+                            callbackRequest,
                             clientOAuthSessionItem,
                             ipvSessionItem);
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -111,7 +111,7 @@ public enum ErrorResponse {
     ERROR_MOBILE_APP_RESPONSE_STATUS(1097, "Mobile app cri response has status error"),
     INVALID_PROCESS_MOBILE_APP_JOURNEY_TYPE(1098, "Invalid process mobile app journey type"),
     FAILED_TO_PARSE_MOBILE_APP_CALLBACK_REQUEST_BODY(
-            1099, "Failed to parse mobile app callback request bpdy"),
+            1099, "Failed to parse mobile app callback request body"),
     CRI_RESPONSE_ITEM_NOT_FOUND(1100, "CRI response item cannot be found");
 
     private static final String ERROR = "error";

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -474,7 +474,11 @@ public interface VcFixtures {
 
     VerifiableCredential VC_ADDRESS =
             generateAddressVc(
-                    TestVc.TestCredentialSubject.builder().address(List.of(ADDRESS_1)).build());
+                    TestVc.TestCredentialSubject.builder()
+                            .address(List.of(ADDRESS_1))
+                            .name(null)
+                            .birthDate(null)
+                            .build());
 
     static VerifiableCredential vcAddressEmpty() {
         return generateAddressVc(TestVc.TestCredentialSubject.builder().build());
@@ -503,6 +507,7 @@ public interface VcFixtures {
             generateAddressVc(
                     TestVc.TestCredentialSubject.builder()
                             .name(null)
+                            .birthDate(null)
                             .address(List.of(ADDRESS_3))
                             .build());
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Check doc ID in auth source check

### Why did it change

We want to be more sure that when using a previously attained driving licence VC to dodge the auth source check, that the document used is the same as that used at DCMAW.

This checks that the document identifiers in both VCs match, and if not route to an auth source check.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7508](https://govukverify.atlassian.net/browse/PYIC-7508)


[PYIC-7508]: https://govukverify.atlassian.net/browse/PYIC-7508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ