### PR TITLE
Pyic 7531 international address context

### DIFF
--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -6,10 +6,35 @@ Feature: P2 App journey
     And I activate the 'internationalAddress' feature sets
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
-    When I submit an 'international' event
+
+  Scenario: Visit UK landing page - yes
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+
+  Scenario: Visit UK landing page - no
+    When I submit a 'international' event
     Then I get a 'dcmaw' CRI response
 
+  Scenario: International address user sends a next event on exit page from DCMAW
+    When I submit a 'international' event
+    Then I get a 'dcmaw' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'non-uk-no-app' page response
+    When I submit a 'next' event
+    Then I get a 'dcmaw' CRI response
+
+  Scenario: International address user sends an end event on exit page from DCMAW
+    When I submit a 'international' event
+    Then I get a 'dcmaw' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'non-uk-no-app' page response
+    When I submit a 'end' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+
   Scenario: Successful P2 identity via DCMAW using passport
+    When I submit an 'international' event
+    Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-passport-valid' details to the CRI stub
     Then I get a 'page-dcmaw-success' page response
     When I submit a 'next' event

--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -1,0 +1,27 @@
+@Build
+Feature: P2 App journey
+
+  Background:
+    Given I start a new 'medium-confidence' journey
+    And I activate the 'internationalAddress' feature sets
+    And I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit an 'international' event
+    Then I get a 'dcmaw' CRI response
+
+  Scenario: Successful P2 identity via DCMAW using passport
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-changed' details with attributes to the CRI stub
+      | Attribute | Values               |
+      | context   | "international_user" |
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -34,43 +34,6 @@ Feature: P2 Web document journey
       | drivingLicence | kenneth-driving-permit-valid |
       | ukPassport     | kenneth-passport-valid       |
 
-  Scenario Outline: Visit UK landing page - yes
-    Given I activate the 'internationalAddress' feature set
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'next' event
-    Then I get a 'page-ipv-identity-document-start' page response
-
-  Scenario Outline: Visit UK landing page - no
-    Given I activate the 'internationalAddress' feature set
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'end' event
-    Then I get a 'dcmaw' CRI response
-
-  Scenario Outline: International address user sends a next event on exit page from DCMAW
-    Given I activate the 'internationalAddress' feature set
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'end' event
-    Then I get a 'dcmaw' CRI response
-    When I call the CRI stub and get an 'access_denied' OAuth error
-    Then I get a 'non-uk-no-app' page response
-    When I submit a 'next' event
-    Then I get a 'dcmaw' CRI response
-
-  Scenario Outline: International address user sends an end event on exit page from DCMAW
-    Given I activate the 'internationalAddress' feature set
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'end' event
-    Then I get a 'dcmaw' CRI response
-    When I call the CRI stub and get an 'access_denied' OAuth error
-    Then I get a 'non-uk-no-app' page response
-    When I submit a 'end' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-
   Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV
     Given I activate the 'dwpKbvTest' feature set
     When I start a new 'medium-confidence' journey

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
@@ -1,0 +1,73 @@
+@Build
+Feature: Identity reuse update details
+
+    Background:
+        Given the subject already has the following credentials
+            | CRI     | scenario                     |
+            | dcmaw   | kenneth-driving-permit-valid |
+            | address | kenneth-current              |
+            | fraud   | kenneth-score-2              |
+        When I start a new 'medium-confidence' journey
+        And I activate the 'internationalAddress' feature sets
+        Then I get a 'page-ipv-reuse' page response
+        When I submit a 'update-details' event
+        Then I get a 'update-details' page response
+
+    Scenario: Address Change
+        When I submit a 'address-only' event
+        Then I get a 'address' CRI response
+        When I submit 'kenneth-changed' details with attributes to the CRI stub
+            | Attribute | Values               |
+            | context   | "international_user" |
+        Then I get a 'fraud' CRI response
+        When I submit 'kenneth-score-2' details to the CRI stub
+        Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
+        When I submit a 'next' event
+        Then I get an OAuth response
+        When I use the OAuth response to get my identity
+        Then I get a 'P2' identity
+        And my address 'buildingNumber' is '28'
+
+    Scenario: Address and Family Name Change
+        When I submit a 'family-name-and-address' event
+        Then I get a 'page-update-name' page response
+        When I submit a 'update-name' event
+        Then I get a 'dcmaw' CRI response
+        When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
+        Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
+        When I submit a 'next' event
+        Then I get a 'address' CRI response
+        When I submit 'kenneth-changed' details with attributes to the CRI stub
+            | Attribute | Values               |
+            | context   | "international_user" |
+        Then I get a 'fraud' CRI response
+        When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+        Then I get a 'page-ipv-success' page response
+        When I submit a 'next' event
+        Then I get an OAuth response
+        When I use the OAuth response to get my identity
+        Then I get a 'P2' identity
+        And my identity 'FamilyName' is 'Smith'
+        And my address 'addressLocality' is 'Bristol'
+
+    Scenario: Address and Given Name Change
+        When I submit a 'given-names-and-address' event
+        Then I get a 'page-update-name' page response
+        When I submit a 'update-name' event
+        Then I get a 'dcmaw' CRI response
+        When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+        Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
+        When I submit a 'next' event
+        Then I get a 'address' CRI response
+        When I submit 'kenneth-changed' details with attributes to the CRI stub
+            | Attribute | Values               |
+            | context   | "international_user" |
+        Then I get a 'fraud' CRI response
+        When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
+        Then I get a 'page-ipv-success' page response
+        When I submit a 'next' event
+        Then I get an OAuth response
+        When I use the OAuth response to get my identity
+        Then I get a 'P2' identity
+        And my identity 'GivenName' is 'Ken'
+        And my address 'streetName' is 'King Road'

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
@@ -6,7 +6,7 @@ entryEvents:
     targetState: CRI_ADDRESS
   enhanced-verification:
     targetState: CRI_ADDRESS
-  askInternationalAddress:
+  internationalUser:
     targetState: CRI_ADDRESS_ASK_INTERNATIONAL
 nestedJourneyStates:
   CRI_ADDRESS:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -831,9 +831,9 @@ states:
       type: page
       pageId: live-in-uk
     events:
-      next:
+      uk:
         targetState: IDENTITY_START_PAGE
-      end:
+      international:
         targetState: APP_DOC_CHECK_INTERNATIONAL_ADDRESS
         targetEntryEvent: next
 
@@ -855,4 +855,4 @@ states:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_J1
-        targetEntryEvent: askInternationalAddress
+        targetEntryEvent: internationalUser

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -818,7 +818,7 @@ states:
     nestedJourney: APP_DOC_CHECK
     exitEvents:
       next:
-        targetState: POST_APP_DOC_CHECK_SUCCESS_PAGE
+        targetState: POST_APP_DOC_CHECK_INTERNATIONAL_SUCCESS_PAGE
       incomplete:
         targetState: NON_UK_NO_APP_PAGE
       incomplete-invalid-dl:
@@ -847,3 +847,12 @@ states:
         targetEntryEvent: next
       end:
         targetState: RETURN_TO_RP
+
+  POST_APP_DOC_CHECK_INTERNATIONAL_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-dcmaw-success
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD_J1
+        targetEntryEvent: askInternationalAddress

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -82,7 +82,7 @@ states:
         checkFeatureFlag:
           internationalAddressEnabled:
             targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
-            targetEntryEvent: askInternationalAddress
+            targetEntryEvent: internationalUser
 
   ADDRESS_AND_FRAUD_UPDATE_ADDRESS:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -491,7 +491,7 @@ states:
         checkFeatureFlag:
           internationalAddressEnabled:
             targetState: ADDRESS_AND_FRAUD_GIVEN
-            targetEntryEvent: askInternationalAddress
+            targetEntryEvent: internationalUser
 
   POST_APP_DOC_CHECK_FAMILY_WITH_ADDRESS:
     response:
@@ -504,7 +504,7 @@ states:
         checkFeatureFlag:
           internationalAddressEnabled:
             targetState: ADDRESS_AND_FRAUD_FAMILY
-            targetEntryEvent: askInternationalAddress
+            targetEntryEvent: internationalUser
 
   ADDRESS_AND_FRAUD_GIVEN:
     nestedJourney: ADDRESS_AND_FRAUD


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add international address context for international P2 users
Also add some missing API tests and rename some events

### Why did it change

Part of the new international address work

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7531](https://govukverify.atlassian.net/browse/PYIC-7531)


[PYIC-7531]: https://govukverify.atlassian.net/browse/PYIC-7531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ