### PR TITLE
PYIC-7701: Use single coi check for update name journeys

### DIFF
--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -79,11 +79,11 @@ Feature: Repeat fraud check failures
       Then I get a 'pyi-no-match' page response
 
     Scenario: Failed COI check
-      When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
+      When I submit 'alice-passport-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+      When I submit 'alice-score-2' details to the CRI stub
       Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -50,16 +50,6 @@ Feature: Repeat fraud check journeys
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
     Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
-    When I submit a 'next' event
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P2' identity
-    And my identity 'GivenName' is 'Kenneth'
-    And my identity 'FamilyName' is 'Smith'
 
   Scenario: Fraud 6 Months Expiry + Address Update
     # Repeat fraud check with update address
@@ -105,18 +95,6 @@ Feature: Repeat fraud check journeys
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
     Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
-    When I submit a 'next' event
-    Then I get a 'address' CRI response
-    When I submit 'kenneth-changed' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P2' identity
-    And my identity 'GivenName' is 'Ken'
-    And my address 'streetName' is 'King Road'
 
   Scenario: Unsupported Changes
     # Repeat fraud check with various unsupported events and back navigation

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
@@ -12,52 +12,29 @@ Feature: Identity reuse update details
         When I submit a 'update-details' event
         Then I get a 'update-details' page response
 
-    Scenario: Given Name Change Failure
-        When I submit a 'given-names-only' event
+    Scenario Outline: Successful name change - <selected-name-change> name change but user updates <actual-name-change> name instead
+        When I submit a '<selected-name-change>' event
         Then I get a 'page-update-name' page response
         When I submit a 'update-name' event
         Then I get a 'dcmaw' CRI response
-        When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
+        When I submit '<details>' details to the CRI stub
         Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
         When I submit a 'next' event
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
-        Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
+        When I submit '<fraud-details>' details to the CRI stub
+        Then I get a 'page-ipv-success' page response
+        When I submit a 'next' event
+        Then I get an OAuth response
+        When I use the OAuth response to get my identity
+        Then I get a 'P2' identity
+        And my identity 'GivenName' is '<expected-given-name>'
+        And my identity 'FamilyName' is '<expected-family-name>'
         And an 'IPV_USER_DETAILS_UPDATE_END' audit event was recorded [local only]
 
-    Scenario: Given Name Change
-        When I submit a 'given-names-only' event
-        Then I get a 'page-update-name' page response
-        When I submit a 'update-name' event
-        Then I get a 'dcmaw' CRI response
-        When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
-        When I submit a 'next' event
-        Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
-        Then I get a 'page-ipv-success' page response
-        When I submit a 'next' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P2' identity
-        And my identity 'GivenName' is 'Ken'
-
-    Scenario: Family Name Change
-        When I submit a 'family-name-only' event
-        Then I get a 'page-update-name' page response
-        When I submit a 'update-name' event
-        Then I get a 'dcmaw' CRI response
-        When I submit 'kenneth-changed-family-name-driving-permit-valid' details to the CRI stub
-        Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
-        When I submit a 'next' event
-        Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
-        Then I get a 'page-ipv-success' page response
-        When I submit a 'next' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P2' identity
-        And my identity 'FamilyName' is 'Smith'
+    Examples:
+        | selected-name-change | actual-name-change | details                                          | fraud-details                       | expected-given-name | expected-family-name |
+        | given-names-only     | family             | kenneth-changed-family-name-driving-permit-valid | kenneth-changed-family-name-score-2 | Kenneth             | Smith                |
+        | family-name-only     | given              | kenneth-changed-given-name-driving-permit-valid  | kenneth-changed-given-name-score-2  | Ken                 | Decerqueira          |
 
     Scenario: Address Change
         When I submit a 'address-only' event

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
@@ -76,18 +76,6 @@ Feature: Identity reuse update details
         Then I get a 'dcmaw' CRI response
         When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
         Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
-        When I submit a 'next' event
-        Then I get a 'address' CRI response
-        When I submit 'kenneth-changed' details to the CRI stub
-        Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
-        Then I get a 'page-ipv-success' page response
-        When I submit a 'next' event
-        Then I get an OAuth response
-        When I use the OAuth response to get my identity
-        Then I get a 'P2' identity
-        And my identity 'GivenName' is 'Ken'
-        And my address 'streetName' is 'King Road'
 
     Scenario: Unsupported Changes
         When I submit a 'dob' event

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -146,10 +146,8 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
             var combinedCredentials = Stream.concat(oldVcs.stream(), sessionVcs.stream()).toList();
             var successfulCheck =
                     switch (checkType) {
-                        case GIVEN_NAMES_AND_DOB -> userIdentityService
-                                .areGivenNamesAndDobCorrelated(combinedCredentials);
-                        case FAMILY_NAME_AND_DOB -> userIdentityService
-                                .areFamilyNameAndDobCorrelatedForCoiCheck(combinedCredentials);
+                        case GIVEN_OR_FAMILY_NAME_AND_DOB -> userIdentityService
+                                .areNamesAndDobCorrelated(combinedCredentials);
                         case FULL_NAME_AND_DOB -> userIdentityService.areVcsCorrelated(
                                 combinedCredentials);
                     };

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -71,9 +71,8 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CRED
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_CHECK_TYPE;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_IPV_SESSION_ID;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_CHECK_TYPE;
-import static uk.gov.di.ipv.core.library.enums.CoiCheckType.FAMILY_NAME_AND_DOB;
 import static uk.gov.di.ipv.core.library.enums.CoiCheckType.FULL_NAME_AND_DOB;
-import static uk.gov.di.ipv.core.library.enums.CoiCheckType.GIVEN_NAMES_AND_DOB;
+import static uk.gov.di.ipv.core.library.enums.CoiCheckType.GIVEN_OR_FAMILY_NAME_AND_DOB;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_ADDRESS_VC;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.M1A_EXPERIAN_FRAUD_VC;
 import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.NamePartGenerator.createNamePart;
@@ -147,7 +146,7 @@ class CheckCoiHandlerTest {
         class SuccessfulChecks {
             @Test
             void shouldReturnPassedForSuccessfulGivenNamesAndDobCheck() throws Exception {
-                when(mockUserIdentityService.areGivenNamesAndDobCorrelated(
+                when(mockUserIdentityService.areNamesAndDobCorrelated(
                                 List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                         .thenReturn(true);
                 when(mockClientSessionItem.getScopeClaims())
@@ -156,7 +155,8 @@ class CheckCoiHandlerTest {
                 var request =
                         ProcessRequest.processRequestBuilder()
                                 .ipvSessionId(IPV_SESSION_ID)
-                                .lambdaInput(Map.of("checkType", GIVEN_NAMES_AND_DOB.name()))
+                                .lambdaInput(
+                                        Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                                 .build();
 
                 var responseMap = checkCoiHandler.handleRequest(request, mockContext);
@@ -169,13 +169,13 @@ class CheckCoiHandlerTest {
                         AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
                         auditEventsCaptured.get(0).getEventName());
                 assertEquals(
-                        new AuditExtensionCoiCheck(GIVEN_NAMES_AND_DOB, null),
+                        new AuditExtensionCoiCheck(GIVEN_OR_FAMILY_NAME_AND_DOB, null),
                         auditEventsCaptured.get(0).getExtensions());
                 assertEquals(
                         AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END,
                         auditEventsCaptured.get(1).getEventName());
                 assertEquals(
-                        new AuditExtensionCoiCheck(GIVEN_NAMES_AND_DOB, true),
+                        new AuditExtensionCoiCheck(GIVEN_OR_FAMILY_NAME_AND_DOB, true),
                         auditEventsCaptured.get(1).getExtensions());
 
                 var restrictedAuditData =
@@ -189,7 +189,7 @@ class CheckCoiHandlerTest {
 
             @Test
             void shouldReturnPassedForSuccessfulFamilyNameAndDobCheck() throws Exception {
-                when(mockUserIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(
+                when(mockUserIdentityService.areNamesAndDobCorrelated(
                                 List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                         .thenReturn(true);
                 when(mockClientSessionItem.getScopeClaims())
@@ -198,7 +198,8 @@ class CheckCoiHandlerTest {
                 var request =
                         ProcessRequest.processRequestBuilder()
                                 .ipvSessionId(IPV_SESSION_ID)
-                                .lambdaInput(Map.of("checkType", FAMILY_NAME_AND_DOB.name()))
+                                .lambdaInput(
+                                        Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                                 .build();
 
                 var responseMap = checkCoiHandler.handleRequest(request, mockContext);
@@ -211,13 +212,13 @@ class CheckCoiHandlerTest {
                         AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
                         auditEventsCaptured.get(0).getEventName());
                 assertEquals(
-                        new AuditExtensionCoiCheck(FAMILY_NAME_AND_DOB, null),
+                        new AuditExtensionCoiCheck(GIVEN_OR_FAMILY_NAME_AND_DOB, null),
                         auditEventsCaptured.get(0).getExtensions());
                 assertEquals(
                         AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END,
                         auditEventsCaptured.get(1).getEventName());
                 assertEquals(
-                        new AuditExtensionCoiCheck(FAMILY_NAME_AND_DOB, true),
+                        new AuditExtensionCoiCheck(GIVEN_OR_FAMILY_NAME_AND_DOB, true),
                         auditEventsCaptured.get(1).getExtensions());
                 var restrictedAuditData =
                         getRestrictedAuditDataNodeFromEvent(auditEventsCaptured.get(1));
@@ -421,7 +422,7 @@ class CheckCoiHandlerTest {
         class FailedChecks {
             @Test
             void shouldReturnFailedForFailedGivenNamesAndDobCheck() throws Exception {
-                when(mockUserIdentityService.areGivenNamesAndDobCorrelated(
+                when(mockUserIdentityService.areNamesAndDobCorrelated(
                                 List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                         .thenReturn(false);
                 when(mockClientSessionItem.getScopeClaims())
@@ -430,7 +431,8 @@ class CheckCoiHandlerTest {
                 var request =
                         ProcessRequest.processRequestBuilder()
                                 .ipvSessionId(IPV_SESSION_ID)
-                                .lambdaInput(Map.of("checkType", GIVEN_NAMES_AND_DOB.name()))
+                                .lambdaInput(
+                                        Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                                 .build();
 
                 var responseMap = checkCoiHandler.handleRequest(request, mockContext);
@@ -443,13 +445,13 @@ class CheckCoiHandlerTest {
                         AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
                         auditEventsCaptured.get(0).getEventName());
                 assertEquals(
-                        new AuditExtensionCoiCheck(GIVEN_NAMES_AND_DOB, null),
+                        new AuditExtensionCoiCheck(GIVEN_OR_FAMILY_NAME_AND_DOB, null),
                         auditEventsCaptured.get(0).getExtensions());
                 assertEquals(
                         AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END,
                         auditEventsCaptured.get(1).getEventName());
                 assertEquals(
-                        new AuditExtensionCoiCheck(GIVEN_NAMES_AND_DOB, false),
+                        new AuditExtensionCoiCheck(GIVEN_OR_FAMILY_NAME_AND_DOB, false),
                         auditEventsCaptured.get(1).getExtensions());
 
                 var restrictedAuditData =
@@ -463,7 +465,7 @@ class CheckCoiHandlerTest {
 
             @Test
             void shouldReturnFailedForFailedFamilyNameAndDobCheck() throws Exception {
-                when(mockUserIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(
+                when(mockUserIdentityService.areNamesAndDobCorrelated(
                                 List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                         .thenReturn(false);
                 when(mockClientSessionItem.getScopeClaims())
@@ -472,7 +474,8 @@ class CheckCoiHandlerTest {
                 var request =
                         ProcessRequest.processRequestBuilder()
                                 .ipvSessionId(IPV_SESSION_ID)
-                                .lambdaInput(Map.of("checkType", FAMILY_NAME_AND_DOB.name()))
+                                .lambdaInput(
+                                        Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                                 .deviceInformation(DEVICE_INFORMATION)
                                 .build();
 
@@ -486,13 +489,13 @@ class CheckCoiHandlerTest {
                         AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
                         auditEventsCaptured.get(0).getEventName());
                 assertEquals(
-                        new AuditExtensionCoiCheck(FAMILY_NAME_AND_DOB, null),
+                        new AuditExtensionCoiCheck(GIVEN_OR_FAMILY_NAME_AND_DOB, null),
                         auditEventsCaptured.get(0).getExtensions());
                 assertEquals(
                         AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END,
                         auditEventsCaptured.get(1).getEventName());
                 assertEquals(
-                        new AuditExtensionCoiCheck(FAMILY_NAME_AND_DOB, false),
+                        new AuditExtensionCoiCheck(GIVEN_OR_FAMILY_NAME_AND_DOB, false),
                         auditEventsCaptured.get(1).getExtensions());
             }
 
@@ -577,7 +580,7 @@ class CheckCoiHandlerTest {
         @Test
         void shouldReturnErrorIfFamilyNameCorrelationCheckThrowsHttpResponseException()
                 throws Exception {
-            when(mockUserIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(
+            when(mockUserIdentityService.areNamesAndDobCorrelated(
                             List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                     .thenThrow(
                             new HttpResponseExceptionWithErrorBody(
@@ -586,7 +589,7 @@ class CheckCoiHandlerTest {
             var request =
                     ProcessRequest.processRequestBuilder()
                             .ipvSessionId(IPV_SESSION_ID)
-                            .lambdaInput(Map.of("checkType", FAMILY_NAME_AND_DOB.name()))
+                            .lambdaInput(Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                             .build();
 
             var responseMap = checkCoiHandler.handleRequest(request, mockContext);
@@ -600,14 +603,14 @@ class CheckCoiHandlerTest {
                     AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
                     auditEventsCaptured.get(0).getEventName());
             assertEquals(
-                    new AuditExtensionCoiCheck(CoiCheckType.FAMILY_NAME_AND_DOB, null),
+                    new AuditExtensionCoiCheck(CoiCheckType.GIVEN_OR_FAMILY_NAME_AND_DOB, null),
                     auditEventsCaptured.get(0).getExtensions());
         }
 
         @Test
         void shouldReturnErrorIfGivenNameCorrelationCheckThrowsHttpResponseException()
                 throws Exception {
-            when(mockUserIdentityService.areGivenNamesAndDobCorrelated(
+            when(mockUserIdentityService.areNamesAndDobCorrelated(
                             List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                     .thenThrow(
                             new HttpResponseExceptionWithErrorBody(
@@ -616,7 +619,7 @@ class CheckCoiHandlerTest {
             var request =
                     ProcessRequest.processRequestBuilder()
                             .ipvSessionId(IPV_SESSION_ID)
-                            .lambdaInput(Map.of("checkType", GIVEN_NAMES_AND_DOB.name()))
+                            .lambdaInput(Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                             .build();
 
             var responseMap = checkCoiHandler.handleRequest(request, mockContext);
@@ -630,7 +633,7 @@ class CheckCoiHandlerTest {
                     AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
                     auditEventsCaptured.get(0).getEventName());
             assertEquals(
-                    new AuditExtensionCoiCheck(CoiCheckType.GIVEN_NAMES_AND_DOB, null),
+                    new AuditExtensionCoiCheck(CoiCheckType.GIVEN_OR_FAMILY_NAME_AND_DOB, null),
                     auditEventsCaptured.get(0).getExtensions());
         }
 
@@ -709,7 +712,7 @@ class CheckCoiHandlerTest {
 
         @Test
         void shouldReturnIfFindIdentityClaimThrowsHttpResponseException() throws Exception {
-            when(mockUserIdentityService.areGivenNamesAndDobCorrelated(
+            when(mockUserIdentityService.areNamesAndDobCorrelated(
                             List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                     .thenReturn(true);
             when(mockUserIdentityService.findIdentityClaim(any()))
@@ -720,7 +723,7 @@ class CheckCoiHandlerTest {
             var request =
                     ProcessRequest.processRequestBuilder()
                             .ipvSessionId(IPV_SESSION_ID)
-                            .lambdaInput(Map.of("checkType", GIVEN_NAMES_AND_DOB.name()))
+                            .lambdaInput(Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                             .build();
 
             var responseMap = checkCoiHandler.handleRequest(request, mockContext);
@@ -734,14 +737,14 @@ class CheckCoiHandlerTest {
         @Test
         void shouldLogRuntimeExceptionsAndRethrow() throws Exception {
             // Arrange
-            when(mockUserIdentityService.areGivenNamesAndDobCorrelated(
+            when(mockUserIdentityService.areNamesAndDobCorrelated(
                             List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                     .thenThrow(new RuntimeException("Test error"));
 
             var request =
                     ProcessRequest.processRequestBuilder()
                             .ipvSessionId(IPV_SESSION_ID)
-                            .lambdaInput(Map.of("checkType", GIVEN_NAMES_AND_DOB.name()))
+                            .lambdaInput(Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                             .build();
 
             var logCollector = LogCollector.getLogCollectorFor(CheckCoiHandler.class);

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -71,7 +71,7 @@ states:
           updateSupported: true
       given-names-only:
         targetJourney: UPDATE_NAME
-        targetState: GIVEN_ONLY_AFTER_RFC_START
+        targetState: NAMES_ONLY_AFTER_RFC_START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -80,7 +80,7 @@ states:
           updateSupported: true
       family-name-only:
         targetJourney: UPDATE_NAME
-        targetState: FAMILY_ONLY_AFTER_RFC_START
+        targetState: NAMES_ONLY_AFTER_RFC_START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -89,7 +89,7 @@ states:
           updateSupported: true
       given-names-and-address:
         targetJourney: UPDATE_NAME
-        targetState: GIVEN_WITH_ADDRESS_AFTER_RFC_START
+        targetState: NAMES_WITH_ADDRESS_AFTER_RFC_START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED
@@ -98,7 +98,7 @@ states:
           updateSupported: true
       family-name-and-address:
         targetJourney: UPDATE_NAME
-        targetState: FAMILY_WITH_ADDRESS_AFTER_RFC_START
+        targetState: NAMES_WITH_ADDRESS_AFTER_RFC_START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_START
           - IPV_USER_DETAILS_UPDATE_SELECTED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -130,7 +130,7 @@ states:
           updateSupported: true
       given-names-only:
         targetJourney: UPDATE_NAME
-        targetState: GIVEN_ONLY_AFTER_REUSE_START
+        targetState: NAMES_ONLY_AFTER_REUSE_START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -138,7 +138,7 @@ states:
           updateSupported: true
       family-name-only:
         targetJourney: UPDATE_NAME
-        targetState: FAMILY_ONLY_AFTER_REUSE_START
+        targetState: NAMES_ONLY_AFTER_REUSE_START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -146,7 +146,7 @@ states:
           updateSupported: true
       given-names-and-address:
         targetJourney: UPDATE_NAME
-        targetState: GIVEN_WITH_ADDRESS_AFTER_REUSE_START
+        targetState: NAMES_WITH_ADDRESS_AFTER_REUSE_START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:
@@ -154,7 +154,7 @@ states:
           updateSupported: true
       family-name-and-address:
         targetJourney: UPDATE_NAME
-        targetState: FAMILY_WITH_ADDRESS_AFTER_REUSE_START
+        targetState: NAMES_WITH_ADDRESS_AFTER_REUSE_START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_SELECTED
         auditContext:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -7,45 +7,25 @@ description: >-
 states:
 # Entry points
 
-  GIVEN_ONLY_AFTER_REUSE_START:
+  NAMES_ONLY_AFTER_REUSE_START:
     events:
       next:
-        targetState: GIVEN_ONLY_AFTER_REUSE
+        targetState: NAMES_ONLY_AFTER_REUSE
 
-  GIVEN_ONLY_AFTER_RFC_START:
+  NAMES_ONLY_AFTER_RFC_START:
     events:
       next:
-        targetState: GIVEN_ONLY_AFTER_RFC
+        targetState: NAMES_ONLY_AFTER_RFC
 
-  FAMILY_ONLY_AFTER_REUSE_START:
+  NAMES_WITH_ADDRESS_AFTER_REUSE_START:
     events:
       next:
-        targetState: FAMILY_ONLY_AFTER_REUSE
+        targetState: NAMES_WITH_ADDRESS_AFTER_REUSE
 
-  FAMILY_ONLY_AFTER_RFC_START:
+  NAMES_WITH_ADDRESS_AFTER_RFC_START:
     events:
       next:
-        targetState: FAMILY_ONLY_AFTER_RFC
-
-  GIVEN_WITH_ADDRESS_AFTER_REUSE_START:
-    events:
-      next:
-        targetState: GIVEN_WITH_ADDRESS_AFTER_REUSE
-
-  GIVEN_WITH_ADDRESS_AFTER_RFC_START:
-    events:
-      next:
-        targetState: GIVEN_WITH_ADDRESS_AFTER_RFC
-
-  FAMILY_WITH_ADDRESS_AFTER_REUSE_START:
-    events:
-      next:
-        targetState: FAMILY_WITH_ADDRESS_AFTER_REUSE
-
-  FAMILY_WITH_ADDRESS_AFTER_RFC_START:
-    events:
-      next:
-        targetState: FAMILY_WITH_ADDRESS_AFTER_RFC
+        targetState: NAMES_WITH_ADDRESS_AFTER_RFC
 
   # Parent States
 
@@ -106,28 +86,101 @@ states:
 
   # Journey States
 
-   # WITHOUT ADDRESS
+  # WITHOUT ADDRESS
 
-  GIVEN_ONLY_AFTER_REUSE:
+  NAMES_ONLY_AFTER_REUSE:
     response:
       type: page
       pageId: page-update-name
     events:
       update-name:
-        targetState: RESET_IDENTITY_GIVEN_ONLY
+        targetState: RESET_IDENTITY_NAMES_ONLY
       end:
         targetState: RETURN_TO_RP
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
 
-  GIVEN_ONLY_AFTER_RFC:
+  RESET_IDENTITY_NAMES_ONLY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: NAME_ONLY_CHANGE
+    events:
+      next:
+        targetState: APP_DOC_CHECK_NAMES_ONLY
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_NAMES_ONLY
+            targetEntryEvent: appTriage
+
+  APP_DOC_CHECK_NAMES_ONLY:
+    nestedJourney: APP_DOC_CHECK
+    exitEvents:
+      next:
+        targetState: POST_APP_DOC_CHECK_NAMES_ONLY
+      incomplete:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+      incomplete-invalid-dl:
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+      context: noF2f
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK_NAMES_ONLY
+        targetEntryEvent: next
+      returnToRp:
+        targetState: RETURN_TO_RP
+
+  STRATEGIC_APP_TRIAGE_NAMES_ONLY:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetState: POST_APP_DOC_CHECK_NAMES_ONLY
+      sessionError:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      anotherWay:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+
+  POST_APP_DOC_CHECK_NAMES_ONLY:
+    response:
+      type: page
+      pageId: page-dcmaw-success
+      context: coiNoAddress
+    events:
+      next:
+        targetState: FRAUD_CHECK_NAMES_ONLY
+
+  FRAUD_CHECK_NAMES_ONLY:
+    response:
+      type: cri
+      criId: fraud
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: CHECK_COI_NAMES
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
+
+  NAMES_ONLY_AFTER_RFC:
     response:
       type: page
       pageId: page-update-name
       context: repeatFraudCheck
     events:
       update-name:
-        targetState: RESET_IDENTITY_GIVEN_ONLY
+        targetState: RESET_IDENTITY_NAMES_ONLY
       end:
         targetState: RETURN_TO_RP
         auditEvents:
@@ -137,205 +190,29 @@ states:
         targetState: START
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
-
-  FAMILY_ONLY_AFTER_REUSE:
-    response:
-      type: page
-      pageId: page-update-name
-    events:
-      update-name:
-        targetState: RESET_IDENTITY_FAMILY_ONLY
-      end:
-        targetState: RETURN_TO_RP
-        auditEvents:
-          - IPV_USER_DETAILS_UPDATE_ABORTED
-
-  FAMILY_ONLY_AFTER_RFC:
-    response:
-      type: page
-      pageId: page-update-name
-      context: repeatFraudCheck
-    events:
-      update-name:
-        targetState: RESET_IDENTITY_FAMILY_ONLY
-      end:
-        targetState: RETURN_TO_RP
-        auditEvents:
-          - IPV_USER_DETAILS_UPDATE_ABORTED
-      back:
-        targetJourney: REPEAT_FRAUD_CHECK
-        targetState: START
-        auditEvents:
-          - IPV_USER_DETAILS_UPDATE_ABORTED
-
-  RESET_IDENTITY_GIVEN_ONLY:
-    response:
-      type: process
-      lambda: reset-session-identity
-      lambdaInput:
-        resetType: NAME_ONLY_CHANGE
-    events:
-      next:
-        targetState: APP_DOC_CHECK_GIVEN_ONLY
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_GIVEN_ONLY
-            targetEntryEvent: appTriage
-
-  STRATEGIC_APP_TRIAGE_GIVEN_ONLY:
-    nestedJourney: STRATEGIC_APP_TRIAGE
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_GIVEN_ONLY
-      sessionError:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      anotherWay:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
-
-  RESET_IDENTITY_FAMILY_ONLY:
-    response:
-      type: process
-      lambda: reset-session-identity
-      lambdaInput:
-        resetType: NAME_ONLY_CHANGE
-    events:
-      next:
-        targetState: APP_DOC_CHECK_FAMILY_ONLY
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_FAMILY_ONLY
-            targetEntryEvent: appTriage
-
-  STRATEGIC_APP_TRIAGE_FAMILY_ONLY:
-    nestedJourney: STRATEGIC_APP_TRIAGE
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_FAMILY_ONLY
-      sessionError:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      anotherWay:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
-
-  APP_DOC_CHECK_GIVEN_ONLY:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_GIVEN_ONLY
-      incomplete:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
-      incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_ONLY
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_ONLY:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-      context: noF2f
-    events:
-      anotherTypePhotoId:
-        targetState: APP_DOC_CHECK_GIVEN_ONLY
-        targetEntryEvent: next
-      returnToRp:
-        targetState: RETURN_TO_RP
-
-  APP_DOC_CHECK_FAMILY_ONLY:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_FAMILY_ONLY
-      incomplete:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
-      incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_FAMILY_ONLY
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_FAMILY_ONLY:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-      context: noF2f
-    events:
-      anotherTypePhotoId:
-        targetState: APP_DOC_CHECK_FAMILY_ONLY
-        targetEntryEvent: next
-      returnToRp:
-        targetState: RETURN_TO_RP
-
-  POST_APP_DOC_CHECK_GIVEN_ONLY:
-    response:
-      type: page
-      pageId: page-dcmaw-success
-      context: coiNoAddress
-    events:
-      next:
-        targetState: FRAUD_CHECK_GIVEN_ONLY
-
-  POST_APP_DOC_CHECK_FAMILY_ONLY:
-    response:
-      type: page
-      pageId: page-dcmaw-success
-      context: coiNoAddress
-    events:
-      next:
-        targetState: FRAUD_CHECK_FAMILY_ONLY
-
-  FRAUD_CHECK_GIVEN_ONLY:
-    response:
-      type: cri
-      criId: fraud
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CHECK_COI_GIVEN
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
-
-  FRAUD_CHECK_FAMILY_ONLY:
-    response:
-      type: cri
-      criId: fraud
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CHECK_COI_FAMILY
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
 
   # WITH ADDRESS
 
-  GIVEN_WITH_ADDRESS_AFTER_REUSE:
+  NAMES_WITH_ADDRESS_AFTER_REUSE:
     response:
       type: page
       pageId: page-update-name
     events:
       update-name:
-        targetState: RESET_IDENTITY_GIVEN_WITH_ADDRESS
+        targetState: RESET_IDENTITY_NAMES_WITH_ADDRESS
       end:
         targetState: RETURN_TO_RP
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
 
-  GIVEN_WITH_ADDRESS_AFTER_RFC:
+  NAMES_WITH_ADDRESS_AFTER_RFC:
     response:
       type: page
       pageId: page-update-name
       context: repeatFraudCheck
     events:
       update-name:
-        targetState: RESET_IDENTITY_GIVEN_WITH_ADDRESS
+        targetState: RESET_IDENTITY_NAMES_WITH_ADDRESS
       end:
         targetState: RETURN_TO_RP
         auditEvents:
@@ -346,37 +223,7 @@ states:
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_ABORTED
 
-  FAMILY_WITH_ADDRESS_AFTER_REUSE:
-    response:
-      type: page
-      pageId: page-update-name
-    events:
-      update-name:
-        targetState: RESET_IDENTITY_FAMILY_WITH_ADDRESS
-      end:
-        targetState: RETURN_TO_RP
-        auditEvents:
-          - IPV_USER_DETAILS_UPDATE_ABORTED
-
-  FAMILY_WITH_ADDRESS_AFTER_RFC:
-    response:
-      type: page
-      pageId: page-update-name
-      context: repeatFraudCheck
-    events:
-      update-name:
-        targetState: RESET_IDENTITY_FAMILY_WITH_ADDRESS
-      end:
-        targetState: RETURN_TO_RP
-        auditEvents:
-          - IPV_USER_DETAILS_UPDATE_ABORTED
-      back:
-        targetJourney: REPEAT_FRAUD_CHECK
-        targetState: START
-        auditEvents:
-          - IPV_USER_DETAILS_UPDATE_ABORTED
-
-  RESET_IDENTITY_GIVEN_WITH_ADDRESS:
+  RESET_IDENTITY_NAMES_WITH_ADDRESS:
     response:
       type: process
       lambda: reset-session-identity
@@ -384,17 +231,17 @@ states:
         resetType: ALL
     events:
       next:
-        targetState: APP_DOC_CHECK_GIVEN_WITH_ADDRESS
+        targetState: APP_DOC_CHECK_NAMES_WITH_ADDRESS
         checkFeatureFlag:
           strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_GIVEN_WITH_ADDRESS
+            targetState: STRATEGIC_APP_TRIAGE_NAMES_WITH_ADDRESS
             targetEntryEvent: appTriage
 
-  STRATEGIC_APP_TRIAGE_GIVEN_WITH_ADDRESS:
+  STRATEGIC_APP_TRIAGE_NAMES_WITH_ADDRESS:
     nestedJourney: STRATEGIC_APP_TRIAGE
     exitEvents:
       next:
-        targetState: POST_APP_DOC_CHECK_GIVEN_WITH_ADDRESS
+        targetState: POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       sessionError:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -402,152 +249,62 @@ states:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
 
-  RESET_IDENTITY_FAMILY_WITH_ADDRESS:
-    response:
-      type: process
-      lambda: reset-session-identity
-      lambdaInput:
-        resetType: ALL
-    events:
-      next:
-        targetState: APP_DOC_CHECK_FAMILY_WITH_ADDRESS
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_FAMILY_WITH_ADDRESS
-            targetEntryEvent: appTriage
-
-  STRATEGIC_APP_TRIAGE_FAMILY_WITH_ADDRESS:
-    nestedJourney: STRATEGIC_APP_TRIAGE
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_FAMILY_WITH_ADDRESS
-      sessionError:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-      anotherWay:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
-
-  APP_DOC_CHECK_GIVEN_WITH_ADDRESS:
+  APP_DOC_CHECK_NAMES_WITH_ADDRESS:
     nestedJourney: APP_DOC_CHECK
     exitEvents:
       next:
-        targetState: POST_APP_DOC_CHECK_GIVEN_WITH_ADDRESS
+        targetState: POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       incomplete:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
       incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_WITH_ADDRESS
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       alternate-doc-invalid-dl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
 
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_GIVEN_WITH_ADDRESS:
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS:
     response:
       type: page
       pageId: prove-identity-another-way
       context: noF2f
     events:
       anotherTypePhotoId:
-        targetState: APP_DOC_CHECK_GIVEN_WITH_ADDRESS
+        targetState: APP_DOC_CHECK_NAMES_WITH_ADDRESS
         targetEntryEvent: next
       returnToRp:
         targetState: RETURN_TO_RP
 
-  APP_DOC_CHECK_FAMILY_WITH_ADDRESS:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_FAMILY_WITH_ADDRESS
-      incomplete:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
-      incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_FAMILY_WITH_ADDRESS
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_FAMILY_WITH_ADDRESS:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-      context: noF2f
-    events:
-      anotherTypePhotoId:
-        targetState: APP_DOC_CHECK_FAMILY_WITH_ADDRESS
-        targetEntryEvent: next
-      returnToRp:
-        targetState: RETURN_TO_RP
-
-  POST_APP_DOC_CHECK_GIVEN_WITH_ADDRESS:
+  POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS:
     response:
       type: page
       pageId: page-dcmaw-success
       context: coiAddress
     events:
       next:
-        targetState: ADDRESS_AND_FRAUD_GIVEN
+        targetState: ADDRESS_AND_FRAUD
         checkFeatureFlag:
           internationalAddressEnabled:
-            targetState: ADDRESS_AND_FRAUD_GIVEN
+            targetState: ADDRESS_AND_FRAUD
             targetEntryEvent: internationalUser
 
-  POST_APP_DOC_CHECK_FAMILY_WITH_ADDRESS:
-    response:
-      type: page
-      pageId: page-dcmaw-success
-      context: coiAddress
-    events:
-      next:
-        targetState: ADDRESS_AND_FRAUD_FAMILY
-        checkFeatureFlag:
-          internationalAddressEnabled:
-            targetState: ADDRESS_AND_FRAUD_FAMILY
-            targetEntryEvent: internationalUser
-
-  ADDRESS_AND_FRAUD_GIVEN:
+  ADDRESS_AND_FRAUD:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
-        targetState: CHECK_COI_GIVEN
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
-
-  ADDRESS_AND_FRAUD_FAMILY:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: CHECK_COI_FAMILY
+        targetState: CHECK_COI_NAMES
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
 
   # SHARED STATES
 
-  CHECK_COI_GIVEN:
+  CHECK_COI_NAMES:
     response:
       type: process
       lambda: check-coi
       lambdaInput:
-        checkType: FAMILY_NAME_AND_DOB
-    events:
-      coi-check-passed:
-        targetState: EVALUATE_GPG45_SCORES
-      coi-check-failed:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
-  CHECK_COI_FAMILY:
-    response:
-      type: process
-      lambda: check-coi
-      lambdaInput:
-        checkType: GIVEN_NAMES_AND_DOB
+        checkType: GIVEN_OR_FAMILY_NAME_AND_DOB
     events:
       coi-check-passed:
         targetState: EVALUATE_GPG45_SCORES
@@ -571,6 +328,7 @@ states:
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+
   STORE_IDENTITY_BEFORE_SUCCESS:
     response:
       type: process

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/CoiCheckType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/CoiCheckType.java
@@ -4,7 +4,6 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 
 @ExcludeFromGeneratedCoverageReport
 public enum CoiCheckType {
-    GIVEN_NAMES_AND_DOB,
-    FAMILY_NAME_AND_DOB,
     FULL_NAME_AND_DOB,
+    GIVEN_OR_FAMILY_NAME_AND_DOB
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/RequestHelperTest.java
@@ -30,7 +30,7 @@ import static uk.gov.di.ipv.core.library.domain.Cri.CLAIMED_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_CHECK_TYPE;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_RESET_TYPE;
-import static uk.gov.di.ipv.core.library.enums.CoiCheckType.GIVEN_NAMES_AND_DOB;
+import static uk.gov.di.ipv.core.library.enums.CoiCheckType.GIVEN_OR_FAMILY_NAME_AND_DOB;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.NAME_ONLY_CHANGE;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.ENCODED_DEVICE_INFORMATION_HEADER;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.FEATURE_SET_HEADER;
@@ -511,10 +511,10 @@ class RequestHelperTest {
     void getCoiCheckTypeShouldReturnCoiCheckType() throws Exception {
         ProcessRequest request =
                 ProcessRequest.processRequestBuilder()
-                        .lambdaInput(Map.of("checkType", GIVEN_NAMES_AND_DOB.name()))
+                        .lambdaInput(Map.of("checkType", GIVEN_OR_FAMILY_NAME_AND_DOB.name()))
                         .build();
 
-        assertEquals(GIVEN_NAMES_AND_DOB, RequestHelper.getCoiCheckType(request));
+        assertEquals(GIVEN_OR_FAMILY_NAME_AND_DOB, RequestHelper.getCoiCheckType(request));
     }
 
     @Test

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -553,205 +553,70 @@ class UserIdentityServiceTest {
     }
 
     @Nested
-    class AreGivenNamesAndDobCorrelated {
-        @Test
-        void shouldReturnTrueForCorrelatedGivenNames() throws Exception {
-            // Arrange
-            var vcs =
-                    List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    ADDRESS,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    DCMAW,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Bones", "1000-01-01")));
+    class AreNamesAndDobCorrelated {
+        private VerifiableCredential PASSPORT_VC_JIMBO_JONES_2000_01_01 =
+                generateVerifiableCredential(
+                        USER_ID_1,
+                        PASSPORT,
+                        createCredentialWithNameAndBirthDate("Jimbo", "Jones", "2000-01-01"));
+        private VerifiableCredential PASSPORT_VC_JIMBO_SMITH_2000_01_01 =
+                generateVerifiableCredential(
+                        USER_ID_1,
+                        PASSPORT,
+                        createCredentialWithNameAndBirthDate("Jimbo", "SMITH", "2000-01-01"));
+        private VerifiableCredential PASSPORT_VC_TIMMY_JONES_2000_01_01 =
+                generateVerifiableCredential(
+                        USER_ID_1,
+                        PASSPORT,
+                        createCredentialWithNameAndBirthDate("Timmy", "Jones", "2000-01-01"));
+        private VerifiableCredential PASSPORT_VC_TIMMY_SMITH_2000_01_01 =
+                generateVerifiableCredential(
+                        USER_ID_1,
+                        PASSPORT,
+                        createCredentialWithNameAndBirthDate("Timmy", "Smith", "2000-01-01"));
+        private VerifiableCredential PASSPORT_VC_JIMBO_JONES_2002_02_02 =
+                generateVerifiableCredential(
+                        USER_ID_1,
+                        PASSPORT,
+                        createCredentialWithNameAndBirthDate("Timmy", "Smith", "2002-02-02"));
+        private VerifiableCredential PASSPORT_VC_JIMBO_JONATHON_JONES_2002_02_02 =
+                generateVerifiableCredential(
+                        USER_ID_1,
+                        PASSPORT,
+                        createCredentialWithNameAndBirthDate(
+                                "Timmy", "Jonathon", "Smith", "2002-02-02"));
 
-            // Act & Assert
-            assertTrue(userIdentityService.areGivenNamesAndDobCorrelated(vcs));
-        }
-
-        @Test
-        void shouldReturnFalseIfGivenNamesDiffer() throws Exception {
-            // Arrange
-            var vcs =
-                    List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Dimbo", "Bones", "1000-01-01")));
-
-            // Act & Assert
-            assertFalse(userIdentityService.areGivenNamesAndDobCorrelated(vcs));
-        }
-
-        @Test
-        void shouldReturnFalseIfExtraGivenName() throws Exception {
-            // Arrange
-            var vcs =
-                    List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Dimbo", "Bones", "1000-01-01")));
-
-            // Act & Assert
-            assertFalse(userIdentityService.areGivenNamesAndDobCorrelated(vcs));
-        }
-
-        @Test
-        void shouldReturnFalseIfDobDiffers() throws Exception {
-            // Arrange
-            var vcs =
-                    List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Bones", "2000-01-01")));
-
-            // Act & Assert
-            assertFalse(userIdentityService.areGivenNamesAndDobCorrelated(vcs));
-        }
-
-        @ParameterizedTest
-        @NullAndEmptySource
-        void shouldThrowIfMissingGivenName(String missingName) {
-            // Arrange
-            var vcs =
-                    List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            missingName, "Bones", "1000-01-01")));
-
-            // Act
-            HttpResponseExceptionWithErrorBody thrownError =
-                    assertThrows(
-                            HttpResponseExceptionWithErrorBody.class,
-                            () -> userIdentityService.areGivenNamesAndDobCorrelated(vcs));
-
-            // Assert
-            assertEquals(500, thrownError.getResponseCode());
-            assertEquals(ErrorResponse.FAILED_NAME_CORRELATION, thrownError.getErrorResponse());
-        }
-
-        @ParameterizedTest
-        @NullAndEmptySource
-        void shouldThrowIfMissingDob(String missingDob) {
-            // Arrange
-            var vcs =
-                    List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Bones", missingDob)));
-
-            // Act
-            HttpResponseExceptionWithErrorBody thrownError =
-                    assertThrows(
-                            HttpResponseExceptionWithErrorBody.class,
-                            () -> userIdentityService.areGivenNamesAndDobCorrelated(vcs));
-
-            // Assert
-            assertEquals(500, thrownError.getResponseCode());
-            assertEquals(
-                    ErrorResponse.FAILED_BIRTHDATE_CORRELATION, thrownError.getErrorResponse());
-        }
-    }
-
-    @Nested
-    class AreFamilyNameAndDobCorrelated {
         @BeforeEach
         void setup() {
             when(mockConfigService.getParameter(COI_CHECK_FAMILY_NAME_CHARS)).thenReturn("5");
         }
 
         @Test
-        void shouldReturnTrueForCorrelatedFamilyNames() throws Exception {
+        void shouldReturnTrueForCorrelatedGivenNamesAndDobAndDifferentFamilyNames()
+                throws Exception {
             // Arrange
             var vcs =
                     List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    ADDRESS,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    DCMAW,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Dimbo", "Jones", "1000-01-01")));
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_SMITH_2000_01_01);
 
             // Act & Assert
-            assertTrue(userIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(vcs));
+            assertTrue(userIdentityService.areNamesAndDobCorrelated(vcs));
+        }
+
+        @Test
+        void shouldReturnTrueForCorrelatedFamilyNamesAndDobAndDifferentGivenNames()
+                throws Exception {
+            // Arrange
+            var vcs =
+                    List.of(
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_TIMMY_JONES_2000_01_01);
+
+            // Act & Assert
+            assertTrue(userIdentityService.areNamesAndDobCorrelated(vcs));
         }
 
         @Test
@@ -760,49 +625,38 @@ class UserIdentityServiceTest {
             when(mockConfigService.getParameter(COI_CHECK_FAMILY_NAME_CHARS)).thenReturn("500");
             var vcs =
                     List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    ADDRESS,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    DCMAW,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Dimbo", "Jones", "1000-01-01")));
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_SMITH_2000_01_01);
 
             // Act & Assert
-            assertTrue(userIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(vcs));
+            assertTrue(userIdentityService.areNamesAndDobCorrelated(vcs));
         }
 
         @Test
-        void shouldReturnFalseIfFamilyNameDiffers() throws Exception {
+        void shouldReturnFalseIfGivenNamesAndFamilyNamesBothDiffer() throws Exception {
             // Arrange
             var vcs =
                     List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Dimbo", "Bones", "1000-01-01")));
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_TIMMY_SMITH_2000_01_01);
 
             // Act & Assert
-            assertFalse(userIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(vcs));
+            assertFalse(userIdentityService.areNamesAndDobCorrelated(vcs));
+        }
+
+        @Test
+        void shouldReturnFalseIfExtraGivenName() throws Exception {
+            // Arrange
+            var vcs =
+                    List.of(
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONATHON_JONES_2002_02_02);
+
+            // Act & Assert
+            assertFalse(userIdentityService.areNamesAndDobCorrelated(vcs));
         }
 
         @Test
@@ -810,24 +664,37 @@ class UserIdentityServiceTest {
             // Arrange
             var vcs =
                     List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Dimbo", "Jones", "2000-01-01")));
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2002_02_02);
 
             // Act & Assert
-            assertFalse(userIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(vcs));
+            assertFalse(userIdentityService.areNamesAndDobCorrelated(vcs));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldThrowIfMissingGivenName(String missingName) {
+            // Arrange
+            var vcs =
+                    List.of(
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            generateVerifiableCredential(
+                                    USER_ID_1,
+                                    PASSPORT,
+                                    createCredentialWithNameAndBirthDate(
+                                            missingName, "Jones", "1000-01-01")));
+
+            // Act
+            HttpResponseExceptionWithErrorBody thrownError =
+                    assertThrows(
+                            HttpResponseExceptionWithErrorBody.class,
+                            () -> userIdentityService.areNamesAndDobCorrelated(vcs));
+
+            // Assert
+            assertEquals(500, thrownError.getResponseCode());
+            assertEquals(ErrorResponse.FAILED_NAME_CORRELATION, thrownError.getErrorResponse());
         }
 
         @MockitoSettings(strictness = LENIENT)
@@ -837,16 +704,8 @@ class UserIdentityServiceTest {
             // Arrange
             var vcs =
                     List.of(
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
                             generateVerifiableCredential(
                                     USER_ID_1,
                                     PASSPORT,
@@ -857,9 +716,7 @@ class UserIdentityServiceTest {
             HttpResponseExceptionWithErrorBody thrownError =
                     assertThrows(
                             HttpResponseExceptionWithErrorBody.class,
-                            () ->
-                                    userIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(
-                                            vcs));
+                            () -> userIdentityService.areNamesAndDobCorrelated(vcs));
 
             // Assert
             assertEquals(500, thrownError.getResponseCode());
@@ -872,29 +729,19 @@ class UserIdentityServiceTest {
             // Arrange
             var vcs =
                     List.of(
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
                             generateVerifiableCredential(
                                     USER_ID_1,
                                     PASSPORT,
                                     createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Jimbo", "Jones", "1000-01-01")),
-                            generateVerifiableCredential(
-                                    USER_ID_1,
-                                    PASSPORT,
-                                    createCredentialWithNameAndBirthDate(
-                                            "Dimbo", "Jones", missingDob)));
+                                            "Jimbo", "Jones", missingDob)));
 
             // Act
             HttpResponseExceptionWithErrorBody thrownError =
                     assertThrows(
                             HttpResponseExceptionWithErrorBody.class,
-                            () ->
-                                    userIdentityService.areFamilyNameAndDobCorrelatedForCoiCheck(
-                                            vcs));
+                            () -> userIdentityService.areNamesAndDobCorrelated(vcs));
 
             // Assert
             assertEquals(500, thrownError.getResponseCode());

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -554,32 +554,32 @@ class UserIdentityServiceTest {
 
     @Nested
     class AreNamesAndDobCorrelated {
-        private VerifiableCredential PASSPORT_VC_JIMBO_JONES_2000_01_01 =
+        private VerifiableCredential jimboJones2000 =
                 generateVerifiableCredential(
                         USER_ID_1,
                         PASSPORT,
                         createCredentialWithNameAndBirthDate("Jimbo", "Jones", "2000-01-01"));
-        private VerifiableCredential PASSPORT_VC_JIMBO_SMITH_2000_01_01 =
+        private VerifiableCredential jimboSmith2000 =
                 generateVerifiableCredential(
                         USER_ID_1,
                         PASSPORT,
                         createCredentialWithNameAndBirthDate("Jimbo", "SMITH", "2000-01-01"));
-        private VerifiableCredential PASSPORT_VC_TIMMY_JONES_2000_01_01 =
+        private VerifiableCredential timmyJones2000 =
                 generateVerifiableCredential(
                         USER_ID_1,
                         PASSPORT,
                         createCredentialWithNameAndBirthDate("Timmy", "Jones", "2000-01-01"));
-        private VerifiableCredential PASSPORT_VC_TIMMY_SMITH_2000_01_01 =
+        private VerifiableCredential timmySmith2000 =
                 generateVerifiableCredential(
                         USER_ID_1,
                         PASSPORT,
                         createCredentialWithNameAndBirthDate("Timmy", "Smith", "2000-01-01"));
-        private VerifiableCredential PASSPORT_VC_JIMBO_JONES_2002_02_02 =
+        private VerifiableCredential jimboJones2002 =
                 generateVerifiableCredential(
                         USER_ID_1,
                         PASSPORT,
                         createCredentialWithNameAndBirthDate("Timmy", "Smith", "2002-02-02"));
-        private VerifiableCredential PASSPORT_VC_JIMBO_JONATHON_JONES_2002_02_02 =
+        private VerifiableCredential jimboJonathonJones2002 =
                 generateVerifiableCredential(
                         USER_ID_1,
                         PASSPORT,
@@ -595,11 +595,7 @@ class UserIdentityServiceTest {
         void shouldReturnTrueForCorrelatedGivenNamesAndDobAndDifferentFamilyNames()
                 throws Exception {
             // Arrange
-            var vcs =
-                    List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_SMITH_2000_01_01);
+            var vcs = List.of(jimboJones2000, jimboJones2000, jimboSmith2000);
 
             // Act & Assert
             assertTrue(userIdentityService.areNamesAndDobCorrelated(vcs));
@@ -609,11 +605,7 @@ class UserIdentityServiceTest {
         void shouldReturnTrueForCorrelatedFamilyNamesAndDobAndDifferentGivenNames()
                 throws Exception {
             // Arrange
-            var vcs =
-                    List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_TIMMY_JONES_2000_01_01);
+            var vcs = List.of(jimboJones2000, jimboJones2000, timmyJones2000);
 
             // Act & Assert
             assertTrue(userIdentityService.areNamesAndDobCorrelated(vcs));
@@ -623,11 +615,7 @@ class UserIdentityServiceTest {
         void shouldReturnTrueWhenFamilyNameShorterThanCheckChars() throws Exception {
             // Arrange
             when(mockConfigService.getParameter(COI_CHECK_FAMILY_NAME_CHARS)).thenReturn("500");
-            var vcs =
-                    List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_SMITH_2000_01_01);
+            var vcs = List.of(jimboJones2000, jimboJones2000, jimboSmith2000);
 
             // Act & Assert
             assertTrue(userIdentityService.areNamesAndDobCorrelated(vcs));
@@ -636,11 +624,7 @@ class UserIdentityServiceTest {
         @Test
         void shouldReturnFalseIfGivenNamesAndFamilyNamesBothDiffer() throws Exception {
             // Arrange
-            var vcs =
-                    List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_TIMMY_SMITH_2000_01_01);
+            var vcs = List.of(jimboJones2000, jimboJones2000, timmySmith2000);
 
             // Act & Assert
             assertFalse(userIdentityService.areNamesAndDobCorrelated(vcs));
@@ -649,11 +633,7 @@ class UserIdentityServiceTest {
         @Test
         void shouldReturnFalseIfExtraGivenName() throws Exception {
             // Arrange
-            var vcs =
-                    List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONATHON_JONES_2002_02_02);
+            var vcs = List.of(jimboJones2000, jimboJones2000, jimboJonathonJones2002);
 
             // Act & Assert
             assertFalse(userIdentityService.areNamesAndDobCorrelated(vcs));
@@ -662,11 +642,7 @@ class UserIdentityServiceTest {
         @Test
         void shouldReturnFalseIfDobDiffers() throws Exception {
             // Arrange
-            var vcs =
-                    List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2002_02_02);
+            var vcs = List.of(jimboJones2000, jimboJones2000, jimboJones2002);
 
             // Act & Assert
             assertFalse(userIdentityService.areNamesAndDobCorrelated(vcs));
@@ -678,8 +654,8 @@ class UserIdentityServiceTest {
             // Arrange
             var vcs =
                     List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            jimboJones2000,
+                            jimboJones2000,
                             generateVerifiableCredential(
                                     USER_ID_1,
                                     PASSPORT,
@@ -704,8 +680,8 @@ class UserIdentityServiceTest {
             // Arrange
             var vcs =
                     List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            jimboJones2000,
+                            jimboJones2000,
                             generateVerifiableCredential(
                                     USER_ID_1,
                                     PASSPORT,
@@ -729,8 +705,8 @@ class UserIdentityServiceTest {
             // Arrange
             var vcs =
                     List.of(
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
-                            PASSPORT_VC_JIMBO_JONES_2000_01_01,
+                            jimboJones2000,
+                            jimboJones2000,
                             generateVerifiableCredential(
                                     USER_ID_1,
                                     PASSPORT,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- use single COI check for update family + given name journeys
- combines above routing
- update api tests as now user can still successfully update their e.g. given name despite selecting to update their family name at the start of the journey

Update to audit events is here: https://github.com/govuk-one-login/event-catalogue/pull/308

### Why did it change
Using a singe coi check for update-given and update-family name journeys means we can reduce duplication and simplify the journey map. It also lets us cut down on some of the api tests.

<img width="1484" alt="Screenshot 2024-11-18 at 15 38 44" src="https://github.com/user-attachments/assets/58e6e47d-0840-4631-987f-9bb270a0c639">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7701](https://govukverify.atlassian.net/browse/PYIC-7701)


[PYIC-7701]: https://govukverify.atlassian.net/browse/PYIC-7701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ