### PR TITLE
BAU: Add fail-with-no-ci option to FRAUD_CHECK_NAMES_ONLY

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -220,17 +220,6 @@ states:
       fail-with-no-ci:
         targetState: EVALUATE_GPG45_SCORES_RFC
 
-  ADDRESS_AND_FRAUD_RFC:
-    nestedJourney: ADDRESS_AND_FRAUD
-    exitEvents:
-      next:
-        targetState: EVALUATE_GPG45_SCORES_RFC
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS
-      fraud-fail-with-no-ci:
-        targetState: EVALUATE_GPG45_SCORES_RFC
-
   EVALUATE_GPG45_SCORES_RFC:
     response:
       type: process

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -158,6 +158,8 @@ states:
       enhanced-verification:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      fail-with-no-ci:
+        targetState: CHECK_COI_NAMES
 
   NAMES_ONLY_AFTER_RFC:
     response:


### PR DESCRIPTION
## Proposed changes

### What changed

- Add fail-with-no-ci option to FRAUD_CHECK_NAMES_ONLY, taking the user to attempt to evaluate scores

### Why did it change

- Since we should attempt to evaluate if fraud gives an applicable_authoritative_source failed check

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7650](https://govukverify.atlassian.net/browse/PYIC-7650)

[PYIC-7650]: https://govukverify.atlassian.net/browse/PYIC-7650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ