### PR TITLE
PYIC-7799: Create traffic when deploying

### DIFF
--- a/api-tests/cucumber.js
+++ b/api-tests/cucumber.js
@@ -16,3 +16,8 @@ export const codepipeline = {
   ...base,
   retry: 1,
 };
+
+export const trafficGeneration = {
+  ...base,
+  parallel: 3,
+};

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -1,4 +1,5 @@
 @Build
+@TrafficGeneration
 Feature: P2 App journey
 
   Background:

--- a/api-tests/features/p2-reuse-journey.feature
+++ b/api-tests/features/p2-reuse-journey.feature
@@ -1,4 +1,5 @@
 @Build
+@TrafficGeneration
 Feature: P2 Reuse journey
 
   Scenario: Successful P2 reuse journey

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -1,4 +1,5 @@
 @Build
+@TrafficGeneration
 Feature: P2 Web document journey
   Background: Start P2 journey and ineligible for the app
     Given I start a new 'medium-confidence' journey

--- a/api-tests/secure-pipeline/run-tests.sh
+++ b/api-tests/secure-pipeline/run-tests.sh
@@ -2,10 +2,20 @@
 
 set -eo pipefail
 
+get_current_status() {
+  aws codepipeline get-pipeline-state --name "$1" \
+    | jq -r '.stageStates[] | select(.stageName == "Deploy") | .actionStates[] | select(.actionName == "Deploy") | .latestExecution.status'
+}
+
+generate_traffic() {
+  while true; do
+    echo "Running @TrafficGeneration tests"
+    npm run test:build -- --profile trafficGeneration --tags '@TrafficGeneration'
+  done
+}
+
 # Ensure the test report dir exists
 [ -e "$TEST_REPORT_ABSOLUTE_DIR" ] && mkdir -p "$TEST_REPORT_ABSOLUTE_DIR"
-
-echo "Running API tests against the build environment"
 
 CORE_BACK_INTERNAL_API_KEY=$(aws secretsmanager get-secret-value --secret-id CoreBackInternalTestingApiKey | jq -r .SecretString)
 export CORE_BACK_INTERNAL_API_KEY
@@ -19,7 +29,7 @@ export CRI_STUB_GEN_CRED_API_KEY
 MANAGEMENT_TICF_API_KEY=$(aws secretsmanager get-secret-value --secret-id /build/core/credentialIssuers/ticf/connections/stub/apiKey | jq -r .SecretString)
 export MANAGEMENT_TICF_API_KEY
 
-MANAGEMENT_CIMIT_STUB_API_KEY=$(aws ssm get-parameter --name /tests/core-back-build/cimit_api_key | jq -r .Parameter.Value)
+MANAGEMENT_CIMIT_STUB_API_KEY=$(aws secretsmanager get-secret-value --secret-id /build/core/cimitManagementApi/apiKey | jq -r .SecretString)
 export MANAGEMENT_CIMIT_STUB_API_KEY
 
 CIMIT_INTERNAL_API_KEY=$(aws secretsmanager get-secret-value --secret-id /build/core/cimitApi/apiKey | jq -r .SecretString)
@@ -27,15 +37,40 @@ export CIMIT_INTERNAL_API_KEY
 
 cd /api-tests
 
-npm run test:build -- --profile codepipeline
+if [[ "${DEV_PLATFORM_STAGE}" == "TRAFFIC_TEST" ]]; then
+  sleep 30 # Wait to ensure deploy action is up and running
+  generate_traffic & # Start API tests to generate traffic and send to the background
+  tests_pid=$!
+  trap 'kill $tests_pid' EXIT
+  echo "Started running API tests in background with PID: ${tests_pid}"
 
-api_tests_exit_code=$?
-cp reports/api-tests-cucumber-report.json "$TEST_REPORT_ABSOLUTE_DIR"
+  core_back_pipeline_name=$(aws codepipeline list-pipelines \
+    | jq -r '.pipelines[] | select(.name | contains("core-back-pipeline")) | .name')
+  deploy_status=$(get_current_status "${core_back_pipeline_name}")
 
-if [ $api_tests_exit_code != 0 ]
-then
-  echo "API tests failed with exit code ${api_tests_exit_code}"
-  exit $api_tests_exit_code
+  start_time=$(date +%s)
+  echo "Start time: ${start_time}"
+  # Loop until the deploy action is not in progress, or until 30 minutes has passed
+  while [[ "${deploy_status}" = "InProgress" && "${start_time}" -gt $(($(date +%s)-1800)) ]]; do
+    sleep 10
+    deploy_status=$(get_current_status "${core_back_pipeline_name}")
+  done
+
+  echo "Deploy status: '${deploy_status}' - Stopping tests execution"
+  exit 0
+
 else
-  echo "API tests passed"
+  echo "Running API tests against the build environment"
+  npm run test:build -- --profile codepipeline
+
+  api_tests_exit_code=$?
+  cp reports/api-tests-cucumber-report.json "$TEST_REPORT_ABSOLUTE_DIR"
+
+  if [ $api_tests_exit_code != 0 ]
+  then
+    echo "API tests failed with exit code ${api_tests_exit_code}"
+    exit $api_tests_exit_code
+  else
+    echo "API tests passed"
+  fi
 fi


### PR DESCRIPTION
**This can't be merged without https://github.com/govuk-one-login/devplatform-deploy/pull/2188**

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Create traffic when deploying

### Why did it change

This updates the api-tests image to be able to run in a mode that will just generate traffic in the build env. This is to ensure we have traffic to inform the canarys.

It will poll for the status of the deploy action, and stop sending traffic when it's no longer in progress.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7799](https://govukverify.atlassian.net/browse/PYIC-7799)


[PYIC-7799]: https://govukverify.atlassian.net/browse/PYIC-7799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ