### PR TITLE
PYIC-7532: Routing for new strategic app abandoned page

### DIFF
--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -164,5 +164,5 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
     When I submit a 'neither' event
     Then I get a 'non-uk-no-app-options' page response
-    When I submit a 'back' event
+    When I submit a 'useApp' event
     Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -151,3 +151,18 @@ Feature: M2B Strategic App Journeys
     Then I get a 'non-uk-no-passport' page response
     When I submit a 'useApp' event
     Then I get a 'identify-device' page response
+  Scenario: Strategic app non-uk address user retries with app
+    Given I start a new 'medium-confidence' journey
+    And I activate the 'internationalAddress,strategicApp' feature sets
+    And I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'international' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+    When I submit a 'neither' event
+    Then I get a 'non-uk-no-app-options' page response
+    When I submit a 'back' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -151,12 +151,15 @@ Feature: M2B Strategic App Journeys
     Then I get a 'non-uk-no-passport' page response
     When I submit a 'useApp' event
     Then I get a 'identify-device' page response
+
   Scenario: Strategic app non-uk address user retries with app
     Given I start a new 'medium-confidence' journey
     And I activate the 'internationalAddress,strategicApp' feature sets
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
+    Then I get a 'non-uk-passport' page response
+    When I submit a 'next' event
     Then I get a 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -173,6 +176,8 @@ Feature: M2B Strategic App Journeys
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
+    Then I get a 'non-uk-passport' page response
+    When I submit a 'next' event
     Then I get a 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -166,3 +166,19 @@ Feature: M2B Strategic App Journeys
     Then I get a 'non-uk-no-app-options' page response
     When I submit a 'useApp' event
     Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+
+  Scenario: Strategic app non-uk address user wants to prove identity another way from download page
+    Given I start a new 'medium-confidence' journey
+    And I activate the 'internationalAddress,strategicApp' feature sets
+    And I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'international' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+    When I submit a 'iphone' event
+    Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone'
+    When I submit a 'preferNoApp' event
+    Then I get a 'non-uk-no-app-options' page response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -41,6 +41,9 @@ nestedJourneyStates:
         targetState: DAD_ANDROID_START_SESSION
       neither:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: DAD_SELECT_SMARTPHONE_NON_UK_NO_APP_OPTIONS
 
   DAD_SELECT_SMARTPHONE_EXIT_BUFFER:
     response:
@@ -86,6 +89,9 @@ nestedJourneyStates:
         targetState: CHECK_MOBILE_APP_RESULT
       preferNoApp:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -109,6 +115,9 @@ nestedJourneyStates:
         targetState: CHECK_MOBILE_APP_RESULT
       preferNoApp:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -191,6 +200,9 @@ nestedJourneyStates:
         targetState: CHECK_MOBILE_APP_RESULT
       preferNoApp:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -214,6 +226,9 @@ nestedJourneyStates:
         targetState: CHECK_MOBILE_APP_RESULT
       preferNoApp:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkFeatureFlag:
+          internationalAddressEnabled:
+            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -224,6 +239,56 @@ nestedJourneyStates:
     events:
       anotherWay:
         exitEventToEmit: anotherWay
+      back:
+        targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+
+  DAD_SELECT_SMARTPHONE_NON_UK_NO_APP_OPTIONS:
+    response:
+      type: page
+      pageId: non-uk-no-app-options
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      back:
+        targetState: DAD_SELECT_SMARTPHONE
+
+  DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
+    response:
+      type: page
+      pageId: non-uk-no-app-options
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      back:
+        targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
+
+  DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
+    response:
+      type: page
+      pageId: non-uk-no-app-options
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      back:
+        targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
+
+  MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
+    response:
+      type: page
+      pageId: non-uk-no-app-options
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      back:
+        targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
+
+  MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
+    response:
+      type: page
+      pageId: non-uk-no-app-options
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
       back:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -249,7 +249,7 @@ nestedJourneyStates:
     events:
       returnToRp:
         exitEventToEmit: returnToRp
-      back:
+      useApp:
         targetState: DAD_SELECT_SMARTPHONE
 
   DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
@@ -259,7 +259,7 @@ nestedJourneyStates:
     events:
       returnToRp:
         exitEventToEmit: returnToRp
-      back:
+      useApp:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
 
   DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
@@ -269,7 +269,7 @@ nestedJourneyStates:
     events:
       returnToRp:
         exitEventToEmit: returnToRp
-      back:
+      useApp:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
 
   MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
@@ -279,7 +279,7 @@ nestedJourneyStates:
     events:
       returnToRp:
         exitEventToEmit: returnToRp
-      back:
+      useApp:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
 
   MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
@@ -289,7 +289,7 @@ nestedJourneyStates:
     events:
       returnToRp:
         exitEventToEmit: returnToRp
-      back:
+      useApp:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
 
   CHECK_MOBILE_APP_RESULT:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -147,6 +147,8 @@ states:
         targetState: ERROR
       anotherWay:
         targetState: MULTIPLE_DOC_CHECK_PAGE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   F2F_START_PAGE:
     response:
@@ -563,6 +565,8 @@ states:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_01_APP_DOC_CHECK:
     nestedJourney: APP_DOC_CHECK
@@ -655,6 +659,8 @@ states:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   APP_DOC_CHECK_PYI_ESCAPE:
     nestedJourney: APP_DOC_CHECK

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -184,6 +184,8 @@ states:
         targetState: ERROR
       anotherWay:
         targetState: MULTIPLE_DOC_CHECK_PAGE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   F2F_START_PAGE:
     response:
@@ -623,6 +625,8 @@ states:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_01_APP_DOC_CHECK:
     nestedJourney: APP_DOC_CHECK
@@ -715,6 +719,8 @@ states:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   APP_DOC_CHECK_PYI_ESCAPE:
     nestedJourney: APP_DOC_CHECK

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -121,6 +121,8 @@ states:
       anotherWay:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   CRI_DCMAW:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -135,6 +135,8 @@ states:
       anotherWay:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   POST_APP_DOC_CHECK_NAMES_ONLY:
     response:
@@ -232,6 +234,8 @@ states:
       anotherWay:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   APP_DOC_CHECK_NAMES_WITH_ADDRESS:
     nestedJourney: APP_DOC_CHECK


### PR DESCRIPTION

## Proposed changes

### What changed

For when the Strategic App goes live. The user may want to exit or prove their identity another way when given the option across the pages on the international address journey.

Subsequent PR for new page:  https://github.com/govuk-one-login/ipv-core-front/pull/1739

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7532](https://govukverify.atlassian.net/browse/PYIC-7532)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7532]: https://govukverify.atlassian.net/browse/PYIC-7532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ