### PR TITLE
PYIC-7811: Reprove identity with F2F

### DIFF
--- a/api-tests/features/p2-reprove-identity.feature
+++ b/api-tests/features/p2-reprove-identity.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: Reprove Identity Journey
 
-    Scenario: User needs to reprove their identity
+    Scenario: User reproves with F2F
         Given the subject already has the following credentials
             | CRI     | scenario                     |
             | dcmaw   | kenneth-driving-permit-valid |
@@ -11,6 +11,28 @@ Feature: Reprove Identity Journey
         Then I get a 'reprove-identity-start' page response
         When I submit a 'next' event
         Then I get a 'page-ipv-identity-document-start' page response
+        When I submit an 'end' event
+        Then I get a 'page-ipv-identity-postoffice-start' page response
+        When I submit a 'next' event
+        Then I get a 'claimedIdentity' CRI response
+        When I submit 'kenneth-current' details to the CRI stub
+        Then I get an 'address' CRI response
+        When I submit 'kenneth-current' details to the CRI stub
+        Then I get a 'fraud' CRI response
+        When I submit 'kenneth-score-2' details to the CRI stub
+        Then I get a 'f2f' CRI response
+        When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+            | Attribute          | Values                                          |
+            | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+        Then I get a 'page-face-to-face-handoff' page response
+
+        # Return journey after popping out to the Post Office
+        When I start a new 'medium-confidence' journey and return to a 'page-ipv-reuse' page response
+        When I submit a 'next' event
+        Then I get an OAuth response
+        When I use the OAuth response to get my identity
+        Then I get a 'P2' identity
+        And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
     Scenario: User needs to reprove their identity with F2F pending
         Given I start a new 'medium-confidence' journey
@@ -25,10 +47,12 @@ Feature: Reprove Identity Journey
         Then I get a 'fraud' CRI response
         When I submit 'kenneth-score-2' details to the CRI stub
         Then I get a 'f2f' CRI response
-        When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
             | Attribute          | Values                                          |
             | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
         Then I get a 'page-face-to-face-handoff' page response
+
+        # Users been to the Post Office but sadly now has an account intervention
         When I start a new 'medium-confidence' journey with reprove identity
         Then I get a 'reprove-identity-start' page response
         When I submit a 'next' event

--- a/api-tests/features/p2-reprove-identity.feature
+++ b/api-tests/features/p2-reprove-identity.feature
@@ -1,5 +1,32 @@
 @Build
 Feature: Reprove Identity Journey
+    Scenario: User reproves identity
+        Given the subject already has the following credentials
+            | CRI     | scenario                     |
+            | dcmaw   | kenneth-driving-permit-valid |
+            | address | kenneth-current              |
+            | fraud   | kenneth-score-2              |
+        When I start a new 'medium-confidence' journey with reprove identity
+        Then I get a 'reprove-identity-start' page response
+        When I submit a 'next' event
+        Then I get a 'page-ipv-identity-document-start' page response
+        When I submit an 'appTriage' event
+        Then I get a 'dcmaw' CRI response
+        When I submit 'kenneth-passport-valid' details to the CRI stub
+        Then I get a 'page-dcmaw-success' page response
+        When I submit a 'next' event
+        Then I get an 'address' CRI response
+        When I submit 'kenneth-current' details to the CRI stub
+        Then I get a 'fraud' CRI response
+        When I submit 'kenneth-score-2' details to the CRI stub
+        Then I get a 'page-ipv-success' page response
+        When I submit a 'next' event
+        Then I get an OAuth response
+        When I use the OAuth response to get my identity
+        Then I get a 'P2' identity
+        And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
+        And an 'IPV_ACCOUNT_INTERVENTION_START' audit event was recorded [local only]
+        And an 'IPV_ACCOUNT_INTERVENTION_END' audit event was recorded [local only]
 
     Scenario: User reproves with F2F
         Given the subject already has the following credentials
@@ -27,7 +54,7 @@ Feature: Reprove Identity Journey
         Then I get a 'page-face-to-face-handoff' page response
 
         # Return journey after popping out to the Post Office
-        When I start a new 'medium-confidence' journey and return to a 'page-ipv-reuse' page response
+        When I start a new 'medium-confidence' journey with reprove identity and return to a 'page-ipv-reuse' page response
         When I submit a 'next' event
         Then I get an OAuth response
         When I use the OAuth response to get my identity

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -169,16 +169,17 @@ When(
 
 // Variant of the journey start that retries, e.g. to wait for an async F2F request
 When(
-  /I start a new '([\w-]+)' journey and return to a '([\w-]+)' page response$/,
+  /I start a new '([\w-]+)' journey( with reprove identity)? and return to a '([\w-]+)' page response$/,
   { timeout: MAX_ATTEMPTS * RETRY_DELAY_MILLIS + 5000 },
   async function (
     this: World,
     journeyType: string,
+    reproveIdentity: " with reprove identity" | undefined,
     expectedPage: string,
   ): Promise<void> {
     let attempt = 1;
     while (attempt <= MAX_ATTEMPTS) {
-      await startNewJourney(this, journeyType, false, undefined);
+      await startNewJourney(this, journeyType, !!reproveIdentity, undefined);
 
       if (!this.lastJourneyEngineResponse) {
         throw new Error("No last journey engine response found.");

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1959,7 +1959,7 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBCrudPolicy:
             TableName: !Ref SessionsTable
-        - DynamoDBCrudPolicy:
+        - DynamoDBReadPolicy:
             TableName: !Ref CRIResponseTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -273,7 +273,8 @@ public class CheckExistingIdentityHandler
                             clientOAuthSessionItem.getUserId(), govukSigninJourneyId, ipAddress);
 
             var reproveIdentity = TRUE.equals(clientOAuthSessionItem.getReproveIdentity());
-            // Don't start a new reprove journey if user is returning from F2F reprove journey
+            // Only skip starting a new reprove identity journey if the user is returning from a F2F
+            // journey
             if (reproveIdentity && !isReprovingWithF2f(f2fResponseItem, credentialBundle)
                     || configService.enabled(RESET_IDENTITY)) {
                 if (lowestGpg45ConfidenceRequested == Vot.P1) {
@@ -319,7 +320,6 @@ public class CheckExistingIdentityHandler
                                 .getParsedVtr()
                                 .getLowestStrengthRequestedVot(configService));
                 ipvSessionService.updateIpvSession(ipvSessionItem);
-                removeReproveIdentityFlag(f2fResponseItem);
                 return profileMatchResponse.get();
             }
 
@@ -327,8 +327,6 @@ public class CheckExistingIdentityHandler
             if (isF2FIncomplete) {
                 return buildF2FIncompleteResponse(f2fResponseItem);
             }
-
-            removeReproveIdentityFlag(f2fResponseItem);
 
             // No profile match
             return isF2FComplete
@@ -611,17 +609,5 @@ public class CheckExistingIdentityHandler
         // does the user have a F2F response item that was created in response to an intervention,
         // and they're returning to core with a pending identity
         return f2fRequest != null && f2fRequest.isReproveIdentity() && vcBundle.isPendingIdentity();
-    }
-
-    private void removeReproveIdentityFlag(CriResponseItem f2fResponseItem) {
-        if (f2fResponseItem != null && f2fResponseItem.isReproveIdentity()) {
-            // Remove the reprove identity flag, so we won't skip reprove identity on a future
-            // journey
-            LOGGER.info(
-                    LogHelper.buildLogMessage(
-                            "Removing reprove identity flag from F2F CRI response item"));
-            f2fResponseItem.setReproveIdentity(false);
-            criResponseService.updateCriResponseItem(f2fResponseItem);
-        }
     }
 }

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -83,7 +83,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -129,6 +131,7 @@ import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_REPROVE_ID
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_REUSE_WITH_STORE_PATH;
+import static uk.gov.di.ipv.core.library.service.CriResponseService.STATUS_PENDING;
 
 @ExtendWith(MockitoExtension.class)
 class CheckExistingIdentityHandlerTest {
@@ -171,6 +174,7 @@ class CheckExistingIdentityHandlerTest {
             new JourneyResponse(JOURNEY_REPEAT_FRAUD_CHECK_PATH);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final VerifiableCredential gpg45Vc = vcDrivingPermit();
+    private static final VerifiableCredential f2fVc = vcF2fM1a();
     private static ECDSASigner jwtSigner;
     private static VerifiableCredential pcl200Vc;
     private static VerifiableCredential pcl250Vc;
@@ -301,7 +305,7 @@ class CheckExistingIdentityHandlerTest {
 
         @ParameterizedTest
         @EnumSource(names = {"M1A", "M1B", "M2B"})
-        void shouldReturnJourneyReuseResponseIfScoresSatisfyM1AGpg45Profile(
+        void shouldReturnJourneyReuseResponseIfScoresSatisfyGpg45Profile(
                 Gpg45Profile matchedProfile) throws Exception {
             var hmrcMigrationVC = vcHmrcMigrationPCL200();
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
@@ -576,8 +580,8 @@ class CheckExistingIdentityHandlerTest {
         when(mockEvcsService.getVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fM1a()))));
-        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID))
-                .thenReturn(createCriResponseStoreItem(CriResponseService.STATUS_PENDING));
+        CriResponseItem criResponseItem = createCriResponseStoreItem(STATUS_PENDING);
+        when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(criResponseItem);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(false);
 
         clientOAuthSessionItem.setVtr(List.of(Vot.PCL250.name(), PCL200.name(), P2.name()));
@@ -1008,42 +1012,180 @@ class CheckExistingIdentityHandlerTest {
         assertEquals(JOURNEY_FAIL_WITH_CI_PATH, journeyResponse.getJourney());
     }
 
-    @Test
-    void shouldReturnReproveP2JourneyStepResponseIfResetIdentityTrue() throws Exception {
-        when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(cimitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
-                .thenReturn(List.of());
-        when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
+    @Nested
+    class ReproveIdentity {
+        @BeforeEach
+        public void beforeEach() throws Exception {
+            when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID))
+                    .thenReturn(ipvSessionItem);
+            when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                    .thenReturn(clientOAuthSessionItem);
+        }
 
-        var journeyResponse =
-                toResponseClass(
-                        checkExistingIdentityHandler.handleRequest(event, context),
-                        JourneyResponse.class);
+        @Test
+        void shouldReturnReproveP2JourneyIfReproveIdentityFlagSet() {
+            clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
 
-        assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH, journeyResponse.getJourney());
-        assertEquals(P2, ipvSessionItem.getTargetVot());
-    }
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-    @Test
-    void shouldReturnReproveP1JourneyStepResponseIfResetIdentityTrueAndP1InVtr() throws Exception {
-        when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
-        when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(cimitService.getContraIndicators(TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
-                .thenReturn(List.of());
-        when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
-        when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
+            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH, journeyResponse.getJourney());
+            assertEquals(P2, ipvSessionItem.getTargetVot());
+        }
 
-        var journeyResponse =
-                toResponseClass(
-                        checkExistingIdentityHandler.handleRequest(event, context),
-                        JourneyResponse.class);
+        @Test
+        void shouldReturnReproveP1JourneyIfReproveIdentityFlagSet() {
+            clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
+            clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
+            lenient().when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
 
-        assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_LOW_PATH, journeyResponse.getJourney());
-        assertEquals(P1, ipvSessionItem.getTargetVot());
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_LOW_PATH, journeyResponse.getJourney());
+            assertEquals(P1, ipvSessionItem.getTargetVot());
+        }
+
+        @Test
+        void shouldReturnReproveP2JourneyIfReproveIdentityFlagSetAndPendingF2FDoesNotHaveFlag() {
+            clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
+            when(criResponseService.getFaceToFaceRequest(TEST_USER_ID))
+                    .thenReturn(
+                            CriResponseItem.builder()
+                                    .reproveIdentity(false)
+                                    .status(STATUS_PENDING)
+                                    .build());
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH, journeyResponse.getJourney());
+            assertEquals(P2, ipvSessionItem.getTargetVot());
+        }
+
+        @Test
+        void shouldNotReturnReproveJourneyIfUserHasPendingF2FWithReproveFlag() {
+            clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
+            when(criResponseService.getFaceToFaceRequest(TEST_USER_ID))
+                    .thenReturn(
+                            CriResponseItem.builder()
+                                    .reproveIdentity(true)
+                                    .status(STATUS_PENDING)
+                                    .build());
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_PENDING_PATH, journeyResponse.getJourney());
+
+            verify(criResponseService, never()).updateCriResponseItem(any());
+        }
+
+        @Test
+        void shouldClearReproveFlagFromPendingF2FIfProfileMatched() throws Exception {
+            clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
+            var f2fResponseItem =
+                    spy(
+                            CriResponseItem.builder()
+                                    .reproveIdentity(true)
+                                    .status(STATUS_PENDING)
+                                    .build());
+            when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(f2fResponseItem);
+            when(mockEvcsService.getVerifiableCredentialsByState(
+                            TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
+                    .thenReturn(Map.of(PENDING_RETURN, new ArrayList<>(List.of(f2fVc))));
+            when(mockVotMatcher.matchFirstVot(List.of(P2), List.of(f2fVc), List.of(), true))
+                    .thenReturn(
+                            Optional.of(
+                                    new VotMatchingResult(P2, M1A, Gpg45Scores.builder().build())));
+            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_REUSE_WITH_STORE_PATH, journeyResponse.getJourney());
+
+            var inorder = inOrder(f2fResponseItem, criResponseService);
+            inorder.verify(f2fResponseItem).setReproveIdentity(false);
+            inorder.verify(criResponseService).updateCriResponseItem(f2fResponseItem);
+            inorder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        void shouldClearReproveFlagFromPendingF2FIfF2FCompleteButNoProfileMatched()
+                throws Exception {
+            clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
+            var f2fResponseItem =
+                    spy(
+                            CriResponseItem.builder()
+                                    .reproveIdentity(true)
+                                    .status(STATUS_PENDING)
+                                    .build());
+            when(criResponseService.getFaceToFaceRequest(TEST_USER_ID)).thenReturn(f2fResponseItem);
+            when(mockEvcsService.getVerifiableCredentialsByState(
+                            TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
+                    .thenReturn(Map.of(PENDING_RETURN, new ArrayList<>(List.of(f2fVc))));
+            when(mockVotMatcher.matchFirstVot(List.of(P2), List.of(f2fVc), List.of(), true))
+                    .thenReturn(Optional.empty());
+            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_F2F_FAIL_PATH, journeyResponse.getJourney());
+
+            var inorder = inOrder(f2fResponseItem, criResponseService);
+            inorder.verify(f2fResponseItem).setReproveIdentity(false);
+            inorder.verify(criResponseService).updateCriResponseItem(f2fResponseItem);
+            inorder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        void shouldReturnReproveP2JourneyStepResponseIfResetIdentityTrue() throws Exception {
+            when(cimitService.getContraIndicators(
+                            TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
+                    .thenReturn(List.of());
+            when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH, journeyResponse.getJourney());
+            assertEquals(P2, ipvSessionItem.getTargetVot());
+        }
+
+        @Test
+        void shouldReturnReproveP1JourneyStepResponseIfResetIdentityTrueAndP1InVtr()
+                throws Exception {
+            clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
+            when(cimitService.getContraIndicators(
+                            TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP))
+                    .thenReturn(List.of());
+            when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
+            when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
+
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_LOW_PATH, journeyResponse.getJourney());
+            assertEquals(P1, ipvSessionItem.getTargetVot());
+        }
     }
 
     @Test

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -370,7 +370,6 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldIncludeCurrentInheritedIdentityInVcBundleWhenPendingReturn() throws Exception {
             var inheritedIdentityVc = vcHmrcMigrationPCL200();
-            var f2fVc = vcF2fM1a();
 
             when(mockEvcsService.getVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
@@ -1026,7 +1025,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldReturnReproveP2JourneyIfReproveIdentityFlagSet() {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
 
-            JourneyResponse journeyResponse =
+            var journeyResponse =
                     toResponseClass(
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);
@@ -1060,7 +1059,7 @@ class CheckExistingIdentityHandlerTest {
                                     .status(STATUS_PENDING)
                                     .build());
 
-            JourneyResponse journeyResponse =
+            var journeyResponse =
                     toResponseClass(
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);
@@ -1070,7 +1069,11 @@ class CheckExistingIdentityHandlerTest {
         }
 
         @Test
-        void shouldNotReturnReproveJourneyIfUserHasPendingF2FWithReproveFlag() {
+        void shouldReturnReproveP2JourneyIfReproveIdentityFlagSetAndIdentityIsNotPending()
+                throws Exception {
+            when(mockEvcsService.getVerifiableCredentialsByState(
+                            TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
+                    .thenReturn(Map.of(CURRENT, new ArrayList<>(List.of(gpg45Vc, f2fVc))));
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
             when(criResponseService.getFaceToFaceRequest(TEST_USER_ID))
                     .thenReturn(
@@ -1079,7 +1082,29 @@ class CheckExistingIdentityHandlerTest {
                                     .status(STATUS_PENDING)
                                     .build());
 
-            JourneyResponse journeyResponse =
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH, journeyResponse.getJourney());
+            assertEquals(P2, ipvSessionItem.getTargetVot());
+        }
+
+        @Test
+        void shouldNotReturnReproveJourneyIfUserHasPendingF2FWithReproveFlag() throws Exception {
+            clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
+            when(mockEvcsService.getVerifiableCredentialsByState(
+                            TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
+                    .thenReturn(Map.of(PENDING_RETURN, new ArrayList<>(List.of(gpg45Vc))));
+            when(criResponseService.getFaceToFaceRequest(TEST_USER_ID))
+                    .thenReturn(
+                            CriResponseItem.builder()
+                                    .reproveIdentity(true)
+                                    .status(STATUS_PENDING)
+                                    .build());
+
+            var journeyResponse =
                     toResponseClass(
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);
@@ -1108,7 +1133,7 @@ class CheckExistingIdentityHandlerTest {
                                     new VotMatchingResult(P2, M1A, Gpg45Scores.builder().build())));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
 
-            JourneyResponse journeyResponse =
+            var journeyResponse =
                     toResponseClass(
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);
@@ -1139,7 +1164,7 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(Optional.empty());
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
 
-            JourneyResponse journeyResponse =
+            var journeyResponse =
                     toResponseClass(
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);
@@ -1159,7 +1184,7 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(List.of());
             when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
 
-            JourneyResponse journeyResponse =
+            var journeyResponse =
                     toResponseClass(
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);
@@ -1178,7 +1203,7 @@ class CheckExistingIdentityHandlerTest {
             when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
             when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
 
-            JourneyResponse journeyResponse =
+            var journeyResponse =
                     toResponseClass(
                             checkExistingIdentityHandler.handleRequest(event, context),
                             JourneyResponse.class);

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -75,7 +75,8 @@ class ProcessAsyncCriCredentialHandlerTest {
                     null,
                     CriResponseService.STATUS_PENDING,
                     0,
-                    List.of());
+                    List.of(),
+                    false);
 
     private static final String TEST_ASYNC_ACCESS_DENIED_ERROR = "access_denied";
     private static final String TEST_ASYNC_ERROR = "invalid";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/CriResponseItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/CriResponseItem.java
@@ -27,6 +27,7 @@ public class CriResponseItem implements PersistenceItem {
     private String status;
     private long ttl;
     private List<String> featureSet;
+    private boolean reproveIdentity;
 
     @DynamoDbPartitionKey
     public String getUserId() {

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -4,6 +4,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
+import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
 
 import java.time.Instant;
@@ -43,7 +44,7 @@ public class CriResponseService {
     }
 
     public void persistCriResponse(
-            String userId,
+            ClientOAuthSessionItem clientOAuthSessionItem,
             Cri credentialIssuer,
             String issuerResponse,
             String oauthState,
@@ -51,13 +52,15 @@ public class CriResponseService {
             List<String> featureSet) {
         CriResponseItem criResponseItem =
                 CriResponseItem.builder()
-                        .userId(userId)
+                        .userId(clientOAuthSessionItem.getUserId())
                         .credentialIssuer(credentialIssuer.getId())
                         .issuerResponse(issuerResponse)
                         .oauthState(oauthState)
                         .dateCreated(Instant.now())
                         .status(status)
                         .featureSet(featureSet)
+                        .reproveIdentity(
+                                Boolean.TRUE.equals(clientOAuthSessionItem.getReproveIdentity()))
                         .build();
         dataStore.create(criResponseItem, ConfigurationVariable.CRI_RESPONSE_TTL);
     }

--- a/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/service/CriResponseServiceTest.java
+++ b/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/service/CriResponseServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
+import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
 
 import java.time.Instant;
@@ -65,7 +66,10 @@ class CriResponseServiceTest {
     void shouldPersistCriResponse() {
         var featureSet = List.of(TEST_FEATURE_SET);
         criResponseService.persistCriResponse(
-                TEST_USER_ID,
+                ClientOAuthSessionItem.builder()
+                        .userId(TEST_USER_ID)
+                        .reproveIdentity(Boolean.FALSE)
+                        .build(),
                 F2F,
                 TEST_ISSUER_RESPONSE,
                 TEST_OAUTH_STATE,

--- a/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
+++ b/libs/cri-storing-service/src/main/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringService.java
@@ -109,13 +109,6 @@ public class CriStoringService {
             throws JsonProcessingException {
         var userId = clientOAuthSessionItem.getUserId();
 
-        var auditEventUser =
-                new AuditEventUser(
-                        userId,
-                        ipvSessionId,
-                        clientOAuthSessionItem.getGovukSigninJourneyId(),
-                        ipAddress);
-
         var vcResponseDto =
                 VerifiableCredentialResponseDto.builder()
                         .userId(userId)
@@ -123,12 +116,19 @@ public class CriStoringService {
                         .build();
 
         criResponseService.persistCriResponse(
-                userId,
+                clientOAuthSessionItem,
                 cri,
                 OBJECT_MAPPER.writeValueAsString(vcResponseDto),
                 criOAuthSessionId,
                 CriResponseService.STATUS_PENDING,
                 featureSet);
+
+        var auditEventUser =
+                new AuditEventUser(
+                        userId,
+                        ipvSessionId,
+                        clientOAuthSessionItem.getGovukSigninJourneyId(),
+                        ipAddress);
 
         sendAuditEventForProcessedVcResponse(
                 CriResourceRetrievedType.PENDING.getType(), cri, auditEventUser, deviceInformation);

--- a/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
+++ b/libs/cri-storing-service/src/test/java/uk/gov/di/ipv/core/library/cristoringservice/CriStoringServiceTest.java
@@ -59,7 +59,7 @@ class CriStoringServiceTest {
     @Mock private CimitService mockCimitService;
     @Mock private IpvSessionItem mockIpvSessionItem;
     @InjectMocks private CriStoringService criStoringService;
-    @Captor private ArgumentCaptor<String> userIdCaptor;
+    @Captor private ArgumentCaptor<ClientOAuthSessionItem> clientSessionItemCaptor;
     @Captor private ArgumentCaptor<Cri> criCaptor;
     @Captor private ArgumentCaptor<String> vcResponseCaptor;
     @Captor private ArgumentCaptor<String> criOAuthSessionIdCaptor;
@@ -107,7 +107,7 @@ class CriStoringServiceTest {
         // verify
         verify(mockCriResponseService)
                 .persistCriResponse(
-                        userIdCaptor.capture(),
+                        clientSessionItemCaptor.capture(),
                         criCaptor.capture(),
                         vcResponseCaptor.capture(),
                         criOAuthSessionIdCaptor.capture(),
@@ -121,7 +121,9 @@ class CriStoringServiceTest {
         assertEquals(F2F, criCaptor.getValue());
         assertEquals(TEST_CRI_OAUTH_SESSION_ID, criOAuthSessionIdCaptor.getValue());
 
-        assertEquals(clientOAuthSessionItem.getUserId(), userIdCaptor.getValue());
+        assertEquals(
+                clientOAuthSessionItem.getUserId(), clientSessionItemCaptor.getValue().getUserId());
+        assertEquals(Boolean.TRUE, clientSessionItemCaptor.getValue().getReproveIdentity());
         var expectedVcResponseDto =
                 VerifiableCredentialResponseDto.builder()
                         .userId(clientOAuthSessionItem.getUserId())
@@ -361,6 +363,7 @@ class CriStoringServiceTest {
         return ClientOAuthSessionItem.builder()
                 .userId(TEST_USER_ID)
                 .scope(ScopeConstants.OPENID)
+                .reproveIdentity(Boolean.TRUE)
                 .build();
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Reprove identity with F2F

### Why did it change

This change allows a user to use the F2F route to reprove their identity after receiving an intervention.

We store the fact that a F2F journey was started after an intervention on the CriResponse item, and then clear that flag once they've completed the journey.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7811](https://govukverify.atlassian.net/browse/PYIC-7811)


[PYIC-7811]: https://govukverify.atlassian.net/browse/PYIC-7811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ