### PR TITLE
IPS-1185 lambda canary 50percent5minutes added

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -108,6 +108,7 @@ Parameters:
       - Linear10PercentEvery1Minute
       - Linear10PercentEvery2Minutes
       - Linear10PercentEvery3Minutes
+      - LambdaCanary50Percent5Minutes
   StepFunctionDeploymentPreference:
     Description: "Specifies the configuration to enable gradual StepFunction deployment."
     Type: String


### PR DESCRIPTION
## Proposed changes

### What changed

Allowed value of LambdaCanary50Percent5Minutes added to the canary deployment.

### Why did it change

Deployment strategy has been set to 50Percent5Minutes in dev and build for canary deployments. This is an even split deployment to test for issues in the two versions of a lambda.
This change is required in order to allow this new value to be used in the pipeline.

error when updating pipeline without this change:
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/a06a34bd-5e46-4f48-877b-18dd0269dc07" />


### Issue tracking


- [IPS-1185](https://govukverify.atlassian.net/browse/IPS-1185)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1185]: https://govukverify.atlassian.net/browse/IPS-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ