### PR TITLE
BAU: Add get permissions for ProcessMobileAppCallback to read CriOAuthSessionsTable

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1151,6 +1151,7 @@ Resources:
           ENVIRONMENT: !Sub "${Environment}"
           POWERTOOLS_SERVICE_NAME: !Sub process-mobile-app-callback-${Environment}
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
+          CRI_OAUTH_SESSIONS_TABLE_NAME: !Ref CriOAuthSessionsTable
           CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
       VpcConfig:
@@ -1167,6 +1168,8 @@ Resources:
             TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref CriOAuthSessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref CRIResponseTable
         - SSMParameterReadPolicy:


### PR DESCRIPTION
## Proposed changes

### What changed

- Add CriOAuthSessionsTable read permissions for ProcessMobileAppCallback

### Why did it change

- It wasn't allowed to get the session in the other case, and it needed to.

### Issue tracking

- [PYIC-6245](https://govukverify.atlassian.net/browse/PYIC-6245)

[PYIC-6245]: https://govukverify.atlassian.net/browse/PYIC-6245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ