### PR TITLE
PYIC-7802 Tidy up dobExperianCheckEnabled feature flag

### DIFF
--- a/api-tests/data/cri-stub-requests/bav/kenneth-with-breaching-ci/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/bav/kenneth-with-breaching-ci/credentialSubject.json
@@ -13,6 +13,11 @@
       ]
     }
   ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ],
   "bankAccount": [
     {
       "sortCode": "103233",

--- a/api-tests/data/cri-stub-requests/bav/kenneth/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/bav/kenneth/credentialSubject.json
@@ -13,6 +13,11 @@
       ]
     }
   ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ],
   "bankAccount": [
     {
       "sortCode": "103233",

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -12,8 +12,7 @@ public enum CoreFeatureFlag implements FeatureFlag {
     P1_JOURNEYS_ENABLED("p1JourneysEnabled"),
     SQS_ASYNC("sqsAsync"),
     KID_JAR_HEADER("kidJarHeaderEnabled"),
-    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
-    DOB_EXPERIAN_CHECK_ENABLED("dobExperianCheckEnabled");
+    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck");
 
     private final String name;
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -48,9 +48,7 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COI_CHECK_
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_ALWAYS_REQUIRED;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_NON_CI_BREACHING_P0;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.DOB_EXPERIAN_CHECK_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
-import static uk.gov.di.ipv.core.library.domain.Cri.BAV;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.DRIVING_LICENCE;
 import static uk.gov.di.ipv.core.library.domain.Cri.HMRC_MIGRATION;
@@ -68,7 +66,7 @@ public class UserIdentityService {
     private static final List<Cri> DRIVING_PERMIT_CRI_TYPES = List.of(DCMAW, DRIVING_LICENCE);
 
     private static final List<Cri> CRI_TYPES_EXCLUDED_FOR_NAME_CORRELATION = List.of(ADDRESS);
-    private static final List<Cri> CRI_TYPES_EXCLUDED_FOR_DOB_CORRELATION = List.of(ADDRESS, BAV);
+    private static final List<Cri> CRI_TYPES_EXCLUDED_FOR_DOB_CORRELATION = List.of(ADDRESS);
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String NINO_PROPERTY_NAME = "socialSecurityRecord";
@@ -318,15 +316,7 @@ public class UserIdentityService {
         for (var vc : vcs) {
             IdentityClaim identityClaim = getIdentityClaim(vc);
             if (isBirthDateEmpty(identityClaim.getBirthDate())) {
-                List<Cri> criTypesExcludedForDobCorrelation =
-                        new ArrayList<>(CRI_TYPES_EXCLUDED_FOR_DOB_CORRELATION);
-                if (configService.enabled(DOB_EXPERIAN_CHECK_ENABLED)) {
-                    criTypesExcludedForDobCorrelation =
-                            criTypesExcludedForDobCorrelation.stream()
-                                    .filter(cri -> !BAV.equals(cri))
-                                    .toList();
-                }
-                if (criTypesExcludedForDobCorrelation.contains(vc.getCri())) {
+                if (CRI_TYPES_EXCLUDED_FOR_DOB_CORRELATION.contains(vc.getCri())) {
                     continue;
                 }
                 addLogMessage(vc, "Birthdate property is missing from VC");

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -426,32 +426,6 @@ class UserIdentityServiceTest {
         assertTrue(userIdentityService.areVcsCorrelated(vcs));
     }
 
-    @ParameterizedTest
-    @NullAndEmptySource
-    void areVCsCorrelatedShouldReturnTrueWhenBavHasMissingBirthDate(String missing)
-            throws Exception {
-        // Arrange
-        var vcs =
-                List.of(
-                        generateVerifiableCredential(
-                                USER_ID_1,
-                                BAV,
-                                createCredentialWithNameAndBirthDate("Jimbo", "Jones", missing)),
-                        generateVerifiableCredential(
-                                USER_ID_1,
-                                PASSPORT,
-                                createCredentialWithNameAndBirthDate(
-                                        "Jimbo", "Jones", "1000-01-01")),
-                        generateVerifiableCredential(
-                                USER_ID_1,
-                                EXPERIAN_FRAUD,
-                                createCredentialWithNameAndBirthDate(
-                                        "Jimbo", "Jones", "1000-01-01")));
-
-        // Act & Assert
-        assertTrue(userIdentityService.areVcsCorrelated(vcs));
-    }
-
     @Test
     void areVCsCorrelatedShouldReturnFalseIfBavHasDifferentBirthDate() throws Exception {
         // Arrange


### PR DESCRIPTION
## Proposed changes

### What changed

Remove dobExperianCheckEnabled feature flag 

### Why did it change

Now that we're live this should be enabled by default across all envs, and we no longer need it flagged, so can clean up the flag entirely

### Issue tracking
- [PYIC-7802](https://govukverify.atlassian.net/browse/PYIC-7802)


[PYIC-7802]: https://govukverify.atlassian.net/browse/PYIC-7802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ