### PR TITLE
PYIC-7746: Embedded metrics for CRI completion

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ powertools = "1.18.0"
 
 [libraries]
 aspectj = { module = "org.aspectj:aspectjrt", version = { strictly = "1.9.8" } }
+awsEmbededMetrics = "software.amazon.cloudwatchlogs:aws-embedded-metrics:4.2.0"
 awsLambdaJavaCore = "com.amazonaws:aws-lambda-java-core:1.2.3"
 awsLambdaJavaEvents = "com.amazonaws:aws-lambda-java-events:3.14.0"
 awsSdkBom = { module = "software.amazon.awssdk:bom", version.ref = "awsSdk" }

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -38,6 +38,7 @@ import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45ProfileEvaluator;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45Scores;
+import uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.oauthkeyservice.OAuthKeyService;
@@ -75,6 +76,8 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_IS
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_TARGET_VOT;
 import static uk.gov.di.ipv.core.library.domain.EvidenceRequest.SCORING_POLICY_GPG45;
+import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Dimension.CRI;
+import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.CRI_REDIRECT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_REDIRECT_URI;
 import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getFeatureSet;
@@ -210,6 +213,9 @@ public class BuildCriOauthRequestHandler
                             configService.getParameter(ConfigurationVariable.COMPONENT_ID),
                             auditEventUser,
                             new AuditRestrictedDeviceInformation(input.getDeviceInformation())));
+
+            EmbeddedMetricHelper.createMetrics(
+                    Map.of(CRI, cri.getId()), Map.of(CRI_REDIRECT, 1.0), govukSigninJourneyId);
 
             var message =
                     new StringMapMessage()

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 			libs.diVocab
 	implementation platform(libs.awsSdkBom),
 			platform(libs.openTelemetryBom),
+			libs.awsEmbededMetrics,
 			libs.awsLambdaJavaEvents,
 			libs.awsSdkDynamodb,
 			libs.awsSdkDynamodbEnhanced,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/EmbeddedMetricHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/EmbeddedMetricHelper.java
@@ -1,0 +1,61 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
+import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.Map;
+
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE;
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_GOVUK_SIGNIN_JOURNEY_ID;
+
+@ExcludeFromGeneratedCoverageReport
+public class EmbeddedMetricHelper {
+    private static final MetricsLogger METRICS_LOGGER = getMetricsLogger();
+    private static final String CORE_BACK_EMBEDDED_METRICS_NAMESPACE = "CoreBackEmbeddedMetrics";
+
+    @Getter
+    @AllArgsConstructor
+    @ExcludeFromGeneratedCoverageReport
+    public enum Metric {
+        CRI_REDIRECT("criRedirect"),
+        CRI_RETURN("criReturn");
+
+        private final String name;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @ExcludeFromGeneratedCoverageReport
+    public enum Dimension {
+        CRI("cri");
+
+        private final String name;
+    }
+
+    public static void createMetrics(
+            Map<Dimension, String> dimensions,
+            Map<Metric, Double> metrics,
+            String govukSigninJourneyId) {
+        METRICS_LOGGER.setNamespace(CORE_BACK_EMBEDDED_METRICS_NAMESPACE);
+        METRICS_LOGGER.putProperty(
+                LOG_GOVUK_SIGNIN_JOURNEY_ID.getFieldName(),
+                govukSigninJourneyId == null
+                        ? GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE
+                        : govukSigninJourneyId);
+        dimensions.forEach(
+                (dimension, value) ->
+                        METRICS_LOGGER.putDimensions(DimensionSet.of(dimension.getName(), value)));
+        metrics.forEach((metric, value) -> METRICS_LOGGER.putMetric(metric.getName(), value));
+
+        METRICS_LOGGER.flush();
+    }
+
+    private static MetricsLogger getMetricsLogger() {
+        var metricsLogger = new MetricsLogger();
+        metricsLogger.setFlushPreserveDimensions(false);
+        return metricsLogger;
+    }
+}


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Embedded metrics for CRI completion

### Why did it change
This change starts sending custom metrics to track the rate of users being sent to CRIs and then returning. We can compare these two metrics to help us understand if the completion rates for different CRIs is changing. And alert on it in future.

We're using the logging mechanism, rather than sending custom metrics directly with the cloudwatch SDK to avoid having to have a new AWS client that needs to be initialised. The logs may also be useful for more refined queries.

This uses the embedded metrics mechanism, rather than creating a metric log filter, as it's more explicit and will be harder to break accidentally (by changing a log message for example).

### Screenshots - generated by running the selenium tests

<img width="1434" alt="Screenshot 2024-12-12 at 17 42 57" src="https://github.com/user-attachments/assets/10a9ffaf-5947-4990-ba9f-99e9ab951efd" />
---
<img width="1214" alt="Screenshot 2024-12-12 at 17 46 06" src="https://github.com/user-attachments/assets/f0760cad-4df9-4f54-a516-dfd18e5a51f6" />

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7746](https://govukverify.atlassian.net/browse/PYIC-7746)


[PYIC-7746]: https://govukverify.atlassian.net/browse/PYIC-7746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ