### PR TITLE
PYIC-7532: Add initial journey routing for non-uk strategic app users and amend api-tests

### DIFF
--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -11,12 +11,15 @@ Feature: P2 App journey
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
 
-  Scenario: Visit UK landing page - no
-    When I submit a 'international' event
-    Then I get a 'dcmaw' CRI response
-
   Scenario: International address user sends a next event on exit page from DCMAW
     When I submit a 'international' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response
+    When I submit a 'iphone' event
+    Then I get a 'pyi-triage-desktop-download-app' page response
+    When I submit a 'next' event
+    Then I get a 'pyi-triage-desktop-download-app' page response
     Then I get a 'dcmaw' CRI response
     When I call the CRI stub and get an 'access_denied' OAuth error
     Then I get a 'non-uk-no-app' page response

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -113,3 +113,17 @@ Feature: M2B Strategic App Journeys
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response
+
+  Scenario: Strategic app non-uk address user gets to download app
+    Given I start a new 'medium-confidence' journey
+    And I activate the 'internationalAddress,strategicApp' feature sets
+    And I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'international' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response
+    When I submit a 'iphone' event
+    Then I get a 'pyi-triage-desktop-download-app' page response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -834,8 +834,8 @@ states:
       uk:
         targetState: IDENTITY_START_PAGE
       international:
-        targetState: APP_DOC_CHECK_INTERNATIONAL_ADDRESS
-        targetEntryEvent: next
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   NON_UK_NO_APP_PAGE:
     response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add initial wiring up of non-uk strategic app users
For now create api-tests up until the download pages, follow up ticket to test the full journey

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7532](https://govukverify.atlassian.net/browse/PYIC-7532)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[PYIC-7532]: https://govukverify.atlassian.net/browse/PYIC-7532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ