### PR TITLE
PYIC-7842: Add international address test

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
@@ -262,7 +262,9 @@ class CredentialTests {
                 .status(200)
                 .body(
                         new PactJwtIgnoreSignatureBodyBuilder(
-                                VALID_VC_HEADER, VALID_VC_INTERNATIONAL_ADDRESS_BODY, VALID_VC_INTERNATIONAL_ADDRESS_SIGNATURE))
+                                VALID_VC_HEADER,
+                                VALID_VC_INTERNATIONAL_ADDRESS_BODY,
+                                VALID_VC_INTERNATIONAL_ADDRESS_SIGNATURE))
                 .toPact();
     }
 
@@ -320,9 +322,9 @@ class CredentialTests {
                                 JsonNode addressNode = credentialSubject.get("address").get(0);
 
                                 // Just check the bits specific to international addresses
-                                assertEquals("North Kivu", addressNode.get("addressRegion").asText());
                                 assertEquals(
-                                        "CD", addressNode.get("addressCountry").asText());
+                                        "North Kivu", addressNode.get("addressRegion").asText());
+                                assertEquals("CD", addressNode.get("addressCountry").asText());
 
                             } catch (VerifiableCredentialException | JsonProcessingException e) {
                                 throw new RuntimeException(e);


### PR DESCRIPTION
NOTE: The new pact file has been sent to the Orange team to check that they are happy with it. If they aren't then this PR may need to change.

## Proposed changes

### What changed

New contract test for international address

### Why did it change

To check core back can handle international addresses

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7842](https://govukverify.atlassian.net/browse/PYIC-7842)


[PYIC-7146]: https://govukverify.atlassian.net/browse/PYIC-7146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PYIC-7842]: https://govukverify.atlassian.net/browse/PYIC-7842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ