### PR TITLE
PYIC-7637: MFA failureCode and failureDescription

### DIFF
--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -29,7 +29,7 @@ Feature: MFA reset journey
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result with failureCode 'identity_check_failed'
+    Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'
 
     # New journey with same user id
     When I start a new 'medium-confidence' journey
@@ -42,7 +42,7 @@ Feature: MFA reset journey
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result with failureCode 'identity_check_incomplete'
+    Then I get an unsuccessful MFA reset result with failure code 'identity_check_incomplete'
 
   Scenario: Failed MFA reset journey - no photo id
     When I submit an 'end' event
@@ -50,7 +50,7 @@ Feature: MFA reset journey
     When I submit an 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result with failureCode 'identity_check_incomplete'
+    Then I get an unsuccessful MFA reset result with failure code 'identity_check_incomplete'
 
   Scenario: Failed MFA reset journey - failed verification score
     When I submit an 'appTriage' event
@@ -60,7 +60,7 @@ Feature: MFA reset journey
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result with failureCode 'identity_check_failed'
+    Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'
 
   Scenario: Failed MFA reset journey - non-matching identity
     When I submit an 'appTriage' event
@@ -72,4 +72,4 @@ Feature: MFA reset journey
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result with failureCode 'identity_did_not_match'
+    Then I get an unsuccessful MFA reset result with failure code 'identity_did_not_match'

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -29,7 +29,7 @@ Feature: MFA reset journey
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result
+    Then I get an unsuccessful MFA reset result with failureCode 'identity_check_failed'
 
     # New journey with same user id
     When I start a new 'medium-confidence' journey
@@ -42,7 +42,7 @@ Feature: MFA reset journey
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result
+    Then I get an unsuccessful MFA reset result with failureCode 'identity_check_incomplete'
 
   Scenario: Failed MFA reset journey - no photo id
     When I submit an 'end' event
@@ -50,7 +50,7 @@ Feature: MFA reset journey
     When I submit an 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result
+    Then I get an unsuccessful MFA reset result with failureCode 'identity_check_incomplete'
 
   Scenario: Failed MFA reset journey - failed verification score
     When I submit an 'appTriage' event
@@ -60,7 +60,7 @@ Feature: MFA reset journey
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result
+    Then I get an unsuccessful MFA reset result with failureCode 'identity_check_failed'
 
   Scenario: Failed MFA reset journey - non-matching identity
     When I submit an 'appTriage' event
@@ -72,4 +72,4 @@ Feature: MFA reset journey
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
-    Then I get an unsuccessful MFA reset result
+    Then I get an unsuccessful MFA reset result with failureCode 'identity_did_not_match'

--- a/api-tests/src/clients/core-back-external-client.ts
+++ b/api-tests/src/clients/core-back-external-client.ts
@@ -100,7 +100,6 @@ export const getMfaResetResult = async (
 
   const body = await response.json();
   await validateResponseSchema(body, "reverificationResponse");
-
   return body;
 };
 

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -503,8 +503,12 @@ Then(
 );
 
 Then(
-  /^I get a(?:n)? (successful|unsuccessful) MFA reset result$/,
-  async function (this: World, expectedMfaResetResult: string): Promise<void> {
+  /^I get a(?:n)? (successful|unsuccessful) MFA reset result( with failureCode '([\w_]+)')?$/,
+  async function (
+    this: World,
+    expectedMfaResetResult: string,
+    expectedFailureCode: string | undefined,
+  ): Promise<void> {
     if (!this.mfaResetResult) {
       throw new Error("No MFA reset result found.");
     }
@@ -514,6 +518,14 @@ Then(
       expectedMfaResetResult === "successful",
       "MFA reset results do not match.",
     );
+
+    if (expectedFailureCode) {
+      assert.equal(
+        this.mfaResetResult.failure_code,
+        expectedFailureCode,
+        "MFA failure codes do not match.",
+      );
+    }
   },
 );
 

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -503,7 +503,7 @@ Then(
 );
 
 Then(
-  /^I get a(?:n)? (successful|unsuccessful) MFA reset result( with failureCode '([\w_]+)')?$/,
+  /^I get a(?:n)? (successful|unsuccessful) MFA reset result( with failure code '([\w_]+)')?$/,
   async function (
     this: World,
     expectedMfaResetResult: string,

--- a/api-tests/src/types/external-api.ts
+++ b/api-tests/src/types/external-api.ts
@@ -36,8 +36,8 @@ interface ReturnCode {
 export interface MfaResetResult {
   sub: string;
   success: boolean;
-  errorDescription?: string;
-  errorCode?: string;
+  failure_description?: string;
+  failure_code?: string;
 }
 
 export interface VcJwtPayload extends JWTClass {

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
+import uk.gov.di.ipv.core.library.domain.ReverificationFailureCode;
 import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
 import uk.gov.di.ipv.core.library.domain.ScopeConstants;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
@@ -169,6 +170,10 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
                         successfulCheck
                                 ? ReverificationStatus.SUCCESS
                                 : ReverificationStatus.FAILED);
+                if (!successfulCheck) {
+                    ipvSession.setFailureCode(ReverificationFailureCode.IDENTITY_DID_NOT_MATCH);
+                    ipvSession.setFailureDescription("Failed to match identity.");
+                }
             }
 
             if (!successfulCheck) {

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -172,7 +172,7 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
                                 : ReverificationStatus.FAILED);
                 if (!successfulCheck) {
                     ipvSession.setFailureCode(ReverificationFailureCode.IDENTITY_DID_NOT_MATCH);
-                    ipvSession.setFailureDescription("Failed to match identity.");
+                    ipvSessionService.updateIpvSession(ipvSession);
                 }
             }
 

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -90,7 +90,8 @@ public class CheckMobileAppVcReceiptHandler
                         new UserIdentityService(configService),
                         cimitService,
                         new CimitUtilityService(configService),
-                        sessionCredentialsService);
+                        sessionCredentialsService,
+                        ipvSessionService);
     }
 
     @Override

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -122,7 +122,8 @@ public class ProcessCriCallbackHandler
                         new UserIdentityService(configService),
                         cimitService,
                         new CimitUtilityService(configService),
-                        sessionCredentialsService);
+                        sessionCredentialsService,
+                        ipvSessionService);
         criStoringService =
                 new CriStoringService(
                         configService,

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.domain.ReverificationFailureCode;
 import uk.gov.di.ipv.core.library.domain.ScopeConstants;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
@@ -252,11 +253,13 @@ public class CriCheckingService {
                 sessionCredentialsService.getCredentials(
                         ipvSessionItem.getIpvSessionId(), clientOAuthSessionItem.getUserId());
         if (!userIdentityService.areVcsCorrelated(sessionVcs)) {
+            setFailedIdentityCheckOnIpvSessionItem(ipvSessionItem);
             return JOURNEY_VCS_NOT_CORRELATED;
         }
 
         for (var vc : newVcs) {
             if (!VcHelper.isSuccessfulVc(vc)) {
+                setFailedIdentityCheckOnIpvSessionItem(ipvSessionItem);
                 return JOURNEY_FAIL_WITH_NO_CI;
             }
         }
@@ -267,6 +270,11 @@ public class CriCheckingService {
         }
 
         return JOURNEY_NEXT;
+    }
+
+    private void setFailedIdentityCheckOnIpvSessionItem(IpvSessionItem ipvSessionItem) {
+        ipvSessionItem.setFailureCode(ReverificationFailureCode.IDENTITY_CHECK_FAILED);
+        ipvSessionItem.setFailureDescription("Identity check failed.");
     }
 
     private boolean requiresAuthoritativeSourceCheck(

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -28,6 +28,7 @@ import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.CimitService;
 import uk.gov.di.ipv.core.library.service.CimitUtilityService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredentialResponse;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.DL_AUTH_SOURCE_CHECK;
@@ -84,6 +86,7 @@ class CriCheckingServiceTest {
     @Mock private CimitUtilityService mockCimitUtilityService;
     @Mock private SessionCredentialsService mockSessionCredentialsService;
     @Mock private MockedStatic<VcHelper> mockedVcHelper;
+    @Mock private IpvSessionService mockIpvSessionService;
     @InjectMocks private CriCheckingService criCheckingService;
 
     @Test
@@ -559,6 +562,7 @@ class CriCheckingServiceTest {
         assertEquals(new JourneyResponse(JOURNEY_VCS_NOT_CORRELATED), result);
         verify(mockCimitService, never()).getContraIndicators(any(), any(), any());
         verify(mockCimitUtilityService, never()).getMitigationJourneyIfBreaching(any(), any());
+        verify(mockIpvSessionService, times(1)).updateIpvSession(ipvSessionItem);
     }
 
     @Test

--- a/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
+++ b/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
@@ -83,12 +83,8 @@ public class UserReverificationHandler extends UserIdentityRequestHandler
                         ipvSessionItem.getFailureCode() != null
                                 ? ipvSessionItem.getFailureCode()
                                 : DEFAULT_FAILURE_CODE;
-                var failureDesc =
-                        ipvSessionItem.getFailureDescription() != null
-                                ? ipvSessionItem.getFailureDescription()
-                                : DEFAULT_FAILURE_MESSAGE;
 
-                response = ReverificationResponse.failureResponse(userId, failureCode, failureDesc);
+                response = ReverificationResponse.failureResponse(userId, failureCode);
             }
             return ApiGatewayResponseGenerator.proxyJsonResponse(HTTPResponse.SC_OK, response);
         } catch (ParseException e) {

--- a/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
+++ b/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
@@ -36,7 +36,6 @@ public class UserReverificationHandler extends UserIdentityRequestHandler
 
     private static final ReverificationFailureCode DEFAULT_FAILURE_CODE =
             ReverificationFailureCode.IDENTITY_CHECK_INCOMPLETE;
-    private static final String DEFAULT_FAILURE_MESSAGE = "Unable to complete identity check.";
 
     public UserReverificationHandler(
             IpvSessionService ipvSessionService,

--- a/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
+++ b/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
@@ -12,6 +12,7 @@ import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.builduseridentity.UserIdentityRequestHandler;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.ReverificationFailureCode;
 import uk.gov.di.ipv.core.library.domain.ReverificationResponse;
 import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
 import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
@@ -32,6 +33,10 @@ import static uk.gov.di.ipv.core.library.domain.ScopeConstants.REVERIFICATION;
 public class UserReverificationHandler extends UserIdentityRequestHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final ReverificationFailureCode DEFAULT_FAILURE_CODE =
+            ReverificationFailureCode.IDENTITY_CHECK_INCOMPLETE;
+    private static final String DEFAULT_FAILURE_MESSAGE = "Unable to complete identity check.";
 
     public UserReverificationHandler(
             IpvSessionService ipvSessionService,
@@ -73,11 +78,17 @@ public class UserReverificationHandler extends UserIdentityRequestHandler
                             .equals(ReverificationStatus.SUCCESS)) {
                 response = ReverificationResponse.successResponse(userId);
             } else {
-                response =
-                        ReverificationResponse.failureResponse(
-                                userId,
-                                ipvSessionItem.getErrorCode(),
-                                ipvSessionItem.getErrorDescription());
+
+                var failureCode =
+                        ipvSessionItem.getFailureCode() != null
+                                ? ipvSessionItem.getFailureCode()
+                                : DEFAULT_FAILURE_CODE;
+                var failureDesc =
+                        ipvSessionItem.getFailureDescription() != null
+                                ? ipvSessionItem.getFailureDescription()
+                                : DEFAULT_FAILURE_MESSAGE;
+
+                response = ReverificationResponse.failureResponse(userId, failureCode, failureDesc);
             }
             return ApiGatewayResponseGenerator.proxyJsonResponse(HTTPResponse.SC_OK, response);
         } catch (ParseException e) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationFailureCode.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationFailureCode.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.core.library.domain;
 
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
 public enum ReverificationFailureCode {
     NO_IDENTITY_AVAILABLE("no_identity_available"),
     IDENTITY_CHECK_INCOMPLETE("identity_check_incomplete"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationFailureCode.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationFailureCode.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.core.library.domain;
+
+public enum ReverificationFailureCode {
+    NO_IDENTITY_AVAILABLE("no_identity_available"),
+    IDENTITY_CHECK_INCOMPLETE("identity_check_incomplete"),
+    IDENTITY_CHECK_FAILED("identity_check_failed"),
+    IDENTITY_DID_NOT_MATCH("identity_did_not_match");
+
+    private final String failureCode;
+
+    ReverificationFailureCode(String failureCode) {
+        this.failureCode = failureCode;
+    }
+
+    public String getFailureCode() {
+        return failureCode;
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationFailureCode.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationFailureCode.java
@@ -4,18 +4,24 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 
 @ExcludeFromGeneratedCoverageReport
 public enum ReverificationFailureCode {
-    NO_IDENTITY_AVAILABLE("no_identity_available"),
-    IDENTITY_CHECK_INCOMPLETE("identity_check_incomplete"),
-    IDENTITY_CHECK_FAILED("identity_check_failed"),
-    IDENTITY_DID_NOT_MATCH("identity_did_not_match");
+    NO_IDENTITY_AVAILABLE("no_identity_available", "No existing identity available."),
+    IDENTITY_CHECK_INCOMPLETE("identity_check_incomplete", "Unable to complete identity check."),
+    IDENTITY_CHECK_FAILED("identity_check_failed", "Identity check failed."),
+    IDENTITY_DID_NOT_MATCH("identity_did_not_match", "Failed to match identity.");
 
     private final String failureCode;
+    private final String failureDescription;
 
-    ReverificationFailureCode(String failureCode) {
+    ReverificationFailureCode(String failureCode, String failureDescription) {
         this.failureCode = failureCode;
+        this.failureDescription = failureDescription;
     }
 
     public String getFailureCode() {
         return failureCode;
+    }
+
+    public String getFailureDescription() {
+        return failureDescription;
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationResponse.java
@@ -2,13 +2,15 @@ package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
+@ExcludeFromGeneratedCoverageReport
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReverificationResponse(
         boolean success,
         String sub,
-        @JsonProperty("failure_code") String errorCode,
-        @JsonProperty("failure_description") String errorDescription) {
+        @JsonProperty("failure_code") String failureCode,
+        @JsonProperty("failure_description") String failureDescription) {
     public static ReverificationResponse successResponse(String sub) {
         return new ReverificationResponse(true, sub, null, null);
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationResponse.java
@@ -7,14 +7,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record ReverificationResponse(
         boolean success,
         String sub,
-        @JsonProperty("error_code") String errorCode,
-        @JsonProperty("error_description") String errorDescription) {
+        @JsonProperty("failure_code") String errorCode,
+        @JsonProperty("failure_description") String errorDescription) {
     public static ReverificationResponse successResponse(String sub) {
         return new ReverificationResponse(true, sub, null, null);
     }
 
     public static ReverificationResponse failureResponse(
-            String sub, String errorCode, String errorDescription) {
-        return new ReverificationResponse(false, sub, errorCode, errorDescription);
+            String sub, ReverificationFailureCode failureCode, String failureDescription) {
+        return new ReverificationResponse(
+                false, sub, failureCode.getFailureCode(), failureDescription);
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ReverificationResponse.java
@@ -16,8 +16,8 @@ public record ReverificationResponse(
     }
 
     public static ReverificationResponse failureResponse(
-            String sub, ReverificationFailureCode failureCode, String failureDescription) {
+            String sub, ReverificationFailureCode failureCode) {
         return new ReverificationResponse(
-                false, sub, failureCode.getFailureCode(), failureDescription);
+                false, sub, failureCode.getFailureCode(), failureCode.getFailureDescription());
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.JourneyState;
+import uk.gov.di.ipv.core.library.domain.ReverificationFailureCode;
 import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.dto.AuthorizationCodeMetadata;
@@ -36,6 +37,10 @@ public class IpvSessionItem implements PersistenceItem {
     private String emailAddress;
     private ReverificationStatus reverificationStatus;
     private List<String> stateStack = new ArrayList<>();
+
+    // These are used as part of an unsuccessful reverification response
+    private ReverificationFailureCode failureCode;
+    private String failureDescription;
 
     /*
      * journeyContext is used a way of tracking the origin of journeys

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -40,7 +40,6 @@ public class IpvSessionItem implements PersistenceItem {
 
     // These are used as part of an unsuccessful reverification response
     private ReverificationFailureCode failureCode;
-    private String failureDescription;
 
     /*
      * journeyContext is used a way of tracking the origin of journeys

--- a/openAPI/core-back-external.yaml
+++ b/openAPI/core-back-external.yaml
@@ -324,9 +324,10 @@ components:
           type: boolean
         sub:
           type: string
-        error_code:
+        failure_code:
           type: string
-        error_description:
+          enum: ["no_identity_available", "identity_check_incomplete", "identity_check_failed", "identity_did_not_match"]
+        failure_description:
           type: string
       required:
         - success


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- returns identity_check_incomplete by default if reverification is unsuccessful
- returns identity_check_failed in the CRI callback when user fails CRI
- returns identity_did_not_match in the COI check when check fails
- updates api tests
- updates
<img width="799" alt="Screenshot 2024-11-27 at 10 27 55" src="https://github.com/user-attachments/assets/33e5d2e0-3c40-4aa3-b7d8-d7b13b3bab36">
 openAPI schema

note: contract tests do not need to be updated as the consumer tests only have cases for a successful reverification response and an invalid access token.

### Why did it change
We were originally using the `errorCode` from the ipvSession to set these values on the reverification response but these are used for OAuth errors and will never be set as the `reverification` endpoint won't ever be reached once we get one. Instead, we should use a separate `failureCode` + desc to be returned on the reverification response

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7637](https://govukverify.atlassian.net/browse/PYIC-7637)


[PYIC-7637]: https://govukverify.atlassian.net/browse/PYIC-7637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ