### PR TITLE
Pyic 7709 low confidence fix

### DIFF
--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -42,8 +42,6 @@ Feature: P1 No Photo Id Journey
     When I call the CRI stub and get an 'access_denied' OAuth error
     Then I get a 'page-multiple-doc-check' page response with context 'nino'
     When I submit a 'nino' event
-    Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
-    When I submit a 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details with attributes to the CRI stub
       | Attribute | Values         |

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -225,7 +225,9 @@ states:
       drivingLicence:
         targetState: WEB_DL_OR_PASSPORT
       nino:
-        targetState: NINO_START_PAGE
+        targetState: CRI_CLAIMED_IDENTITY_NO_PHOTO_ID
+        auditEvents:
+          - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/session-timeout.yaml
@@ -18,11 +18,3 @@ states:
     response:
       type: page
       pageId: pyi-timeout-unrecoverable
-    events:
-      next:
-        targetState: RETURN_TO_RP
-
-  RETURN_TO_RP:
-    response:
-      type: process
-      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -420,31 +420,6 @@ class ProcessJourneyEventHandlerTest {
     }
 
     @Test
-    void shouldReturnSessionEndJourneyIfStateIsSessionTimeout() throws Exception {
-        var input =
-                JourneyRequest.builder()
-                        .ipAddress(TEST_IP)
-                        .journey(JOURNEY_NEXT)
-                        .ipvSessionId(TEST_SESSION_ID)
-                        .build();
-
-        IpvSessionItem ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.pushState(new JourneyState(SESSION_TIMEOUT, TIMEOUT_UNRECOVERABLE_STATE));
-
-        when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionService.getClientOAuthSession(any()))
-                .thenReturn(getClientOAuthSessionItem());
-
-        Map<String, Object> output =
-                getProcessJourneyStepHandler().handleRequest(input, mockContext);
-
-        assertEquals(JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE, output.get("journey"));
-    }
-
-    @Test
     void shouldClearOauthSessionIfItExists() throws Exception {
         var input =
                 JourneyRequest.builder()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fixed low confidence no-photo ID journey

### Why did it change

We asked the user if they had a NINO twice.

Also removed a misleading bit of journey map that was never used

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7709](https://govukverify.atlassian.net/browse/PYIC-7709)


[PYIC-7709]: https://govukverify.atlassian.net/browse/PYIC-7709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ