### PR TITLE
PYIC-7761: Recreate http client with tracing

### DIFF
--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClientTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClientTest.java
@@ -1,11 +1,10 @@
-package uk.gov.di.ipv.core.library;
+package uk.gov.di.ipv.core.library.tracing;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
 
 import java.io.IOException;
 import java.net.URI;
@@ -22,19 +21,6 @@ import static org.mockito.Mockito.when;
 class TracingHttpClientTest {
     @Mock private HttpClient mockHttpClient;
     @InjectMocks private TracingHttpClient tracingHttpClient;
-
-    @Test
-    void sendShouldRetryGoawayResponse() throws Exception {
-        when(mockHttpClient.send(any(), any()))
-                .thenThrow(new IOException("GOAWAY received"))
-                .thenReturn(null);
-
-        tracingHttpClient.send(
-                HttpRequest.newBuilder().uri(URI.create("https://example.com")).build(),
-                HttpResponse.BodyHandlers.ofString());
-
-        verify(mockHttpClient, times(2)).send(any(), any());
-    }
 
     @Test
     void sendShouldRetryConnectionReset() throws Exception {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Recreate http client with tracing

### Why did it change

We introduced logic to recreate the base client in our tracing http client every hour. The new base client wasn't being created with instrumentation though, and so we lost things like spans in Dynatrace. This updates to recreate the client in the same way we create in initially.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7761](https://govukverify.atlassian.net/browse/PYIC-7761)


[PYIC-7761]: https://govukverify.atlassian.net/browse/PYIC-7761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ