### PR TITLE
PYIC-7861: Add routing for the new app / doc triage page

### DIFF
--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -7,16 +7,14 @@ Feature: P2 App journey
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
 
-  Scenario: Visit UK landing page - yes
+  Scenario: User resides in the UK and navigates to the start page
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
 
-  Scenario: Visit UK landing page - no
-    When I submit a 'international' event
-    Then I get a 'dcmaw' CRI response
-
   Scenario: International address user sends a next event on exit page from DCMAW
     When I submit a 'international' event
+    Then I get a 'non-uk-app-intro' page response
+    When I submit a 'useApp' event
     Then I get a 'dcmaw' CRI response
     When I call the CRI stub and get an 'access_denied' OAuth error
     Then I get a 'non-uk-no-app' page response
@@ -25,6 +23,8 @@ Feature: P2 App journey
 
   Scenario: International address user sends an end event on exit page from DCMAW
     When I submit a 'international' event
+    Then I get a 'non-uk-app-intro' page response
+    When I submit a 'useApp' event
     Then I get a 'dcmaw' CRI response
     When I call the CRI stub and get an 'access_denied' OAuth error
     Then I get a 'non-uk-no-app' page response
@@ -34,6 +34,8 @@ Feature: P2 App journey
 
   Scenario: Successful P2 identity via DCMAW using passport
     When I submit an 'international' event
+    Then I get a 'non-uk-app-intro' page response
+    When I submit a 'useApp' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-passport-valid' details to the CRI stub
     Then I get a 'page-dcmaw-success' page response
@@ -50,3 +52,11 @@ Feature: P2 App journey
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
+
+  Scenario: User looks for alternative methods to prove identity without using the app
+    When I submit an 'international' event
+    Then I get a 'non-uk-app-intro' page response
+    When I submit a 'returnToRp' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P0' identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -834,12 +834,22 @@ states:
       uk:
         targetState: IDENTITY_START_PAGE
       international:
-        targetState: APP_DOC_CHECK_INTERNATIONAL_ADDRESS
-        targetEntryEvent: next
+        targetState: NON_UK_APP_INTRO_PAGE
         checkFeatureFlag:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE
             targetEntryEvent: appTriage
+
+  NON_UK_APP_INTRO_PAGE:
+    response:
+      type: page
+      pageId: non-uk-app-intro
+    events:
+      useApp:
+        targetState: APP_DOC_CHECK_INTERNATIONAL_ADDRESS
+        targetEntryEvent: next
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   NON_UK_NO_APP_PAGE:
     response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add routing for the new app / doc triage page
Subsequent PR: https://github.com/govuk-one-login/ipv-core-front/pull/1744

### Why did it change

A new page is needed to tell international users that they can only prove their identity using the app and a chipped passport. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7861](https://govukverify.atlassian.net/browse/PYIC-7861)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7861]: https://govukverify.atlassian.net/browse/PYIC-7861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ