### PR TITLE
PYIC-7446: Set AWS_EMF_ENVIRONMENT in local

### DIFF
--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -44,10 +44,6 @@ dependencies {
 			project(":libs:oauth-key-service")
 }
 
-run.doFirst {
-	environment 'AWS_XRAY_CONTEXT_MISSING', 'IGNORE_ERROR'
-}
-
 java {
 	sourceCompatibility = JavaVersion.VERSION_17
 	targetCompatibility = JavaVersion.VERSION_17
@@ -58,6 +54,11 @@ application {
 	applicationDefaultJvmArgs = [
 		"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5002"
 	]
+}
+
+tasks.named('run', JavaExec) {
+	environment 'AWS_EMF_ENVIRONMENT', 'Local'
+	environment 'AWS_XRAY_CONTEXT_MISSING', 'IGNORE_ERROR'
 }
 
 sonar {

--- a/local-running/compose.yaml
+++ b/local-running/compose.yaml
@@ -68,6 +68,7 @@ services:
       CI_STORAGE_POST_MITIGATIONS_LAMBDA_ARN: arn:aws:lambda:eu-west-2:388905755587:function:postMitigations-production
       CI_STORAGE_PUT_LAMBDA_ARN: arn:aws:lambda:eu-west-2:388905755587:function:putContraIndicators-production
       ENVIRONMENT: local
+      AWS_EMF_ENVIRONMENT: Local
       AWS_XRAY_CONTEXT_MISSING: IGNORE_ERROR
     ports:
       - "4502:4502"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set AWS_EMF_ENVIRONMENT in local

### Why did it change

When running locally, if you don't override the EMF environment to local, you get a whole bunch of grim looking TCP errors. The metrics are trying to be sent to a sink that doesn't exist.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7446](https://govukverify.atlassian.net/browse/PYIC-7446)


[PYIC-7446]: https://govukverify.atlassian.net/browse/PYIC-7446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ