### PR TITLE
PYIC-7761: Add OTEL tracing to AWS SDK and Java Http

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -49,6 +49,7 @@ Globals:
             - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}' # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
+        OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING: true
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         POWERTOOLS_TRACER_CAPTURE_RESPONSE: false
         POWERTOOLS_TRACER_CAPTURE_ERROR: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,9 @@ mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockitoJunit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 nimbusdsOauth2OidcSdk = "com.nimbusds:oauth2-oidc-sdk:11.20"
 notificationsJavaClient = "uk.gov.service.notify:notifications-java-client:5.2.0-RELEASE"
+openTelemetryBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.10.0-alpha"
+openTelemetryAwsSdkAutoConfigure = { module = "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure" }
+openTelemetryJavaHttpClient = { module = "io.opentelemetry.instrumentation:opentelemetry-java-http-client" }
 pactConsumerJunit = { module = "au.com.dius.pact.consumer:junit5", version.ref = "pact" }
 pactProviderJunit = { module = "au.com.dius.pact.provider:junit5", version.ref = "pact" }
 powertoolsLogging = { module = "software.amazon.lambda:powertools-logging", version.ref = "powertools" }

--- a/lambdas/build.gradle
+++ b/lambdas/build.gradle
@@ -9,3 +9,14 @@ allprojects {
 		}
 	}
 }
+
+subprojects {
+	afterEvaluate { subproject ->
+		if (subproject.plugins.hasPlugin('java')) {
+			dependencies {
+				runtimeOnly platform(libs.openTelemetryBom),
+						libs.openTelemetryAwsSdkAutoConfigure
+			}
+		}
+	}
+}

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	api libs.nimbusdsOauth2OidcSdk,
 			libs.diVocab
 	implementation platform(libs.awsSdkBom),
+			platform(libs.openTelemetryBom),
 			libs.awsLambdaJavaEvents,
 			libs.awsSdkDynamodb,
 			libs.awsSdkDynamodbEnhanced,
@@ -17,6 +18,7 @@ dependencies {
 			libs.commonsCollections,
 			libs.jacksonDatabind,
 			libs.jacksonDataformatYaml,
+			libs.openTelemetryJavaHttpClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			libs.powertoolsTracing

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java
@@ -4,6 +4,8 @@ import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Subsegment;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.httpclient.JavaHttpClientTelemetry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -46,7 +48,10 @@ public class TracingHttpClient extends HttpClient {
     }
 
     public static HttpClient newHttpClient() {
-        return new TracingHttpClient(HttpClient.newHttpClient());
+        return new TracingHttpClient(
+                JavaHttpClientTelemetry.builder(GlobalOpenTelemetry.get())
+                        .build()
+                        .newHttpClient(HttpClient.newHttpClient()));
     }
 
     // Synchronize to prevent race conditions when multiple threads attempt to recreate client


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add OTEL tracing to AWS SDK and Java Http

### Why did it change

This adds instrumentation to the AWS SDK and the Java HTTP client, so that we can see more details traces in dynatrace.

This will be more useful on lambdas that are invoked directly by the API gateway, as the trace ID from core-front will be propogated correctly, allowing for a completely joined up view in dynatrace. For step-function invoked lambdas the WC3 trace headers are not propegated correctly, and so a new root span is geneated in the lambda. The AWS and http calls be be traced with that new root as their parent. This may still be useful.

### Link to dynatrace 

https://khw46367.apps.dynatrace.com/ui/apps/dynatrace.distributedtracing/explorer?filter=dt.entity.service.entity.name+%3D+di-ipv-core-front+AND+host.name+%3D+CORE-FRONT-WYNNE+AND+endpoint.name+%3D+%22%2Fcredential-issuer%2Fcallback%22*&cv=u%2Cfalse&sidebar=a%2Cfalse&tf=now-30m%3Bnow&traceId=6641f937895839b5a76522146864ddb1&tt=2024-12-06T13%3A53%3A38.370217000Z&spanId=ae7938ec57b9495c

### Screenshot

![Screenshot 2024-12-06 at 14 00 41](https://github.com/user-attachments/assets/34d53706-a25c-4190-811f-3e73c29d25fb)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7761](https://govukverify.atlassian.net/browse/PYIC-7761)

[PYIC-7761]: https://govukverify.atlassian.net/browse/PYIC-7761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ