### PR TITLE
PYIC-7650: Fix API test to run on build and add separate return code …

### DIFF
--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -51,7 +51,6 @@ Feature: P2 App journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
-    And I get 'fraud-check-unavailable' return codes
     And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: User looks for alternative methods to prove identity without using the app

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -182,3 +182,28 @@ Feature: Return exit codes
     When I use the OAuth response to get my identity
     Then I get a 'P0' identity
     And I get 'breaching' return codes
+
+  Scenario: Successful P2 international identity via DCMAW using passport returns fraud-check-unavailable
+    Given I start a new 'medium-confidence' journey
+    And I activate the 'internationalAddress' feature sets
+    And I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit an 'international' event
+    Then I get a 'non-uk-app-intro' page response
+    When I submit a 'useApp' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-changed' details with attributes to the CRI stub
+      | Attribute | Values               |
+      | context   | "international_user" |
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-no-applicable' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And I get 'fraud-check-unavailable' return codes


### PR DESCRIPTION
…test

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Removed return code from test that runs in build, and added separate return code test

### Why did it change

We want to test the return code, but the build environment uses the real code rather than the test value.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7650](https://govukverify.atlassian.net/browse/PYIC-7650)


[PYIC-7650]: https://govukverify.atlassian.net/browse/PYIC-7650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ