### PR TITLE
PYIC-7799: Ensure TrafficGeneration continues on failure

### DIFF
--- a/api-tests/secure-pipeline/run-tests.sh
+++ b/api-tests/secure-pipeline/run-tests.sh
@@ -10,7 +10,7 @@ get_current_status() {
 generate_traffic() {
   while true; do
     echo "Running @TrafficGeneration tests"
-    npm run test:build -- --profile trafficGeneration --tags '@TrafficGeneration'
+    npm run test:build -- --profile trafficGeneration --tags '@TrafficGeneration' || true
   done
 }
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Ensure TrafficGeneration continues on failure

### Why did it change

If the API tests failed for any reason then the process returns a non-zero exit code. Because we have the error exit option set, this causes the background process to exit, and no more test cycles are run.

We can prevent this by falling back to returning true - this will ensure that the loop continues.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7799](https://govukverify.atlassian.net/browse/PYIC-7799)


[PYIC-7799]: https://govukverify.atlassian.net/browse/PYIC-7799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ