### PR TITLE
PYIC-7532: Use journeyContext to determine internationalAddress user

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -41,8 +41,8 @@ nestedJourneyStates:
         targetState: DAD_ANDROID_START_SESSION
       neither:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
-        checkFeatureFlag:
-          internationalAddressEnabled:
+        checkJourneyContext:
+          internationalAddress:
             targetState: DAD_SELECT_SMARTPHONE_NON_UK_NO_APP_OPTIONS
 
   DAD_SELECT_SMARTPHONE_EXIT_BUFFER:
@@ -89,8 +89,8 @@ nestedJourneyStates:
         targetState: CHECK_MOBILE_APP_RESULT
       preferNoApp:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
-        checkFeatureFlag:
-          internationalAddressEnabled:
+        checkJourneyContext:
+          internationalAddress:
             targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
@@ -115,8 +115,8 @@ nestedJourneyStates:
         targetState: CHECK_MOBILE_APP_RESULT
       preferNoApp:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
-        checkFeatureFlag:
-          internationalAddressEnabled:
+        checkJourneyContext:
+          internationalAddress:
             targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
@@ -200,8 +200,8 @@ nestedJourneyStates:
         targetState: CHECK_MOBILE_APP_RESULT
       preferNoApp:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
-        checkFeatureFlag:
-          internationalAddressEnabled:
+        checkJourneyContext:
+          internationalAddress:
             targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
@@ -226,8 +226,8 @@ nestedJourneyStates:
         targetState: CHECK_MOBILE_APP_RESULT
       preferNoApp:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
-        checkFeatureFlag:
-          internationalAddressEnabled:
+        checkJourneyContext:
+          internationalAddress:
             targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -846,6 +846,7 @@ states:
             targetState: NON_UK_PASSPORT
 
   NON_UK_PASSPORT:
+    journeyContext: internationalAddress
     response:
       type: page
       pageId: non-uk-passport


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use journeyContext to determine internationalAddress user
Routing needs to change based on the actual address of the user not just based on the featureFlag
Checked there shouldnt be any overlap with the existing journeyContext for rfc. <- follow up ticket to find a better solution

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7532](https://govukverify.atlassian.net/browse/PYIC-7532)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7532]: https://govukverify.atlassian.net/browse/PYIC-7532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ