### PR TITLE
BAU: Update no-ipv but client oauth session error description

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -269,7 +269,8 @@ public class BuildClientOauthResponseHandler
             ClientOAuthSessionItem clientOAuthSessionItem) throws URISyntaxException {
         URIBuilder uriBuilder = new URIBuilder(clientOAuthSessionItem.getRedirectUri());
         uriBuilder.addParameter("error", OAuth2Error.ACCESS_DENIED.getCode());
-        uriBuilder.addParameter("error_description", "Missing Context");
+        uriBuilder.addParameter(
+                "error_description", "No ipvSession for existing ClientOAuthSession.");
 
         if (StringUtils.isNotBlank(clientOAuthSessionItem.getState())) {
             uriBuilder.addParameter(STATE, clientOAuthSessionItem.getState());

--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -217,7 +217,7 @@ class BuildClientOauthResponseHandlerTest {
                 URLEncodedUtils.parse(actualRedirectUrl, StandardCharsets.UTF_8);
         assertEquals("example.com", actualRedirectUrl.getHost());
         assertEquals("access_denied", params.get(0).getValue());
-        assertEquals("Missing Context", params.get(1).getValue());
+        assertEquals("No ipvSession for existing ClientOAuthSession.", params.get(1).getValue());
         assertEquals("test-state", params.get(2).getValue());
         verify(mockConfigService).setFeatureSet(List.of(TEST_FEATURE_SET));
     }


### PR DESCRIPTION
## Proposed changes

### What changed

- Change ClientOAuthSessionError description to be more relevant to the cause of the error.

### Why did it change

- It was "Missing context", which is vague. We should want the error description to implicate the cause of the error (there is a ClientOAuthSession but not an IpvSession).

### Issue tracking

- [PYIC-6245](https://govukverify.atlassian.net/browse/PYIC-6245)

[PYIC-6245]: https://govukverify.atlassian.net/browse/PYIC-6245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ