### PR TITLE
PYIC-7862 Add dependabot registries config for github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,19 @@
 # See also: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+registries:
+  github-npm:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.GITHUB_TOKEN }}
+  github-maven:
+    type: maven-repository
+    url: https://maven.pkg.github.com
+    token: ${{ secrets.GITHUB_TOKEN }}
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
+    registries: *
     schedule:
       interval: "daily"
       time: "03:00"
@@ -47,6 +57,7 @@ updates:
           - "@typescript-eslint/*"
   - package-ecosystem: "npm"
     directory: "/api-tests"
+    registries: *
     schedule:
       interval: "daily"
       time: "03:00"


### PR DESCRIPTION
## Proposed changes

### What changed

Add Maven and NPM GitHub packages registries

### Why did it change

By default dependabot cannot authenticate with these registries

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7862](https://govukverify.atlassian.net/browse/PYIC-7862)


[PYIC-7862]: https://govukverify.atlassian.net/browse/PYIC-7862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ