### PR TITLE
PYIC-7757: use public enc key from core-back jwks endpoint for api tests

### DIFF
--- a/api-tests/.env.build
+++ b/api-tests/.env.build
@@ -2,7 +2,6 @@
 CORE_BACK_COMPONENT_ID="https://identity.build.account.gov.uk"
 CORE_BACK_INTERNAL_API_URL="https://internal-test-api.identity.build.account.gov.uk"
 CORE_BACK_EXTERNAL_API_URL="https://api.identity.build.account.gov.uk"
-CORE_BACK_PUBLIC_ENCRYPTION_KEY='{"kty":"RSA","e":"AQAB","n":"nel7ibmSTaXWhwEAdqKTiEVcxsYgv6CdXaz90aVN7IorlaCeNj0j06OsA4zdmWEjj21wEZULsxPoZo5N_tsQ7NtOnOkcnDc-g_Nbpt0jelzJSbFRkx3kwXy8YIYKR_myNbiHNTTc7S6GkQRg0N1MPWtzoEKYJs41AN4onrsvUzgpCypWwPy2-ppsaDvms_11YA7A7x3zHj9oKCPJ_uk_0MV3vZAxCxbiPb9ABGWcoGQ5QKGfv40ylBsEdOhE3w-3SAAQIrrHyMRGGiPxcNO161XVL-lOnYt93FgEe16LgpfE22UdENfHnG0UQaTgph1Dm24oqn7qpPTY2DfER5HCKQ"}' # pragma: allowlist secret
 CORE_BACK_CRI_CLIENT_ID="ipv-core-build"
 ORCHESTRATOR_REDIRECT_URL="https://orch.stubs.account.gov.uk/callback"
 # The below private key is a test key that is already in the public domain. It is not used for anything sensitive.

--- a/api-tests/.env.local
+++ b/api-tests/.env.local
@@ -3,7 +3,6 @@ CORE_BACK_COMPONENT_ID="https://identity.local.account.gov.uk"
 CORE_BACK_INTERNAL_API_URL="http://localhost:4502"
 CORE_BACK_INTERNAL_API_KEY=
 CORE_BACK_EXTERNAL_API_URL="http://localhost:4502"
-CORE_BACK_PUBLIC_ENCRYPTION_KEY='{"kty": "RSA","n": "0465qJwo8nCkC2tvV4niuWF6IM6pNjmeYszhTwHPY609-HVAtO8PoRLUyA86rzQ-QzbT7XxbzCjfyRXoRFOGleZqTuwlc25ezDxV58bhecPiWFMaFYOS1W7zIDsVFo37gjjvtkcD6OqK8PKAv6n5tUphjDCcnnmpTMIyGAnzmQCbSkJWu6V_gc3tirAugXoZukMCohxw3_-c6prhMN0smDNv0qWmva3oqokabePwe1OS72DXyXR-TPd_Dtz4-tRr9jvZwHulX4Zcs1BBbjBpIim3WNY8asv9yjlBxkdt-nckhCMZekPuT7xWSTrvccB_fnnSUgEQW_5irLNdnr5MWQ","e": "AQAB","alg": "RS256"}' # pragma: allowlist secret
 CORE_BACK_CRI_CLIENT_ID="ipv-core-local"
 ORCHESTRATOR_REDIRECT_URL="http://localhost:4500/callback"
 JAR_SIGNING_KEY='{"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04", "kid":"orch-signing-stubs-prod-FI4xysvMVdRtkt6xmO5gqcaTF4Tf9NKD1zdg3T8y69M"}' # pragma: allowlist secret

--- a/api-tests/src/config/config.ts
+++ b/api-tests/src/config/config.ts
@@ -27,7 +27,6 @@ const config = {
     internalApiUrl: getMandatoryConfig("CORE_BACK_INTERNAL_API_URL"),
     internalApiKey: getOptionalConfig("CORE_BACK_INTERNAL_API_KEY"),
     externalApiUrl: getMandatoryConfig("CORE_BACK_EXTERNAL_API_URL"),
-    encryptionKey: getMandatoryConfig("CORE_BACK_PUBLIC_ENCRYPTION_KEY"),
     criClientId: getMandatoryConfig("CORE_BACK_CRI_CLIENT_ID"),
   },
   orch: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- uses public enc key from core-back jwks endpoint for api tests
- removes `CORE_BACK_PUBLIC_ENCRYPTION_KEY` config from endpoint

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7757](https://govukverify.atlassian.net/browse/PYIC-7757)



[PYIC-7757]: https://govukverify.atlassian.net/browse/PYIC-7757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ