### PR TITLE
PYIC-7857: Implement fraud check unavailable return code

### DIFF
--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -225,7 +225,7 @@ public class EvaluateGpg45ScoresHandler
 
             for (Vot requestedVot : gpg45Vots) {
                 var profiles = requestedVot.getSupportedGpg45Profiles();
-                if (requestedVot == Vot.P2 && userIdentityService.allowM1C(vcs)) {
+                if (requestedVot == Vot.P2 && userIdentityService.isFraudCheckUnavailable(vcs)) {
                     profiles = new ArrayList<>(profiles);
                     profiles.add(Gpg45Profile.M1C);
                 }

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -366,7 +366,7 @@ class EvaluateGpg45ScoresHandlerTest {
         when(sessionCredentialsService.getCredentials(TEST_SESSION_ID, TEST_USER_ID))
                 .thenReturn(vcs);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-        when(userIdentityService.allowM1C(vcs)).thenReturn(false);
+        when(userIdentityService.isFraudCheckUnavailable(vcs)).thenReturn(false);
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(P2_PROFILES)))
                 .thenReturn(Optional.empty());
         when(gpg45ProfileEvaluator.buildScore(any()))

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -337,6 +337,7 @@ class EvaluateGpg45ScoresHandlerTest {
         when(sessionCredentialsService.getCredentials(TEST_SESSION_ID, TEST_USER_ID))
                 .thenReturn(vcs);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+        when(userIdentityService.isFraudCheckUnavailable(vcs)).thenReturn(true);
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(P2_PROFILES_PLUS_M1C)))
                 .thenReturn(Optional.of(M1C));
         when(gpg45ProfileEvaluator.buildScore(any()))

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -45,6 +45,7 @@ public enum ConfigurationVariable {
     OAUTH_KEY_CACHE_DURATION_MINS("self/oauthKeyCacheDurationMins"),
     PUBLIC_KEY_MATERIAL_FOR_CORE_TO_VERIFY("clients/%s/publicKeyMaterialForCoreToVerify"),
     RETURN_CODES_ALWAYS_REQUIRED("self/returnCodes/alwaysRequired"),
+    RETURN_CODES_FRAUD_CHECK_UNAVAILABLE("self/returnCodes/fraudCheckUnavailable"),
     RETURN_CODES_NON_CI_BREACHING_P0("self/returnCodes/nonCiBreachingP0"),
     SESSION_CREDENTIALS_TTL("self/sessionCredentialTtl"),
     SIGNING_KEY_ID("self/signingKeyId"),

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -51,6 +51,7 @@ import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COI_CHECK_
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COI_CHECK_GIVEN_NAME_CHARS;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_ALWAYS_REQUIRED;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_FRAUD_CHECK_UNAVAILABLE;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.RETURN_CODES_NON_CI_BREACHING_P0;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
@@ -111,7 +112,7 @@ public class UserIdentityService {
         return userIdentityBuilder.build();
     }
 
-    public boolean allowM1C(List<VerifiableCredential> vcs) {
+    public boolean isFraudCheckUnavailable(List<VerifiableCredential> vcs) {
         var fraudVcList = vcs.stream().filter(vc -> vc.getCri() == Cri.EXPERIAN_FRAUD).toList();
 
         if (fraudVcList.isEmpty()) {
@@ -286,9 +287,15 @@ public class UserIdentityService {
         if (Vot.P0.equals(achievedVot)) {
             userIdentityBuilder.returnCode(getFailReturnCode(contraIndicators, targetVot));
         } else {
+            var returnCodes = new ArrayList<>(getSuccessReturnCode(contraIndicators));
+            if (isFraudCheckUnavailable(vcs)) {
+                returnCodes.add(
+                        new ReturnCode(
+                                configService.getParameter(RETURN_CODES_FRAUD_CHECK_UNAVAILABLE)));
+            }
             var successfulVcs = vcs.stream().filter(VcHelper::isSuccessfulVc).toList();
             addUserIdentityClaims(profileType, successfulVcs, userIdentityBuilder);
-            userIdentityBuilder.returnCode(getSuccessReturnCode(contraIndicators));
+            userIdentityBuilder.returnCode(returnCodes);
         }
     }
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/VotMatcher.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/VotMatcher.java
@@ -69,7 +69,7 @@ public class VotMatcher {
             List<ContraIndicator> contraIndicators) {
 
         var achievableProfiles = requestedVot.getSupportedGpg45Profiles();
-        if (requestedVot == Vot.P2 && userIdentityService.allowM1C(gpg45Vcs)) {
+        if (requestedVot == Vot.P2 && userIdentityService.isFraudCheckUnavailable(gpg45Vcs)) {
             achievableProfiles = new ArrayList<>(achievableProfiles);
             achievableProfiles.add(Gpg45Profile.M1C);
         }

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/VotMatcherTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/VotMatcherTest.java
@@ -146,7 +146,7 @@ public class VotMatcherTest {
         var expectedProfiles =
                 List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B, Gpg45Profile.M1C);
         when(mockUseridentityService.checkRequiresAdditionalEvidence(gpg45Vcs)).thenReturn(false);
-        when(mockUseridentityService.allowM1C(gpg45Vcs)).thenReturn(true);
+        when(mockUseridentityService.isFraudCheckUnavailable(gpg45Vcs)).thenReturn(true);
         when(mockGpg45ProfileEvaluator.buildScore(gpg45Vcs)).thenReturn(GPG_45_SCORES);
         when(mockGpg45ProfileEvaluator.getFirstMatchingProfile(GPG_45_SCORES, expectedProfiles))
                 .thenReturn(Optional.of(Gpg45Profile.M1C));

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -26,6 +26,7 @@ core:
     returnCodes:
       alwaysRequired: always-required
       nonCiBreachingP0: non-ci-breaching
+      fraudCheckUnavailable: fraud-check-unavailable
     govUkNotify:
       emailTemplates:
         UserTriggeredIdentityResetConfirmation: "dummy-value"


### PR DESCRIPTION
## Proposed changes

### What changed

- Add fraud check unavailable return code to config service
- Add check into generateUserIdentity
- Update tests

### Why did it change

- Implement fraud check unavailable return code

### Issue tracking

- [PYIC-7646](https://govukverify.atlassian.net/browse/PYIC-7646)

[PYIC-7646]: https://govukverify.atlassian.net/browse/PYIC-7646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ