### PR TITLE
PYIC-7646: Add International Address biometric passport triage routing

### DIFF
--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -150,4 +150,4 @@ Feature: M2B Strategic App Journeys
     When I submit a 'end' event
     Then I get a 'non-uk-no-passport' page response
     When I submit a 'back' event
-    Then I get a 'non-uk-passport' page response
+    Then I get a 'identify-device' page response

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -135,7 +135,7 @@ Feature: M2B Strategic App Journeys
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
     Then I get a 'non-uk-passport' page response
-    When I submit a 'end' event
+    When I submit a 'abandon' event
     Then I get a 'non-uk-no-passport' page response
     When I submit a 'returnToRp' event
     Then I get an OAuth response
@@ -147,7 +147,7 @@ Feature: M2B Strategic App Journeys
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
     Then I get a 'non-uk-passport' page response
-    When I submit a 'end' event
+    When I submit a 'abandon' event
     Then I get a 'non-uk-no-passport' page response
-    When I submit a 'next' event
+    When I submit a 'useApp' event
     Then I get a 'identify-device' page response

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -149,5 +149,5 @@ Feature: M2B Strategic App Journeys
     Then I get a 'non-uk-passport' page response
     When I submit a 'end' event
     Then I get a 'non-uk-no-passport' page response
-    When I submit a 'back' event
+    When I submit a 'next' event
     Then I get a 'identify-device' page response

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -115,11 +115,12 @@ Feature: M2B Strategic App Journeys
     Then I get a 'page-ipv-identity-postoffice-start' page response
 
   Scenario: Strategic app non-uk address user gets to download app
-    Given I start a new 'medium-confidence' journey
-    And I activate the 'internationalAddress,strategicApp' feature sets
+    Given I activate the 'internationalAddress,strategicApp' feature sets
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
+    Then I get a 'non-uk-passport' page response
+    When I submit a 'next' event
     Then I get a 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -127,3 +128,26 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
     When I submit a 'iphone' event
     Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone'
+
+  Scenario: Strategic app non-uk address user abandons due to no biometric passport
+    Given I activate the 'internationalAddress,strategicApp' feature sets
+    And I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'international' event
+    Then I get a 'non-uk-passport' page response
+    When I submit a 'end' event
+    Then I get a 'non-uk-no-passport' page response
+    When I submit a 'returnToRp' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+
+  Scenario: Strategic app non-uk address user abandons due to no biometric passport then returns
+    Given I activate the 'internationalAddress,strategicApp' feature sets
+    And I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'international' event
+    Then I get a 'non-uk-passport' page response
+    When I submit a 'end' event
+    Then I get a 'non-uk-no-passport' page response
+    When I submit a 'back' event
+    Then I get a 'non-uk-passport' page response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -848,7 +848,7 @@ states:
       next:
         targetState: STRATEGIC_APP_TRIAGE
         targetEntryEvent: appTriage
-      end:
+      abandon:
         targetState: NON_UK_NO_PASSPORT
 
   NON_UK_NO_PASSPORT:
@@ -858,7 +858,7 @@ states:
     events:
       returnToRp:
         targetState: RETURN_TO_RP
-      next:
+      useApp:
         targetState: STRATEGIC_APP_TRIAGE
         targetEntryEvent: appTriage
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -858,7 +858,7 @@ states:
     events:
       returnToRp:
         targetState: RETURN_TO_RP
-      back:
+      next:
         targetState: STRATEGIC_APP_TRIAGE
         targetEntryEvent: appTriage
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -859,7 +859,8 @@ states:
       returnToRp:
         targetState: RETURN_TO_RP
       back:
-        targetState: NON_UK_PASSPORT
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   NON_UK_NO_APP_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -834,27 +834,27 @@ states:
       uk:
         targetState: IDENTITY_START_PAGE
       international:
-        targetState: NON_UK_PASSPORT
-
-  NON_UK_PASSPORT:
-    response:
-      type: page
-      pageId: non-uk-no-app
-    events:
-      next:
         targetState: APP_DOC_CHECK_INTERNATIONAL_ADDRESS
         targetEntryEvent: next
         checkFeatureFlag:
           strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+            targetState: NON_UK_PASSPORT
+
+  NON_UK_PASSPORT:
+    response:
+      type: page
+      pageId: non-uk-passport
+    events:
+      next:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
       end:
         targetState: NON_UK_NO_PASSPORT
 
   NON_UK_NO_PASSPORT:
     response:
       type: page
-      pageId: non-uk-no-app
+      pageId: non-uk-no-passport
     events:
       returnToRp:
         targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -834,12 +834,32 @@ states:
       uk:
         targetState: IDENTITY_START_PAGE
       international:
+        targetState: NON_UK_PASSPORT
+
+  NON_UK_PASSPORT:
+    response:
+      type: page
+      pageId: non-uk-no-app
+    events:
+      next:
         targetState: APP_DOC_CHECK_INTERNATIONAL_ADDRESS
         targetEntryEvent: next
         checkFeatureFlag:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE
             targetEntryEvent: appTriage
+      end:
+        targetState: NON_UK_NO_PASSPORT
+
+  NON_UK_NO_PASSPORT:
+    response:
+      type: page
+      pageId: non-uk-no-app
+    events:
+      returnToRp:
+        targetState: RETURN_TO_RP
+      back:
+        targetState: NON_UK_PASSPORT
 
   NON_UK_NO_APP_PAGE:
     response:


### PR DESCRIPTION
## Proposed changes

### What changed

- Add routing for biometric passport if int address
- API tests for these and updated existing int address work to include them

### Why did it change

- Initiative work

### Issue tracking

- [PYIC-7646](https://govukverify.atlassian.net/browse/PYIC-7646)

[PYIC-7646]: https://govukverify.atlassian.net/browse/PYIC-7646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ