### PR TITLE
PYIC-7547: Remove criOAuthSessionId as a GSI of SessionsTable

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2711,8 +2711,6 @@ Resources:
           AttributeType: "S"
         - AttributeName: "accessToken"
           AttributeType: "S"
-        - AttributeName: "criOAuthSessionId"
-          AttributeType: "S"
         - AttributeName: "clientOAuthSessionId"
           AttributeType: "S"
       KeySchema:
@@ -2728,12 +2726,6 @@ Resources:
         - IndexName: "accessToken"
           KeySchema:
             - AttributeName: "accessToken"
-              KeyType: "HASH"
-          Projection:
-            ProjectionType: "ALL"
-        - IndexName: "criOAuthSessionId"
-          KeySchema:
-            - AttributeName: "criOAuthSessionId"
               KeyType: "HASH"
           Projection:
             ProjectionType: "ALL"


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove `criOAuthSessionId` as a GSI of SessionsTable

### Why did it change

- Unused/able
- Costs money

### Notes

- Will look to merge this after the code freeze. (EPA)

### Issue tracking

- [PYIC-7547](https://govukverify.atlassian.net/browse/PYIC-7547)

[PYIC-7547]: https://govukverify.atlassian.net/browse/PYIC-7547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ