### PR TITLE
PYIC-7888 Temporarily disable DT for one lambda in build

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -10,44 +10,44 @@ Globals:
       ApplyOn: PublishedVersions
     Architectures:
       - arm64
-    MemorySize: !If [IsDevelopment, 1024, 3072]
+    MemorySize: !If [UseDynatrace, 3072, 1024]
     Runtime: java17
     Environment:
       Variables:
         AWS_LAMBDA_EXEC_WRAPPER: !If
-          - IsDevelopment
-          - !Ref AWS::NoValue
+          - UseDynatrace
           - /opt/dynatrace
-        DT_CONNECTION_AUTH_TOKEN: !If
-          - IsDevelopment
           - !Ref AWS::NoValue
+        DT_CONNECTION_AUTH_TOKEN: !If
+          - UseDynatrace
           - !Sub
             - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}' # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
-        DT_CONNECTION_BASE_URL: !If
-          - IsDevelopment
           - !Ref AWS::NoValue
+        DT_CONNECTION_BASE_URL: !If
+          - UseDynatrace
           - !Sub
             - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}' # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
-        DT_CLUSTER_ID: !If
-          - IsDevelopment
           - !Ref AWS::NoValue
+        DT_CLUSTER_ID: !If
+          - UseDynatrace
           - !Sub
             - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}' # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
-        DT_LOG_COLLECTION_AUTH_TOKEN: !If
-          - IsDevelopment
           - !Ref AWS::NoValue
+        DT_LOG_COLLECTION_AUTH_TOKEN: !If
+          - UseDynatrace
           - !Sub
             - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}' # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
-        DT_TENANT: !If
-          - IsDevelopment
           - !Ref AWS::NoValue
+        DT_TENANT: !If
+          - UseDynatrace
           - !Sub
             - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}' # pragma: allowlist secret
             - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
+          - !Ref AWS::NoValue
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
         OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING: true
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
@@ -67,11 +67,11 @@ Globals:
       - !Ref AWS::NoValue
     Layers:
       - !If
-        - IsDevelopment
-        - !Ref AWS::NoValue
+        - UseDynatrace
         - !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}' # pragma: allowlist secret or NODEJS_LAYER or PYTHON_LAYER
           - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
+        - !Ref AWS::NoValue
     DeploymentPreference:
       Type: !Ref LambdaDeploymentPreference
       Role: !GetAtt CodeDeployServiceRole.Arn
@@ -120,11 +120,12 @@ Parameters:
 
 Conditions:
   IsDevelopment: !Or
-    - !Equals [ !Ref AWS::AccountId, "130355686670"]
-    - !Equals [ !Ref AWS::AccountId, "175872367215"]
-  IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670"]
+    - !Equals [ !Ref AWS::AccountId, "130355686670" ]
+    - !Equals [ !Ref AWS::AccountId, "175872367215" ]
+  IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670" ]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
-  IsProduction: !Equals [ !Ref Environment, "production"]
+  IsBuild: !Equals [ !Ref Environment, "build" ]
+  IsProduction: !Equals [ !Ref Environment, "production" ]
   IsSubscriptionEnviroment: !Or
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
@@ -145,6 +146,7 @@ Conditions:
   UseCanaryDeploymentAlarms: !Or
     - !Not [ !Equals [ !Ref StepFunctionDeploymentPreference, ALL_AT_ONCE ]]
     - !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
+  UseDynatrace: !Not [ !Condition IsDevelopment ]
 
 # The AWS Account Id is used in the following mapping section because we have
 # multiple developer environments and it is undesirable to have to keep this
@@ -747,6 +749,24 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
+          # PYIC-7888 Temporarily disable DT in build
+          AWS_LAMBDA_EXEC_WRAPPER: !If
+            - UseDynatrace
+            - !If
+              - IsBuild
+              - !Ref AWS::NoValue
+              - /opt/dynatrace
+            - !Ref AWS::NoValue
+      Layers:
+        - !If
+          - UseDynatrace
+          - !If
+            - IsBuild
+            - !Ref AWS::NoValue
+            - !Sub
+              - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}' # pragma: allowlist secret or NODEJS_LAYER or PYTHON_LAYER
+              - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
+          - !Ref AWS::NoValue
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA


### PR DESCRIPTION
## Proposed changes

### What changed

- Refactored cloudformation to decouple Dynatrace enablement from the environment
- Override the `BuildClientOauthResponse` lambda to disable DT in build

### Why did it change

We have been seeing relatively frequent segfaults in production, and less frequent (but still consistent) segfaults in build.

We suspect that Dynatrace may be partially to blame, so we'll try running one of the lambdas without DT for a while to see if it stops the errors there.

### Issue tracking

- [PYIC-7888](https://govukverify.atlassian.net/browse/PYIC-7888)


[PYIC-7888]: https://govukverify.atlassian.net/browse/PYIC-7888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ