### PR TITLE
IPS-1291 testing api added to 5xx canary alarms

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3189,7 +3189,7 @@ Resources:
       MetricName: 5XXError
       Dimensions:
         - Name: ApiName
-          Value: !Sub IPV Core Private API Gateway ${Environment}
+          Value: !If [IsTestApiEnv, !Sub "IPV Core Private Testing API Gateway ${Environment}", !Sub "IPV Core Private API Gateway ${Environment}"]
         - Name: Method
           Value: POST
         - Name: Stage
@@ -3243,7 +3243,7 @@ Resources:
       MetricName: 5XXError
       Dimensions:
         - Name: ApiName
-          Value: !Sub IPV Core Private API Gateway ${Environment}
+          Value: !If [IsTestApiEnv, !Sub "IPV Core Private Testing API Gateway ${Environment}", !Sub "IPV Core Private API Gateway ${Environment}"]
         - Name: Method
           Value: POST
         - Name: Stage
@@ -3377,7 +3377,7 @@ Resources:
       MetricName: 5XXError
       Dimensions:
         - Name: ApiName
-          Value: !Sub IPV Core Private API Gateway ${Environment}
+          Value: !If [IsTestApiEnv, !Sub "IPV Core Private Testing API Gateway ${Environment}", !Sub "IPV Core Private API Gateway ${Environment}"]
         - Name: Method
           Value: POST
         - Name: Stage
@@ -3460,7 +3460,7 @@ Resources:
       MetricName: 5XXError
       Dimensions:
         - Name: ApiName
-          Value: !Sub IPV Core Private API Gateway ${Environment}
+          Value: !If [IsTestApiEnv, !Sub "IPV Core Private Testing API Gateway ${Environment}", !Sub "IPV Core Private API Gateway ${Environment}"]
         - Name: Method
           Value: POST
         - Name: Stage


### PR DESCRIPTION
## Proposed changes

### What changed
Conditional added for 5xx canary alarms dimensions for endpoints that use a testing api gateway

- /user/proven-identity-details
- /journey/{journeyStep+}
- /session/initialise
- /cri/callback


### Why did it change

This ensures that canary deployment in build works as intended and will rollback if there is an issue.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1291](https://govukverify.atlassian.net/browse/IPS-1291)

Deployed this in dev, and the dimension used is IPV Core Private **Testing** API Gateway dev instead of IPV Core Private API Gateway dev as intended:

![image](https://github.com/user-attachments/assets/16db3375-8d98-4783-a2b3-9f80fb78e72c)


## Checklists

### Environment variables or secrets



[IPS-1291]: https://govukverify.atlassian.net/browse/IPS-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ