### PR TITLE
PYIC-7756: Update api tests for bav: enabled as default

### DIFF
--- a/api-tests/.env.template
+++ b/api-tests/.env.template
@@ -4,13 +4,13 @@
 # Required for F2F journeys in local, should correspond to the environment
 # ASYNC_QUEUE_NAME="stubQueue_local_dev-<name>"
 
-# Required for CIMIT journeys in local, found in API Gateway for CIMIT external API
+# Required for CIMIT journeys in local, found in API Gateway for CIMIT stub external API
 # MANAGEMENT_CIMIT_STUB_API_KEY=
 
-# Required for posting VCs directly into CIMIT, found in API Gateway for CIMIT internal API
+# Required for posting VCs directly into CIMIT, found in API Gateway for CIMIT stub internal API
 # CIMIT_INTERNAL_API_KEY=
 
-# Required for generating VCs directly with the CRI stubs, found in stubs-common-infra generateCredentialApiKey
+# Required for generating VCs directly with the CRI stubs, found in stubs-common-infra generateCredentialApiKey, production
 # CRI_STUB_GEN_CRED_API_KEY=
 
 # Required for sending VCs directly to the EVCS stub, found in core-common-infra

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -160,13 +160,13 @@ Feature: P2 F2F journey
       When I submit a 'end' event
       Then I get an OAuth response
 
-  Scenario: F2F PYI escpae route
+  Scenario: F2F PYI escape route
     Given I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'end' event
       Then I get a 'page-ipv-identity-postoffice-start' page response
       When I submit an 'end' event
-      Then I get a 'pyi-escape' page response
+      Then I get a 'prove-identity-no-photo-id' page response
 
   Rule: F2F evidence requested strength score
     Background: User has pending F2F verification

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -25,7 +25,9 @@ Feature: Return exit codes
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response
     When I submit an 'end' event
-    Then I get a 'pyi-escape' page response
+    Then I get a 'prove-identity-no-photo-id' page response
+    When I submit a 'end' event
+    Then I get a 'no-photo-id-exit-find-another-way' page response
     When I submit a 'end' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -74,7 +74,9 @@ Feature: TICF failed/error journeys
       When I submit an 'end' event
       Then I get a 'page-ipv-identity-postoffice-start' page response
       When I submit an 'end' event
-      Then I get a 'pyi-escape' page response
+      Then I get a 'prove-identity-no-photo-id' page response
+      When I submit an 'end' event
+      Then I get a 'no-photo-id-exit-find-another-way' page response
       When I submit an 'end' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -297,7 +297,7 @@ core:
     bav:
       id: bav
       name: Bank account verification
-      enabled: "false"
+      enabled: "true"
       unavailable: false # temporarily unavailable
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"


### PR DESCRIPTION
## Proposed changes

### What changed

- Updated API tests for bav enabled as default
- Added some descriptors to .env.template comments for api-tests
- Setting bav enabled as "true" for local-running 

### Why did it change

- Bav enabled as default
- Would have found the specifications I make in the comments useful in fixing local config

### Issue tracking

- [PYIC-7756](https://govukverify.atlassian.net/browse/PYIC-7756)

[PYIC-7756]: https://govukverify.atlassian.net/browse/PYIC-7756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ