### PR TITLE
PYIC-7862 dedicated token for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,13 @@ registries:
   github-npm:
     type: npm-registry
     url: https://npm.pkg.github.com
-    token: ${{ secrets.GITHUB_TOKEN }}
+    username: ${{ secrets.DEPENDABOT_GITHUB_USERNAME }}
+    password: ${{ secrets.DEPENDABOT_GITHUB_TOKEN }}
   github-maven:
     type: maven-repository
     url: https://maven.pkg.github.com
-    token: ${{ secrets.GITHUB_TOKEN }}
+    username: ${{ secrets.DEPENDABOT_GITHUB_USERNAME }}
+    password: ${{ secrets.DEPENDABOT_GITHUB_TOKEN }}
 updates:
   - package-ecosystem: "gradle"
     directory: "/"


### PR DESCRIPTION
GITHUB_TOKEN is not available when github runs (see https://github.com/dependabot/dependabot-core/issues/10144 and https://github.com/dependabot/dependabot-core/issues/8411)

Instead, try using an explicitly configured token