### PR TITLE
PYIC-6246: Add cross-browser recovery restart journey

### DIFF
--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -16,6 +16,9 @@ dependencies {
 			project(":libs:user-identity-service"),
 			project(":libs:evcs-service")
 
+	compileOnly libs.lombok
+	annotationProcessor libs.lombok
+
 	testImplementation libs.hamcrest,
 			libs.jacksonDatabind,
 			libs.junitJupiter,

--- a/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
@@ -63,8 +63,8 @@ class CheckMobileAppVcReceiptHandlerTest {
     @Mock private ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     @Mock private CriResponseService criResponseService;
     @Mock private CriCheckingService criCheckingService;
-    @Mock private SessionCredentialsService sessionCredentialsService;
     @Mock private EvcsService evcsService;
+    @Mock private SessionCredentialsService sessionCredentialsService;
     @InjectMocks private CheckMobileAppVcReceiptHandler checkMobileAppVcReceiptHandler;
 
     @Test

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -41,6 +41,12 @@ states:
       pending:
         targetJourney: F2F_PENDING
         targetState: PENDING
+      dcmaw-async-vc-received-low:
+        targetJourney: NEW_P1_IDENTITY
+        targetState: DCMAW_ASYNC_COMPLETE
+      dcmaw-async-vc-received-medium:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: DCMAW_ASYNC_COMPLETE
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -42,6 +42,11 @@ states:
       next:
         targetState: REPROVE_IDENTITY_START
 
+  DCMAW_ASYNC_COMPLETE:
+    events:
+      next:
+        targetState: POST_APP_DOC_CHECK_SUCCESS_PAGE
+
   # Parent states
 
   CRI_STATE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -45,6 +45,11 @@ states:
       next:
         targetState: REPROVE_IDENTITY_START
 
+  DCMAW_ASYNC_COMPLETE:
+    events:
+      next:
+        targetState: POST_APP_DOC_CHECK_SUCCESS_PAGE
+
   # Parent states
 
   CRI_STATE:

--- a/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
+++ b/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
+import uk.gov.di.ipv.core.library.exception.InvalidCriResponseException;
 import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
@@ -29,7 +30,6 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.CriOAuthSessionService;
 import uk.gov.di.ipv.core.library.service.CriResponseService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
-import uk.gov.di.ipv.core.library.service.exception.InvalidCriResponseException;
 import uk.gov.di.ipv.core.processmobileappcallback.dto.MobileAppCallbackRequest;
 import uk.gov.di.ipv.core.processmobileappcallback.exception.InvalidMobileAppCallbackRequestException;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -49,7 +49,8 @@ public enum ConfigurationVariable {
     RETURN_CODES_NON_CI_BREACHING_P0("self/returnCodes/nonCiBreachingP0"),
     SESSION_CREDENTIALS_TTL("self/sessionCredentialTtl"),
     SIGNING_KEY_ID("self/signingKeyId"),
-    SIGNING_KEY_JWK("self/signingKey");
+    SIGNING_KEY_JWK("self/signingKey"),
+    DCMAW_ASYNC_VC_PENDING_RETURN_TTL("self/dcmawAsyncVcPendingReturnTtl");
 
     private final String path;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -113,7 +113,8 @@ public enum ErrorResponse {
     FAILED_TO_PARSE_MOBILE_APP_CALLBACK_REQUEST_BODY(
             1099, "Failed to parse mobile app callback request body"),
     CRI_RESPONSE_ITEM_NOT_FOUND(1100, "CRI response item cannot be found"),
-    MISSING_TARGET_VOT(1101, "Target VOT missing from session");
+    MISSING_TARGET_VOT(1101, "Target VOT missing from session"),
+    INVALID_VTR_CLAIM(1102, "Invalid VTR claim");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
@@ -45,7 +45,7 @@ public class JourneyUris {
     public static final String JOURNEY_NOT_FOUND_PATH = "/journey/not-found";
     public static final String JOURNEY_OPERATIONAL_PROFILE_REUSE_PATH =
             "/journey/operational-profile-reuse";
-    public static final String JOURNEY_PENDING_PATH = "/journey/pending";
+    public static final String JOURNEY_F2F_PENDING_PATH = "/journey/pending";
     public static final String JOURNEY_REPEAT_FRAUD_CHECK_PATH = "/journey/repeat-fraud-check";
     public static final String JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH =
             "/journey/reprove-identity";
@@ -61,4 +61,8 @@ public class JourneyUris {
     public static final String JOURNEY_UNMET_PATH = "/journey/unmet";
     public static final String JOURNEY_VCS_NOT_CORRELATED = "/journey/vcs-not-correlated";
     public static final String JOURNEY_ABANDON_PATH = "/journey/abandon";
+    public static final String JOURNEY_DCMAW_ASYNC_VC_RECEIVED_LOW_PATH =
+            "/journey/dcmaw-async-vc-received-low";
+    public static final String JOURNEY_DCMAW_ASYNC_VC_RECEIVED_MEDIUM_PATH =
+            "/journey/dcmaw-async-vc-received-medium";
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.DRIVING_LICENCE;
 import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_FRAUD;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
@@ -999,6 +1000,24 @@ public interface VcFixtures {
                                             .build())
                             .build(),
                     Instant.ofEpochSecond(1705986521));
+
+    static VerifiableCredential vcDcmawAsync() {
+        TestVc.TestCredentialSubject credentialSubject =
+                TestVc.TestCredentialSubject.builder()
+                        .name(List.of((ALICE_PARKER_NAME)))
+                        .birthDate(List.of(createBirthDate("1970-01-01")))
+                        .drivingPermit(List.of(DRIVING_PERMIT_DVLA))
+                        .build();
+        return generateVerifiableCredential(
+                "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
+                DCMAW_ASYNC,
+                TestVc.builder()
+                        .evidence(DCMAW_EVIDENCE_DATA_CHECK)
+                        .credentialSubject(credentialSubject)
+                        .build(),
+                "https://driving-license-cri.stubs.account.gov.uk",
+                Instant.ofEpochSecond(1705986521));
+    }
 
     static VerifiableCredential vcF2fM1a() {
         TestVc.TestCredentialSubject credentialSubject =

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static com.nimbusds.jose.jwk.KeyType.EC;
 import static com.nimbusds.jose.jwk.KeyType.RSA;
+import static com.nimbusds.jwt.JWTClaimNames.ISSUED_AT;
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static com.nimbusds.jwt.JWTClaimNames.JWT_ID;
 import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
@@ -97,6 +98,7 @@ public class VerifiableCredentialGenerator {
                             .claim(SUBJECT, userId)
                             .claim(ISSUER, issuer)
                             .claim(NOT_BEFORE, nbf.getEpochSecond())
+                            .claim(ISSUED_AT, nbf.getEpochSecond())
                             .claim(VC_CLAIM, OBJECT_MAPPER.convertValue(vcClaim, Map.class))
                             .build();
             return signTestVc(userId, cri, claimsSet, signingKeyType);

--- a/libs/cri-response-service/build.gradle
+++ b/libs/cri-response-service/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
+			libs.bundles.awsLambda,
 			libs.awsSdkDynamodbEnhanced,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/domain/AsyncCriStatus.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/domain/AsyncCriStatus.java
@@ -1,0 +1,91 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.helpers.LogHelper;
+
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ABANDON_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_PENDING_PATH;
+
+public record AsyncCriStatus(
+        Cri cri,
+        String incompleteStatus,
+        boolean isAwaitingVc,
+        boolean isPendingReturn,
+        boolean isReproveIdentity) {
+    public static final String STATUS_PENDING = "pending";
+    public static final String STATUS_ERROR = "error";
+    public static final String STATUS_ABANDON = "abandon";
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final JourneyResponse JOURNEY_F2F_PENDING =
+            new JourneyResponse(JOURNEY_F2F_PENDING_PATH);
+    private static final JourneyResponse JOURNEY_F2F_FAIL =
+            new JourneyResponse(JOURNEY_F2F_FAIL_PATH);
+    private static final JourneyResponse JOURNEY_ABANDON =
+            new JourneyResponse(JOURNEY_ABANDON_PATH);
+    private static final JourneyResponse JOURNEY_ERROR = new JourneyResponse(JOURNEY_ERROR_PATH);
+
+    public JourneyResponse getJourneyForAwaitingVc(boolean isSameSession) {
+        LOGGER.info(
+                LogHelper.buildLogMessage(cri.getId() + " processing status: " + incompleteStatus));
+        return switch (incompleteStatus) {
+            case STATUS_PENDING -> getJourneyPending(isSameSession);
+            case STATUS_ABANDON -> getJourneyAbandon(isSameSession);
+            case STATUS_ERROR -> getJourneyError();
+            default -> {
+                LOGGER.warn(LogHelper.buildLogMessage("Unexpected status: " + incompleteStatus));
+                yield JOURNEY_ERROR;
+            }
+        };
+    }
+
+    private JourneyResponse getJourneyPending(boolean isSameSession) {
+        return switch (cri) {
+            case DCMAW_ASYNC -> {
+                if (isSameSession) {
+                    yield null;
+                } else {
+                    throw getUnsupportedCriResponseLogicException();
+                }
+            }
+            case F2F -> JOURNEY_F2F_PENDING;
+            default -> logUnexpectedCri();
+        };
+    }
+
+    private JourneyResponse getJourneyAbandon(boolean isSameSession) {
+        return switch (cri) {
+            case DCMAW_ASYNC -> {
+                if (isSameSession) {
+                    yield JOURNEY_ABANDON;
+                } else {
+                    throw getUnsupportedCriResponseLogicException();
+                }
+            }
+            case F2F -> JOURNEY_F2F_FAIL;
+            default -> logUnexpectedCri();
+        };
+    }
+
+    private JourneyResponse getJourneyError() {
+        return switch (cri) {
+            case DCMAW_ASYNC -> JOURNEY_ERROR;
+            case F2F -> JOURNEY_F2F_FAIL;
+            default -> logUnexpectedCri();
+        };
+    }
+
+    private JourneyResponse logUnexpectedCri() {
+        LOGGER.warn(LogHelper.buildLogMessage("Unexpected cri: " + cri.getId()));
+        return JOURNEY_ERROR;
+    }
+
+    private RuntimeException getUnsupportedCriResponseLogicException() {
+        return new RuntimeException(
+                "Unsupported CRI response situation. When the DCMAW async VC does not exist, it is implicitly assumed to caused by user abandoned.");
+    }
+}

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/exception/InvalidCriResponseException.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/exception/InvalidCriResponseException.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.core.library.service.exception;
+package uk.gov.di.ipv.core.library.exception;
 
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/service/CriResponseService.java
@@ -1,18 +1,25 @@
 package uk.gov.di.ipv.core.library.service;
 
+import com.nimbusds.jwt.util.DateUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.AsyncCriStatus;
 import uk.gov.di.ipv.core.library.domain.Cri;
+import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
 
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.DCMAW_ASYNC_VC_PENDING_RETURN_TTL;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CRI_RESPONSE_TABLE_NAME;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
+import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 
 public class CriResponseService {
 
@@ -20,16 +27,19 @@ public class CriResponseService {
     public static final String STATUS_ERROR = "error";
     public static final String STATUS_ABANDON = "abandon";
     public static final String ERROR_ACCESS_DENIED = "access_denied";
+    private final ConfigService configService;
     private final DataStore<CriResponseItem> dataStore;
 
     @ExcludeFromGeneratedCoverageReport
     public CriResponseService(ConfigService configService) {
         this.dataStore =
                 DataStore.create(CRI_RESPONSE_TABLE_NAME, CriResponseItem.class, configService);
+        this.configService = configService;
     }
 
-    public CriResponseService(DataStore<CriResponseItem> dataStore) {
+    public CriResponseService(DataStore<CriResponseItem> dataStore, ConfigService configService) {
         this.dataStore = dataStore;
+        this.configService = configService;
     }
 
     public Optional<CriResponseItem> getCriResponseItemWithState(String userId, String state) {
@@ -65,15 +75,55 @@ public class CriResponseService {
         dataStore.create(criResponseItem, ConfigurationVariable.CRI_RESPONSE_TTL);
     }
 
-    public CriResponseItem getFaceToFaceRequest(String userId) {
-        return dataStore.getItem(userId, "f2f");
-    }
-
     public void deleteCriResponseItem(String userId, Cri credentialIssuer) {
         dataStore.delete(userId, credentialIssuer.getId());
     }
 
     public void updateCriResponseItem(CriResponseItem responseItem) {
         dataStore.update(responseItem);
+    }
+
+    public AsyncCriStatus getAsyncResponseStatus(
+            String userId, List<VerifiableCredential> credentials, boolean isPendingReturn) {
+        // F2F CRI response item blocks other async CRI routes, except for
+        // enhanced-verification-f2f-fail, which enforces the user stays on the same mitigation
+        // route, so it is fine here as we check F2F first.
+        var f2fCriResponseItem = getCriResponseItem(userId, F2F);
+        if (f2fCriResponseItem != null) {
+            var f2fVc = credentials.stream().filter(vc -> vc.getCri().equals(F2F)).findFirst();
+            var hasVc = f2fVc.isPresent();
+
+            return new AsyncCriStatus(
+                    F2F,
+                    f2fCriResponseItem.getStatus(),
+                    !hasVc,
+                    isPendingReturn,
+                    f2fCriResponseItem.isReproveIdentity());
+        }
+
+        // DCMAW async VC existence determines success or abandonment
+        var dcmawAsyncVc =
+                credentials.stream().filter(vc -> vc.getCri().equals(DCMAW_ASYNC)).findFirst();
+        if (dcmawAsyncVc.isPresent()) {
+            var issuedAt = dcmawAsyncVc.get().getClaimsSet().getIssueTime();
+            if (issuedAt != null) {
+                var now = DateUtils.toSecondsSinceEpoch(new Date());
+                var expiry =
+                        DateUtils.toSecondsSinceEpoch(issuedAt)
+                                + Integer.parseInt(
+                                        configService.getParameter(
+                                                DCMAW_ASYNC_VC_PENDING_RETURN_TTL));
+                if (now < expiry) {
+                    return new AsyncCriStatus(
+                            DCMAW_ASYNC,
+                            null,
+                            false,
+                            isPendingReturn,
+                            getCriResponseItem(userId, DCMAW_ASYNC).isReproveIdentity());
+                }
+            }
+        }
+
+        return new AsyncCriStatus(null, null, false, false, false);
     }
 }

--- a/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/domain/AsyncCriStatusTest.java
+++ b/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/domain/AsyncCriStatusTest.java
@@ -1,0 +1,72 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
+import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
+
+@ExtendWith(MockitoExtension.class)
+class AsyncCriStatusTest {
+    @ParameterizedTest
+    @MethodSource("DcmawAsyncSameSessionJourneysAndCriResponseItemStatuses")
+    void getJourneyForAwaitingVcShouldReturnCorrectJourneyForDcmawAsyncSameSession(
+            String incompleteStatus, String expectedJourney) {
+        // Arrange
+        var asyncCriStatus = new AsyncCriStatus(DCMAW_ASYNC, incompleteStatus, false, false, false);
+
+        // Act
+        var journeyResponse = asyncCriStatus.getJourneyForAwaitingVc(true);
+
+        // Assert
+        assertEquals(expectedJourney, journeyResponse.getJourney());
+    }
+
+    static Stream<Arguments> DcmawAsyncSameSessionJourneysAndCriResponseItemStatuses() {
+        return Stream.of(
+                Arguments.of(AsyncCriStatus.STATUS_ABANDON, "/journey/abandon"),
+                Arguments.of(AsyncCriStatus.STATUS_ERROR, "/journey/error"),
+                Arguments.of("not a status", "/journey/error"));
+    }
+
+    void getJourneyForAwaitingVcShouldReturnCorrectJourneyForDcmawAsyncSameSession() {
+        // Arrange
+        var asyncCriStatus =
+                new AsyncCriStatus(DCMAW_ASYNC, AsyncCriStatus.STATUS_PENDING, false, false, false);
+
+        // Act
+        var journeyResponse = asyncCriStatus.getJourneyForAwaitingVc(true);
+
+        // Assert
+        assertNull(journeyResponse.getJourney());
+    }
+
+    @ParameterizedTest
+    @MethodSource("F2fJourneysAndCriResponseItemStatuses")
+    void getJourneyForAwaitingVcShouldReturnCorrectJourneyForF2f(
+            String incompleteStatus, String expectedJourney) {
+        // Arrange
+        var asyncCriStatus = new AsyncCriStatus(F2F, incompleteStatus, false, false, false);
+
+        // Act
+        var journeyResponse = asyncCriStatus.getJourneyForAwaitingVc(false);
+
+        // Assert
+        assertEquals(expectedJourney, journeyResponse.getJourney());
+    }
+
+    static Stream<Arguments> F2fJourneysAndCriResponseItemStatuses() {
+        return Stream.of(
+                Arguments.of(AsyncCriStatus.STATUS_PENDING, "/journey/pending"),
+                Arguments.of(AsyncCriStatus.STATUS_ABANDON, "/journey/f2f-fail"),
+                Arguments.of(AsyncCriStatus.STATUS_ERROR, "/journey/f2f-fail"),
+                Arguments.of("not a status", "/journey/error"));
+    }
+}

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -8,6 +8,7 @@ core:
     jwtTtlSeconds: 3600
     maxAllowedAuthClientTtl: 3600
     fraudCheckExpiryPeriodHours: 720
+    dcmawAsyncVcPendingReturnTtl: 1800
     coreVtmClaim: "https://oidc.local.account.gov.uk/trustmark"
     backendSessionTimeout: 3600
     backendSessionTtl: 3600


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add Cross-browser recovery restart journey logic to CheckExistingIdentityHandler
- Centralise Async CRI status checking with new AsyncCriStatus class

### Why did it change

- Deal with case of return from separate-session mobile app.
- F2F and DCMAW async both require similar logic and exception-handling.

### NB

- Will squash when I merge, since there are a lot here.
- API tests will be covered in https://govukverify.atlassian.net/browse/PYIC-7785

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6246](https://govukverify.atlassian.net/browse/PYIC-6246)

[PYIC-6246]: https://govukverify.atlassian.net/browse/PYIC-6246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ