### PR TITLE
PYIC-7761: Log potential tracing headers

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.cimit.exception.CiPostMitigationsException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiPutException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
+import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.criapiservice.CriApiService;
 import uk.gov.di.ipv.core.library.criapiservice.exception.CriApiException;
 import uk.gov.di.ipv.core.library.cristoringservice.CriStoringService;
@@ -56,6 +57,7 @@ import uk.gov.di.ipv.core.processcricallback.service.CriCheckingService;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
@@ -141,6 +143,24 @@ public class ProcessCriCallbackHandler
     @Logging(clearState = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        // temporary logging to check which tracing headers are being used by dynatrace
+        if ("build".equals(configService.getEnvironmentVariable(EnvironmentVariable.ENVIRONMENT))) {
+            var headers = input.getHeaders();
+            LOGGER.info(
+                    LogHelper.buildLogMessage("Tracing headers")
+                            .with(
+                                    "traceparent",
+                                    Optional.ofNullable(headers.get("traceparent"))
+                                            .orElse("not set"))
+                            .with(
+                                    "tracestate",
+                                    Optional.ofNullable(headers.get("tracestate"))
+                                            .orElse("not set"))
+                            .with(
+                                    "x-dynatrace",
+                                    Optional.ofNullable(headers.get("x-dynatrace"))
+                                            .orElse("not set")));
+        }
         CriCallbackRequest callbackRequest = null;
 
         try {


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Log potential tracing headers

### Why did it change

Dynatrace supports the WC3 trace headers, but it also uses its own proprietary header. Deploying dynatrace into a dev env doesn't appear to work, so this adds logging for only the build env to help show which headers are being passed in from the frontend.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7761](https://govukverify.atlassian.net/browse/PYIC-7761)


[PYIC-7761]: https://govukverify.atlassian.net/browse/PYIC-7761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ